### PR TITLE
display: Fix filament loading and unloading feature

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -516,8 +516,12 @@ type: command
 name: Load Filament
 gcode:
     M83
-    G1 E200 F1000
-    G1 E100 F300
+    G1 E50 F1000
+    G1 E50 F1000
+    G1 E50 F1000
+    G1 E50 F1000
+    G1 E50 F300
+    G1 E50 F300
     M82
 
 [menu __filament __unload]
@@ -525,8 +529,14 @@ type: command
 name: Unload Filament
 gcode:
     M83
-    G1 E-200 F1000
-    G1 E-200 F1800
+    G1 E-50 F1000
+    G1 E-50 F1000
+    G1 E-50 F1000
+    G1 E-50 F1000
+    G1 E-50 F1800
+    G1 E-50 F1800
+    G1 E-50 F1800
+    G1 E-50 F1800
     M82
 
 [menu __filament __feed]


### PR DESCRIPTION
As discussed in #1057, the default loading- and unloading procedure does
not behave as expected. Setting the extruder to relative mode fixes this.

Fixes #1057

Signed-off-by: Nils Friedchen <Nils.Friedchen@googlemail.com>