### PR TITLE
Update FAQ.md

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -71,6 +71,14 @@ Follow the directions in the
 "[Where's my serial port?](#wheres-my-serial-port)" section to prevent
 this from occurring.
 
+### My micro-controller is wired to UART0 pins and refuses to flash.
+
+You likely need to add `dtoverlay=disable_bt` to `/boot/config.txt`. Raspberry
+pi reuses UART0 for the bluetooth host chip, so the serial port will show up as
+`/dev/AMA0` but be flooded with garbage until bluetooth is disabled. UART0 is
+not recommended in general, but works reliably with this fix if your system
+requires it.
+
 ### The "make flash" command doesn't work
 
 The code attempts to flash the device using the most common method for


### PR DESCRIPTION
module: Add UART0 tip to FAQ

Adding an important tip for the hard-wired UART0 pins to FAQ. There isn't a great
reason to use these other than compatibility with existing wiring in a system, but
for those that need it this will save several hours of debugging. The standard
raspbian build we recommend installing Klipper on has the bluetooth chip enabled
and routed through UART0, so this serial port will show up in the OS but not work
until bluetooth is disabled.

Signed-off-by: Nick Parker <nmp67@cornell.edu>