### PR TITLE
sync channel for fast move_queue population

### DIFF
--- a/config/sample-pwm-tool.cfg
+++ b/config/sample-pwm-tool.cfg
@@ -3,7 +3,7 @@
 # See docs/Using_PWM_Tools.md for a more detailed description.
 
 [output_pin TOOL]
-pin: !ar9       # use your fan's pin number
+pin: !PIN       # use your fan's pin number
 pwm: True
 #hardware_pwm: True
 # Using hardware PWM is optional.
@@ -27,19 +27,26 @@ high_throughput: True
 # needs to be in default speed (off), or else the MCU will
 # do a safety-shutdown.
 
+[output_pin TOOL_ENABLE]
+pin: !OTHER_PIN
+shutdown_value: 0
+
 [gcode_macro M3]
 gcode:
+    SET_PIN PIN=TOOL_ENABLE VALUE=1
     {% set S = params.S|default(0.0)|float %}
     SET_PIN PIN=TOOL VALUE={S / 255.0}
 
 [gcode_macro M4]
 gcode:
+    SET_PIN PIN=TOOL_ENABLE VALUE=1
     {% set S = params.S|default(0.0)|float %}
     SET_PIN PIN=TOOL VALUE={S / 255.0}
 
 [gcode_macro M5]
 gcode:
     SET_PIN PIN=TOOL VALUE=0
+    SET_PIN PIN=TOOL_ENABLE VALUE=0
 
 
 # Optional: LCD Menu Control
@@ -47,13 +54,13 @@ gcode:
 [menu __main __control __toolonoff]
 type: input
 enable: {'output_pin TOOL' in printer}
-name: Fan: {'ON ' if menu.input else 'OFF'}
+name: Tool: {'ON ' if menu.input else 'OFF'}
 input: {printer['output_pin TOOL'].value}
 input_min: 0
 input_max: 1
 input_step: 1
 gcode:
-    M3 S{255 if menu.input else 0}
+    SET_PIN PIN=TOOL_ENABLE VALUE={1 if menu.input else 0}
 
 [menu __main __control __toolspeed]
 type: input

--- a/config/sample-pwm-tool.cfg
+++ b/config/sample-pwm-tool.cfg
@@ -5,17 +5,27 @@
 [output_pin TOOL]
 pin: !ar9       # use your fan's pin number
 pwm: True
-hardware_pwm: True
+#hardware_pwm: True
+# Using hardware PWM is optional.
 cycle_time: 0.001
 shutdown_value: 0
-maximum_mcu_duration: 5
+high_throughput: True
+# This enables the high throughput mode.
+# Suggested to only use on one output pin.
+
+#maximum_mcu_duration: 5
+#   Warning: The maximum mcu duration will _not_ yet
+#   split long running moves.
+#   This will lead to a shutdown if individual moves
+#   do run longer.
 # Default: 0 (disabled)
 # Amount of time in which the host has to acknowledge
 # a non-shutdown output value.
 # Suggested value is around 5 seconds.
 # Use a value that does not burn up your stock.
 # Please note that during homing, your tool
-# needs to be in default speed.
+# needs to be in default speed (off), or else the MCU will
+# do a safety-shutdown.
 
 [gcode_macro M3]
 gcode:

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3117,6 +3117,14 @@ pin:
 #   then the 'value' parameter can be specified using the desired
 #   amperage for the stepper. The default is to not scale the 'value'
 #   parameter.
