### PR TITLE
menu: allow to show different menu on a long click

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3251,6 +3251,9 @@ lcd_type:
 #   Name of the main menu section to show when clicking the encoder
 #   on the home screen. The defaults is __main, and this shows the
 #   the default menus as defined in klippy/extras/display/menu.cfg
+#menu_root_long_click:
+#   Name of the main menu section to show when the encoder is long
+#   clicked on the home screen. The defaults is to use menu_root.
 #menu_reverse_navigation:
 #   When enabled it will reverse up and down directions for list
 #   navigation. The default is False. This parameter is optional.

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -698,7 +698,9 @@ class MenuManager:
         self.gcode_queue = []
         self.context = {}
         self.root = None
+        self.root_long_click = None
         self._root = config.get('menu_root', '__main')
+        self._root_long_click = config.get('menu_root_long_click', self._root)
         self.cols, self.rows = self.display.get_dimensions()
         self.timeout = config.getint('menu_timeout', 0)
         self.timer = 0
@@ -718,6 +720,9 @@ class MenuManager:
         self.load_menuitems(config)
         # Load menu root
         self.root = self.lookup_menuitem(self._root)
+        # Load long click menu
+        if self._root_long_click != self._root:
+            self.root_long_click = self.lookup_menuitem(self._root_long_click)
         # send init event
         self.send_event('init', self)
 
@@ -746,16 +751,21 @@ class MenuManager:
     def is_running(self):
         return self.running
 
-    def begin(self, eventtime):
+    def begin(self, eventtime, event):
         self.menustack = []
         self.timer = 0
-        if isinstance(self.root, MenuContainer):
+
+        container = self.root
+        if event == 'long_click' and self.root_long_click != None:
+            container = self.root_long_click
+
+        if isinstance(container, MenuContainer):
             # send begin event
             self.send_event('begin', self)
             self.update_context(eventtime)
-            if isinstance(self.root, MenuContainer):
-                self.root.init_selection()
-            self.stack_push(self.root)
+            if isinstance(container, MenuContainer):
+                container.init_selection()
+            self.stack_push(container)
             self.running = True
             return
         elif self.root is not None:
@@ -1023,7 +1033,7 @@ class MenuManager:
             self.press(event)
         else:
             # lets start and populate the menu items
-            self.begin(eventtime)
+            self.begin(eventtime, event)
 
     def key_event(self, key, eventtime):
         if key == 'click':


### PR DESCRIPTION
This allows to configure a different menu to show when an encoder is long clicked.

Example, use case: show `Tune`, or any other live adjustment tool.

