### PR TITLE
rp2040 bootloader request, make flash, and chipid support

### DIFF
--- a/scripts/flash-uf2.sh
+++ b/scripts/flash-uf2.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script installs a uf2 imag to a given rp2040 BOOTSEL disk
+
+DISK=$1
+BIN_FILE=$2
+
+if [[ "$DISK" = "" || "$BIN_FILE" = "" ]]; then
+    echo "Usage: $0 <disk> <uf2 file>" >&2
+    exit -1
+fi
+
+MOUNT_POINT="$(mktemp -d)"
+function cleanup {
+    umount "$MOUNT_POINT" &>/dev/null
+    rm -rf "$MOUNT_POINT"
+}
+trap cleanup EXIT
+
+mount "/dev/${DISK}1" "$MOUNT_POINT"
+cp "$BIN_FILE" "$MOUNT_POINT/"

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -43,8 +43,5 @@ $(OUT)klipper.uf2: $(OUT)klipper.elf $(OUT)lib/rp2040/elf2uf2/elf2uf2
 
 # Flash rules
 flash: $(OUT)klipper.uf2
-	@echo "Error: Flashing not supported on rp2040."
-	@echo "Place target board in bootloader mode (hold bootsel button"
-	@echo "during powerup), mount the device as a usb drive, and copy"
-	@echo "$< to the device."
-	@exit -1
+	@echo "  Flashing $< to $(FLASH_DEVICE)"
+	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(OUT)klipper.uf2


### PR DESCRIPTION
This adds a bootloader request (using the standard 1200 baud method), then builds `make flash` support on top of this.

To better support multiple chips, chipid support is also added. The rp2040 chips are all identical, and have no chip ID, but their flash chips do. At startup we decouple the XIP layer, ask the flash chip for UID, then re-engage the XIP layer.

Finally a small linker fix is included, as newer binutils(>=2.36) can't link without this change, see the corresponding commit.

/Lasse