+high_throughput: False
+#   This enables the high throughput mode for using e.g. PWM
+#   controlled tools (see docs/Using_PWM_Tools.md)
+#   Suggested to only use on one output pin, currently.
+#   Warning: Setting a maximum_mcu_duration will _not_ yet
+#   split long running moves.
+#   This will lead to a shutdown if individual moves
+#   do run longer in high throughput mode.
 ```
 
 ### [static_digital_output]

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -21,18 +21,10 @@ _fully on_ for the time it takes the MCU to start up again.
 For good measure, it is recommended to _always_ wear appropriate
 laser-goggles of the right wavelength if the laser is powered;
 and to disconnect the laser when it is not needed.
-Also, you should configure a safety timeout,
-so that when your host or MCU encounters an error, the tool will stop.
+Also, you should consider using a safety timeout,
+so that when your host dies unexpectedly, the tool will stop.
 
 For an example configuration, see [config/sample-pwm-tool.cfg](/config/sample-pwm-tool.cfg).
-
-## Current Limitations
-
-There is a limitation of how frequent PWM updates may occur.
-While being very precise, a PWM update may only occur every 0.1 seconds,
-rendering it almost useless for raster engraving.
-However, there exists an [experimental branch](https://github.com/Cirromulus/klipper/tree/laser_tool) with its own tradeoffs.
-In long term, it is planned to add this functionality to main-line klipper.
 
 ## Commands
 

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -23,6 +23,8 @@ laser-goggles of the right wavelength if the laser is powered;
 and to disconnect the laser when it is not needed.
 Also, you should consider using a safety timeout,
 so that when your host dies unexpectedly, the tool will stop.
+An additional safety layer would be powering your tool through the hotend-heater pin.
+In the configuration, the additional `[output_pin]` would be activated by `M3/M4` and disabled by `M5`.
 
 For an example configuration, see [config/sample-pwm-tool.cfg](/config/sample-pwm-tool.cfg).
 

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -54,11 +54,19 @@ defs_stepcompress = """
         , uint64_t start_clock, uint64_t end_clock);
 
     struct steppersync *steppersync_alloc(struct serialqueue *sq
-        , struct stepcompress **sc_list, int sc_num, int move_num);
+        , struct stepcompress **sc_list, int sc_num
+        , struct sync_channel **pc_list, int pc_num, int move_num);
     void steppersync_free(struct steppersync *ss);
     void steppersync_set_time(struct steppersync *ss
         , double time_offset, double mcu_freq);
     int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+"""
+
+defs_sync_channel = """
+    struct sync_channel *sync_channel_alloc();
+    void sync_channel_free(struct sync_channel *pc);
+    int sync_channel_queue_msg(struct sync_channel *pc
+        , uint32_t *data, int len, uint64_t req_clock);
 """
 
 defs_itersolve = """
@@ -215,7 +223,7 @@ defs_std = """
 
 defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std, defs_stepcompress,
-    defs_itersolve, defs_trapq, defs_trdispatch,
+    defs_sync_channel, defs_itersolve, defs_trapq, defs_trdispatch,
     defs_kin_cartesian, defs_kin_corexy, defs_kin_corexz, defs_kin_delta,
     defs_kin_deltesian, defs_kin_polar, defs_kin_rotary_delta, defs_kin_winch,
     defs_kin_extruder, defs_kin_shaper, defs_kin_idex,

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -33,10 +33,15 @@ int stepcompress_extract_old(struct stepcompress *sc
                              , struct pull_history_steps *p, int max
                              , uint64_t start_clock, uint64_t end_clock);
 
+struct sync_channel *sync_channel_alloc(); //uint32_t oid); // not needed?
+void sync_channel_free(struct sync_channel *pc);
+void sync_channel_queue_msg(struct sync_channel *pc, uint32_t *data, int len,
+        uint64_t req_clock);
+
 struct serialqueue;
 struct steppersync *steppersync_alloc(
-    struct serialqueue *sq, struct stepcompress **sc_list, int sc_num
-    , int move_num);
+    struct serialqueue *sq, struct stepcompress **sc_list, int sc_num,
+    struct sync_channel **pc_list, int pc_num, int move_num);
 void steppersync_free(struct steppersync *ss);
 void steppersync_set_time(struct steppersync *ss, double time_offset
                           , double mcu_freq);

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -63,7 +63,7 @@ class PrinterOutputPin:
         return {'value': self.last_value}
     def _set_pin(self, print_time, value, cycle_time, is_resend=False):
         if value == self.last_value and cycle_time == self.last_cycle_time:
-            if not is_resend:
+            if not is_resend or value == self.shutdown_value:
                 return
         print_time = max(print_time, self.last_print_time + self._pin_min_time)
         if self.is_pwm:

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+PIN_MIN_TIME = 0.100
 RESEND_HOST_TIME = 0.300
 MAX_SCHEDULE_TIME = 5.0
 
@@ -12,6 +13,7 @@ class PrinterOutputPin:
         self.printer = config.get_printer()
         ppins = self.printer.lookup_object('pins')
         self.is_pwm = config.getboolean('pwm', False)
+        self._pin_min_time = PIN_MIN_TIME
         if self.is_pwm:
             self.mcu_pin = ppins.setup_pin('pwm', config.get('pin'))
             cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
@@ -38,6 +40,7 @@ class PrinterOutputPin:
         else:
             if config.getboolean('high_throughput', False):
                 self.mcu_pin.setup_high_throughput_mode()
+                self._pin_min_time = self.default_cycle_time
 
             max_mcu_duration = config.getfloat('maximum_mcu_duration', 0.,
                                                minval=0.500,
@@ -62,7 +65,7 @@ class PrinterOutputPin:
         if value == self.last_value and cycle_time == self.last_cycle_time:
             if not is_resend:
                 return
-        print_time = max(print_time, self.last_print_time + cycle_time)
+        print_time = max(print_time, self.last_print_time + self._pin_min_time)
         if self.is_pwm:
             self.mcu_pin.set_pwm(print_time, value, cycle_time)
         else:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -378,11 +378,13 @@ class MCU_pwm:
         self._mcu.register_config_callback(self._build_config)
         self._pin = pin_params['pin']
         self._invert = pin_params['invert']
+        self._is_ht = False
         self._start_value = self._shutdown_value = float(self._invert)
         self._is_static = False
         self._last_clock = self._last_cycle_ticks = 0
         self._pwm_max = 0.
         self._set_cmd = self._set_cycle_ticks = None
+
     def get_mcu(self):
         return self._mcu
     def setup_max_duration(self, max_duration):
@@ -399,11 +401,12 @@ class MCU_pwm:
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
         self._is_static = is_static
+    def setup_high_throughput_mode(self):
+        self._is_ht = True
     def _build_config(self):
         if self._max_duration and self._start_value != self._shutdown_value:
             raise pins.error("Pin with max duration must have start"
                              " value equal to shutdown value")
-        cmd_queue = self._mcu.alloc_command_queue()
         curtime = self._mcu.get_printer().get_reactor().monotonic()
         printtime = self._mcu.estimated_print_time(curtime)
         self._last_clock = self._mcu.print_time_to_clock(printtime + 0.200)
@@ -411,6 +414,7 @@ class MCU_pwm:
         mdur_ticks = self._mcu.seconds_to_clock(self._max_duration)
         if mdur_ticks >= 1<<31:
             raise pins.error("PWM pin max duration too large")
+        self._min_clock_diff = cycle_ticks
         if self._hardware_pwm:
             self._pwm_max = self._mcu.get_constant_float("PWM_MAX")
             if self._is_static:
@@ -419,8 +423,10 @@ class MCU_pwm:
                     % (self._pin, cycle_ticks,
                        self._start_value * self._pwm_max))
                 return
-            self._mcu.request_move_queue_slot()
             self._oid = self._mcu.create_oid()
+            if not self._is_ht:
+                self._mcu.request_move_queue_slot()
+
             self._mcu.add_config_cmd(
                 "config_pwm_out oid=%d pin=%s cycle_ticks=%d value=%d"
                 " default_value=%d max_duration=%d"
@@ -432,7 +438,8 @@ class MCU_pwm:
                                      % (self._oid, self._last_clock, svalue),
                                      on_restart=True)
             self._set_cmd = self._mcu.lookup_command(
-                "queue_pwm_out oid=%c clock=%u value=%hu", cq=cmd_queue)
+                "queue_pwm_out oid=%c clock=%u value=%hu",
+                fast_track=self._is_ht) # might be ugly without cq?
             return
         # Software PWM
         if self._shutdown_value not in [0., 1.]:
@@ -443,8 +450,11 @@ class MCU_pwm:
             return
         if cycle_ticks >= 1<<31:
             raise pins.error("PWM pin cycle time too large")
-        self._mcu.request_move_queue_slot()
         self._oid = self._mcu.create_oid()
+        cmd_queue = None
+        if not self._is_ht:
+            self._mcu.request_move_queue_slot()
+            cmd_queue = self._mcu.alloc_command_queue()
         self._mcu.add_config_cmd(
             "config_digital_out oid=%d pin=%s value=%d"
             " default_value=%d max_duration=%d"
@@ -459,34 +469,48 @@ class MCU_pwm:
             "queue_digital_out oid=%d clock=%d on_ticks=%d"
             % (self._oid, self._last_clock, svalue), is_init=True)
         self._set_cmd = self._mcu.lookup_command(
-            "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue)
+            "queue_digital_out oid=%c clock=%u on_ticks=%u",
+            fast_track=self._is_ht)
         self._set_cycle_ticks = self._mcu.lookup_command(
-            "set_digital_out_pwm_cycle oid=%c cycle_ticks=%u", cq=cmd_queue)
+            "set_digital_out_pwm_cycle oid=%c cycle_ticks=%u", cq=None)
     def set_pwm(self, print_time, value, cycle_time=None):
-        clock = self._mcu.print_time_to_clock(print_time)
+        req_clock = self._mcu.print_time_to_clock(print_time)
+        # FIXME: let sync_channel replace uncommitted values
+        #        so that this is not necessary
         minclock = self._last_clock
-        self._last_clock = clock
+        clock = max(req_clock, self._last_clock + self._min_clock_diff)
         if self._invert:
             value = 1. - value
         if self._hardware_pwm:
             v = int(max(0., min(1., value)) * self._pwm_max + 0.5)
-            self._set_cmd.send([self._oid, clock, v],
+            # queue_pwm_out oid=%c clock=%u value=%hu
+            #data = (self._set_cmd, self._oid, clock & 0xFFFFFFFF, v)
+            self._set_cmd.send([self._oid, clock & 0xFFFFFFFF, v],
+                                minclock=minclock, reqclock=clock)
+        else:
+            # Soft pwm update
+            if cycle_time is None:
+                cycle_time = self._cycle_time
+            cycle_ticks = self._mcu.seconds_to_clock(cycle_time)
+            if cycle_ticks != self._last_cycle_ticks:
+                if cycle_ticks >= 1<<31:
+                    raise self._mcu.get_printer().command_error(
+                        "PWM cycle time too large")
+                self._set_cycle_ticks.send([self._oid, cycle_ticks],
+                                           minclock=minclock, reqclock=clock)
+                # FIXME: this makes sure new cycle_ticks is applied
+                # _before_ new on_ticks arrive
+                clock = self._mcu.print_time_to_clock(print_time +
+                                                      self._last_cycle_ticks)
+                self._last_cycle_ticks = cycle_ticks
+                self._min_clock_diff = cycle_ticks
+            on_ticks = int(max(0., min(1., value)) * float(cycle_ticks) + 0.5)
+            # queue_digital_out oid=%c clock=%u on_ticks=%u
+            #data = (self._set_cmd, self._oid, clock & 0xFFFFFFFF, on_ticks)
+            self._set_cmd.send([self._oid, clock & 0xFFFFFFFF, on_ticks],
                                minclock=minclock, reqclock=clock)
-            return
-        # Soft pwm update
-        if cycle_time is None:
-            cycle_time = self._cycle_time
-        cycle_ticks = self._mcu.seconds_to_clock(cycle_time)
-        if cycle_ticks != self._last_cycle_ticks:
-            if cycle_ticks >= 1<<31:
-                raise self._mcu.get_printer().command_error(
-                    "PWM cycle time too large")
-            self._set_cycle_ticks.send([self._oid, cycle_ticks],
-                                       minclock=minclock, reqclock=clock)
-            self._last_cycle_ticks = cycle_ticks
-        on_ticks = int(max(0., min(1., value)) * float(cycle_ticks) + 0.5)
-        self._set_cmd.send([self._oid, clock, on_ticks],
-                           minclock=minclock, reqclock=clock)
+
+        self._last_clock = clock
 
 class MCU_adc:
     def __init__(self, mcu, pin_params):
@@ -551,6 +575,22 @@ class MCU_adc:
 # Main MCU class
 ######################################################################
 
+class FastCommandWrapper:
+    def __init__(self, mcu, cmd_id, sync_channel, queue_msg_fn):
+        self._mcu = mcu
+        self._cmd_id = cmd_id
+        self._sync_channel = sync_channel
+        self._queue_msg_fn = queue_msg_fn
+        self._reactor = mcu.get_printer().get_reactor()
+        self._toolhead = mcu.get_printer().lookup_object('toolhead')
+    def send(self, data, minclock, reqclock):
+        data.insert(0, self._cmd_id)
+        self._queue_msg_fn(self._sync_channel, data, len(data), reqclock)
+        print_time = self._mcu.clock_to_print_time(reqclock)
+        # TODO: Is here actually `_async_` needed?
+        self._reactor.register_async_callback(
+            lambda ev: self._toolhead.note_synchronous_command(print_time))
+
 class MCU:
     error = error
     def __init__(self, config, clocksync):
@@ -598,12 +638,18 @@ class MCU:
         self._init_cmds = []
         self._mcu_freq = 0.
         # Move command queuing
-        ffi_main, self._ffi_lib = chelper.get_ffi()
+        self._ffi_main, self._ffi_lib = chelper.get_ffi()
         self._max_stepper_error = config.getfloat('max_stepper_error', 0.000025,
                                                   minval=0.)
         self._reserved_move_slots = 0
         self._stepqueues = []
         self._steppersync = None
+
+        #
+        self._sync_channels = []
+        self._active_fasttrack_queues = 0
+        #
+
         # Stats
         self._get_status_info = {}
         self._stats_sumsq_base = 0.
@@ -768,9 +814,12 @@ class MCU:
         ffi_main, ffi_lib = chelper.get_ffi()
         self._steppersync = ffi_main.gc(
             ffi_lib.steppersync_alloc(self._serial.get_serialqueue(),
-                                      self._stepqueues, len(self._stepqueues),
-                                      move_count-self._reserved_move_slots),
-            ffi_lib.steppersync_free)
+                              self._stepqueues, len(self._stepqueues),
+                              self._sync_channels, len(self._sync_channels),
+                              move_count-self._reserved_move_slots),
+            ffi_lib.steppersync_free
+        )
+
         ffi_lib.steppersync_set_time(self._steppersync, 0., self._mcu_freq)
         # Log config information
         move_msg = "Configured MCU '%s' (%d moves)" % (self._name, move_count)
@@ -854,6 +903,8 @@ class MCU:
         return self.print_time_to_clock(t) + slot
     def register_stepqueue(self, stepqueue):
         self._stepqueues.append(stepqueue)
+    def register_sync_channel(self, sync_channel):
+        self._sync_channels.append(sync_channel)
     def request_move_queue_slot(self):
         self._reserved_move_slots += 1
     def seconds_to_clock(self, time):
@@ -869,8 +920,22 @@ class MCU:
         self._serial.register_response(cb, msg, oid)
     def alloc_command_queue(self):
         return self._serial.alloc_command_queue()
-    def lookup_command(self, msgformat, cq=None):
-        return CommandWrapper(self._serial, msgformat, cq)
+    def lookup_command(self, msgformat, cq=None, fast_track=False):
+        if not fast_track:
+            return CommandWrapper(self._serial, msgformat, cq)
+
+        if self._active_fasttrack_queues > 0:
+            raise error ("Currently, only one high throughput pin is allowed!")
+        self._active_fasttrack_queues = self._active_fasttrack_queues + 1
+        sync_channel = self._ffi_main.gc(
+                self._ffi_lib.sync_channel_alloc(),
+                self._ffi_lib.sync_channel_free)
+        self.register_sync_channel(sync_channel)
+        cmd_tag = self.lookup_command(msgformat).get_command_tag()
+        return FastCommandWrapper(self, cmd_tag,
+                                  sync_channel,
+                                  self._ffi_lib.sync_channel_queue_msg)
+
     def lookup_query_command(self, msgformat, respformat, oid=None,
                              cq=None, is_async=False):
         return CommandQueryWrapper(self._serial, msgformat, respformat, oid,

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -483,8 +483,6 @@ class MCU_pwm:
             value = 1. - value
         if self._hardware_pwm:
             v = int(max(0., min(1., value)) * self._pwm_max + 0.5)
-            # queue_pwm_out oid=%c clock=%u value=%hu
-            #data = (self._set_cmd, self._oid, clock & 0xFFFFFFFF, v)
             self._set_cmd.send([self._oid, clock & 0xFFFFFFFF, v],
                                 minclock=minclock, reqclock=clock)
         else:
@@ -505,8 +503,6 @@ class MCU_pwm:
                 self._last_cycle_ticks = cycle_ticks
                 self._min_clock_diff = cycle_ticks
             on_ticks = int(max(0., min(1., value)) * float(cycle_ticks) + 0.5)
-            # queue_digital_out oid=%c clock=%u on_ticks=%u
-            #data = (self._set_cmd, self._oid, clock & 0xFFFFFFFF, on_ticks)
             self._set_cmd.send([self._oid, clock & 0xFFFFFFFF, on_ticks],
                                minclock=minclock, reqclock=clock)
 


### PR DESCRIPTION
This PR adds the possibility to update SW/HW PWM faster than the original implementation (0.100s).
This would close https://github.com/KevinOConnor/klipper/issues/133, enabling laser raster engraving.
While it will probably not reach the stepper step-times (which are compressed), I suppose it may come close to some multiples of `cycle_time` in bursts, depending on the serial bandwidth to the MCU.
Early testers report around 400-800 updates per second, peaks higher (as the queue is buffered).

### Known Issues
  - Code seems to work on some different hardware setups. *More testers appreciated!*

If you want to try this out, you may follow this [small HowTo](https://github.com/Cirromulus/klipper/blob/pwm_sync_channel/docs/Using_PWM_Tools.md).

### How it works
This PR adds a "sync_channel" (name may be subject to change) to the steppersync/stepcompress system.
Basically, it allows a command to be inserted into the mcu's `move_queue` while respecting the watermark and timing.
This enables much tighter packing of pin-update commands.
To ensure the steppersync queues are flushed regularly even when the toolhead is not generating any movement,
a combination of `note_kinematic_activity()`, `update_move_time()` and `check_stall()` is used.

### Other Notes
PWM Frequency: I suggest to not mean too well with the tool frequency. Choose the lowest frequency that still has a pulse time of a small multiple of your highest resolution. E.g. Resolution of 0.1mm at a speed of 50mm/s I recommend 1kHz (cycle_time: 0.001)

Hardware-PWM may be less calculation intense on the MCU, but the MCU will choose in "best effort" a frequency that is near the desired frequency.
The maximum pin update-rate is this chosen frequency.
Software-PWM will be less precise, but may offer more flexibility at odd frequencies.
So if you plan to have an update rate of 1000 updates / s, choose at least a frequency of 1kHz, thus a cycle_time of 0.001.

### Unaddressed features, Roadmap
1. This PR wraps the "ht-mode" (high throughput) at the command wrapper, reducing the impact on `MCU_pwm` code.
In the state of this PR, one pin can be put in ht-mode. In long term (another PR), I plan to rework the stepcompress system, dividing the two functionalities (1. compressing steps, 2. making sure the move queue is populated and ordered), so that the PWM updates don't need to "piggy back" on kinematics-stepper update flushes. This would enable even faster pinupdates and, most importantly, any number of ht-mode pins.

2. This PR only adds the possibility to update a pin much more frequently.
For laser applications, a _proportionality feature_ is useful. This would dim the laser during acceleration and deceleration phase proportional to its actual speed (see also *S*-Parameter in [G0 in RepRap documentation](https://reprap.org/wiki/G-code#G-commands)), just like it does with the extruder *E* command.
