### PR TITLE
Experiment with "standardized" pin aliases in example config files

### DIFF
--- a/config/generic-melzi.cfg
+++ b/config/generic-melzi.cfg
@@ -11,49 +11,76 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 200
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 200
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -62,22 +89,12 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD2
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0

--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -3,83 +3,40 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PC0
-dir_pin: PL1
-enable_pin: !PA7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PB6
-#endstop_pin: ^PA2
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_y]
-step_pin: PC1
-dir_pin: !PL0
-enable_pin: !PA6
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PB5
-#endstop_pin: ^PA1
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_z]
-step_pin: PC2
-dir_pin: PL2
-enable_pin: !PA5
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PB4
-#endstop_pin: ^PC7
-position_endstop: 0.5
-position_max: 200
-
-[extruder]
-step_pin: PC3
-dir_pin: PL6
-enable_pin: !PA4
-microsteps: 16
-rotation_distance: 33.500
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PH6
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
-control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
-min_temp: 0
-max_temp: 250
-
-#[extruder1]
-#step_pin: PC4
-#dir_pin: PL7
-#enable_pin: !PA3
-#heater_pin: PH4
-#sensor_pin: PF1
-#...
-
-[heater_bed]
-heater_pin: PE5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
-control: watermark
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH5
-
-#[heater_fan nozzle_cooling_fan]
-#pin: PH3
-
 [mcu]
 serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
 
 [printer]
 kinematics: cartesian
@@ -88,8 +45,71 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0.5
+position_max: 200
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: RAMBO_FAN0
+
+#[heater_fan nozzle_cooling_fan]
+#pin: RAMBO_FAN1
+
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 # Scale the config so that the channel value can be specified in amps.
 # (For Rambo v1.0d boards, use 1.56 instead.)
 scale: 2.08
@@ -103,24 +123,11 @@ channel_6: 1.1
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
-
-# Common EXP1 / EXP2 (display) pins
-[board_pins]
-aliases:
-    # Common EXP1/EXP2 headers found on RAMBo v1.4
-    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
-    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
-    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-
-# See the sample-lcd.cfg file for definitions of common LCD displays.
+pins: !RAMBO_LED

