### PR TITLE
Add sync_extruder_steppers

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -170,6 +170,9 @@ The following standard commands are supported:
 - `ACTIVATE_EXTRUDER EXTRUDER=<config_name>`: In a printer with
   multiple extruders this command is used to change the active
   extruder.
+- `SYNC_EXTRUDER_STEPPERS EXTRUDER=<config_name> [TO=<config_name>]`:
+  Synchronize extruders steppers. To unsynchronize an extruder, omits the TO
+  parameter.
 - `SET_PRESSURE_ADVANCE [EXTRUDER=<config_name>] [ADVANCE=<pressure_advance>]
   [SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
   parameters. If EXTRUDER is not specified, it defaults to the active

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -222,7 +222,6 @@ class PrinterExtruder:
     cmd_SYNC_EXTRUDER_STEPPERS_help = "Synchronize extruders steppers"
     def cmd_SYNC_EXTRUDER_STEPPERS(self, gcmd):
         name_master = gcmd.get('TO', None)
-        heater = self.get_heater()
         if name_master == self.name or name_master is None:
             # unsync
             self.sync_stepper(self.stepper)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -219,7 +219,7 @@ class PrinterExtruder:
         toolhead.flush_step_generation()
         toolhead.set_extruder(self, self.stepper.get_commanded_position())
         self.printer.send_event("extruder:activate_extruder")
-    cmd_SYNC_EXTRUDER_STEPPERS_help = "Synchronize extruders heaters and motors"
+    cmd_SYNC_EXTRUDER_STEPPERS_help = "Synchronize extruders steppers"
     def cmd_SYNC_EXTRUDER_STEPPERS(self, gcmd):
         name_master = gcmd.get('TO', None)
         heater = self.get_heater()


### PR DESCRIPTION
Add the possibility to synchronize multiple extruder steppers.
Typical usage is to mimic extruder with extruder1 on an IDEX printer printing in duplication or mirrored mode.
Related to PR #4464, replace #4445. 

Signed-off-by: Fabrice GALLET tircown@gmail.com