### PR TITLE
menu: auto-refresh menu visible items

### DIFF
--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -346,9 +346,15 @@ class MenuContainer(MenuElement):
         self.send_event('populate', self)
 
     def update_items(self):
+        selected_item = self.selected_item()
+
         _a = [(item, name) for item, name in self._allitems
-              if item.is_enabled()]
+            if item.is_enabled() or item == selected_item]
         self._items, self._names = zip(*_a) or ([], [])
+
+        # ensure that prior item is selected
+        if selected_item:
+            self.select_item(selected_item)
 
     # select methods
     def init_selection(self):
@@ -597,6 +603,10 @@ class MenuList(MenuContainer):
         self._viewport_top = 0
         #  add back as first item
         self.insert_item(self._itemBack, 0)
+
+    def heartbeat(self, eventtime):
+        super(MenuList, self).heartbeat(eventtime)
+        self.update_items()
 
     def draw_container(self, nrows, eventtime):
         display = self.manager.display

--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -606,7 +606,8 @@ class MenuList(MenuContainer):
 
     def heartbeat(self, eventtime):
         super(MenuList, self).heartbeat(eventtime)
-        self.update_items()
+        if self._allitems:
+            self.update_items()
 
     def draw_container(self, nrows, eventtime):
         display = self.manager.display


### PR DESCRIPTION
This makes to dynamically refresh menu items on a heartbeat
according to current print state.

To make things slightly more stable, we always keep
the current selected item always visible.

This is a follow-up after the: https://github.com/KevinOConnor/klipper/pull/4336.