### PR TITLE
stm32: Stop the watchdog clock when the core is halted.

### DIFF
--- a/src/stm32/watchdog.c
+++ b/src/stm32/watchdog.c
@@ -21,5 +21,6 @@ watchdog_init(void)
     IWDG->PR = 0;
     IWDG->RLR = 0x0FFF; // 410-512ms timeout (depending on stm32 chip)
     IWDG->KR = 0xCCCC;
+    DBGMCU->APB1FZ |= 0x1000; // stop the watchdog with debug.
 }
 DECL_INIT(watchdog_init);

--- a/src/stm32/watchdog.c
+++ b/src/stm32/watchdog.c
@@ -21,7 +21,7 @@ watchdog_init(void)
     IWDG->PR = 0;
     IWDG->RLR = 0x0FFF; // 410-512ms timeout (depending on stm32 chip)
     IWDG->KR = 0xCCCC;
-#ifndef MACH_STM32F1
+#ifndef CONFIG_MACH_STM32F1
     DBGMCU->APB1FZ |= 0x1000; // stop the watchdog with debug.
 #endif
 }

--- a/src/stm32/watchdog.c
+++ b/src/stm32/watchdog.c
@@ -21,6 +21,8 @@ watchdog_init(void)
     IWDG->PR = 0;
     IWDG->RLR = 0x0FFF; // 410-512ms timeout (depending on stm32 chip)
     IWDG->KR = 0xCCCC;
+#ifndef MACH_STM32F1
     DBGMCU->APB1FZ |= 0x1000; // stop the watchdog with debug.
+#endif
 }
 DECL_INIT(watchdog_init);


### PR DESCRIPTION
Since the watchdog is always enabled it is impossible to debug using
stlink or jtag. Set the DBG_IWDG_STOP bit so the watchdog clock stops
when the core is halted.

An alternative would be to provide a compile time option to disable
the watchdog.