### PR TITLE
config: Add working printer configuration for Wanhao Duplicator i3 v2.1

### DIFF
--- a/config/printer-wanhao_duplicator_i3_v21.cfg
+++ b/config/printer-wanhao_duplicator_i3_v21.cfg
@@ -28,7 +28,8 @@
 #   See https://github.com/KevinOConnor/klipper/blob/master/docs/FAQ.md#the-make-flash-command-doesnt-work
 #   if you have problems.
 # 
-# - Copy this sample file to ~/printer.cfg, and customize the following parameters:
+# - Copy this sample file you are currently reading to ~/printer.cfg, 
+#   and customize the following parameters:
 #   * [extruder] > step_distance
 # 
 #     This is the inverse of "E steps" (extruder steps per mm) from the stock 
@@ -51,31 +52,33 @@
 # 		 heated bed: M303 E-1 S<temp>
 # 		 
 # 	  After the autotune process completes, PID parameter results 
-# 	  can be found in the Octoprint terminal (if you're quick) 
+# 	  can be found in the Octoprint terminal tab (if you're quick) 
 # 	  or in /tmp/klippy.log.
 # 	  
-# 	  Enter the PID parameters into the appropriate sections of this 
-# 	  config file.
+# 	  Enter the PID parameters into the appropriate sections of ~/printer.cfg .
 # 
 #   * [extruder] > max_temp
 #   * [heater_bed] > max_temp
 #
-#     The max temps included in this sample config are limited to 230 for extruder
-#     and 70 for heated bed. If you have an upgraded hot end or a separate MOSFET
-#     for your heated bed, you may want to increase these values.
+#     The max temps included in this printer config are limited to 230 for extruder
+#     and 70 for heated bed. If your printer has been modified to handle higher temps
+#     (like an upgraded hot end or a separate MOSFET for your heated bed), you may
+#     want to increase these values.
 #     
 #   * [mcu] > serial
 #   
 #     Enter the USB serial port of the printer in /dev/serial/by-id/ format 
 # 	  for best results.
 # 	  
-#  - Power cycle the Wanhao Duplicator i3
+# - Power cycle the Wanhao Duplicator i3 
 #
-#  - Run "sudo service klipper restart"
-#    You should see the LCD status screen appear.
+# - Issue the command "RESTART" via the Octoprint terminal tab (similar to 
+#   how you would send a manual gcode command, but send the word RESTART).
+#   This tells klipper to reload its config file and do an internal reset.
+#   You should then see a status screen appear on the printer's LCD.
 #
-#  - Be sure to follow these instructions before attempting any prints:
-#    https://github.com/KevinOConnor/klipper/blob/master/docs/Config_checks.md 
+# - Be sure to follow these instructions before attempting any prints:
+#   https://github.com/KevinOConnor/klipper/blob/master/docs/Config_checks.md 
 
 [stepper_x]
 step_pin: PD7


### PR DESCRIPTION
Working printer configuration for a Wanhao Duplicator i3 v2.1 and its clones, including Monoprice Maker Select and Cocoon Create. Includes a working config for the st7920-based front panel LCD.

Signed-off-by: Andy Ellsworth <andy+github@dar.net>