### PR TITLE
safe_power: Stepper Driver Anti-SNAFU Protection

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -9,9 +9,13 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
-# Note: The initial revision of this board has a flaw that can cause
-# damage to itself and other boards. Be sure to verify the board is
-# not impacted by this flaw before using it.
+# WARNING: For use only on SKR 2 Rev B board and later.
+# Initial board (Rev A) have a flaw causing a permanent malfunction in
+# stepper drivers, if you have Rev A then consult BIGTREETECH's
+# announcement at https://bit.ly/3t5d9JQ for further actions.
+# If you are in doubt whether you have Rev A, check the announcement where
+# there is a link to identify Rev A in the "Announcement summary" section.
+
 
 [stepper_x]
 step_pin: PE2
@@ -88,9 +92,15 @@ pin: PB7
 #[heater_fan fan2]
 #pin: PB5
 
-[output_pin motor_power]
+#[bltouch]
+#sensor_pin: ^PE4
+#control_pin: PE5
+#x_offset:
+#y_offset:
+#z_offset:
+
+[safe_power my_mcu_safe_power]
 pin: PC13
-value: 1
 
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3907,6 +3907,47 @@ host_mcu:
 #   (True sets CFG5 high, False sets it low). The default is True.
 ```
 
+## [safe_power my_mcu_safe_power]
+
+Stepper Driver Anti-SNAFU Protection.
+
+Some micro-controllers have protection against incorrect plugged
+stepper drivers.
+Applying this section to the config file will let Klipper check the
+correct orientation of configured stepper drivers.
+If incorrect orientation then Klipper raise an error with message like this:
+"[stepper_z] driver is backward!"
+If the message appears then turn off the printer before any attempt on
+resolving the issue.
+
+If one may use TMC drivers the safe_power section have to be before
+any TMC sections in printer.cfg. It will check and raise config error if any
+TMC section is before the safe_power section.
+
+**WARNING: Using this on micro-controllers without a Stepper Driver Anti-SNAFU
+Protection may lead to undesirable results.**
+
+See the [generic-bigtreetech-skr-2.cfg](../config/generic-bigtreetech-skr-2.cfg)
+file for an example.
+
+```
+[safe_power my_mcu_safe_power]
+pin:
+#   Control pin of driver/heater/fan power supply
+```
+
+## [safe_power my_extra_mcu_safe_power]
+
+Additional micro-controllers with Stepper Driver Anti-SNAFU Protection
+(one may define any number of sections
+with an "safe_power" prefix). Additional micro-controllers may introduce
+additional safe power pin.
+
+```
+[safe_power my_extra_mcu_safe_power]
+# See the "safe_power" section for configuration parameters.
+```
+
 # Other Custom Modules
 
 ## [palette2]

--- a/klippy/extras/safe_power.py
+++ b/klippy/extras/safe_power.py
@@ -1,0 +1,112 @@
+# Stepper Driver Anti-SNAFU Protection support
+#
+# Copyright (C) 2021  Lars R. Hansen <popshansen@hotmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+SF_INVERT_STEP = 1<<2
+
+class Safe_Power:
+    def __init__(self, config):
+        self.name = config.get_name()
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        ppins = self.printer.lookup_object('pins')
+        pin_params = ppins.lookup_pin(config.get('pin'))
+        self.mcu = pin_params['chip']
+        self.oid = self.mcu.create_oid()
+        self.pin = pin_params['pin']
+        self.mcu_pin = self.mcu.setup_pin('digital_out', pin_params)
+        self.mcu_pin.setup_start_value(0, 0, False)
+        self.set_digital_out_cmd = self.read_digital_in_cmd = None
+        self.steppers = {}
+        for s in config.get_prefix_sections('stepper_'):
+            self._register_stepper(s, ppins)
+        for s in config.get_prefix_sections('extruder'):
+            self._register_stepper(s, ppins)
+        for s in config.get_prefix_sections('manual_stepper'):
+            self._register_stepper(s, ppins)
+        if config.has_section('dual_carriage'):
+            self._register_stepper(config.getsection('dual_carriage'), ppins)
+        #Check config order
+        for name, obj in self.printer.lookup_objects():
+            if name.startswith('tmc'):
+               raise self.printer.config_error(
+                     "[%s] section should be before"
+                     " any tmc section in printer.cfg" % (self.name,))
+        self.mcu.register_config_callback(self._build_config)
+        self.printer.register_event_handler("klippy:connect",
+                                            self._connect)
+    def _build_config(self):
+        self.set_digital_out_cmd = self.mcu.lookup_command(
+            "set_digital_out pin=%u value=%c")
+        self.read_digital_in_cmd = self.mcu.lookup_query_command(
+            "read_digital_in pin=%u pull_up=%c",
+            "read_digital_in_value pin=%u value=%c")
+    def _connect(self):
+        ucmd = self.set_digital_out_cmd.send
+        res = None
+        # Disabling mcu power
+        ucmd([self.pin, 0])
+        if len(self.steppers) > 0:
+            logging.info("%s starting checks for stepper"
+                         " driver backwards" % (self.name,))
+            for stepper in self.steppers.values():
+                res = self._check_driver(stepper)
+                if res is not None:
+                    break
+        if res is not None:
+            raise self.printer.command_error(res)
+        else:
+            # Enabling mcu power
+            ucmd([self.pin, 1])
+    def _register_stepper(self, config, ppins):
+        name = config.get_name()
+        enable_pin = config.get('enable_pin', None, note_valid=False)
+        step_pin = config.get('step_pin', None, note_valid=False)
+        # Only register stepper driver with enable and step pins
+        if enable_pin is not None and step_pin is not None:
+            enable_pin_params = ppins.parse_pin(enable_pin, can_invert=True)
+            step_pin_params = ppins.parse_pin(step_pin, can_invert=True)
+            # Only register stepper driver belongs to current mcu
+            if (step_pin_params['chip'] is self.mcu
+                    and enable_pin_params['chip'] is self.mcu):
+                self.steppers[name] = StepperTracking(
+                    name, step_pin_params, enable_pin_params)
+    def _check_driver(self, stepper):
+        logging.info("Checking [%s]" % (stepper.name,))
+        res = None
+        # Reconfig stepper driver pins
+        curtime = self.reactor.monotonic()
+        print_time = self.mcu.estimated_print_time(curtime)
+        minclock = self.mcu.print_time_to_clock(print_time + .100)
+        self.set_digital_out_cmd.send([stepper.step_pin_params['pin'],0],
+                                      minclock=minclock)
+        # Do the stepper driver check
+        minclock = self.mcu.print_time_to_clock(print_time + .200)
+        params = self.read_digital_in_cmd.send(
+            [stepper.enable_pin_params['pin'],0], minclock=minclock)
+        if params['value'] == 0:
+            res = ("[%s] driver is backward!"
+                   % (stepper.name,))
+        # Restore stepper driver pins
+        step_flags = SF_INVERT_STEP if stepper.step_pin_params['invert'] else 0
+        self.set_digital_out_cmd.send([stepper.step_pin_params['pin'],
+                                      step_flags & SF_INVERT_STEP])
+        enable_flags = stepper.enable_pin_params['invert']
+        self.set_digital_out_cmd.send([stepper.enable_pin_params['pin'],
+                                      (not not enable_flags)])
+        return res
+
+class StepperTracking:
+    def __init__(self, name, step_pin_params, enable_pin_params):
+        self.name = name
+        self.step_pin_params = step_pin_params
+        self.enable_pin_params = enable_pin_params
+
+def load_config_prefix(config):
+    return Safe_Power(config)
+
+def load_config(config):
+    return Safe_Power(config)

--- a/src/gpiocmds.c
+++ b/src/gpiocmds.c
@@ -213,3 +213,12 @@ command_set_digital_out(uint32_t *args)
     gpio_out_setup(args[0], args[1]);
 }
 DECL_COMMAND(command_set_digital_out, "set_digital_out pin=%u value=%c");
+
+void
+command_read_digital_in(uint32_t *args)
+{
+    struct gpio_in n = gpio_in_setup(args[0], args[1]);
+    uint8_t val = gpio_in_read(n);
+    sendf("read_digital_in_value pin=%u value=%c", args[0], val);
+}
+DECL_COMMAND(command_read_digital_in, "read_digital_in pin=%u pull_up=%c");


### PR DESCRIPTION
safe_power: Stepper Driver Anti-SNAFU Protection

Add stepper driver protection for boards to Klipper in form of 
safe_power module. The "Stepper Driver Anti-SNAFU Protection"
was introduced by BIGTREETECH in the "SKR 2" board and "SKR SE BX"
board. The protection give Klipper the option to check if Stepper Driver
is plugged into boards in correct orientation.

Signed-off-by: Lars R. Hansen popshansen@hotmail.com