--- a/config/generic-ramps.cfg
+++ b/config/generic-ramps.cfg
@@ -4,80 +4,32 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE5
-#endstop_pin: ^PE4
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_y]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ1
-#endstop_pin: ^PJ0
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PD3
-#endstop_pin: ^PD2
-position_endstop: 0.5
-position_max: 200
-
-[extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 33.500
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
-min_temp: 0
-max_temp: 250
-
-#[extruder1]
-#step_pin: PC1
-#dir_pin: PC3
-#enable_pin: !PC7
-#heater_pin: PH6
-#sensor_pin: PK7
-#...
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
-control: watermark
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH6
-
 [mcu]
 serial: /dev/ttyACM0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
+    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=PG0
 
 [printer]
 kinematics: cartesian
@@ -86,16 +38,63 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
-# Common EXP1 / EXP2 (display) pins
-[board_pins]
-aliases:
-    # Common EXP1 header found on many "all-in-one" ramps clones
-    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
-    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
-    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-    # Note, some boards wire: EXP2_8=<RST>, EXP2_10=PG0
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 200
+homing_speed: 50
 
-# See the sample-lcd.cfg file for definitions of common LCD displays.
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: RAMPS_FAN0

--- a/config/printer-anet-a4-2018.cfg
+++ b/config/printer-anet-a4-2018.cfg
@@ -8,45 +8,72 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: delta
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+delta_radius: 113
+
 [stepper_a]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: 215
 arm_length: 215
 homing_speed: 50
 
 [stepper_b]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 
 [stepper_c]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 homing_speed: 20
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.440
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 30.48
 pid_Ki: 2.71
@@ -55,25 +82,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: delta
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-delta_radius: 113
+pin: MELZI_FAN0
 
 [delta_calibrate]
 radius: 70

--- a/config/printer-anet-a8-2017.cfg
+++ b/config/printer-anet-a8-2017.cfg
@@ -8,52 +8,79 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: -30
 position_max: 220
 position_min: -30
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: -8
 position_min: -8
 position_max: 220
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 240
 homing_speed: 20
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 2.151492
 pid_Ki: 0.633897
@@ -62,25 +89,15 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: hd44780

--- a/config/printer-anet-e10-2018.cfg
+++ b/config/printer-anet-e10-2018.cfg
@@ -8,75 +8,25 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^!PC2
-position_endstop: -3
-position_max: 220
-position_min: -3
-homing_speed: 50
-
-[stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^!PC3
-position_endstop: -22
-position_min: -22
-position_max: 270
-homing_speed: 50
-
-[stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^!PC4
-position_endstop: 0.5
-position_max: 300
-homing_speed: 20
-
-[extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
-microsteps: 16
-rotation_distance: 32.000
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PD5
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
-control: pid
-pid_Kp: 27.0
-pid_Ki: 1.3
-pid_Kd: 136.09
-min_temp: 10
-max_temp: 250
-
-[heater_bed]
-heater_pin: PD4
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
-control: pid
-pid_Kp: 72.8
-pid_Ki: 1.2
-pid_Kd: 1100
-min_temp: 10
-max_temp: 130
-
-[fan]
-pin: PB4
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
 
 [printer]
 kinematics: cartesian
@@ -85,8 +35,75 @@ max_accel: 1000
 max_z_velocity: 20
 max_z_accel: 1000
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!X_MIN
+position_endstop: -3
+position_max: 220
+position_min: -3
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!Y_MIN
+position_endstop: -22
+position_min: -22
+position_max: 270
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^!PC4
+position_endstop: 0.5
+position_max: 300
+homing_speed: 20
+
+[extruder]
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
+microsteps: 16
+rotation_distance: 32.000
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 27.0
+pid_Ki: 1.3
+pid_Kd: 136.09
+min_temp: 10
+max_temp: 250
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 72.8
+pid_Ki: 1.2
+pid_Kd: 1100
+min_temp: 10
+max_temp: 130
+
+[fan]
+pin: MELZI_FAN0
+
 [display]
 lcd_type: st7920
 cs_pin: PA4
 sclk_pin: PA1
-sid_pin:PA3
+sid_pin: PA3

--- a/config/printer-anet-e16-2019.cfg
+++ b/config/printer-anet-e16-2019.cfg
@@ -8,52 +8,79 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 1000
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: -3
 position_max: 300
 position_min: -3
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: -22
 position_min: -22
 position_max: 300
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 400
 homing_speed: 20
 
 [extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32.000
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 27.0
 pid_Ki: 1.3
@@ -62,9 +89,9 @@ min_temp: 10
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 72.8
 pid_Ki: 1.2
@@ -73,17 +100,7 @@ min_temp: 10
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 1000
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-anycubic-4max-2018.cfg
+++ b/config/printer-anycubic-4max-2018.cfg
@@ -3,52 +3,84 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 1200
+max_accel: 1500
+max_z_velocity: 40
+max_z_accel: 60
+
 [stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PE5
+endstop_pin: ^!X_MIN
 position_min: -2
 position_endstop: -2
 position_max: 205
 homing_speed: 60.0
 
 [stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PJ1
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 215
 homing_speed: 60.0
 
 [stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PD3
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 305
 homing_speed: 8.0
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 33.133
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_only_distance: 2000
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_kp: 27.725
 pid_ki: 1.224
@@ -57,9 +89,9 @@ min_temp: 0
 max_temp: 300
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_kp: 73.735
 pid_ki: 1.437
@@ -68,18 +100,8 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: PH6
+pin: RAMPS_FAN0
 kick_start_time: 1.0
-
-[mcu]
-serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
-
-[printer]
-kinematics: cartesian
-max_velocity: 1200
-max_accel: 1500
-max_z_velocity: 40
-max_z_accel: 60
 
 [heater_fan extruder_fan]
 pin: PL5
@@ -90,15 +112,15 @@ kick_start_time: 1.0
 
 [display]
 lcd_type: st7920
-cs_pin: PH1
-sclk_pin: PA1
-sid_pin: PH0
-encoder_pins: ^PC6, ^PC4
-click_pin: ^!PC2
-kill_pin: ^!PG0
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+kill_pin: ^!EXP2_8
 
 [filament_switch_sensor e0_sensor]
-switch_pin: PD2
+switch_pin: Z_MAX
 
 [gcode_macro START_PRINT]
 gcode:

--- a/config/printer-anycubic-i3-mega-2017.cfg
+++ b/config/printer-anycubic-i3-mega-2017.cfg
@@ -6,22 +6,54 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 10
+max_z_accel: 60
+
 [stepper_x]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PE5
+endstop_pin: ^!X_MIN
 position_min: -5
 position_endstop: -5
 position_max: 210
 homing_speed: 30.0
 
 [stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^!PL7
@@ -30,35 +62,35 @@ position_max: 210
 homing_speed: 30.0
 
 [stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PD3
+endstop_pin: ^!Z_MIN
 position_endstop: 0.0
 position_max: 205
 homing_speed: 5.0
 
 [stepper_z1]
-step_pin: PC1
-dir_pin: PC3
-enable_pin: !PC7
+step_pin: E1_STEP
+dir_pin: E1_DIR
+enable_pin: !E1_ENABLE
 microsteps: 16
 rotation_distance: 8
 endstop_pin: ^!PL6
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 34.557
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 15.717
 pid_Ki: 0.569
@@ -70,9 +102,9 @@ max_temp: 245
 pin: PL5
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 74.883
 pid_Ki: 1.809
@@ -81,17 +113,7 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: PH6
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 10
-max_z_accel: 60
+pin: RAMPS_FAN0
 
 [heater_fan stepstick_fan]
 pin: PH4

--- a/config/printer-anycubic-kossel-2016.cfg
+++ b/config/printer-anycubic-kossel-2016.cfg
@@ -7,73 +7,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_a]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE4
-homing_speed: 60
-# The next parameter needs to be adjusted for
-# your printer. You may want to start with 280
-# and meassure the distance from nozzle to bed.
-# This value then needs to be added.
-position_endstop: 273.0
-arm_length: 229.4
-
-[stepper_b]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ0
-
-[stepper_c]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PD2
-
-[extruder]
-step_pin: PA4
-dir_pin: !PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 35.165
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 25.349
-pid_Ki: 1.216
-pid_Kd: 132.130
-min_extrude_temp: 150
-min_temp: 0
-max_temp: 275
-
-#[heater_bed]
-#heater_pin: PH5
-#sensor_type: EPCOS 100K B57560G104F
-#sensor_pin: PK6
-#control: watermark
-#min_temp: 0
-#max_temp: 130
-
-[fan]
-pin: PH6
-kick_start_time: 0.200
-
-[heater_fan extruder_cooler_fan]
-pin: PL5
-
 [mcu]
 serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: delta
@@ -83,6 +40,71 @@ max_z_velocity: 200
 delta_radius: 99.8
 # if you want to DELTA_CALIBRATE you may need that
 #minimum_z_position: -5
+
+[stepper_a]
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MAX
+homing_speed: 60
+# The next parameter needs to be adjusted for
+# your printer. You may want to start with 280
+# and meassure the distance from nozzle to bed.
+# This value then needs to be added.
+position_endstop: 273.0
+arm_length: 229.4
+
+[stepper_b]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MAX
+
+[stepper_c]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Z_MAX
+
+[extruder]
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 35.165
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 25.349
+pid_Ki: 1.216
+pid_Kd: 132.130
+min_extrude_temp: 150
+min_temp: 0
+max_temp: 275
+
+#[heater_bed]
+#heater_pin: BED_HEATER
+#sensor_type: EPCOS 100K B57560G104F
+#sensor_pin: BED_THERMISTOR
+#control: watermark
+#min_temp: 0
+#max_temp: 130
+
+[fan]
+pin: RAMPS_FAN0
+kick_start_time: 0.200
+
+[heater_fan extruder_cooler_fan]
+pin: PL5
 
 [idle_timeout]
 timeout: 360
@@ -101,12 +123,12 @@ timeout: 360
 # "RepRapDiscount 2004 Smart Controller" type displays
 [display]
 lcd_type: hd44780
-rs_pin: PH1
-e_pin: PH0
-d4_pin: PA1
-d5_pin: PA3
-d6_pin: PA5
-d7_pin: PA7
-encoder_pins: ^PC6, ^PC4
-click_pin: ^!PC2
-kill_pin: ^!PG0
+rs_pin: EXP1_4
+e_pin: EXP1_3
+d4_pin: EXP1_5
+d5_pin: EXP1_6
+d6_pin: EXP1_7
+d7_pin: EXP1_8
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+kill_pin: ^!EXP2_8

--- a/config/printer-anycubic-kossel-plus-2017.cfg
+++ b/config/printer-anycubic-kossel-plus-2017.cfg
@@ -7,82 +7,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_a]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE4
-homing_speed: 60
-# The next parameter needs to be adjusted for
-# your printer. You may want to start with 280
-# and meassure the distance from nozzle to bed.
-# This value then needs to be added.
-position_endstop: 295.6
-arm_length: 269.0
-
-[stepper_b]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ0
-
-[stepper_c]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PD2
-
-[extruder]
-step_pin: PA4
-dir_pin: !PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 33.333
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 25.349
-pid_Ki: 1.216
-pid_Kd: 132.130
-min_extrude_temp: 150
-min_temp: 0
-max_temp: 275
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
-control: pid
-pid_kp: 73.517
-pid_ki: 1.132
-pid_kd: 1193.728
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH6
-kick_start_time: 0.200
-
-[heater_fan extruder_cooler_fan]
-pin: PL5
-
-# if you want to use your probe for DELTA_CALIBRATE you will need that
-#[probe]
-#pin: ^PD3
-#z_offset: 15.9
-#samples: 3
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: delta
@@ -92,6 +40,80 @@ max_z_velocity: 200
 delta_radius: 134.4
 # if you want to DELTA_CALIBRATE you may need that
 #minimum_z_position: -5
+
+[stepper_a]
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MAX
+homing_speed: 60
+# The next parameter needs to be adjusted for
+# your printer. You may want to start with 280
+# and meassure the distance from nozzle to bed.
+# This value then needs to be added.
+position_endstop: 295.6
+arm_length: 269.0
+
+[stepper_b]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MAX
+
+[stepper_c]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Z_MAX
+
+[extruder]
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 33.333
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 25.349
+pid_Ki: 1.216
+pid_Kd: 132.130
+min_extrude_temp: 150
+min_temp: 0
+max_temp: 275
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_kp: 73.517
+pid_ki: 1.132
+pid_kd: 1193.728
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: RAMPS_FAN0
+kick_start_time: 0.200
+
+[heater_fan extruder_cooler_fan]
+pin: PL5
+
+# if you want to use your probe for DELTA_CALIBRATE you will need that
+#[probe]
+#pin: ^Z_MIN
+#z_offset: 15.9
+#samples: 3
 
 [idle_timeout]
 timeout: 360
@@ -104,12 +126,12 @@ radius: 115
 # "RepRapDiscount 2004 Smart Controller" type displays
 [display]
 lcd_type: hd44780
-rs_pin: PH1
-e_pin: PH0
-d4_pin: PA1
-d5_pin: PA3
-d6_pin: PA5
-d7_pin: PA7
-encoder_pins: ^PC6, ^PC4
-click_pin: ^!PC2
-kill_pin: ^!PG0
+rs_pin: EXP1_4
+e_pin: EXP1_3
+d4_pin: EXP1_5
+d5_pin: EXP1_6
+d6_pin: EXP1_7
+d7_pin: EXP1_8
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+kill_pin: ^!EXP2_8

--- a/config/printer-creality-cr10-2017.cfg
+++ b/config/printer-creality-cr10-2017.cfg
@@ -11,49 +11,76 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC2
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC3
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^PC4
+endstop_pin: ^Z_MIN
 position_endstop: 0.0
 position_max: 400
 
 [extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.57
 pid_Ki: 1.72
@@ -62,9 +89,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 426.68
 pid_Ki: 78.92
@@ -73,17 +100,7 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-creality-cr10mini-2017.cfg
+++ b/config/printer-creality-cr10mini-2017.cfg
@@ -11,49 +11,76 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC2
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 300
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC3
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 220
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^PC4
+endstop_pin: ^Z_MIN
 position_endstop: 0.0
 position_max: 300
 
 [extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.57
 pid_Ki: 1.72
@@ -62,9 +89,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 426.68
 pid_Ki: 78.92
@@ -73,17 +100,7 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-creality-cr10s-2017.cfg
+++ b/config/printer-creality-cr10s-2017.cfg
@@ -3,72 +3,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE5
-position_endstop: 0
-position_max: 300
-homing_speed: 50
-
-[stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ1
-position_endstop: 0
-position_max: 300
-homing_speed: 50
-
-[stepper_z]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PD3
-position_endstop: 0
-position_max: 400
-
-[extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 33.683
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
-min_temp: 0
-max_temp: 250
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PK6
-control: pid
-pid_Kp: 690.34
-pid_Ki: 111.47
-pid_Kd: 1068.83
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH6
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: cartesian
@@ -77,10 +35,74 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0
+position_max: 400
+
+[extruder]
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 33.683
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 690.34
+pid_Ki: 111.47
+pid_Kd: 1068.83
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: RAMPS_FAN0
+
 [display]
 lcd_type: st7920
-cs_pin: PH1
-sclk_pin: PA1
-sid_pin: PH0
-encoder_pins: ^PC4, ^PC6
-click_pin: ^!PC2
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2

--- a/config/printer-creality-cr20-2018.cfg
+++ b/config/printer-creality-cr20-2018.cfg
@@ -3,72 +3,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE5
-position_endstop: 0
-position_max: 235
-homing_speed: 50
-
-[stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ1
-position_endstop: 0
-position_max: 235
-homing_speed: 50
-
-[stepper_z]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PD3
-position_endstop: 0
-position_max: 250
-
-[extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 33.683
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
-min_temp: 0
-max_temp: 250
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
-control: pid
-pid_Kp: 690.34
-pid_Ki: 111.47
-pid_Kd: 1068.83
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH6
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: cartesian
@@ -77,9 +35,73 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0
+position_max: 250
+
+[extruder]
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 33.683
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 690.34
+pid_Ki: 111.47
+pid_Kd: 1068.83
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: RAMPS_FAN0
+
 [display]
 lcd_type: uc1701
-cs_pin: PA3
-a0_pin: PA5
-encoder_pins: ^PC4, ^PC6
-click_pin: ^!PC2
+cs_pin: EXP1_6
+a0_pin: EXP1_7
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2

--- a/config/printer-creality-cr20-pro-2019.cfg
+++ b/config/printer-creality-cr20-pro-2019.cfg
@@ -3,32 +3,64 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06SLT2-if00-port0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PE5
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 235
 homing_speed: 100
 
 [stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PJ1
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 235
 homing_speed: 100
 
 [stepper_z]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
@@ -37,16 +69,16 @@ homing_speed: 10.0
 position_min: -1.0
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -55,7 +87,7 @@ min_temp: 0
 max_temp: 250
 
 [bltouch]
-sensor_pin: ^PD3
+sensor_pin: ^Z_MIN
 control_pin: PB5
 z_offset: 3.60
 x_offset: 46
@@ -77,9 +109,9 @@ mesh_max: 281,229
 probe_count: 3,3
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -88,21 +120,11 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PH6
-
-[mcu]
-serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06SLT2-if00-port0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: RAMPS_FAN0
 
 [display]
 lcd_type: uc1701
-cs_pin: PA3
-a0_pin: PA5
-encoder_pins: ^PC4, ^PC6
-click_pin: ^!PC2
+cs_pin: EXP1_6
+a0_pin: EXP1_7
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2

--- a/config/printer-creality-ender2-2017.cfg
+++ b/config/printer-creality-ender2-2017.cfg
@@ -11,42 +11,69 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1500
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC2
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 165
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC3
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 165
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^PC4
+endstop_pin: ^Z_MIN
 position_endstop: 0.0
 position_max: 205
 
 [extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 34.410
 nozzle_diameter: 0.400
@@ -54,9 +81,9 @@ filament_diameter: 1.750
 max_extrude_only_distance: 500.0
 max_extrude_only_velocity: 200.0
 max_extrude_only_accel: 500.0
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 21.73
 pid_Ki: 1.54
@@ -65,9 +92,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 # PID Tuned for 60C
 pid_Kp: 72.487
@@ -77,17 +104,7 @@ min_temp: 0
 max_temp: 100
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1500
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: uc1701

--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -11,50 +11,77 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC2
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 235
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC3
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 235
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^PC4
+endstop_pin: ^Z_MIN
 position_endstop: 0.0
 position_max: 250
 
 [extruder]
 max_extrude_only_distance: 100.0
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 # tuned for stock hardware with 200 degree Celsius target
 pid_Kp: 21.527
@@ -64,9 +91,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 # tuned for stock hardware with 50 degree Celsius target
 pid_Kp: 54.027
@@ -76,17 +103,7 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -11,50 +11,77 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC2
+endstop_pin: ^X_MIN
 position_endstop: 235
 position_max: 235
 homing_speed: 30
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PC3
+endstop_pin: ^Y_MIN
 position_endstop: 235
 position_max: 235
 homing_speed: 30
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8 # Use 4 for Ender5 versions after late 2019
-endstop_pin: ^PC4
+endstop_pin: ^Z_MIN
 position_endstop: 0.0
 position_max: 300
 
 [extruder]
 max_extrude_only_distance: 100.0
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 # tuned for stock hardware with 200 degree Celsius target
 pid_Kp: 21.527
@@ -64,9 +91,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 # tuned for stock hardware with 50 degree Celsius target
 pid_Kp: 54.027
@@ -76,17 +103,7 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-creality-ender5plus-2019.cfg
+++ b/config/printer-creality-ender5plus-2019.cfg
@@ -5,32 +5,64 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 2500
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PE5
+endstop_pin: ^X_MIN
 position_endstop: 350
 position_max: 350
 homing_speed: 100
 
 [stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^PJ1
+endstop_pin: ^Y_MIN
 position_endstop: 350
 position_max: 350
 homing_speed: 100
 
 [stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
@@ -39,16 +71,16 @@ position_min: 0
 homing_speed: 10.0
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 33.683
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -63,7 +95,7 @@ z_hop: 10
 z_hop_speed: 5
 
 [bltouch]
-sensor_pin: ^PD3
+sensor_pin: ^Z_MIN
 control_pin: PB5
 x_offset: -45
 y_offset: 0
@@ -79,9 +111,9 @@ mesh_max: 300,300
 probe_count: 3,3
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -90,17 +122,4 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PH6
-
-[mcu]
-serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
-
-[filament_switch_sensor filament_sensor]
-switch_pin:PE4
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 2500
-max_z_velocity: 5
-max_z_accel: 100
+pin: RAMPS_FAN0

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -6,37 +6,78 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 2
+max_z_accel: 10
+
 [stepper_x]
-step_pin: PC0
-dir_pin: PL1
-enable_pin: !PA7
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PB6
+endstop_pin: ^X_MIN
 position_endstop: -20
 position_min: -20
 position_max: 300
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC1
-dir_pin: !PL0
-enable_pin: !PA6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PA1
+endstop_pin: ^Y_MAX
 position_endstop: 306
 position_min: -20
 position_max: 306
 homing_speed: 50
 
 [stepper_z]
-step_pin: PC2
-dir_pin: PL2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 2
-endstop_pin: ^!PB4
+endstop_pin: ^!Z_MIN
 position_endstop: -0.7
 position_min: -1.5
 position_max: 270
@@ -44,17 +85,17 @@ homing_speed: 1
 
 # settings for "Tilapia" Hexagon extruder (TAZ6 standard)
 [extruder]
-step_pin: PC3
-dir_pin: !PL6
-enable_pin: !PA4
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 gear_ratio: 48:9
 rotation_distance: 20.562
 nozzle_diameter: 0.400
 filament_diameter: 2.920
-heater_pin: PH6
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 28.79
 pid_Ki: 1.91
@@ -65,16 +106,16 @@ min_extrude_temp: 140
 
 # settings for "Angelfish" Aerostruder (E3D Titan Aero V6)
 #[extruder]
-#step_pin: PC3
-#dir_pin: !PL6
-#enable_pin: !PA4
+#step_pin: E_STEP
+#dir_pin: !E_DIR
+#enable_pin: !E_ENABLE
 #microsteps: 16
 #rotation_distance: 7.619
 #nozzle_diameter: 0.400
 #filament_diameter: 2.920
-#heater_pin: PH6
+#heater_pin: E_HEATER
 #sensor_type: ATC Semitec 104GT-2
-#sensor_pin: PF0
+#sensor_pin: E_THERMISTOR
 #control: pid
 #pid_Kp: 21.00
 #pid_Ki: 1.78
@@ -84,9 +125,9 @@ min_extrude_temp: 140
 #min_extrude_temp: 140
 
 [heater_bed]
-heater_pin: PE5
+heater_pin: BED_HEATER
 sensor_type: Honeywell 100K 135-104LAG-J01
-sensor_pin: PF2
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 162.0
 pid_Ki: 17.0
@@ -95,23 +136,13 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-pin: PH5
+pin: RAMBO_FAN0
 
 [heater_fan nozzle_cooling_fan]
-pin: PH3
-
-[mcu]
-serial: /dev/ttyACM0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 2
-max_z_accel: 10
+pin: RAMBO_FAN1
 
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 scale: 2.08
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
 channel_1: 1.34
@@ -123,22 +154,22 @@ channel_6: 1.1
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
+pins: !RAMBO_LED
 
 [display]
 lcd_type: st7920
-cs_pin: PG4
-sclk_pin: PJ2
-sid_pin: PG3
-encoder_pins: ^PJ6,^PJ5
-click_pin: ^!PE2
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_5,^EXP2_3
+click_pin: ^!EXP1_2
 menu_timeout: 5
 
 [probe]

--- a/config/printer-lulzbot-taz6-dual-v3-2017.cfg
+++ b/config/printer-lulzbot-taz6-dual-v3-2017.cfg
@@ -29,13 +29,54 @@
 #-------------------------------------------------------------------------------------------------
 # LULZBOT TAZ6 Dual v3 Required Parameters
 #-------------------------------------------------------------------------------------------------
+[mcu]
+serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 2
+max_z_accel: 10
+
 [stepper_x]
-step_pin: PC0
-dir_pin: PL1
-enable_pin: !PA7
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PB6
+endstop_pin: ^X_MIN
 position_endstop: -20
 position_min: -20
 position_max: 295
@@ -43,12 +84,12 @@ homing_speed: 50
 second_homing_speed: 5
 
 [stepper_y]
-step_pin: PC1
-dir_pin: !PL0
-enable_pin: !PA6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PA1
+endstop_pin: ^Y_MAX
 position_endstop: 306
 position_min: -17
 position_max: 306
@@ -56,12 +97,12 @@ homing_speed: 50
 second_homing_speed: 5
 
 [stepper_z]
-step_pin: PC2
-dir_pin: PL2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 2
-endstop_pin: ^!PB4
+endstop_pin: ^!Z_MIN
 position_endstop: 5.0
 position_min: -5.8
 position_max: 270
@@ -72,16 +113,16 @@ second_homing_speed: 1
 # This is Extruder0 on the dual v3 (all -1 index in schematic)
 # The Dual v3 uses the same temp sensor as the single extruder
 # The Dual v3 uses 2x SOMEstruders with modified PID values
-step_pin: PC4
-dir_pin: !PL7
-enable_pin: !PA3
+step_pin: E1_STEP
+dir_pin: !E1_DIR
+enable_pin: !E1_ENABLE
 microsteps: 16
 rotation_distance: 4.211
 nozzle_diameter: 0.500
 filament_diameter: 2.850
-heater_pin: PH4
+heater_pin: E1_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF1
+sensor_pin: E1_THERMISTOR
 control: pid
 pid_Kp: 47.45
 pid_Ki: 4.83
@@ -94,16 +135,16 @@ min_extrude_temp: 120
 # This is Extruder1 on the dual v3 (all -0 index in schematic)
 # The Dual v3 uses the same temp sensor as the single extruder
 # The Dual v3 uses 2x SOMEstruders with modified PID values
-step_pin: PC3
-dir_pin: PL6
-enable_pin: !PA4
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 4.211
 nozzle_diameter: 0.500
 filament_diameter: 2.850
-heater_pin: PH6
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 47.45
 pid_Ki: 4.83
@@ -114,9 +155,9 @@ min_extrude_temp: 120
 
 [heater_bed]
 #The Heater Bed uses Honeywell 100K 135-104LAG-J01 temp sensor and PID control
-heater_pin: PE5
+heater_pin: BED_HEATER
 sensor_type: Honeywell 100K 135-104LAG-J01
-sensor_pin: PF2
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 162.0
 pid_Ki: 17.0
@@ -125,25 +166,15 @@ min_temp: 0
 max_temp: 130
 
 [fan]
-#On Dual v3 heat break fan is connected to PH3 (part cooling fan on single extruder)
-pin: PH3
+#On Dual v3 heat break fan is connected to RAMBO_FAN1 (part cooling fan on single extruder)
+pin: RAMBO_FAN1
 
 [heater_fan nozzle_cooling_fan]
-#On Dual v3 part fans are connected to PH5 (heat break fan on single extruder)
-pin: PH5
-
-[mcu]
-serial: /dev/ttyACM0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 2
-max_z_accel: 10
+#On Dual v3 part fans are connected to RAMBO_FAN0 (heat break fan on single extruder)
+pin: RAMBO_FAN0
 
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 scale: 2.08
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
 channel_1: 1.34
@@ -155,22 +186,22 @@ channel_6: 1.1
 [static_digital_output stepper_config]
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
+pins: !RAMBO_LED
 
 [display]
 lcd_type: st7920
-cs_pin: PG4
-sclk_pin: PJ2
-sid_pin: PG3
-encoder_pins: ^PJ6,^PJ5
-click_pin: ^!PE2
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_5,^EXP2_3
+click_pin: ^!EXP1_2
 menu_timeout:5
 
 [probe]

--- a/config/printer-makergear-m2-2012.cfg
+++ b/config/printer-makergear-m2-2012.cfg
@@ -3,13 +3,54 @@
 # Allegro A4984 stepper drivers with 1/8th micro-stepping.  To use
 # this config, the firmware should be compiled for the AVR atmega2560.
 
+[mcu]
+serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
 [stepper_x]
-step_pin: PC0
-dir_pin: !PL1
-enable_pin: !PA7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 8
 rotation_distance: 36
-endstop_pin: ^!PB6
+endstop_pin: ^!X_MIN
 position_endstop: 0.0
 position_max: 200
 homing_speed: 50
@@ -18,12 +59,12 @@ homing_speed: 50
 endstop_accuracy: .200
 
 [stepper_y]
-step_pin: PC1
-dir_pin: PL0
-enable_pin: !PA6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 8
 rotation_distance: 36
-endstop_pin: ^!PB5
+endstop_pin: ^!Y_MIN
 position_endstop: 0.0
 position_max: 250
 homing_speed: 50
@@ -32,12 +73,12 @@ homing_speed: 50
 endstop_accuracy: .200
 
 [stepper_z]
-step_pin: PC2
-dir_pin: !PL2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 8
 rotation_distance: 8
-endstop_pin: ^!PB4
+endstop_pin: ^!Z_MIN
 position_min: 0.1
 position_endstop: 0.7
 position_max: 200
@@ -47,17 +88,17 @@ homing_retract_dist: 2.0
 endstop_accuracy: .070
 
 [extruder]
-step_pin: PC3
-dir_pin: PL6
-enable_pin: !PA4
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 8
 gear_ratio: 57:11
 rotation_distance: 35.170
 nozzle_diameter: 0.350
 filament_diameter: 1.750
-heater_pin: PH6
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 7.0
 pid_Ki: 0.1
@@ -66,34 +107,24 @@ min_temp: 0
 max_temp: 210
 
 [heater_bed]
-heater_pin: PE5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 100
 
 [fan]
-pin: PH5
+pin: RAMBO_FAN0
 
 [heater_fan nozzle_fan]
-pin: PH3
+pin: RAMBO_FAN1
 max_power: 0.61
 cycle_time: .000030
 hardware_pwm: True
 
-[mcu]
-serial: /dev/ttyACM0
-
-[printer]
-kinematics: cartesian
-max_velocity: 500
-max_accel: 3000
-max_z_velocity: 25
-max_z_accel: 30
-
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 # Scale the config so that the channel value can be specified in amps
 scale: 1.56
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
@@ -106,10 +137,10 @@ channel_6: 0.82
 # Enable 8 micro-steps on steppers X, Y, Z, E0
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
+pins: !RAMBO_LED

--- a/config/printer-makergear-m2-2016.cfg
+++ b/config/printer-makergear-m2-2016.cfg
@@ -4,35 +4,76 @@
 # 1/16th micro-stepping.  To use this config, the firmware should be
 # compiled for the AVR atmega2560.
 
+[mcu]
+serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PC0
-dir_pin: !PL1
-enable_pin: !PA7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 36
-endstop_pin: ^!PB6
+endstop_pin: ^!X_MIN
 position_endstop: 0
 position_max: 205
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC1
-dir_pin: PL0
-enable_pin: !PA6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 36
-endstop_pin: ^!PB5
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 250
 homing_speed: 50
 
 [stepper_z]
-step_pin: PC2
-dir_pin: !PL2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PB4
+endstop_pin: ^!Z_MIN
 position_min: 0.1
 position_endstop: 0.7
 position_max: 200
@@ -40,17 +81,17 @@ homing_speed: 15
 homing_retract_dist: 2.0
 
 [extruder]
-step_pin: PC3
-dir_pin: PL6
-enable_pin: !PA4
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 gear_ratio: 57:11
 rotation_distance: 31.174
 nozzle_diameter: 0.350
 filament_diameter: 1.750
-heater_pin: PH6
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF0
+sensor_pin: E_THERMISTOR
 control: pid
 pid_kp: 26.137
 pid_ki: 1.489
@@ -60,31 +101,21 @@ max_temp: 275
 max_extrude_only_distance: 150.0
 
 [heater_bed]
-heater_pin: PE5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PF2
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 90
 
 [fan]
-pin: PH5
+pin: RAMBO_FAN0
 
 [heater_fan nozzle_cooling_fan]
-pin: PH3
-
-[mcu]
-serial: /dev/ttyACM0
-
-[printer]
-kinematics: cartesian
-max_velocity: 500
-max_accel: 3000
-max_z_velocity: 25
-max_z_accel: 100
+pin: RAMBO_FAN1
 
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 # Scale the config so that the channel value can be specified in amps.
 scale: 2.08
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
@@ -97,11 +128,11 @@ channel_6: 0.75
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
+pins: !RAMBO_LED

--- a/config/printer-micromake-d1-2016.cfg
+++ b/config/printer-micromake-d1-2016.cfg
@@ -4,44 +4,76 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyACM0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: delta
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 150
+delta_radius: 95
+
 [stepper_a]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PE4
+endstop_pin: ^X_MAX
 homing_speed: 100
 position_endstop: 319.5
 arm_length: 217.0
 
 [stepper_b]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PJ0
+endstop_pin: ^Y_MAX
 
 [stepper_c]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PD2
+endstop_pin: ^Z_MAX
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 20.067
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -51,32 +83,22 @@ max_temp: 250
 max_extrude_only_distance: 100.0
 
 [fan]
-pin: PH6
-
-[mcu]
-serial: /dev/ttyACM0
-
-[printer]
-kinematics: delta
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 150
-delta_radius: 95
+pin: RAMPS_FAN0
 
 [delta_calibrate]
 radius: 80
 
 #[probe]
-#pin: ^!PD3
+#pin: ^!Z_MIN
 
 [display]
 lcd_type: hd44780
-rs_pin: PH1
-e_pin: PH0
-d4_pin: PA1
-d5_pin: PA3
-d6_pin: PA5
-d7_pin: PA7
-encoder_pins: ^PC6, ^PC4
-click_pin: ^!PC2
-kill_pin: ^!PG0
+rs_pin: EXP1_4
+e_pin: EXP1_3
+d4_pin: EXP1_5
+d5_pin: EXP1_6
+d6_pin: EXP1_7
+d7_pin: EXP1_8
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+kill_pin: ^!EXP2_8

--- a/config/printer-mtw-create-2015.cfg
+++ b/config/printer-mtw-create-2015.cfg
@@ -4,52 +4,91 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-UltiMachine__ultimachine.com__RAMBo_854333433343516051F1-if00
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PC0
-dir_pin: !PL1
-enable_pin: !PA7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PB6
-#endstop_pin: ^PA2
+endstop_pin: ^X_MIN
 position_endstop: 0
 position_max: 250
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC1
-dir_pin: PL0
-enable_pin: !PA6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^PB5
-#endstop_pin: ^PA1
+endstop_pin: ^Y_MIN
 position_endstop: 0
 position_max: 320
 homing_speed: 50
 
 [stepper_z]
-step_pin: PC2
-dir_pin: PL2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
-#endstop_pin: ^PC7
+#endstop_pin: ^Z_MAX
 #position_endstop: 0.5
 position_max: 225
 
 [extruder]
-step_pin: PC3
-dir_pin: PL6
-enable_pin: !PA4
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 32.640
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PH6
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -59,17 +98,17 @@ max_temp: 275
 
 #Uncomment below for dual extruder printers
 #[extruder1]
-#step_pin: PC4
-#dir_pin: PL7
-#enable_pin: !PA3
-#heater_pin: PH4
-#sensor_pin: PF1
+#step_pin: E1_STEP
+#dir_pin: E1_DIR
+#enable_pin: !E1_ENABLE
+#heater_pin: E1_HEATER
+#sensor_pin: E1_THERMISTOR
 #microsteps: 16
 #rotation_distance: 32.640
 #nozzle_diameter: 0.400
 #filament_diameter: 1.750
 #sensor_type: ATC Semitec 104GT-2
-#sensor_pin: PF0
+#sensor_pin: E_THERMISTOR
 #control: pid
 #pid_Kp: 22.2
 #pid_Ki: 1.08
@@ -78,15 +117,15 @@ max_temp: 275
 #max_temp: 275
 
 [heater_bed]
-heater_pin: PE5
+heater_pin: BED_HEATER
 sensor_type: NTC 100K beta 3950
-sensor_pin: PF2
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 130
 
 [bltouch]
-sensor_pin: PB4
+sensor_pin: Z_MIN
 control_pin: PL5
 x_offset: -17
 y_offset: 37
@@ -102,23 +141,13 @@ mesh_min: 5,5
 mesh_max: 225,225
 
 [fan]
-pin: PH5
+pin: RAMBO_FAN0
 
 [heater_fan nozzle_cooling_fan]
-pin: PH3
-
-[mcu]
-serial: /dev/serial/by-id/usb-UltiMachine__ultimachine.com__RAMBo_854333433343516051F1-if00
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 5
-max_z_accel: 100
+pin: RAMBO_FAN1
 
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 scale: 2.08
 # Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
 channel_1: 1.34
@@ -130,24 +159,11 @@ channel_6: 1.1
 # Enable 16 micro-steps on steppers X, Y, Z, E0, E1
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
-
-# Common EXP1 / EXP2 (display) pins
-[board_pins]
-aliases:
-    # Common EXP1/EXP2 headers found on RAMBo v1.4
-    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
-    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
-    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"
-
-# See the sample-lcd.cfg file for definitions of common LCD displays.
+pins: !RAMBO_LED

--- a/config/printer-seemecnc-rostock-max-v2-2015.cfg
+++ b/config/printer-seemecnc-rostock-max-v2-2015.cfg
@@ -4,71 +4,39 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_a]
-step_pin: PC0
-dir_pin: !PL1
-enable_pin: !PA7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PA2
-homing_speed: 50
-position_endstop: 380
-arm_length: 290.800
-
-[stepper_b]
-step_pin: PC1
-dir_pin: PL0
-enable_pin: !PA6
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PA1
-
-[stepper_c]
-step_pin: PC2
-dir_pin: !PL2
-enable_pin: !PA5
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PC7
-
-[extruder]
-step_pin: PC3
-dir_pin: !PL6
-enable_pin: !PA4
-microsteps: 16
-rotation_distance: 34.538
-nozzle_diameter: 0.500
-filament_diameter: 1.750
-heater_pin: PH6
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF0
-control: pid
-pid_Kp: 20.9700
-pid_Ki: 1.3400
-pid_Kd: 80.5600
-min_temp: 0
-max_temp: 300
-
-[heater_bed]
-heater_pin: PE5
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PF2
-control: pid
-pid_Kp: 46.510
-pid_Ki: 1.040
-pid_Kd: 500.000
-min_temp: 0
-max_temp: 300
-
-[fan]
-pin: PH5
-
-[heater_fan nozzle_cooling_fan]
-pin: PH4
-heater: extruder
-
 [mcu]
 serial: /dev/ttyACM0
+
+# Add human-readable names for pins on "rambo" style boards
+[board_pins rambo]
+aliases:
+    # Stepper motor pins
+    X_STEP=PC0, X_DIR=PL1, X_ENABLE=PA7,
+    Y_STEP=PC1, Y_DIR=PL0, Y_ENABLE=PA6,
+    Z_STEP=PC2, Z_DIR=PL2, Z_ENABLE=PA5,
+    E_STEP=PC3, E_DIR=PL6, E_ENABLE=PA4,
+    E1_STEP=PC4, E1_DIR=PL7, E1_ENABLE=PA3,
+    # Endstop pins
+    X_MIN=PB6, X_MAX=PA2, Y_MIN=PB5, Y_MAX=PA1, Z_MIN=PB4, Z_MAX=PC7,
+    # Heater and fan pins
+    E_HEATER=PH6, E_THERMISTOR=PF0,
+    E1_HEATER=PH4, E1_THERMISTOR=PF1,
+    BED_HEATER=PE5, BED_THERMISTOR=PF2,
+    RAMBO_FAN0=PH5, RAMBO_FAN1=PH3,
+    # Rambo board specific pins
+    RAMBO_LED=PB7,
+    RAMBO_DIGIPOT_CS=PD7,
+    RAMBO_X_MS1=PG1, RAMBO_X_MS2=PG0,
+    RAMBO_Y_MS1=PK7, RAMBO_Y_MS2=PG2,
+    RAMBO_Z_MS1=PK6, RAMBO_Z_MS2=PK5,
+    RAMBO_E_MS1=PK3, RAMBO_E_MS2=PK4,
+    RAMBO_E1_MS1=PK1, RAMBO_E1_MS2=PK2,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
 
 [printer]
 kinematics: delta
@@ -77,8 +45,71 @@ max_accel: 3000
 max_z_velocity: 150
 delta_radius: 174.75
 
+[stepper_a]
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MAX
+homing_speed: 50
+position_endstop: 380
+arm_length: 290.800
+
+[stepper_b]
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MAX
+
+[stepper_c]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Z_MAX
+
+[extruder]
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 34.538
+nozzle_diameter: 0.500
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 20.9700
+pid_Ki: 1.3400
+pid_Kd: 80.5600
+min_temp: 0
+max_temp: 300
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 46.510
+pid_Ki: 1.040
+pid_Kd: 500.000
+min_temp: 0
+max_temp: 300
+
+[fan]
+pin: RAMBO_FAN0
+
+[heater_fan nozzle_cooling_fan]
+pin: E1_HEATER
+heater: extruder
+
 [ad5206 stepper_digipot]
-enable_pin: PD7
+enable_pin: RAMBO_DIGIPOT_CS
 scale: 2.08
 channel_1: 1.34
 channel_2: 1.0
@@ -88,14 +119,14 @@ channel_6: 1.1
 
 [static_digital_output stepper_config]
 pins:
-    PG1, PG0,
-    PK7, PG2,
-    PK6, PK5,
-    PK3, PK4,
-    PK1, PK2
+    RAMBO_X_MS1, RAMBO_X_MS2,
+    RAMBO_Y_MS1, RAMBO_Y_MS2,
+    RAMBO_Z_MS1, RAMBO_Z_MS2,
+    RAMBO_E_MS1, RAMBO_E_MS2,
+    RAMBO_E1_MS1, RAMBO_E1_MS2
 
 [static_digital_output yellow_led]
-pins: !PB7
+pins: !RAMBO_LED
 
 [display]
 lcd_type: hd44780
@@ -108,13 +139,3 @@ d7_pin: EXP1_8
 encoder_pins: ^EXP2_3, ^EXP2_5
 click_pin: ^!EXP1_2
 #kill_pin: ^!EXP2_8
-
-[board_pins]
-aliases:
-    # Common EXP1/EXP2 headers found on RAMBo v1.4
-    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
-    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
-    # EXP2 header
-    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
-    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
-    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"

--- a/config/printer-sovol-sv01-2020.cfg
+++ b/config/printer-sovol-sv01-2020.cfg
@@ -4,76 +4,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE5
-position_endstop: 0
-position_max: 300
-homing_speed: 50
-
-[stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ1
-position_endstop: 0
-position_max: 255
-homing_speed: 50
-
-[stepper_z]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PD3
-position_endstop: 0
-position_max: 300
-
-[extruder]
-step_pin: PA4
-dir_pin: !PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 7.680
-nozzle_diameter: 0.400
-filament_diameter: 1.750
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 31.147
-pid_Ki: 2.076
-pid_Kd: 116.803
-min_temp: 0
-max_temp: 265
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
-control: pid
-pid_Kp: 72.174
-pid_Ki: 1.816
-pid_Kd: 717.224
-min_temp: 0
-max_temp: 110
-
-[filament_switch_sensor my_sensor]
-switch_pin: PE4
-pause_on_runout: True
-
-[fan]
-pin: PH6
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: cartesian
@@ -82,10 +36,78 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0
+position_max: 255
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0
+position_max: 300
+
+[extruder]
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 7.680
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 31.147
+pid_Ki: 2.076
+pid_Kd: 116.803
+min_temp: 0
+max_temp: 265
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 72.174
+pid_Ki: 1.816
+pid_Kd: 717.224
+min_temp: 0
+max_temp: 110
+
+[filament_switch_sensor my_sensor]
+switch_pin: X_MAX
+pause_on_runout: True
+
+[fan]
+pin: RAMPS_FAN0
+
 [display]
 lcd_type: st7920
-cs_pin: PH1
-sclk_pin: PA1
-sid_pin: PH0
-encoder_pins: ^PC4, ^PC6
-click_pin: ^!PC2
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2

--- a/config/printer-sunlu-s8-2020.cfg
+++ b/config/printer-sunlu-s8-2020.cfg
@@ -1,53 +1,84 @@
 # This file contains pin mappings for the SUNLU S8 v1.01 (circa 2020), which
 # is a modified RAMPS v1.3 board. To use this config, the firmware should be
-# compiled for the AVR atmega2560. The following pins are available for
-# expansion (e.g. ABL): ^PD2 (Z+ endstop), PG5, PE3, PH3, PB5
+# compiled for the AVR atmega2560.
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 10
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PE5
+endstop_pin: ^!X_MIN
 position_endstop: 0
 position_max: 310
 homing_speed: 50
 
 [stepper_y]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PJ1
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 310
 homing_speed: 50
 
 [stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PD3
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 400
 
 [extruder]
-step_pin: PA4
-dir_pin: !PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 rotation_distance: 33.280
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_kp: 25.588
 pid_ki: 1.496
@@ -57,12 +88,12 @@ max_temp: 250
 
 [filament_switch_sensor runout]
 pause_on_runout: True
-switch_pin: ^PE4
+switch_pin: ^X_MAX
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_kp: 74.786
 pid_ki: 0.766
@@ -77,28 +108,18 @@ max_temp: 110
 check_gain_time: 240
 
 [fan]
-pin: PH6
+pin: RAMPS_FAN0
 
 [heater_fan fan1]
 pin: PH4
 
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 3000
-max_z_velocity: 10
-max_z_accel: 100
-
 [display]
 lcd_type: st7920
-cs_pin: PH1
-sclk_pin: PA1
-sid_pin: PH0
-encoder_pins: ^PC4, ^PC6
-click_pin: ^!PC2
+cs_pin: EXP1_4
+sclk_pin: EXP1_5
+sid_pin: EXP1_3
+encoder_pins: ^EXP2_5, ^EXP2_3
+click_pin: ^!EXP1_2
 
 [output_pin beeper]
-pin: PC0
+pin: EXP1_1

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -7,34 +7,66 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 5
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: !PE5
+endstop_pin: !X_MIN
 position_endstop: -13
 position_min: -13
 position_max: 235
 homing_speed: 50
 
 [stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: !PJ1
+endstop_pin: !Y_MIN
 position_endstop: -3
 position_min: -3
 position_max: 235
 homing_speed: 50
 
 [stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
 position_max: 250
@@ -42,24 +74,24 @@ endstop_pin: probe:z_virtual_endstop
 position_min: -2
 
 [stepper_z1]
-step_pin: PC1
-dir_pin: PC3
-enable_pin: !PC7
+step_pin: E1_STEP
+dir_pin: E1_DIR
+enable_pin: !E1_ENABLE
 microsteps: 16
 rotation_distance: 8
 
 [extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
 microsteps: 16
 gear_ratio: 50:17
 rotation_distance: 22.598
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PB4
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 18.547
 pid_Ki: 0.788
@@ -68,9 +100,9 @@ min_temp: 0
 max_temp: 250
 
 [heater_bed]
-heater_pin: PH5
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 38.824
 pid_Ki: 0.539
@@ -82,28 +114,18 @@ max_temp: 70
 pin: PH4
 
 [fan]
-pin: PH6
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 5
-max_z_accel: 100
+pin: RAMPS_FAN0
 
 [display]
 lcd_type: uc1701
-cs_pin: PA3
-a0_pin: PA5
-encoder_pins: ^!PC6, ^!PC4
-click_pin: ^!PC2
+cs_pin: EXP1_6
+a0_pin: EXP1_7
+encoder_pins: ^!EXP2_3, ^!EXP2_5
+click_pin: ^!EXP1_2
 kill_pin: PK2
 
 [bltouch]
-sensor_pin: PD3
+sensor_pin: Z_MIN
 control_pin: PB5
 x_offset: 0
 y_offset: 18

--- a/config/printer-tevo-tarantula-pro-2020.cfg
+++ b/config/printer-tevo-tarantula-pro-2020.cfg
@@ -7,79 +7,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^!PE5
-position_endstop: -2
-position_max: 220
-position_min: -2
-homing_speed: 25.0
-
-[stepper_y]
-step_pin: PF6
-dir_pin: PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^!PJ1
-position_endstop: 0
-position_max: 220
-homing_speed: 25.0
-
-[stepper_z]
-step_pin: PL3
-dir_pin: PL1
-enable_pin: !PK0
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^!PD3
-position_endstop: 0
-position_max: 200
-
-# Enable for dual-z addon
-#[stepper_z1]
-#step_pin: PC1
-#dir_pin: PC3
-#enable_pin: !PC7
-#microsteps: 16
-#rotation_distance: 8
-
-[extruder]
-step_pin: PA4
-dir_pin: PA6
-enable_pin: !PA2
-microsteps: 16
-rotation_distance: 7.904
-nozzle_diameter: 0.400
-filament_diameter: 1.75
-
-heater_pin: PB4
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK5
-control: pid
-pid_Kp: 22.5
-pid_Ki: 1.78
-pid_Kd: 74.16
-min_temp: 0
-max_temp: 220
-
-[heater_bed]
-heater_pin: PH5
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PK6
-control: watermark
-min_temp: 0
-max_temp: 110
-
-[fan]
-pin: PH6
-
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: cartesian
@@ -88,14 +39,85 @@ max_accel: 3000
 max_z_velocity: 50
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!X_MIN
+position_endstop: -2
+position_max: 220
+position_min: -2
+homing_speed: 25.0
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!Y_MIN
+position_endstop: 0
+position_max: 220
+homing_speed: 25.0
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !Z_ENABLE
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^!Z_MIN
+position_endstop: 0
+position_max: 200
+
+# Enable for dual-z addon
+#[stepper_z1]
+#step_pin: E1_STEP
+#dir_pin: E1_DIR
+#enable_pin: !E1_ENABLE
+#microsteps: 16
+#rotation_distance: 8
+
+[extruder]
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !E_ENABLE
+microsteps: 16
+rotation_distance: 7.904
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+
+heater_pin: E_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 22.5
+pid_Ki: 1.78
+pid_Kd: 74.16
+min_temp: 0
+max_temp: 220
+
+[heater_bed]
+heater_pin: BED_HEATER
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: BED_THERMISTOR
+control: watermark
+min_temp: 0
+max_temp: 110
+
+[fan]
+pin: RAMPS_FAN0
+
 [heater_fan nozzle_fan]
 pin: PH4
 
 [display]
 lcd_type: uc1701
-cs_pin: PA3
-a0_pin: PA5
-encoder_pins: ^!PC6, ^!PC4
-click_pin: ^!PC2
-kill_pin: !PG0
+cs_pin: EXP1_6
+a0_pin: EXP1_7
+encoder_pins: ^!EXP2_3, ^!EXP2_5
+click_pin: ^!EXP1_2
+kill_pin: !EXP2_8
 menu_reverse_navigation: true

--- a/config/printer-tronxy-p802e-2020.cfg
+++ b/config/printer-tronxy-p802e-2020.cfg
@@ -9,52 +9,79 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A96PLN7R-if00-port0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: -8
 position_max: 220
 position_min: -8
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_min: 0
 position_max: 220
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0
 position_max: 210
 homing_speed: 20
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_kp: 23.060
 pid_ki: 1.025
@@ -64,9 +91,9 @@ max_temp: 250
 max_extrude_only_distance: 400
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_kp: 72.174
 pid_ki: 1.677
@@ -75,17 +102,7 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A96PLN7R-if00-port0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: hd44780

--- a/config/printer-tronxy-p802m-2020.cfg
+++ b/config/printer-tronxy-p802m-2020.cfg
@@ -9,52 +9,79 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A96PLN7R-if00-port0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: -8
 position_max: 220
 position_min: -45
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_min: -5
 position_max: 220
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0
 position_max: 230
 homing_speed: 20
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 33.600
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_kp: 23.060
 pid_ki: 1.025
@@ -64,9 +91,9 @@ max_temp: 250
 max_extrude_only_distance: 400
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: ATC Semitec 104GT-2
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_kp: 72.174
 pid_ki: 1.677
@@ -75,17 +102,7 @@ min_temp: 0
 max_temp: 110
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A96PLN7R-if00-port0
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: hd44780

--- a/config/printer-tronxy-x5s-2018.cfg
+++ b/config/printer-tronxy-x5s-2018.cfg
@@ -11,49 +11,76 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+[mcu]
+serial: /dev/ttyUSB0
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: !PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: 0
 position_max: 330
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: !PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 310
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: PB2
-enable_pin: !PD6
+step_pin: Z_STEP
+dir_pin: Z_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 400
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 35.520
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -62,9 +89,9 @@ min_temp: 0
 max_temp: 275
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: watermark
 min_temp: 0
 max_temp: 150
@@ -75,17 +102,7 @@ max_temp: 150
 check_gain_time: 600
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-
-[printer]
-kinematics: corexy
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920
@@ -93,4 +110,4 @@ cs_pin: PA1
 sclk_pin: PC0
 sid_pin: PA3
 encoder_pins: ^PD2, ^PD3
-click_pin: ^!PA5
+click_pin: ^!Z_ENABLE

--- a/config/printer-tronxy-x8-2018.cfg
+++ b/config/printer-tronxy-x8-2018.cfg
@@ -15,52 +15,76 @@
 [mcu]
 serial: /dev/ttyUSB0
 
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 1000
+max_z_velocity: 20
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: -47
 position_max: 220
 position_min: -47
 homing_speed: 50
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 32
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 220
 position_min: 0
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PD6
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0
 position_max: 210
 homing_speed: 10
 
 [extruder]
-step_pin: PB1
-dir_pin: PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 31.779
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -69,23 +93,16 @@ min_temp: 0
 max_temp: 275
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: watermark
 max_delta: 2.0
 min_temp: 0
 max_temp: 150
 
 [fan]
-pin: PB4
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 1000
-max_z_velocity: 20
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920

--- a/config/printer-velleman-k8200-2013.cfg
+++ b/config/printer-velleman-k8200-2013.cfg
@@ -6,77 +6,30 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-[stepper_x]
-step_pin: PF0
-dir_pin: !PF1
-enable_pin: !PD7
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PE5
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_y]
-step_pin: PF6
-dir_pin: !PF7
-enable_pin: !PF2
-microsteps: 16
-rotation_distance: 40
-endstop_pin: ^PJ1
-position_endstop: 0
-position_max: 200
-homing_speed: 50
-
-[stepper_z]
-step_pin: PL3
-dir_pin: !PL1
-enable_pin: !PK1
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^PD3
-position_endstop: 0.5
-# Set position_max to 200 if you have the original Z-axis setup.
-position_max: 250
-
-[extruder]
-step_pin: PA4
-# Remove the "!" from dir_pin if you have an original extruder
-dir_pin: !PA6
-enable_pin: !PA2
-# You will have to calculate your own rotation_distance.
-# This is for the belted extruder https://www.thingiverse.com/thing:339928
-microsteps: 16
-rotation_distance: 4.266
-nozzle_diameter: 0.400
-filament_diameter: 2.85
-heater_pin: PB4
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PK5
-control: pid
-pid_Kp: 21.503
-pid_Ki: 1.103
-pid_Kd: 104.825
-min_temp: 0
-max_temp: 250
-
-[heater_bed]
-heater_pin: PH6
-sensor_type: ATC Semitec 104GT-2
-sensor_pin: PK6
-control: pid
-pid_Kp: 75.283
-pid_Ki: 0.588
-pid_Kd: 2408.103
-min_temp: 0
-max_temp: 130
-
-[fan]
-pin: PH5
-kick_start_time: 0.500
-
 [mcu]
 serial: /dev/ttyUSB0
+
+# Add human-readable names for common pins on "ramps" boards
+[board_pins ramps]
+aliases:
+    # Stepper motor pins
+    X_STEP=PF0, X_DIR=PF1, X_ENABLE=PD7,
+    Y_STEP=PF6, Y_DIR=PF7, Y_ENABLE=PF2,
+    Z_STEP=PL3, Z_DIR=PL1, Z_ENABLE=PK0,
+    E_STEP=PA4, E_DIR=PA6, E_ENABLE=PA2,
+    E1_STEP=PC1, E1_DIR=PC3, E1_ENABLE=PC7,
+    # Endstop pins
+    X_MIN=PE5, X_MAX=PE4, Y_MIN=PJ1, Y_MAX=PJ0, Z_MIN=PD3, Z_MAX=PD2,
+    # Heater and fan pins
+    E_HEATER=PB4, E_THERMISTOR=PK5, E1_THERMISTOR=PK7,
+    BED_HEATER=PH5, BED_THERMISTOR=PK6,
+    RAMPS_FAN0=PH6,
+    # EXP1 header pins (see sample-lcd.cfg file for common LCD displays)
+    EXP1_1=PC0, EXP1_3=PH0, EXP1_5=PA1, EXP1_7=PA5, EXP1_9=<GND>,
+    EXP1_2=PC2, EXP1_4=PH1, EXP1_6=PA3, EXP1_8=PA7, EXP1_10=<5V>,
+    # EXP2 header pins
+    EXP2_1=PB3, EXP2_3=PC6, EXP2_5=PC4, EXP2_7=PL0, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PG0, EXP2_10=<RST>
 
 [printer]
 kinematics: cartesian
@@ -85,14 +38,83 @@ max_accel: 1000
 max_z_velocity: 10
 max_z_accel: 100
 
+[stepper_x]
+step_pin: X_STEP
+dir_pin: !X_DIR
+enable_pin: !X_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^X_MIN
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: Y_STEP
+dir_pin: !Y_DIR
+enable_pin: !Y_ENABLE
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^Y_MIN
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !PK1
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^Z_MIN
+position_endstop: 0.5
+# Set position_max to 200 if you have the original Z-axis setup.
+position_max: 250
+
+[extruder]
+step_pin: E_STEP
+# Remove the "!" from dir_pin if you have an original extruder
+dir_pin: !E_DIR
+enable_pin: !E_ENABLE
+# You will have to calculate your own rotation_distance.
+# This is for the belted extruder https://www.thingiverse.com/thing:339928
+microsteps: 16
+rotation_distance: 4.266
+nozzle_diameter: 0.400
+filament_diameter: 2.85
+heater_pin: E_HEATER
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: E_THERMISTOR
+control: pid
+pid_Kp: 21.503
+pid_Ki: 1.103
+pid_Kd: 104.825
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: RAMPS_FAN0
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: BED_THERMISTOR
+control: pid
+pid_Kp: 75.283
+pid_Ki: 0.588
+pid_Kd: 2408.103
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: BED_HEATER
+kick_start_time: 0.500
+
 # The LCD is untested - "RepRapDiscount 2004 Smart Controller" displays
 #[display]
 #lcd_type: hd44780
-#rs_pin: PA5
-#e_pin: PA7
-#d4_pin: PC0
-#d5_pin: PC2
-#d6_pin: PC4
-#d7_pin: PC6
-#encoder_pins: ^PH1, ^PH0
-#click_pin: ^!PA1
+#rs_pin: EXP1_7
+#e_pin: EXP1_8
+#d4_pin: EXP1_1
+#d5_pin: EXP1_2
+#d6_pin: EXP2_5
+#d7_pin: EXP2_3
+#encoder_pins: ^EXP1_4, ^EXP1_3
+#click_pin: ^!EXP1_5

--- a/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
@@ -85,50 +85,78 @@
 # - Be sure to follow these instructions before attempting any prints:
 #   https://www.klipper3d.org/Config_checks.html
 
+[mcu]
+serial: /dev/ttyUSB0
+restart_method: command
+
+# Add human-readable names for pins on "melzi" style boards
+[board_pins melzi]
+aliases:
+    # Stepper motor pins
+    X_STEP=PD7, X_DIR=PC5,
+    Y_STEP=PC6, Y_DIR=PC7,
+    Z_STEP=PB3, Z_DIR=PB2, Z_ENABLE=PA5,
+    E_STEP=PB1, E_DIR=PB0,
+    # Endstop pins
+    X_MIN=PC2, Y_MIN=PC3, Z_MIN=PC4,
+    # Heater and fan pins
+    E_HEATER=PD5, E_THERMISTOR=PA7,
+    BED_HEATER=PD4, BED_THERMISTOR=PA6,
+    MELZI_FAN0=PB4,
+    # Melzi board specific pins
+    MELZI_XYE_ENABLE=PD6
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 1000
+max_z_velocity: 2
+max_z_accel: 100
+
 [stepper_x]
-step_pin: PD7
-dir_pin: PC5
-enable_pin: !PD6
+step_pin: X_STEP
+dir_pin: X_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC2
+endstop_pin: ^!X_MIN
 position_endstop: 0
 position_max: 200
 homing_speed: 40
 
 [stepper_y]
-step_pin: PC6
-dir_pin: PC7
-enable_pin: !PD6
+step_pin: Y_STEP
+dir_pin: Y_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 40
-endstop_pin: ^!PC3
+endstop_pin: ^!Y_MIN
 position_endstop: 0
 position_max: 200
 homing_speed: 40
 
 [stepper_z]
-step_pin: PB3
-dir_pin: !PB2
-enable_pin: !PA5
+step_pin: Z_STEP
+dir_pin: !Z_DIR
+enable_pin: !Z_ENABLE
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^!PC4
+endstop_pin: ^!Z_MIN
 position_endstop: 0.5
 position_max: 180
 homing_speed: 2
 
 [extruder]
-step_pin: PB1
-dir_pin: !PB0
-enable_pin: !PD6
+step_pin: E_STEP
+dir_pin: !E_DIR
+enable_pin: !MELZI_XYE_ENABLE
 microsteps: 16
 rotation_distance: 29.888
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PD5
+heater_pin: E_HEATER
 sensor_type: NTC 100K beta 3950
-sensor_pin: PA7
+sensor_pin: E_THERMISTOR
 control: pid
 pid_Kp: 18.214030
 pid_Ki: 0.616380
@@ -137,9 +165,9 @@ min_temp: 0
 max_temp: 230
 
 [heater_bed]
-heater_pin: PD4
+heater_pin: BED_HEATER
 sensor_type: NTC 100K beta 3950
-sensor_pin: PA6
+sensor_pin: BED_THERMISTOR
 control: pid
 pid_Kp: 71.321
 pid_Ki: 1.989
@@ -148,18 +176,7 @@ min_temp: 0
 max_temp: 70
 
 [fan]
-pin: PB4
-
-[mcu]
-serial: /dev/ttyUSB0
-restart_method: command
-
-[printer]
-kinematics: cartesian
-max_velocity: 200
-max_accel: 1000
-max_z_velocity: 2
-max_z_accel: 100
+pin: MELZI_FAN0
 
 [display]
 lcd_type: st7920


### PR DESCRIPTION
I played a little with using some common alias definitions (eg, X_STEP, X_DIR, X_ENABLE) in some of the example config files.  This PR demonstrates the results of that experiment.

Ultimately, I'm unsure if converting to this scheme is a good idea.  It does make some things nicer - it's easier to compare configs between similar printers with different electronics.  But, some things don't seem to work so well - I fear it wont be immediately apparent to new users what is and isn't an alias, and the block of alias definitions at the end of every config looks pretty intimidating.

One thing interesting that I found is that a large number of common printers use very similar boards, but often do have subtle differences.  The atmega1284p melzi boards are an example of this - basically every printer that uses the atmega1284p is using a melzi derivative, but some define different motor enable pins and many have different exp1/exp2 plugs.

-Kevin