### PR TITLE
docs: Consistency Improvements

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -149,7 +149,7 @@ transition to a "shutdown" state. It behaves similarly to the G-Code
 ### register_remote_method
 
 This endpoint allows clients to register methods that can be called
-from klipper.  It will return an empty object upon success.
+from Klipper. It will return an empty object upon success.
 
 For example:
 `{"id": 123, "method": "register_remote_method",
@@ -168,7 +168,7 @@ gcode:
   {action_call_remote_method("paneldue_beep", frequency=300, duration=1.0)}
 ```
 
-When the PANELDUE_BEEP gcode macro is executed, Klipper would send something
+When the PANELDUE_BEEP G-Code macro is executed, Klipper would send something
 like the following over the socket:
 `{"action": "run_paneldue_beep",
 "params": {"frequency": 300, "duration": 1.0}}`

--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -8,7 +8,8 @@ control the Klipper host software.
 
 In order to use the API server, the klippy.py host software must be
 started with the `-a` parameter. For example:
-```
+
+```bash
 ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer.cfg -a /tmp/klippy_uds -l /tmp/klippy.log
 ```
 
@@ -20,13 +21,15 @@ Klipper.
 
 Messages sent and received on the socket are JSON encoded strings
 terminated by an ASCII 0x03 character:
-```
+
+```json
 <json_object_1><0x03><json_object_2><0x03>...
 ```
 
 Klipper contains a `scripts/whconsole.py` tool that can perform the
 above message framing. For example:
-```
+
+```bash
 ~/klipper/scripts/whconsole.py /tmp/klippy_uds
 ```
 
@@ -158,7 +161,8 @@ will return:
 The remote method `paneldue_beep` may now be called from Klipper. Note
 that if the method takes parameters they should be provided as keyword
 arguments. Below is an example of how it may called from a gcode_macro:
-```
+
+```gcode
 [gcode_macro PANELDUE_BEEP]
 gcode:
   {action_call_remote_method("paneldue_beep", frequency=300, duration=1.0)}

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -86,7 +86,9 @@ let it touch the bed as it should.
 Once the BL-Touch is in inconsistent state, it starts blinking red.
 You can force it to leave that state by issuing:
 
+```gcode
  BLTOUCH_DEBUG COMMAND=reset
+```
 
 This may happen if its calibration is interrupted by the probe being
 blocked from being extracted.

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -222,10 +222,10 @@ calibration steps.
   parameter in the [bltouch] section of the printer config file to
   "5V".
 
-  *** Only use the 5V mode if your controller boards input line is
+  ***Only use the 5V mode if your controller boards input line is
   5V tolerant. This is why the default configuration of these BL-Touch
   versions is OPEN-DRAIN mode. You could potentially damage your
-  controller boards CPU ***
+  controller boards CPU.***
 
   So therefore:
   If a controller board NEEDs 5V mode AND it is 5V tolerant on its

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -215,7 +215,7 @@ calibration steps.
 
 ## BL-Touch output mode
 
-* A BL-Touch V3.0 supports setting a 5V or OPEN-DRAIN output mode,
+- A BL-Touch V3.0 supports setting a 5V or OPEN-DRAIN output mode,
   a BL-Touch V3.1 supports this too, but can also store this in its
   internal EEPROM. If your controller board needs the fixed 5V high
   logic level of the 5V mode you may set the 'set_output_mode'

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -15,7 +15,7 @@ configure these pins according to your wiring. Most BL-Touch devices
 require a pullup on the sensor pin (prefix the pin name with "^"). For
 example:
 
-```
+```cfg
 [bltouch]
 sensor_pin: ^P1.24
 control_pin: P1.26
@@ -26,7 +26,7 @@ probe:z_virtual_endstop` in the `[stepper_z]` config section and add a
 `[safe_z_home]` config section to raise the z axis, home the xy axes,
 move to the center of the bed, and home the z axis. For example:
 
-```
+```cfg
 [safe_z_home]
 home_xy_position: 100,100 # Change coordinates to the center of your print bed
 speed: 50

--- a/docs/Bed_Level.md
+++ b/docs/Bed_Level.md
@@ -115,7 +115,8 @@ choose one of them.
 Run the appropriate command in the OctoPrint terminal window. The
 script will prompt for user interaction in the OctoPrint terminal
 output. It will look something like:
-```
+
+```text
 Recv: // Starting manual Z probe. Use TESTZ to adjust position.
 Recv: // Finish with ACCEPT or ABORT command.
 Recv: // Z position: ?????? --> 5.000 <-- ??????
@@ -135,7 +136,8 @@ down on the bed when moving the paper back and forth.)
 
 Use the TESTZ command to request the nozzle to move closer to the
 paper. For example:
-```
+
+```gcode
 TESTZ Z=-.1
 ```
 
@@ -152,9 +154,11 @@ move the nozzle up. It is also possible to use `TESTZ Z=+` or `TESTZ
 Z=-` to "bisect" the last position - that is to move to a position
 half way between two positions. For example, if one received the
 following prompt from a TESTZ command:
-```
+
+```text
 Recv: // Z position: 0.130 --> 0.230 <-- 0.280
 ```
+
 Then a `TESTZ Z=-` would move the nozzle to a Z position of 0.180
 (half way between 0.130 and 0.230). One can use this feature to help
 rapidly narrow down to a consistent friction. It is also possible to
@@ -163,9 +167,11 @@ example, after the above prompt a `TESTZ Z=--` command would move the
 nozzle to a Z position of 0.130.
 
 After finding a small amount of friction run the ACCEPT command:
-```
+
+```gcode
 ACCEPT
 ```
+
 This will accept the given Z height and proceed with the given
 calibration tool.
 

--- a/docs/Bed_Level.md
+++ b/docs/Bed_Level.md
@@ -219,5 +219,5 @@ then back-off until it disappears.
 The easiest way to apply the desired Z adjustment is to create a
 START_PRINT g-code macro, arrange for the slicer to call that macro
 during the start of each print, and add a SET_GCODE_OFFSET command to
-that macro. See the [slicers](Slicers.md) document for further
+that macro. See the [Slicers](Slicers.md) document for further
 details.

--- a/docs/Bed_Level.md
+++ b/docs/Bed_Level.md
@@ -106,8 +106,8 @@ it is easily accounted for later in the calibration process.
 
 **Use an automated tool to determine precise Z heights!**
 
-Klipper has several helper scripts available (eg, MANUAL_PROBE,
-Z_ENDSTOP_CALIBRATE, PROBE_CALIBRATE, DELTA_CALIBRATE). See the
+Klipper has several helper scripts available (eg, `MANUAL_PROBE`,
+`Z_ENDSTOP_CALIBRATE`, `PROBE_CALIBRATE`, `DELTA_CALIBRATE`). See the
 documents
 [described above](#choose-the-appropriate-calibration-mechanism) to
 choose one of them.
@@ -134,18 +134,18 @@ down on the bed when moving the paper back and forth.)
 
 ![paper-test](img/paper-test.jpg)
 
-Use the TESTZ command to request the nozzle to move closer to the
+Use the `TESTZ` command to request the nozzle to move closer to the
 paper. For example:
 
 ```gcode
 TESTZ Z=-.1
 ```
 
-The TESTZ command will move the nozzle a relative distance from the
+The `TESTZ` command will move the nozzle a relative distance from the
 nozzle's current position. (So, `Z=-.1` requests the nozzle to move
 closer to the bed by .1mm.) After the nozzle stops moving, push the
 paper back and forth to check if the nozzle is in contact with the
-paper and to feel the amount of friction. Continue issuing TESTZ
+paper and to feel the amount of friction. Continue issuing `TESTZ`
 commands until one feels a small amount of friction when testing with
 the paper.
 
@@ -153,7 +153,7 @@ If too much friction is found then one can use a positive Z value to
 move the nozzle up. It is also possible to use `TESTZ Z=+` or `TESTZ
 Z=-` to "bisect" the last position - that is to move to a position
 half way between two positions. For example, if one received the
-following prompt from a TESTZ command:
+following prompt from a `TESTZ` command:
 
 ```text
 Recv: // Z position: 0.130 --> 0.230 <-- 0.280
@@ -166,7 +166,7 @@ use `Z=++` and `Z=--` to return directly to a past measurement - for
 example, after the above prompt a `TESTZ Z=--` command would move the
 nozzle to a Z position of 0.130.
 
-After finding a small amount of friction run the ACCEPT command:
+After finding a small amount of friction run the `ACCEPT` command:
 
 ```gcode
 ACCEPT
@@ -211,13 +211,13 @@ make further adjustment as needed. Adjustments of this type are
 typically in 10s of microns (.010mm).
 
 If the bottom layer consistently appears narrower than subsequent
-layers then one can use the SET_GCODE_OFFSET command to make a
+layers then one can use the `SET_GCODE_OFFSET` command to make a
 negative Z adjustment. If one is unsure, then one can decrease the Z
 adjustment until the bottom layer of prints exhibit a small bulge, and
 then back-off until it disappears.
 
 The easiest way to apply the desired Z adjustment is to create a
-START_PRINT g-code macro, arrange for the slicer to call that macro
-during the start of each print, and add a SET_GCODE_OFFSET command to
+`START_PRINT` G-Code macro, arrange for the slicer to call that macro
+during the start of each print, and add a `SET_GCODE_OFFSET` command to
 that macro. See the [Slicers](Slicers.md) document for further
 details.

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -11,7 +11,7 @@ the probing process.
 Prior to Mesh Calibration you will need to be sure that your Probe's
 Z-Offset is calibrated. If using an endstop for Z homing it will need
 to be calibrated as well. See [Probe_Calibrate](Probe_Calibrate.md)
-and Z_ENDSTOP_CALIBRATE in [Manual_Level](Manual_Level.md) for more
+and `Z_ENDSTOP_CALIBRATE` in [Manual_Level](Manual_Level.md) for more
 information.
 
 ## Basic Configuration
@@ -347,8 +347,10 @@ are identified in green.
 
 ### Calibration
 
-`BED_MESH_CALIBRATE PROFILE=name METHOD=[manual | automatic] [<probe_parameter>=<value>]
- [<mesh_parameter>=<value>]`\
+```gcode
+BED_MESH_CALIBRATE PROFILE=name METHOD=[manual | automatic] [<probe_parameter>=<value>] [<mesh_parameter>=<value>]
+```
+
 _Default Profile:  default_\
 _Default Method:  automatic if a probe is detected, otherwise manual_
 
@@ -377,7 +379,9 @@ applies to the mesh.
 
 ### Profiles
 
-`BED_MESH_PROFILE SAVE=name LOAD=name REMOVE=name`
+```gcode
+BED_MESH_PROFILE SAVE=name LOAD=name REMOVE=name
+```
 
 After a BED_MESH_CALIBRATE has been performed, it is possible to save the
 current mesh state into a named profile. This makes it possible to load
@@ -392,14 +396,18 @@ state is automatically saved to the *default* profile. If this profile
 exists it is automatically loaded when Klipper starts. If this behavior
 is not desirable the _default_ profile can be removed as follows:
 
-`BED_MESH_PROFILE REMOVE=default`
+```gcode
+BED_MESH_PROFILE REMOVE=default
+```
 
 Any other saved profile can be removed in the same fashion, replacing
 _default_ with the named profile you wish to remove.
 
 ### Output
 
-`BED_MESH_OUTPUT PGP=[0 | 1]`
+```gcode
+BED_MESH_OUTPUT PGP=[0 | 1]
+```
 
 Outputs the current mesh state to the terminal. Note that the mesh itself
 is output
@@ -433,13 +441,17 @@ probing the "Probe" points will refer to both the tool and nozzle locations.
 
 ### Clear Mesh State
 
-`BED_MESH_CLEAR`
+```gcode
+BED_MESH_CLEAR
+```
 
 This G-Code may be used to clear the internal mesh state.
 
 ### Apply X/Y offsets
 
-`BED_MESH_OFFSET [X=<value>] [Y=<value>]`
+```gcode
+BED_MESH_OFFSET [X=<value>] [Y=<value>]
+```
 
 This is useful for printers with multiple independent extruders, as an offset
 is necessary to produce correct Z adjustment after a tool change. Offsets

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -17,6 +17,7 @@ information.
 ## Basic Configuration
 
 ### Rectangular Beds
+
 This example assumes a printer with a 250 mm x 220 mm rectangular
 bed and a probe with an x-offset of 24 mm and y-offset of 5 mm.
 
@@ -67,6 +68,7 @@ is at `mesh_max`, the nozzle will be at (206, 193).
 ![bedmesh_rect_basic](img/bedmesh_rect_basic.svg)
 
 ### Round beds
+
 This example assumes a printer equipped with a round bed radius of 100mm.
 We will use the same probe offsets as the rectangular example, 24 mm on X
 and 5 mm on Y.
@@ -363,6 +365,7 @@ mesh points will automatically be adjusted.
 
 It is possible to specify mesh parameters to modify the probed area. The
 following parameters are available:
+
 - Rectangular beds (cartesian):
   - `MESH_MIN`
   - `MESH_MAX`
@@ -374,6 +377,7 @@ following parameters are available:
 - All beds:
   - `RELATIVE_REFERNCE_INDEX`
   - `ALGORITHM`
+
 See the configuration documentation above for details on how each parameter
 applies to the mesh.
 

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -1,16 +1,16 @@
 # Bed Mesh
 
 The Bed Mesh module may be used to compensate for bed surface irregularties to
-achieve a better first layer across the entire bed.  It should be noted that
+achieve a better first layer across the entire bed. It should be noted that
 software based correction will not achieve perfect results, it can only
-approximate the shape of the bed.  Bed Mesh also cannot compensate for
-mechanical and electrical issues.  If an axis is skewed or a probe is not
+approximate the shape of the bed. Bed Mesh also cannot compensate for
+mechanical and electrical issues. If an axis is skewed or a probe is not
 accurate then the bed_mesh module will not receive accurate results from
 the probing process.
 
 Prior to Mesh Calibration you will need to be sure that your Probe's
-Z-Offset is calibrated.  If using an endstop for Z homing it will need
-to be calibrated as well.  See [Probe_Calibrate](Probe_Calibrate.md)
+Z-Offset is calibrated. If using an endstop for Z homing it will need
+to be calibrated as well. See [Probe_Calibrate](Probe_Calibrate.md)
 and Z_ENDSTOP_CALIBRATE in [Manual_Level](Manual_Level.md) for more
 information.
 
@@ -39,28 +39,28 @@ probe_count: 5,3
 
 - `mesh_min: 35,6`\
   _Required_\
-  The first probed coordinate, nearest to the origin.  This coordinate
+  The first probed coordinate, nearest to the origin. This coordinate
   is relative to the probe's location.
 
 - `mesh_max: 240,198`\
   _Required_\
-  The probed coordinate farthest farthest from the origin.  This is not
+  The probed coordinate farthest farthest from the origin. This is not
   necessarily the last point probed, as the probing process occurs in a
-  zig-zag fashion.  As with `mesh_min`, this coordiante is relative to
+  zig-zag fashion. As with `mesh_min`, this coordiante is relative to
   the probe's location.
 
 - `probe_count: 5,3`\
   _Default Value: 3,3_\
   The number of points to probe on each axis, specified as x,y integer
-  values.  In this example 5 points will be probed along the X axis, with
-  3 points along the Y axis, for a total of 15 probed points.  Note that
+  values. In this example 5 points will be probed along the X axis, with
+  3 points along the Y axis, for a total of 15 probed points. Note that
   if you wanted a square grid, for example 3x3, this could be specified
   as a single integer value that is used for both axes, ie `probe_count: 3`.
   Note that a mesh requires a minimum probe_count of 3 along each axis.
 
 The illustration below demonstrates how the `mesh_min`, `mesh_max`, and
-`probe_count` options are used to generate probe points.  The arrows indicate
-the direction of the probing procedure, beginning at `mesh_min`.  For reference,
+`probe_count` options are used to generate probe points. The arrows indicate
+the direction of the probing procedure, beginning at `mesh_min`. For reference,
 when the probe is at `mesh_min` the nozzle will be at (11, 1), and when the probe
 is at `mesh_max`, the nozzle will be at (206, 193).
 
@@ -82,25 +82,25 @@ round_probe_count: 5
 
 - `mesh_radius: 75`\
   _Required_\
-  The radius of the probed mesh in mm, relative to the `mesh_origin`.  Note
-  that the probe's offsets limit the size of the mesh radius.  In this example,
+  The radius of the probed mesh in mm, relative to the `mesh_origin`. Note
+  that the probe's offsets limit the size of the mesh radius. In this example,
   a radius larger than 76 would move the tool beyond the range of the printer.
 
 - `mesh_origin: 0,0`\
   _Default Value: 0,0_\
-  The center point of the mesh.  This coordinate is relative to the probe's
+  The center point of the mesh. This coordinate is relative to the probe's
   location. While the default is 0,0, it may be useful to adjust the origin
-  in an effort to probe a larger portion of the bed.  See the illustration
+  in an effort to probe a larger portion of the bed. See the illustration
   below.
 
 - `round_probe_count: 5`\
   _Default Value: 5_\
   This is an integer value that defines the maximum number of probed points
-  along the X and Y axes.  By "maximum", we mean the number of points probed
-  along the mesh origin.  This value must be an odd number, as it is required
+  along the X and Y axes. By "maximum", we mean the number of points probed
+  along the mesh origin. This value must be an odd number, as it is required
   that the center of the mesh is probed.
 
-The illustration below shows how the probed points are generated.  As you can see,
+The illustration below shows how the probed points are generated. As you can see,
 setting the `mesh_origin` to (-10, 0) allows us to specifiy a larger mesh radius
 of 85.
 
@@ -108,7 +108,7 @@ of 85.
 
 ## Advanced Configuration
 
-Below the more advanced configuration options are explained in detail.  Each
+Below the more advanced configuration options are explained in detail. Each
 example will build upon the basic rectangular bed configuration shown above.
 Each of the advanced options apply to round beds in the same manner.
 
@@ -117,8 +117,8 @@ Each of the advanced options apply to round beds in the same manner.
 While its possible to sample the probed matrix directly using simple bilinear
 interpolation to determine the Z-Values between probed points, it is often
 useful to interpolate extra points using more advanced interpolation algorithms
-to increase mesh density.  These algorithms add curvature to the mesh,
-attempting to simulate the material properties of the bed.  Bed Mesh offers
+to increase mesh density. These algorithms add curvature to the mesh,
+attempting to simulate the material properties of the bed. Bed Mesh offers
 lagrange and bicubic interpolation to accomplish this.
 
 ```cfg
@@ -135,30 +135,30 @@ bicubic_tension: 0.2
 
 - `mesh_pps: 2,3`\
   _Default Value: 2,2_\
-  The `mesh_pps` option is shorthand for Mesh Points Per Segment.  This
+  The `mesh_pps` option is shorthand for Mesh Points Per Segment. This
   option specifies how many points to interpolate for each segment along
-  the x and y axes.  Consider a 'segment' to be the space between each
+  the x and y axes. Consider a 'segment' to be the space between each
   probed point. Like `probe_count`, `mesh_pps` is specified as an x,y
   integer pair, and also may be specified a single integer that is applied
-  to both axes.  In this example there are 4 segments along the X axis
-  and 2 segments along the Y axis.  This evaluates to 8 interpolated
+  to both axes. In this example there are 4 segments along the X axis
+  and 2 segments along the Y axis. This evaluates to 8 interpolated
   points along X, 6 interpolated points along Y, which results in a 13x8
-  mesh.  Note that if mesh_pps is set to 0 then mesh interpolation is
+  mesh. Note that if mesh_pps is set to 0 then mesh interpolation is
   disabled and the probed matrix will be sampled directly.
 
 - `algorithm: lagrange`\
   _Default Value: lagrange_\
-  The algorithm used to interpolate the mesh.  May be `lagrange` or `bicubic`.
+  The algorithm used to interpolate the mesh. May be `lagrange` or `bicubic`.
   Lagrange interpolation is capped at 6 probed points as oscillation tends to
-  occur with a larger number of samples.  Bicubic interpolation requires a
+  occur with a larger number of samples. Bicubic interpolation requires a
   minimum of 4 probed points along each axis, if less than 4 points are
-  specified then lagrange sampling is forced.  If `mesh_pps` is set to 0 then
+  specified then lagrange sampling is forced. If `mesh_pps` is set to 0 then
   this value is ignored as no mesh interpolation is done.
 
 - `bicubic_tension: 0.2`\
   _Default Value: 0.2_\
   If the `algorithm` option is set to bicubic it is possible to specify the
-  tension value.  The higher the tension the more slope is interpolated.  Be
+  tension value. The higher the tension the more slope is interpolated. Be
   careful when adjusting this, as higher values also create more overshoot,
   which will result in interpolated values higher or lower than your probed
   points.
@@ -170,7 +170,7 @@ interpolated mesh.
 
 ### Move Splitting
 
-Bed Mesh works by intercepting gcode move commands and applying a transform
+Bed Mesh works by intercepting G-Code move commands and applying a transform
 to their Z coordinate. Long moves must be and split into smaller moves
 to correctly follow the shape of the bed. The options below control the
 splitting behavior.
@@ -189,19 +189,19 @@ split_delta_z: .025
 - `move_check_distance: 5`\
   _Default Value: 5_\
   The minimum distance to check for the desired change in Z before performing
-  a split.  In this example, a move longer than 5mm will be traversed by the
-  algorithm.  Each 5mm a mesh Z lookup will occur, comparing it with the Z
-  value of the previous move.  If the delta meets the threshold set by
-  `split_delta_z`, the move will be split and traversal will continue.  This
+  a split. In this example, a move longer than 5mm will be traversed by the
+  algorithm. Each 5mm a mesh Z lookup will occur, comparing it with the Z
+  value of the previous move. If the delta meets the threshold set by
+  `split_delta_z`, the move will be split and traversal will continue. This
   process repeats until the end of the move is reached, where a final
-  adjustment will be applied.  Moves shorter than the `move_check_distance`
+  adjustment will be applied. Moves shorter than the `move_check_distance`
   have the correct Z adjustment applied directly to the move without
   traversal or splitting.
 
 - `split_delta_z: .025`\
   _Default Value: .025_\
   As mentioned above, this is the minimum deviation required to trigger a
-  move split.  In this example, any Z value with a deviation +/- .025mm
+  move split. In this example, any Z value with a deviation +/- .025mm
   will trigger a split.
 
 Generally the default values for these options are sufficient, in fact the
@@ -212,12 +212,12 @@ out the optimial first layer.
 ### Mesh Fade
 
 When "fade" is enabled Z adjustment is phased out over a distance defined
-by the configuration.  This is accomplished by applying small adjustments
+by the configuration. This is accomplished by applying small adjustments
 to the layer height, either increasing or decreasing depending on the shape
 of the bed. When fade has completed, Z adjustment is no longer applied,
 allowing the top of the print to be flat rather than mirror the shape of the
-bed.  Fade also may have some undesirable traits, if you fade too quickly it
-can result in visible artifacts on the print.  Also, if your bed is
+bed. Fade also may have some undesirable traits, if you fade too quickly it
+can result in visible artifacts on the print. Also, if your bed is
 significantly warped, fade can shrink or stretch the Z height of the print.
 As such, fade is disabled by default.
 
@@ -235,28 +235,28 @@ fade_target: 0
 
 - `fade_start: 1`\
   _Default Value: 1_\
-  The Z height in which to start phasing out adjustment.  It is a good idea
+  The Z height in which to start phasing out adjustment. It is a good idea
   to get a few layers down before starting the fade process.
 
 - `fade_end: 10`\
   _Default Value: 0_\
-  The Z height in which fade should complete.  If this value is lower than
-  `fade_start` then fade is disabled.  This value may be adjusted depending
-  on how warped the print surface is.  A significantly warped surface should
-  fade out over a longer distance.  A near flat surface may be able to reduce
-  this value to phase out more quickly.  10mm is a sane value to begin with if
+  The Z height in which fade should complete. If this value is lower than
+  `fade_start` then fade is disabled. This value may be adjusted depending
+  on how warped the print surface is. A significantly warped surface should
+  fade out over a longer distance. A near flat surface may be able to reduce
+  this value to phase out more quickly. 10mm is a sane value to begin with if
   using the default value of 1 for `fade_start`.
 
 - `fade_target: 0`\
   _Default Value:  The average Z value of the mesh_\
   The `fade_target` can be thought of as an additional Z offset applied to the
-  entire bed after fade completes.  Generally speaking we would like this value
-  to be 0, however there are circumstances where it should not be.  For
+  entire bed after fade completes. Generally speaking we would like this value
+  to be 0, however there are circumstances where it should not be. For
   example,  lets assume your homing position on the bed is an outlier, its
-  .2 mm lower than the average probed height of the bed.  If the `fade_target`
-  is 0, fade will shrink the print by an average of .2 mm across the bed.  By
+  .2 mm lower than the average probed height of the bed. If the `fade_target`
+  is 0, fade will shrink the print by an average of .2 mm across the bed. By
   setting the `fade_target` to .2, the homed area will expand by .2 mm, however
-  the rest of the bed will have an accurately sized.  Generally its a good idea
+  the rest of the bed will have an accurately sized. Generally its a good idea
   to leave `fade_target` out of the configuration so the average height of the
   mesh is used, however it may be desirable to manually adjust the fade target
   if one wants to print on a specific portion of the bed.
@@ -264,8 +264,8 @@ fade_target: 0
 ### The Relative Reference Index
 
 Most probes are suceptible to drift, ie: inaccuracies in probing introduced by
-heat or interference.  This can make calculating the probe's z-offset
-challenging, particuarly at different bed temperatures.  As such, some printers
+heat or interference. This can make calculating the probe's z-offset
+challenging, particuarly at different bed temperatures. As such, some printers
 use an endstop for homing the Z axis, and a probe for calibrating the mesh.
 These printers can benefit from configuring the relative reference index.
 
@@ -281,32 +281,32 @@ relative_reference_index: 7
 
 - `relative_reference_index: 7`\
   _Default Value: None (disabled)_\
-  When the probed points are generated they are each assigned an index.  You
+  When the probed points are generated they are each assigned an index. You
   can look up this index in klippy.log or by using BED_MESH_OUTPUT (see the
-  section on Bed Mesh GCodes below for more information).  If you assign an
+  section on Bed Mesh G-Codes below for more information). If you assign an
   index to the `relative_reference_index` option, the value probed at this
-  coordinate will replace the probe's z_offset.  This effectively makes
+  coordinate will replace the probe's z_offset. This effectively makes
   this coordinate the "zero" reference for the mesh.
 
 When using the relative reference index, you should choose the index nearest
-to the spot on the bed where Z endstop calibration was done.  Note that
+to the spot on the bed where Z endstop calibration was done. Note that
 when looking up the index using the log or BED_MESH_OUTPUT, you should use
 the coordinates listed under the "Probe" header to find the correct index.
 
 ### Faulty Regions
 
 It is possible for some areas of a bed to report inaccurate results when
-probing due to a "fault" at specific locations.  The best example of this
+probing due to a "fault" at specific locations. The best example of this
 are beds with series of integrated magnets used to retain removable steel
-sheets.  The magnetic field at and around these magnets may cause an inductive
+sheets. The magnetic field at and around these magnets may cause an inductive
 probe to trigger at a distance higher or lower than it would otherwise,
 resulting in a mesh that does not accurately represent the surface at these
-locations.  **Note: This should not be confused with probe location bias, which
+locations. **Note: This should not be confused with probe location bias, which
 produces inaccurate results across the entire bed.**
 
 The `faulty_region` options may be configured to compensate for this affect.
 If a generated point lies within a faulty region bed mesh will attempt to
-probe up to 4 points at the boundaries of this region.  These probed values
+probe up to 4 points at the boundaries of this region. These probed values
 will be averaged and inserted in the mesh as the Z value at the generated
 (X, Y) coordinate.
 
@@ -333,17 +333,17 @@ faulty_region_4_max: 45.0, 210.0
   Faulty Regions are defined in a way similar to that of mesh itself, where
   minimum and maximum (X, Y) coordinates must be specified for each region.
   A faulty region may extend outside of a mesh, however the alternate points
-  generated will always be within the mesh boundary.  No two regions may
+  generated will always be within the mesh boundary. No two regions may
   overlap.
 
 The image below illustrates how replacement points are generated when
-a generated point lies within a faulty region.  The regions shown match those
-in the sample config above.  The replacement points and their coordinates
+a generated point lies within a faulty region. The regions shown match those
+in the sample config above. The replacement points and their coordinates
 are identified in green.
 
 ![bedmesh_interpolated](img/bedmesh_faulty_regions.svg)
 
-## Bed Mesh Gcodes
+## Bed Mesh G-Codes
 
 ### Calibration
 
@@ -356,10 +356,10 @@ Initiates the probing procedure for Bed Mesh Calibration.
 
 The mesh will be saved into a profile specified by the `PROFILE` parameter,
 or `default` if unspecified. If `METHOD=manual` is selected then manual probing
-will occur.  When switching between automatic and manual probing the generated
+will occur. When switching between automatic and manual probing the generated
 mesh points will automatically be adjusted.
 
-It is possible to specify mesh parameters to modify the probed area.  The
+It is possible to specify mesh parameters to modify the probed area. The
 following parameters are available:
 - Rectangular beds (cartesian):
   - `MESH_MIN`
@@ -380,16 +380,16 @@ applies to the mesh.
 `BED_MESH_PROFILE SAVE=name LOAD=name REMOVE=name`
 
 After a BED_MESH_CALIBRATE has been performed, it is possible to save the
-current mesh state into a named profile.  This makes it possible to load
-a mesh without re-probing the bed.  After a profile has been saved using
-`BED_MESH_PROFILE SAVE=name` the `SAVE_CONFIG` gcode may be executed
+current mesh state into a named profile. This makes it possible to load
+a mesh without re-probing the bed. After a profile has been saved using
+`BED_MESH_PROFILE SAVE=name` the `SAVE_CONFIG` G-Code may be executed
 to write the profile to printer.cfg.
 
 Profiles can be loaded by executing `BED_MESH_PROFILE LOAD=name`.
 
 It should be noted that each time a BED_MESH_CALIBRATE occurs, the current
-state is automatically saved to the _default_ profile.  If this profile
-exists it is automatically loaded when Klipper starts.  If this behavior
+state is automatically saved to the *default* profile. If this profile
+exists it is automatically loaded when Klipper starts. If this behavior
 is not desirable the _default_ profile can be removed as follows:
 
 `BED_MESH_PROFILE REMOVE=default`
@@ -401,10 +401,10 @@ _default_ with the named profile you wish to remove.
 
 `BED_MESH_OUTPUT PGP=[0 | 1]`
 
-Outputs the current mesh state to the terminal.  Note that the mesh itself
+Outputs the current mesh state to the terminal. Note that the mesh itself
 is output
 
-The PGP parameter is shorthand for "Print Generated Points".  If `PGP=1` is
+The PGP parameter is shorthand for "Print Generated Points". If `PGP=1` is
 set, the generated probed points will be output to the terminal:
 
 ```text
@@ -428,22 +428,22 @@ set, the generated probed points will be output to the terminal:
 ```
 
 The "Tool Adjusted" points refer to the nozzle location for each point, and
-the "Probe" points refer to the probe location.  Note that when manually
+the "Probe" points refer to the probe location. Note that when manually
 probing the "Probe" points will refer to both the tool and nozzle locations.
 
 ### Clear Mesh State
 
 `BED_MESH_CLEAR`
 
-This gcode may be used to clear the internal mesh state.
+This G-Code may be used to clear the internal mesh state.
 
 ### Apply X/Y offsets
 
 `BED_MESH_OFFSET [X=<value>] [Y=<value>]`
 
 This is useful for printers with multiple independent extruders, as an offset
-is necessary to produce correct Z adjustment after a tool change.  Offsets
-should be specified relative to the primary extruder.  That is, a positive
+is necessary to produce correct Z adjustment after a tool change. Offsets
+should be specified relative to the primary extruder. That is, a positive
 X offset should be specified if the secondary extruder is mounted to the
 right of the primary extruder, and a positive Y offset should be specified
 if the secondary extruder is mounted "behind" the primary extruder.

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -31,27 +31,27 @@ probe_count: 5,3
 ```
 
 - `speed: 120`\
-  _Default Value: 50_\
+  *Default Value: 50*\
   The speed in which the tool moves between points.
 
 - `horizontal_move_z: 5`\
-  _Default Value: 5_\
+  *Default Value: 5*\
   The Z coordinate the probe rises to prior to traveling between points.
 
 - `mesh_min: 35,6`\
-  _Required_\
+  *Required*\
   The first probed coordinate, nearest to the origin. This coordinate
   is relative to the probe's location.
 
 - `mesh_max: 240,198`\
-  _Required_\
+  *Required*\
   The probed coordinate farthest farthest from the origin. This is not
   necessarily the last point probed, as the probing process occurs in a
   zig-zag fashion. As with `mesh_min`, this coordiante is relative to
   the probe's location.
 
 - `probe_count: 5,3`\
-  _Default Value: 3,3_\
+  *Default Value: 3,3*\
   The number of points to probe on each axis, specified as x,y integer
   values. In this example 5 points will be probed along the X axis, with
   3 points along the Y axis, for a total of 15 probed points. Note that
@@ -83,20 +83,20 @@ round_probe_count: 5
 ```
 
 - `mesh_radius: 75`\
-  _Required_\
+  *Required*\
   The radius of the probed mesh in mm, relative to the `mesh_origin`. Note
   that the probe's offsets limit the size of the mesh radius. In this example,
   a radius larger than 76 would move the tool beyond the range of the printer.
 
 - `mesh_origin: 0,0`\
-  _Default Value: 0,0_\
+  *Default Value: 0,0*\
   The center point of the mesh. This coordinate is relative to the probe's
   location. While the default is 0,0, it may be useful to adjust the origin
   in an effort to probe a larger portion of the bed. See the illustration
   below.
 
 - `round_probe_count: 5`\
-  _Default Value: 5_\
+  *Default Value: 5*\
   This is an integer value that defines the maximum number of probed points
   along the X and Y axes. By "maximum", we mean the number of points probed
   along the mesh origin. This value must be an odd number, as it is required
@@ -136,7 +136,7 @@ bicubic_tension: 0.2
 ```
 
 - `mesh_pps: 2,3`\
-  _Default Value: 2,2_\
+  *Default Value: 2,2*\
   The `mesh_pps` option is shorthand for Mesh Points Per Segment. This
   option specifies how many points to interpolate for each segment along
   the x and y axes. Consider a 'segment' to be the space between each
@@ -149,7 +149,7 @@ bicubic_tension: 0.2
   disabled and the probed matrix will be sampled directly.
 
 - `algorithm: lagrange`\
-  _Default Value: lagrange_\
+  *Default Value: lagrange*\
   The algorithm used to interpolate the mesh. May be `lagrange` or `bicubic`.
   Lagrange interpolation is capped at 6 probed points as oscillation tends to
   occur with a larger number of samples. Bicubic interpolation requires a
@@ -158,7 +158,7 @@ bicubic_tension: 0.2
   this value is ignored as no mesh interpolation is done.
 
 - `bicubic_tension: 0.2`\
-  _Default Value: 0.2_\
+  *Default Value: 0.2*\
   If the `algorithm` option is set to bicubic it is possible to specify the
   tension value. The higher the tension the more slope is interpolated. Be
   careful when adjusting this, as higher values also create more overshoot,
@@ -189,7 +189,7 @@ split_delta_z: .025
 ```
 
 - `move_check_distance: 5`\
-  _Default Value: 5_\
+  *Default Value: 5*\
   The minimum distance to check for the desired change in Z before performing
   a split. In this example, a move longer than 5mm will be traversed by the
   algorithm. Each 5mm a mesh Z lookup will occur, comparing it with the Z
@@ -201,7 +201,7 @@ split_delta_z: .025
   traversal or splitting.
 
 - `split_delta_z: .025`\
-  _Default Value: .025_\
+  *Default Value: .025*\
   As mentioned above, this is the minimum deviation required to trigger a
   move split. In this example, any Z value with a deviation +/- .025mm
   will trigger a split.
@@ -236,12 +236,12 @@ fade_target: 0
 ```
 
 - `fade_start: 1`\
-  _Default Value: 1_\
+  *Default Value: 1*\
   The Z height in which to start phasing out adjustment. It is a good idea
   to get a few layers down before starting the fade process.
 
 - `fade_end: 10`\
-  _Default Value: 0_\
+  *Default Value: 0*\
   The Z height in which fade should complete. If this value is lower than
   `fade_start` then fade is disabled. This value may be adjusted depending
   on how warped the print surface is. A significantly warped surface should
@@ -250,7 +250,7 @@ fade_target: 0
   using the default value of 1 for `fade_start`.
 
 - `fade_target: 0`\
-  _Default Value:  The average Z value of the mesh_\
+  *Default Value:  The average Z value of the mesh*\
   The `fade_target` can be thought of as an additional Z offset applied to the
   entire bed after fade completes. Generally speaking we would like this value
   to be 0, however there are circumstances where it should not be. For
@@ -282,7 +282,7 @@ relative_reference_index: 7
 ```
 
 - `relative_reference_index: 7`\
-  _Default Value: None (disabled)_\
+  *Default Value: None (disabled)*\
   When the probed points are generated they are each assigned an index. You
   can look up this index in klippy.log or by using BED_MESH_OUTPUT (see the
   section on Bed Mesh G-Codes below for more information). If you assign an
@@ -331,7 +331,7 @@ faulty_region_4_max: 45.0, 210.0
 
 - `faulty_region_{1...99}_min`\
   `faulty_region_{1..99}_max`\
-  _Default Value: None (disabled)_\
+  *Default Value: None (disabled)*\
   Faulty Regions are defined in a way similar to that of mesh itself, where
   minimum and maximum (X, Y) coordinates must be specified for each region.
   A faulty region may extend outside of a mesh, however the alternate points
@@ -353,8 +353,8 @@ are identified in green.
 BED_MESH_CALIBRATE PROFILE=name METHOD=[manual | automatic] [<probe_parameter>=<value>] [<mesh_parameter>=<value>]
 ```
 
-_Default Profile:  default_\
-_Default Method:  automatic if a probe is detected, otherwise manual_
+*Default Profile:  default*\
+*Default Method:  automatic if a probe is detected, otherwise manual*
 
 Initiates the probing procedure for Bed Mesh Calibration.
 
@@ -398,14 +398,14 @@ Profiles can be loaded by executing `BED_MESH_PROFILE LOAD=name`.
 It should be noted that each time a BED_MESH_CALIBRATE occurs, the current
 state is automatically saved to the *default* profile. If this profile
 exists it is automatically loaded when Klipper starts. If this behavior
-is not desirable the _default_ profile can be removed as follows:
+is not desirable the *default* profile can be removed as follows:
 
 ```gcode
 BED_MESH_PROFILE REMOVE=default
 ```
 
 Any other saved profile can be removed in the same fashion, replacing
-_default_ with the named profile you wish to remove.
+*default* with the named profile you wish to remove.
 
 ### Output
 

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -20,7 +20,7 @@ information.
 This example assumes a printer with a 250 mm x 220 mm rectangular
 bed and a probe with an x-offset of 24 mm and y-offset of 5 mm.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -71,7 +71,7 @@ This example assumes a printer equipped with a round bed radius of 100mm.
 We will use the same probe offsets as the rectangular example, 24 mm on X
 and 5 mm on Y.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -121,7 +121,7 @@ to increase mesh density.  These algorithms add curvature to the mesh,
 attempting to simulate the material properties of the bed.  Bed Mesh offers
 lagrange and bicubic interpolation to accomplish this.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -175,7 +175,7 @@ to their Z coordinate. Long moves must be and split into smaller moves
 to correctly follow the shape of the bed. The options below control the
 splitting behavior.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -221,7 +221,7 @@ can result in visible artifacts on the print.  Also, if your bed is
 significantly warped, fade can shrink or stretch the Z height of the print.
 As such, fade is disabled by default.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -269,7 +269,7 @@ challenging, particuarly at different bed temperatures.  As such, some printers
 use an endstop for homing the Z axis, and a probe for calibrating the mesh.
 These printers can benefit from configuring the relative reference index.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -310,7 +310,7 @@ probe up to 4 points at the boundaries of this region.  These probed values
 will be averaged and inserted in the mesh as the Z value at the generated
 (X, Y) coordinate.
 
-```
+```cfg
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5
@@ -407,7 +407,7 @@ is output
 The PGP parameter is shorthand for "Print Generated Points".  If `PGP=1` is
 set, the generated probed points will be output to the terminal:
 
-```
+```text
 // bed_mesh: generated points
 // Index | Tool Adjusted | Probe
 // 0 | (11.0, 1.0) | (35.0, 6.0)

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -30,7 +30,8 @@ The test is performed using the console.py tool (described in
 [Debugging.md](Debugging.md)). The micro-controller is configured for
 the particular hardware platform (see below) and then the following is
 cut-and-paste into the console.py terminal window:
-```
+
+```text
 SET start_clock {clock+freq}
 SET ticks 1000
 
@@ -63,7 +64,8 @@ ticks parameter until a stable value is found.
 
 On a failure, one can copy-and-paste the following to clear the error
 in preparation for the next test:
-```
+
+```text
 clear_shutdown
 ```
 
@@ -77,7 +79,8 @@ number of steps per second is calculated by multiplying the number of
 active steppers with the nominal mcu frequency and dividing by the
 final ticks parameter. The results are rounded to the nearest K. For
 example, with three active steppers:
-```
+
+```text
 ECHO Test result is: {"%.0fK" % (3. * freq / ticks / 1000.)}
 ```
 
@@ -90,7 +93,8 @@ of these benchmarks are not reported in the Features.md document.
 ### AVR step rate benchmark
 
 The following configuration sequence is used on AVR chips:
-```
+
+```text
 PINS arduino
 allocate_oids count=3
 config_stepper oid=0 step_pin=ar29 dir_pin=ar28 invert_step=0
@@ -113,7 +117,8 @@ results match tests on both a 16Mhz at90usb and a 16Mhz atmega2560).
 ### Arduino Due step rate benchmark
 
 The following configuration sequence is used on the Due:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=PB27 dir_pin=PA21 invert_step=0
 config_stepper oid=1 step_pin=PB26 dir_pin=PC30 invert_step=0
@@ -135,7 +140,8 @@ The test was last run on commit `8d4a5c16` with gcc version
 ### Duet Maestro step rate benchmark
 
 The following configuration sequence is used on the Duet Maestro:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=PC26 dir_pin=PC18 invert_step=0
 config_stepper oid=1 step_pin=PC26 dir_pin=PA8 invert_step=0
@@ -157,7 +163,8 @@ The test was last run on commit `8d4a5c16` with gcc version
 ### Duet Wifi step rate benchmark
 
 The following configuration sequence is used on the Duet Wifi:
-```
+
+```text
 allocate_oids count=4
 config_stepper oid=0 step_pin=PD6 dir_pin=PD11 invert_step=0
 config_stepper oid=1 step_pin=PD7 dir_pin=PD12 invert_step=0
@@ -181,7 +188,8 @@ The test was last run on commit `59a60d68` with gcc version
 ### Beaglebone PRU step rate benchmark
 
 The following configuration sequence is used on the PRU:
-```
+
+```text
 PINS beaglebone
 allocate_oids count=3
 config_stepper oid=0 step_pin=P8_13 dir_pin=P8_12 invert_step=0
@@ -202,7 +210,8 @@ The test was last run on commit `b161a69e` with gcc version `pru-gcc
 ### STM32F042 step rate benchmark
 
 The following configuration sequence is used on the STM32F042:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=PA1 dir_pin=PA2 invert_step=0
 config_stepper oid=1 step_pin=PA3 dir_pin=PA2 invert_step=0
@@ -222,7 +231,8 @@ The test was last run on commit `0b0c47c5` with gcc version
 ### STM32F103 step rate benchmark
 
 The following configuration sequence is used on the STM32F103:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=PC13 dir_pin=PB5 invert_step=0
 config_stepper oid=1 step_pin=PB3 dir_pin=PB6 invert_step=0
@@ -244,7 +254,8 @@ The test was last run on commit `8d4a5c16` with gcc version
 ### STM32F4 step rate benchmark
 
 The following configuration sequence is used on the STM32F4:
-```
+
+```text
 allocate_oids count=4
 config_stepper oid=0 step_pin=PA5 dir_pin=PB5 invert_step=0
 config_stepper oid=1 step_pin=PB2 dir_pin=PB6 invert_step=0
@@ -279,7 +290,8 @@ using a 168Mhz clock).
 ### LPC176x step rate benchmark
 
 The following configuration sequence is used on the LPC176x:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=P1.20 dir_pin=P1.18 invert_step=0
 config_stepper oid=1 step_pin=P1.21 dir_pin=P1.18 invert_step=0
@@ -310,7 +322,8 @@ results were obtained by overclocking an LPC1768 to 120Mhz.
 ### SAMD21 step rate benchmark
 
 The following configuration sequence is used on the SAMD21:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=PA27 dir_pin=PA20 invert_step=0
 config_stepper oid=1 step_pin=PB3 dir_pin=PA21 invert_step=0
@@ -333,7 +346,8 @@ micro-controller.
 ### SAMD51 step rate benchmark
 
 The following configuration sequence is used on the SAMD51:
-```
+
+```text
 allocate_oids count=5
 config_stepper oid=0 step_pin=PA22 dir_pin=PA20 invert_step=0
 config_stepper oid=1 step_pin=PA22 dir_pin=PA21 invert_step=0
@@ -365,7 +379,7 @@ micro-controller.
 
 The following configuration sequence is used on the RP2040:
 
-```
+```text
 allocate_oids count=4
 config_stepper oid=0 step_pin=gpio25 dir_pin=gpio3 invert_step=0
 config_stepper oid=1 step_pin=gpio26 dir_pin=gpio4 invert_step=0
@@ -390,7 +404,8 @@ Pico board.
 ### Linux MCU step rate benchmark
 
 The following configuration sequence is used on a Raspberry Pi:
-```
+
+```text
 allocate_oids count=3
 config_stepper oid=0 step_pin=gpio2 dir_pin=gpio3 invert_step=0
 config_stepper oid=1 step_pin=gpio4 dir_pin=gpio5 invert_step=0
@@ -415,7 +430,8 @@ micro-controller can process. It is primarily a test of the hardware
 communication mechanism. The test is run using the console.py tool
 (described in [Debugging.md](Debugging.md)). The following is
 cut-and-paste into the console.py terminal window:
-```
+
+```text
 DELAY {clock + 2*freq} get_uptime
 FLOOD 100000 0.0 debug_nop
 get_uptime
@@ -456,6 +472,7 @@ It is possible to run timing tests on the host software using the
 [Debugging.md](Debugging.md)). This is typically done by choosing a
 large and complex G-Code file and timing how long it takes for the
 host software to process it. For example:
-```
+
+```bash
 time ~/klippy-env/bin/python ./klippy/klippy.py config/example-cartesian.cfg -i something_complex.gcode -o /dev/null -d out/klipper.dict
 ```

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -108,11 +108,11 @@ The test was last run on commit `01d2183f` with gcc version `avr-gcc
 configured for an atmega644p (previous tests have confirmed simulavr
 results match tests on both a 16Mhz at90usb and a 16Mhz atmega2560).
 
-| avr              | ticks |
-| ---------------- | ----- |
-| 1 stepper        | 104   |
-| 2 stepper        | 296   |
-| 3 stepper        | 472   |
+| avr       | ticks |
+| --------- | ----- |
+| 1 stepper | 104   |
+| 2 stepper | 296   |
+| 3 stepper | 472   |
 
 ### Arduino Due step rate benchmark
 
@@ -178,12 +178,12 @@ The test was last run on commit `59a60d68` with gcc version
 `arm-none-eabi-gcc 7.3.1 20180622 (release)
 [ARM/embedded-7-branch revision 261907]`.
 
-| sam4e8e          | ticks |
-| ---------------- | ----- |
-| 1 stepper        | 519   |
-| 2 stepper        | 520   |
-| 3 stepper        | 525   |
-| 4 stepper        | 703   |
+| sam4e8e   | ticks |
+| --------- | ----- |
+| 1 stepper | 519   |
+| 2 stepper | 520   |
+| 3 stepper | 525   |
+| 4 stepper | 703   |
 
 ### Beaglebone PRU step rate benchmark
 
@@ -201,11 +201,11 @@ finalize_config crc=0
 The test was last run on commit `b161a69e` with gcc version `pru-gcc
 (GCC) 8.0.0 20170530 (experimental)`.
 
-| pru              | ticks |
-| ---------------- | ----- |
-| 1 stepper        | 861   |
-| 2 stepper        | 853   |
-| 3 stepper        | 883   |
+| pru       | ticks |
+| --------- | ----- |
+| 1 stepper | 861   |
+| 2 stepper | 853   |
+| 3 stepper | 883   |
 
 ### STM32F042 step rate benchmark
 
@@ -222,11 +222,11 @@ finalize_config crc=0
 The test was last run on commit `0b0c47c5` with gcc version
 `arm-none-eabi-gcc (Fedora 9.2.0-1.fc30) 9.2.0`.
 
-| stm32f042        | ticks |
-| ---------------- | ----- |
-| 1 stepper        | 247   |
-| 2 stepper        | 328   |
-| 3 stepper        | 558   |
+| stm32f042 | ticks |
+| --------- | ----- |
+| 1 stepper | 247   |
+| 2 stepper | 328   |
+| 3 stepper | 558   |
 
 ### STM32F103 step rate benchmark
 
@@ -417,11 +417,11 @@ The test was last run on commit `db0fb5d5` with gcc version `gcc
 (Raspbian 6.3.0-18+rpi1+deb9u1) 6.3.0 20170516` on a Raspberry Pi 3
 (revision a22082).
 
-| Linux (RPi3)         | ticks |
-| -------------------- | ----- |
-| 1 stepper            | 349   |
-| 2 stepper            | 350   |
-| 3 stepper            | 400   |
+| Linux (RPi3) | ticks |
+| ------------ | ----- |
+| 1 stepper    | 349   |
+| 2 stepper    | 350   |
+| 3 stepper    | 400   |
 
 ## Command dispatch benchmark
 
@@ -448,22 +448,22 @@ Where applicable, the benchmarks below are with console.py running on
 a desktop class machine with the device connected via a high-speed
 hub.
 
-| MCU                 | Rate | Build    | Build compiler      |
-| ------------------- | ---- | -------- | ------------------- |
-| stm32f042 (CAN)     |  18K | c105adc8 | arm-none-eabi-gcc (GNU Tools 7-2018-q3-update) 7.3.1 |
-| atmega2560 (serial) |  23K | b161a69e | avr-gcc (GCC) 4.8.1 |
-| sam3x8e (serial)    |  23K | b161a69e | arm-none-eabi-gcc (Fedora 7.1.0-5.fc27) 7.1.0 |
-| at90usb1286 (USB)   |  75K | 01d2183f | avr-gcc (GCC) 5.4.0 |
-| samd21 (USB)        | 223K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| pru (shared memory) | 260K | c5968a08 | pru-gcc (GCC) 8.0.0 20170530 (experimental) |
-| stm32f103 (USB)     | 355K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| sam3x8e (USB)       | 418K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| lpc1768 (USB)       | 534K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| lpc1769 (USB)       | 628K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| sam4s8c (USB)       | 650K | 8d4a5c16 | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| samd51 (USB)        | 864K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| stm32f446 (USB)     | 870K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0 |
-| rp2040 (USB)        | 873K | c5667193 | arm-none-eabi-gcc (Fedora 10.2.0-4.fc34) 10.2.0 |
+| MCU                 | Rate | Build    | Build compiler                                       |
+| ------------------- | ---- | -------- | ---------------------------------------------------- |
+| stm32f042 (CAN)     | 18K  | c105adc8 | arm-none-eabi-gcc (GNU Tools 7-2018-q3-update) 7.3.1 |
+| atmega2560 (serial) | 23K  | b161a69e | avr-gcc (GCC) 4.8.1                                  |
+| sam3x8e (serial)    | 23K  | b161a69e | arm-none-eabi-gcc (Fedora 7.1.0-5.fc27) 7.1.0        |
+| at90usb1286 (USB)   | 75K  | 01d2183f | avr-gcc (GCC) 5.4.0                                  |
+| samd21 (USB)        | 223K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| pru (shared memory) | 260K | c5968a08 | pru-gcc (GCC) 8.0.0 20170530 (experimental)          |
+| stm32f103 (USB)     | 355K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| sam3x8e (USB)       | 418K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| lpc1768 (USB)       | 534K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| lpc1769 (USB)       | 628K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| sam4s8c (USB)       | 650K | 8d4a5c16 | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| samd51 (USB)        | 864K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| stm32f446 (USB)     | 870K | 01d2183f | arm-none-eabi-gcc (Fedora 7.4.0-1.fc30) 7.4.0        |
+| rp2040 (USB)        | 873K | c5667193 | arm-none-eabi-gcc (Fedora 10.2.0-4.fc34) 10.2.0      |
 
 ## Host Benchmarks
 

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -439,7 +439,7 @@ get_uptime
 
 When the test completes, determine the difference between the clocks
 reported in the two "uptime" response messages. The total number of
-commands per second is then $\frac{100000 \times mcu\_frequency}{\Delta{f}_{clock}}$.
+commands per second is then `100000 * mcu_frequency / clock_diff`.
 
 Note that this test may saturate the USB/CPU capacity of a Raspberry
 Pi. If running on a Raspberry Pi, Beaglebone, or similar host computer

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -439,7 +439,7 @@ get_uptime
 
 When the test completes, determine the difference between the clocks
 reported in the two "uptime" response messages. The total number of
-commands per second is then `100000 * mcu_frequency / clock_diff`.
+commands per second is then $\frac{100000 \times mcu\_frequency}{\Delta{f}_{clock}}$.
 
 Note that this test may saturate the USB/CPU capacity of a Raspberry
 Pi. If running on a Raspberry Pi, Beaglebone, or similar host computer

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -52,7 +52,8 @@ This chip is typically found in the "Arduino Mega" and is very common
 in 3d printer boards.
 
 To flash the bootloader itself use something like:
-```
+
+```bash
 wget 'https://github.com/arduino/Arduino/raw/1.8.5/hardware/arduino/avr/bootloaders/stk500v2/stk500boot_v2_mega2560.hex'
 
 avrdude -cavrispv2 -patmega2560 -P/dev/ttyACM0 -b115200 -e -u -U lock:w:0x3F:m -U efuse:w:0xFD:m -U hfuse:w:0xD8:m -U lfuse:w:0xFF:m
@@ -61,7 +62,8 @@ avrdude -cavrispv2 -patmega2560 -P/dev/ttyACM0 -b115200 -U lock:w:0x0F:m
 ```
 
 To flash an application use something like:
-```
+
+```bash
 avrdude -cwiring -patmega2560 -P/dev/ttyACM0 -b115200 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
@@ -71,7 +73,8 @@ This chip is typically found in earlier versions of the "Arduino
 Mega".
 
 To flash the bootloader itself use something like:
-```
+
+```bash
 wget 'https://github.com/arduino/Arduino/raw/1.8.5/hardware/arduino/avr/bootloaders/atmega/ATmegaBOOT_168_atmega1280.hex'
 
 avrdude -cavrispv2 -patmega1280 -P/dev/ttyACM0 -b115200 -e -u -U lock:w:0x3F:m -U efuse:w:0xF5:m -U hfuse:w:0xDA:m -U lfuse:w:0xFF:m
@@ -80,7 +83,8 @@ avrdude -cavrispv2 -patmega1280 -P/dev/ttyACM0 -b115200 -U lock:w:0x0F:m
 ```
 
 To flash an application use something like:
-```
+
+```bash
 avrdude -carduino -patmega1280 -P/dev/ttyACM0 -b57600 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
@@ -89,7 +93,8 @@ avrdude -carduino -patmega1280 -P/dev/ttyACM0 -b57600 -D -Uflash:w:out/klipper.e
 This chip is commonly found in "Melzi" style 3d printer boards.
 
 To flash the bootloader itself use something like:
-```
+
+```bash
 wget 'https://github.com/Lauszus/Sanguino/raw/1.0.2/bootloaders/optiboot/optiboot_atmega1284p.hex'
 
 avrdude -cavrispv2 -patmega1284p -P/dev/ttyACM0 -b115200 -e -u -U lock:w:0x3F:m -U efuse:w:0xFD:m -U hfuse:w:0xDE:m -U lfuse:w:0xFF:m
@@ -98,14 +103,16 @@ avrdude -cavrispv2 -patmega1284p -P/dev/ttyACM0 -b115200 -U lock:w:0x0F:m
 ```
 
 To flash an application use something like:
-```
+
+```bash
 avrdude -carduino -patmega1284p -P/dev/ttyACM0 -b115200 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
 Note that a number of "Melzi" style boards come preloaded with a
 bootloader that uses a baud rate of 57600. In this case, to flash an
 application use something like this instead:
-```
+
+```bash
 avrdude -carduino -patmega1284p -P/dev/ttyACM0 -b57600 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
@@ -120,7 +127,7 @@ It requires a custom flashing tool from
 [https://github.com/PaulStoffregen/teensy_loader_cli](https://github.com/PaulStoffregen/teensy_loader_cli).
 One can flash an application with it using something like:
 
-```
+```bash
 teensy_loader_cli --mcu=at90usb1286 out/klipper.elf.hex -v
 ```
 
@@ -129,7 +136,8 @@ teensy_loader_cli --mcu=at90usb1286 out/klipper.elf.hex -v
 The atmega168 has limited flash space. If using a bootloader, it is
 recommended to use the Optiboot bootloader. To flash that bootloader
 use something like:
-```
+
+```bash
 wget 'https://github.com/arduino/Arduino/raw/1.8.5/hardware/arduino/avr/bootloaders/optiboot/optiboot_atmega168.hex'
 
 avrdude -cavrispv2 -patmega168 -P/dev/ttyACM0 -b115200 -e -u -U lock:w:0x3F:m -U efuse:w:0x04:m -U hfuse:w:0xDD:m -U lfuse:w:0xFF:m
@@ -139,7 +147,8 @@ avrdude -cavrispv2 -patmega168 -P/dev/ttyACM0 -b115200 -U lock:w:0x0F:m
 
 To flash an application via the Optiboot bootloader use something
 like:
-```
+
+```bash
 avrdude -carduino -patmega168 -P/dev/ttyACM0 -b115200 -D -Uflash:w:out/klipper.elf.hex:i
 ```
 
@@ -161,7 +170,8 @@ can be used to program the SAM3. It is recommended to use version 1.9
 or later.
 
 To flash an application use something like:
-```
+
+```bash
 bossac -U -p /dev/ttyACM0 -a -e -w out/klipper.bin -v -b
 bossac -U -p /dev/ttyACM0 -R
 ```
@@ -181,7 +191,8 @@ can be used to program the SAM4. It is necessary to use version
 `1.8.0` or higher.
 
 To flash an application use something like:
-```
+
+```bash
 bossac --port=/dev/ttyACM0 -b -U -e -w -v -R out/klipper.bin
 ```
 
@@ -193,15 +204,20 @@ Alternatively, one can use a
 [Raspberry Pi with OpenOCD](#running-openocd-on-the-raspberry-pi).
 
 To flash a bootloader with OpenOCD use the following chip config:
-```
+
+```gdb
 source [find target/at91samdXX.cfg]
 ```
+
 Obtain a bootloader - for example:
-```
+
+```bash
 wget 'https://github.com/arduino/ArduinoCore-samd/raw/1.8.3/bootloaders/zero/samd21_sam_ba.bin'
 ```
+
 Flash with OpenOCD commands similar to:
-```
+
+```gdb
 at91samd bootloader 0
 program samd21_sam_ba.bin verify
 ```
@@ -211,7 +227,8 @@ The most common bootloader on the SAMD21 is the one found on the
 compiled with a start address of 8KiB). One can enter this bootloader
 by double clicking the reset button. To flash an application use
 something like:
-```
+
+```bash
 bossac -U -p /dev/ttyACM0 --offset=0x2000 -w out/klipper.bin -v -b -R
 ```
 
@@ -219,7 +236,8 @@ In contrast, the "Arduino M0" uses a 16KiB bootloader (the application
 must be compiled with a start address of 16KiB). To flash an
 application on this bootloader, reset the micro-controller and run the
 flash command within the first few seconds of boot - something like:
-```
+
+```bash
 avrdude -c stk500v2 -p atmega2560 -P /dev/ttyACM0 -u -Uflash:w:out/klipper.elf.hex:i
 ```
 
@@ -229,16 +247,21 @@ Like the SAMD21, the SAMD51 bootloader is flashed via the ARM Serial
 Wire Debug (SWD) interface. To flash a bootloader with
 [OpenOCD on a Raspberry Pi](#running-openocd-on-the-raspberry-pi) use
 the following chip config:
-```
+
+```gdb
 source [find target/atsame5x.cfg]
 ```
+
 Obtain a bootloader - several bootloaders are available from
 [https://github.com/adafruit/uf2-samdx1/releases/latest](https://github.com/adafruit/uf2-samdx1/releases/latest). For example:
-```
+
+```bash
 wget 'https://github.com/adafruit/uf2-samdx1/releases/download/v3.7.0/bootloader-itsybitsy_m4-v3.7.0.bin'
 ```
+
 Flash with OpenOCD commands similar to:
-```
+
+```gdb
 at91samd bootloader 0
 program bootloader-itsybitsy_m4-v3.7.0.bin verify
 at91samd bootloader 16384
@@ -247,7 +270,8 @@ at91samd bootloader 16384
 The SAMD51 uses a 16KiB bootloader (the application must be compiled
 with a start address of 16KiB). To flash an application use something
 like:
-```
+
+```bash
 bossac -U -p /dev/ttyACM0 --offset=0x4000 -w out/klipper.bin -v -b -R
 ```
 
@@ -258,7 +282,8 @@ application via 3.3V serial. To access this ROM, one should connect
 the "boot 0" pin to high and "boot 1" pin to low, and then reset the
 device. The "stm32flash" package can then be used to flash the device
 using something like:
-```
+
+```bash
 stm32flash -w out/klipper.bin -v -g 0 /dev/ttyAMA0
 ```
 
@@ -277,7 +302,8 @@ The "stm32duino" project has a USB capable bootloader - see:
 [https://github.com/rogerclarkmelbourne/STM32duino-bootloader](https://github.com/rogerclarkmelbourne/STM32duino-bootloader)
 
 This bootloader can be flashed via 3.3V serial with something like:
-```
+
+```bash
 wget 'https://github.com/rogerclarkmelbourne/STM32duino-bootloader/raw/master/binaries/generic_boot20_pc13.bin'
 
 stm32flash -w generic_boot20_pc13.bin -v -g 0 /dev/ttyAMA0
@@ -286,7 +312,8 @@ stm32flash -w generic_boot20_pc13.bin -v -g 0 /dev/ttyAMA0
 This bootloader uses 8KiB of flash space (the application must be
 compiled with a start address of 8KiB). Flash an application with
 something like:
-```
+
+```bash
 dfu-util -d 1eaf:0003 -a 2 -R -D out/klipper.bin
 ```
 
@@ -315,19 +342,24 @@ don't have access to a STLink it is also possible to use a
 [Raspberry Pi and OpenOCD](#running-openocd-on-the-raspberry-pi) with
 the following chip config:
 
-```
+```gdb
 source [find target/stm32f1x.cfg]
 ```
+
 If you wish you can make a backup of the current flash with the following
 command.  Note that it may take some time to complete:
-```
+
+```gdb
 flash read_bank 0 btt_skr_mini_e3_backup.bin
 ```
+
 finally, you can flash with commands similar to:
-```
+
+```gdb
 stm32f1x mass_erase 0
 program hid_btt_skr_mini_e3.bin verify 0x08000000
 ```
+
 NOTES:
 - The example above erases the chip then programs the bootloader.  Regardless
   of the method chosen to flash it is recommended to erase the chip prior to
@@ -336,7 +368,8 @@ NOTES:
   that you will no longer be able to update firmware via the sdcard.
 - You may need to hold down the reset button on the board while launching
   OpenOCD.  It should display something like:
-  ```
+
+  ```gdb
   Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
   Licensed under GNU GPL v2
   For bug reports, read
@@ -351,30 +384,34 @@ NOTES:
   Info : starting gdb server for stm32f1x.cpu on 3333
   Info : Listening on port 3333 for gdb connections
   ```
-  After which you can release the reset button.
 
+  After which you can release the reset button.
 
 This bootloader requires 2KiB of flash space (the application
 must be compiled with a start address of 2KiB).
 
 The hid-flash program is used to upload a binary to the bootloader. You
 can install this software with the following commands:
-```
+
+```bash
 sudo apt install libusb-1.0
 cd ~/klipper/lib/hidflash
 make
 ```
 
 If the bootloader is running you can flash with something like:
-```
+
+```bash
 ~/klipper/lib/hidflash/hid-flash ~/klipper/out/klipper.bin
 ```
 alternatively, you can use `make flash` to flash klipper directly:
-```
+
+```bash
 make flash FLASH_DEVICE=1209:BEBA
 ```
 OR if klipper has been previously flashed:
-```
+
+```bash
 make flash FLASH_DEVICE=/dev/ttyACM0
 ```
 
@@ -401,7 +438,8 @@ Unless your board is DFU capable the most accessable flashing method
 is likely via 3.3v serial, which follows the same procedure as
 [flashing the STM32F103 using stm32flash](#stm32f103-micro-controllers-blue-pill-devices).
 For example:
-```
+
+```bash
 wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.5-beta/hid_bootloader_SKR_PRO.bin
 
 stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
@@ -447,7 +485,7 @@ derived from the instructions at:
 Begin by downloading and compiling the software (each step may take
 several minutes and the "make" step may take 30+ minutes):
 
-```
+```bash
 sudo apt-get update
 sudo apt-get install autoconf libtool telnet
 mkdir ~/openocd
@@ -464,13 +502,13 @@ make install
 
 Create an OpenOCD config file:
 
-```
+```bash
 nano ~/openocd/openocd.cfg
 ```
 
 Use a config similar to the following:
 
-```
+```gdb
 # Uses RPi pins: GPIO25 for SWDCLK, GPIO24 for SWDIO, GPIO18 for nRST
 source [find interface/raspberrypi2-native.cfg]
 bcm2835gpio_swd_nums 25 24
@@ -509,7 +547,7 @@ Then power up the Raspberry Pi and provide power to the target chip.
 
 Run OpenOCD:
 
-```
+```bash
 cd ~/openocd/
 sudo ~/openocd/install/bin/openocd -f ~/openocd/openocd.cfg
 ```
@@ -522,7 +560,7 @@ double check the wiring.
 Once OpenOCD is running and is stable, one can send it commands via
 telnet. Open another ssh session and run the following:
 
-```
+```bash
 telnet 127.0.0.1 4444
 ```
 
@@ -536,7 +574,7 @@ commands assume one is running gdb on a desktop class machine.
 
 Add the following to the OpenOCD config file:
 
-```
+```cfg
 bindto 0.0.0.0
 gdb_port 44444
 ```
@@ -544,14 +582,14 @@ gdb_port 44444
 Restart OpenOCD on the Raspberry Pi and then run the following Unix
 command on the desktop machine:
 
-```
+```bash
 cd /path/to/klipper/
 gdb out/klipper.elf
 ```
 
 Within gdb run:
 
-```
+```gdb
 target remote octopi:44444
 ```
 

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -369,21 +369,21 @@ NOTES:
 - You may need to hold down the reset button on the board while launching
   OpenOCD. It should display something like:
 
-  ```gdb
-  Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
-  Licensed under GNU GPL v2
-  For bug reports, read
-          http://openocd.org/doc/doxygen/bugs.html
-  DEPRECATED! use 'adapter speed' not 'adapter_khz'
-  Info : BCM2835 GPIO JTAG/SWD bitbang driver
-  Info : JTAG and SWD modes enabled
-  Info : clock speed 40 kHz
-  Info : SWD DPIDR 0x1ba01477
-  Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
-  Info : stm32f1x.cpu: external reset detected
-  Info : starting gdb server for stm32f1x.cpu on 3333
-  Info : Listening on port 3333 for gdb connections
-  ```
+    ```gdb
+      Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
+      Licensed under GNU GPL v2
+      For bug reports, read
+              http://openocd.org/doc/doxygen/bugs.html
+      DEPRECATED! use 'adapter speed' not 'adapter_khz'
+      Info : BCM2835 GPIO JTAG/SWD bitbang driver
+      Info : JTAG and SWD modes enabled
+      Info : clock speed 40 kHz
+      Info : SWD DPIDR 0x1ba01477
+      Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
+      Info : stm32f1x.cpu: external reset detected
+      Info : starting gdb server for stm32f1x.cpu on 3333
+      Info : Listening on port 3333 for gdb connections
+    ```
 
   After which you can release the reset button.
 

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -27,7 +27,6 @@ developers have accumulated.
 
 ## AVR micro-controllers
 
-
 In general, the Arduino project is a good reference for bootloaders
 and flashing procedures on the 8-bit Atmel Atmega micro-controllers.
 In particular, the "boards.txt" file:
@@ -361,7 +360,8 @@ program hid_btt_skr_mini_e3.bin verify 0x08000000
 ```
 
 NOTES:
-- The example above erases the chip then programs the bootloader.  Regardless
+
+- The example above erases the chip then programs the bootloader. Regardless
   of the method chosen to flash it is recommended to erase the chip prior to
   flashing.
 - Prior flashing the SKR Mini E3 with this bootloader you should be aware

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -21,7 +21,7 @@ bootloader to flash an application where possible.
 
 This document attempts to describe common bootloaders, the steps
 needed to flash a bootloader, and the steps needed to flash an
-application.  This document is not an authoritative reference; it is
+application. This document is not an authoritative reference; it is
 intended as a collection of useful information that the Klipper
 developers have accumulated.
 
@@ -336,8 +336,8 @@ section above, substituting the file name for the desired hid bootloader binary
 (ie: hid_generic_pc13.bin for the blue pill).
 
 It is not possible to use stm32flash for the SKR Mini E3 as the boot0 pin is
-tied directly to ground and not broken out via header pins.  It is recommended
-to use a STLink V2 with STM32Cubeprogrammer to flash the bootloader.   If you
+tied directly to ground and not broken out via header pins. It is recommended
+to use a STLink V2 with STM32Cubeprogrammer to flash the bootloader.  If you
 don't have access to a STLink it is also possible to use a
 [Raspberry Pi and OpenOCD](#running-openocd-on-the-raspberry-pi) with
 the following chip config:
@@ -347,7 +347,7 @@ source [find target/stm32f1x.cfg]
 ```
 
 If you wish you can make a backup of the current flash with the following
-command.  Note that it may take some time to complete:
+command. Note that it may take some time to complete:
 
 ```gdb
 flash read_bank 0 btt_skr_mini_e3_backup.bin
@@ -367,7 +367,7 @@ NOTES:
 - Prior flashing the SKR Mini E3 with this bootloader you should be aware
   that you will no longer be able to update firmware via the sdcard.
 - You may need to hold down the reset button on the board while launching
-  OpenOCD.  It should display something like:
+  OpenOCD. It should display something like:
 
   ```gdb
   Open On-Chip Debugger 0.10.0+dev-01204-gc60252ac-dirty (2020-04-27-16:00)
@@ -404,21 +404,23 @@ If the bootloader is running you can flash with something like:
 ```bash
 ~/klipper/lib/hidflash/hid-flash ~/klipper/out/klipper.bin
 ```
-alternatively, you can use `make flash` to flash klipper directly:
+
+alternatively, you can use `make flash` to flash Klipper directly:
 
 ```bash
 make flash FLASH_DEVICE=1209:BEBA
 ```
-OR if klipper has been previously flashed:
+
+OR if Klipper has been previously flashed:
 
 ```bash
 make flash FLASH_DEVICE=/dev/ttyACM0
 ```
 
 It may be necessary to manually enter the bootloader, this can be done by
-setting "boot 0" low and "boot 1" high.  On the SKR Mini E3 "Boot 1" is
+setting "boot 0" low and "boot 1" high. On the SKR Mini E3 "Boot 1" is
 not available, so it may be done by setting pin PA2 low if you flashed
-"hid_btt_skr_mini_e3.bin".  This pin is labeld "TX0" on the TFT header in
+"hid_btt_skr_mini_e3.bin". This pin is labeld "TX0" on the TFT header in
 the SKR Mini E3's "PIN" document. There is a ground pin next to PA2
 which you can use to pull PA2 low.
 
@@ -426,9 +428,9 @@ which you can use to pull PA2 low.
 
 STM32F4 microcontrollers come equipped with a built-in system bootloader
 capable of flashing over USB (via DFU), 3.3v Serial, and various other
-methods (see STM Document AN2606 for more information).  Some
+methods (see STM Document AN2606 for more information). Some
 STM32F4 boards, such as the SKR Pro 1.1, are not able to enter the DFU
-bootloader.  The HID bootloader is available for STM32F405/407
+bootloader. The HID bootloader is available for STM32F405/407
 based boards should the user prefer flashing over USB over using the sdcard.
 Note that you may need to configure and build a version specific to your
 board, a [build for the SKR Pro 1.1 is available here](
@@ -445,7 +447,7 @@ wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.5-beta
 stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
 ```
 
-This bootloader requires 16Kib of flash space on the STM32F4 (the application
+This bootloader requires 16KiB of flash space on the STM32F4 (the application
 must be compiled with a start address of 16KiB).
 
 As with the STM32F1, the STM32F4 uses the hid-flash tool to upload binaries to
@@ -453,7 +455,7 @@ the MCU. See the instructions above for details on how to build and use
 hid-flash.
 
 It may be necessary to manually enter the bootloader, this can be done by
-setting "boot 0" low, "boot 1" high and plugging in the device.  After
+setting "boot 0" low, "boot 1" high and plugging in the device. After
 programming is complete unplug the device and set "boot 1" back to low
 so the application will be loaded.
 

--- a/docs/CANBUS.md
+++ b/docs/CANBUS.md
@@ -32,7 +32,8 @@ There are currently two common options:
 It is also necessary to configure the host operating system to use the
 adapter. This is typically done by creating a new file named
 `/etc/network/interfaces.d/can0` with the following contents:
-```
+
+```nginx
 auto can0
 iface can0 can static
     bitrate 500000
@@ -66,13 +67,15 @@ Each micro-controller on the CAN bus is assigned a unique id based on
 the factory chip identifier encoded into each micro-controller. To
 find each micro-controller device id, make sure the hardware is
 powered and wired correctly, and then run:
-```
+
+```bash
 ~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0
 ```
 
 If uninitialized CAN devices are detected the above command will
 report lines like the following:
-```
+
+```text
 Found canbus_uuid=11aa22bb33cc
 ```
 
@@ -87,7 +90,8 @@ will no longer appear in the list.
 
 Update the Klipper [mcu configuration](Config_Reference.md#mcu) to use
 the CAN bus to communicate with the device - for example:
-```
+
+```cfg
 [mcu my_can_mcu]
 canbus_uuid: 11aa22bb33cc
 ```

--- a/docs/CANBUS_protocol.md
+++ b/docs/CANBUS_protocol.md
@@ -12,9 +12,9 @@ limited to 8 data bytes and an 11-bit CAN bus identifier. In order to
 support efficient communication, each micro-controller is assigned at
 run-time a unique 1-byte CAN bus nodeid (`canbus_nodeid`) for general
 Klipper command and response traffic. Klipper command messages going
-from host to micro-controller use the CAN bus id of `canbus_nodeid *
-2 + 256`, while Klipper response messages from micro-controller to
-host use `canbus_nodeid * 2 + 256 + 1`.
+from host to micro-controller use the CAN bus id of $canbus\_nodeid \times
+2 + 256$, while Klipper response messages from micro-controller to
+host use $canbus\_nodeid \times 2 + 256 + 1$.
 
 Each micro-controller has a factory assigned unique chip identifier
 that is used during id assignment. This identifier can exceed the
@@ -57,7 +57,7 @@ A micro-controller that has been assigned a nodeid via the
 `CMD_SET_NODEID` command can send and receive data packets.
 
 The packet data in messages using the node's receive CAN bus id
-(`canbus_nodeid * 2 + 256`) are simply appended to a buffer, and when
+($canbus\_nodeid \times 2 + 256$) are simply appended to a buffer, and when
 a complete [mcu protocol message](Protocol.md) is found its contents
 are parsed and processed. The data is treated as a byte stream - there
 is no requirement for the start of a Klipper message block to align
@@ -65,5 +65,5 @@ with the start of a CAN bus packet.
 
 Similarly, mcu protocol message responses are sent from
 micro-controller to host by copying the message data into one or more
-packets with the node's transmit CAN bus id (`canbus_nodeid * 2 +
-256 + 1`).
+packets with the node's transmit CAN bus id ($canbus\_nodeid \times 2 +
+256 + 1$).

--- a/docs/CANBUS_protocol.md
+++ b/docs/CANBUS_protocol.md
@@ -54,7 +54,7 @@ The RESP_NEED_NODEID message format is:
 ## Data Packets
 
 A micro-controller that has been assigned a nodeid via the
-CMD_SET_NODEID command can send and receive data packets.
+`CMD_SET_NODEID` command can send and receive data packets.
 
 The packet data in messages using the node's receive CAN bus id
 (`canbus_nodeid * 2 + 256`) are simply appended to a buffer, and when

--- a/docs/CANBUS_protocol.md
+++ b/docs/CANBUS_protocol.md
@@ -12,9 +12,9 @@ limited to 8 data bytes and an 11-bit CAN bus identifier. In order to
 support efficient communication, each micro-controller is assigned at
 run-time a unique 1-byte CAN bus nodeid (`canbus_nodeid`) for general
 Klipper command and response traffic. Klipper command messages going
-from host to micro-controller use the CAN bus id of $canbus\_nodeid \times
-2 + 256$, while Klipper response messages from micro-controller to
-host use $canbus\_nodeid \times 2 + 256 + 1$.
+from host to micro-controller use the CAN bus id of `canbus_nodeid *
+2 + 256`, while Klipper response messages from micro-controller to
+host use `canbus_nodeid * 2 + 256 + 1`.
 
 Each micro-controller has a factory assigned unique chip identifier
 that is used during id assignment. This identifier can exceed the
@@ -57,7 +57,7 @@ A micro-controller that has been assigned a nodeid via the
 `CMD_SET_NODEID` command can send and receive data packets.
 
 The packet data in messages using the node's receive CAN bus id
-($canbus\_nodeid \times 2 + 256$) are simply appended to a buffer, and when
+(`canbus_nodeid * 2 + 256`) are simply appended to a buffer, and when
 a complete [mcu protocol message](Protocol.md) is found its contents
 are parsed and processed. The data is treated as a byte stream - there
 is no requirement for the start of a Klipper message block to align
@@ -65,5 +65,5 @@ with the start of a CAN bus packet.
 
 Similarly, mcu protocol message responses are sent from
 micro-controller to host by copying the message data into one or more
-packets with the node's transmit CAN bus id ($canbus\_nodeid \times 2 +
-256 + 1$).
+packets with the node's transmit CAN bus id (`canbus_nodeid * 2 +
+256 + 1`).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributions of Code and documentation are managed through github
 pull requests.  Each commit should have a commit message formatted
 similar to the following:
 
-```
+```text
 module: Capitalized, short (50 chars or less) summary
 
 More detailed explanatory text, if necessary.  Wrap it to about 75

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,16 +10,16 @@ an issue.
 
 ## Submitting a pull request
 
-Contributions of Code and documentation are managed through github
-pull requests.  Each commit should have a commit message formatted
+Contributions of Code and documentation are managed through GitHub
+pull requests. Each commit should have a commit message formatted
 similar to the following:
 
 ```text
 module: Capitalized, short (50 chars or less) summary
 
-More detailed explanatory text, if necessary.  Wrap it to about 75
-characters or so.  In some contexts, the first line is treated as the
-subject of an email and the rest of the text as the body.  The blank
+More detailed explanatory text, if necessary. Wrap it to about 75
+characters or so. In some contexts, the first line is treated as the
+subject of an email and the rest of the text as the body. The blank
 line separating the summary from the body is critical (unless you omit
 the body entirely); tools like rebase can get confused if you run the
 two together.

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -410,7 +410,7 @@ some other coordinate system and Klipper has several tools to
 facilitate that. This can be seen by running the GET_POSITION
 command. For example:
 
-```
+```text
 Send: GET_POSITION
 Recv: // mcu: stepper_a:-2060 stepper_b:-1169 stepper_c:-1613
 Recv: // stepper: stepper_a:457.254159 stepper_b:466.085669 stepper_c:465.382132

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -203,7 +203,7 @@ provides further information on the mechanics of moves.
   prioritized, and sent to the micro-controller (via
   **stepcompress.c**:`steppersync` and **serialqueue.c**:`serialqueue`).
 
-* Processing of the queue_step commands on the micro-controller starts
+- Processing of the queue_step commands on the micro-controller starts
   in **src/command.c** which parses the command and calls
   `command_queue_step()`. The `command_queue_step()` code (in
   **src/stepper.c**) just appends the parameters of each queue_step

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -12,10 +12,10 @@ directories contain architecture specific micro-controller code. The
 **src/simulator/** contains code stubs that allow the micro-controller
 to be test compiled on other architectures. The **src/generic/**
 directory contains helper code that may be useful across different
-architectures. The build arranges for includes of "board/somefile.h"
+architectures. The build arranges for includes of **board/somefile.h**
 to first look in the current architecture directory (eg,
-src/avr/somefile.h) and then in the generic directory (eg,
-src/generic/somefile.h).
+**src/avr/somefile.h**) and then in the generic directory (eg,
+**src/generic/somefile.h**).
 
 The **klippy/** directory contains the host software. Most of the host
 software is written in Python, however the **klippy/chelper/**
@@ -124,14 +124,13 @@ provides further information on the mechanics of moves.
 
 - Processing for a move command starts in gcode.py. The goal of
   gcode.py is to translate G-code into internal calls. A G1 command
-  will invoke cmd_G1() in klippy/extras/gcode_move.py. The
-  gcode_move.py code handles changes in origin (eg, G92), changes in
+  will invoke cmd_G1() in **klippy/extras/gcode_move.py**. The
+  **gcode_move.py code** handles changes in origin (eg, G92), changes in
   relative vs absolute positions (eg, G90), and unit changes (eg,
   F6000=100mm/s). The code path for a move is: `_process_data() ->
   _process_commands() -> cmd_G1()`. Ultimately the ToolHead class is
   invoked to execute the actual request: `cmd_G1() -> ToolHead.move()`
 
-* The ToolHead class (in toolhead.py) handles "look-ahead" and tracks
 - The ToolHead class (in toolhead.py) handles "look-ahead" and tracks
   the timing of printing actions. The main codepath for a move is:
   `ToolHead.move() -> MoveQueue.add_move() -> MoveQueue.flush() ->
@@ -140,7 +139,7 @@ provides further information on the mechanics of moves.
   move (in cartesian space and in units of seconds and millimeters).
   - The kinematics class is given the opportunity to audit each move
   (`ToolHead.move() -> kin.check_move()`). The kinematics classes are
-  located in the klippy/kinematics/ directory. The `check_move()` code
+  located in the **klippy/kinematics/** directory. The `check_move()` code
   may raise an error if the move is not valid. If `check_move()`
   completes successfully then the underlying kinematics must be able
   to handle the move.
@@ -166,19 +165,19 @@ provides further information on the mechanics of moves.
   to generate the step times for each stepper. For efficiency reasons,
   the stepper pulse times are generated in C code. The moves are first
   placed on a "trapezoid motion queue": `ToolHead._process_moves() ->
-  trapq_append()` (in klippy/chelper/trapq.c). The step times are then
+  trapq_append()` (in **klippy/chelper/trapq.c**). The step times are then
   generated: `ToolHead._process_moves() ->
   ToolHead._update_move_time() -> MCU_Stepper.generate_steps() ->
   itersolve_generate_steps() -> itersolve_gen_steps_range()` (in
-  klippy/chelper/itersolve.c). The goal of the iterative solver is to
+  **klippy/chelper/itersolve.c**). The goal of the iterative solver is to
   find step times given a function that calculates a stepper position
   from a time. This is done by repeatedly "guessing" various times
   until the stepper position formula returns the desired position of
   the next step on the stepper. The feedback produced from each guess
   is used to improve future guesses so that the process rapidly
   converges to the desired time. The kinematic stepper position
-  formulas are located in the klippy/chelper/ directory (eg,
-  kin_cart.c, kin_corexy.c, kin_delta.c, kin_extruder.c).
+  formulas are located in the **klippy/chelper/** directory (eg,
+  **kin_cart.c**, **kin_corexy.c**, **kin_delta.c**, **kin_extruder.c**).
 
 - Note that the extruder is handled in its own kinematic class:
   `ToolHead._process_moves() -> PrinterExtruder.move()`. Since
@@ -189,7 +188,7 @@ provides further information on the mechanics of moves.
 
 - After the iterative solver calculates the step times they are added
   to an array: `itersolve_gen_steps_range() -> stepcompress_append()`
-  (in klippy/chelper/stepcompress.c). The array (`struct
+  (in **klippy/chelper/stepcompress.c**). The array (`struct
   stepcompress.queue`) stores the corresponding micro-controller clock
   counter times for every step. Here the "micro-controller clock
   counter" value directly corresponds to the micro-controller's
@@ -197,17 +196,17 @@ provides further information on the mechanics of moves.
   last powered up.
 
 - The next major step is to compress the steps: `stepcompress_flush()
-  -> compress_bisect_add()` (in klippy/chelper/stepcompress.c). This
+  -> compress_bisect_add()` (in **klippy/chelper/stepcompress.c**). This
   code generates and encodes a series of micro-controller "queue_step"
   commands that correspond to the list of stepper step times built in
   the previous stage. These "queue_step" commands are then queued,
   prioritized, and sent to the micro-controller (via
-  stepcompress.c:`steppersync` and serialqueue.c:`serialqueue`).
+  **stepcompress.c**:`steppersync` and **serialqueue.c**:`serialqueue`).
 
-- Processing of the queue_step commands on the micro-controller starts
-  in src/command.c which parses the command and calls
-  src/stepper.c) just appends the parameters of each queue_step
+* Processing of the queue_step commands on the micro-controller starts
+  in **src/command.c** which parses the command and calls
   `command_queue_step()`. The `command_queue_step()` code (in
+  **src/stepper.c**) just appends the parameters of each queue_step
   command to a per stepper queue. Under normal operation the
   queue_step command is parsed and queued at least 100ms before the
   time of its first step. Finally, the generation of stepper events is
@@ -231,7 +230,7 @@ mostly just communication and plumbing.
 The Klippy host code has a dynamic module loading capability. If a
 config section named "[my_module]" is found in the printer config file
 then the software will automatically attempt to load the python module
-klippy/extras/my_module.py . This module system is the preferred
+**klippy/extras/my_module.py** . This module system is the preferred
 method for adding new functionality to Klipper.
 
 The easiest way to add a new module is to use an existing module as a
@@ -324,8 +323,8 @@ Useful steps:
    in cartesian coordinates to the movement on each stepper. One
    should be able to copy one of these files as a starting point.
 3. Implement the C stepper kinematic position functions for each
-   stepper if they are not already available (see kin_cart.c,
-   kin_corexy.c, and kin_delta.c in klippy/chelper/). The function
+   stepper if they are not already available (see **kin_cart.c**,
+   **kin_corexy.c**, and **kin_delta.c** in **klippy/chelper/**). The function
    should call `move_get_coord()` to convert a given move time (in
    seconds) to a cartesian coordinate (in millimeters), and then
    calculate the desired stepper position (in millimeters) from that
@@ -359,14 +358,14 @@ Useful steps:
    during the port. Common examples include "CMSIS" wrappers and
    manufacturer "HAL" libraries. All 3rd party code needs to be GNU
    GPLv3 compatible. The 3rd party code should be committed to the
-   Klipper lib/ directory. Update the lib/README file with information
+   Klipper **lib/** directory. Update the **lib/README** file with information
    on where and when the library was obtained. It is preferable to
    copy the code into the Klipper repository unchanged, but if any
    changes are required then those changes should be listed explicitly
-   in the lib/README file.
-2. Create a new architecture sub-directory in the src/ directory and
+   in the **lib/README** file.
+2. Create a new architecture sub-directory in the **src/** directory and
    add initial Kconfig and Makefile support. Use the existing
-   architectures as a guide. The src/simulator provides a basic
+   architectures as a guide. The **src/simulator** provides a basic
    example of a minimum starting point.
 3. The first main coding task is to bring up communication support to
    the target board. This is the most difficult step in a new port.
@@ -374,12 +373,12 @@ Useful steps:
    much easier. It is typical to use an RS-232 style serial port
    during initial development as these types of hardware devices are
    generally easier to enable and control. During this phase, make
-   liberal use of helper code from the src/generic/ directory (check
-   how src/simulator/Makefile includes the generic C code into the
-   build). It is also necessary to define timer_read_time() (which
+   liberal use of helper code from the **src/generic/** directory (check
+   how **src/simulator/Makefile** includes the generic C code into the
+   build). It is also necessary to define `timer_read_time()` (which
    returns the current system clock) in this phase, but it is not
    necessary to fully support timer irq handling.
-4. Get familiar with the the console.py tool (as described in the
+4. Get familiar with the the **console.py** tool (as described in the
    [Debugging document](Debugging.md)) and verify connectivity to the
    micro-controller with it. This tool translates the low-level
    micro-controller communication protocol to a human readable form.

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -314,6 +314,7 @@ kinematics. It also requires software development skills - though one
 should only need to update the host software.
 
 Useful steps:
+
 1. Start by studying the
    "[code flow of a move](#code-flow-of-a-move-command)" section and
    the [Kinematics document](Kinematics.md).
@@ -352,6 +353,7 @@ knowledge of embedded development and hands-on access to the target
 micro-controller.
 
 Useful steps:
+
 1. Start by identifying any 3rd party libraries that will be used
    during the port. Common examples include "CMSIS" wrappers and
    manufacturer "HAL" libraries. All 3rd party code needs to be GNU
@@ -491,6 +493,7 @@ the handling of time within Klipper is critical to correct operation.
 
 There are three types of times tracked internally in the Klipper host
 software:
+
 * System time. The system time uses the system's monotonic clock - it
   is a floating point number stored as seconds and it is (generally)
   relative to when the host computer was last started. System times
@@ -522,6 +525,7 @@ Conversion between the different time formats is primarily implemented
 in the **klippy/clocksync.py** code.
 
 Some things to be aware of when reviewing the code:
+
 * 32bit and 64bit clocks: To reduce bandwidth and to improve
   micro-controller efficiency, clocks on the micro-controller are
   tracked as 32bit integers. When comparing two clocks in the mcu

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -122,7 +122,7 @@ produced on the micro-controller. This section outlines the code flow
 of a typical move command. The [kinematics](Kinematics.md) document
 provides further information on the mechanics of moves.
 
-* Processing for a move command starts in gcode.py. The goal of
+- Processing for a move command starts in gcode.py. The goal of
   gcode.py is to translate G-code into internal calls. A G1 command
   will invoke cmd_G1() in klippy/extras/gcode_move.py. The
   gcode_move.py code handles changes in origin (eg, G92), changes in
@@ -132,35 +132,36 @@ provides further information on the mechanics of moves.
   invoked to execute the actual request: `cmd_G1() -> ToolHead.move()`
 
 * The ToolHead class (in toolhead.py) handles "look-ahead" and tracks
+- The ToolHead class (in toolhead.py) handles "look-ahead" and tracks
   the timing of printing actions. The main codepath for a move is:
   `ToolHead.move() -> MoveQueue.add_move() -> MoveQueue.flush() ->
   Move.set_junction() -> ToolHead._process_moves()`.
-  * `ToolHead.move()` creates a `Move()` object with the parameters of the
+  - `ToolHead.move()` creates a `Move()` object with the parameters of the
   move (in cartesian space and in units of seconds and millimeters).
-  * The kinematics class is given the opportunity to audit each move
+  - The kinematics class is given the opportunity to audit each move
   (`ToolHead.move() -> kin.check_move()`). The kinematics classes are
   located in the klippy/kinematics/ directory. The `check_move()` code
   may raise an error if the move is not valid. If `check_move()`
   completes successfully then the underlying kinematics must be able
   to handle the move.
-  * `MoveQueue.add_move()` places the move object on the "look-ahead"
+  - `MoveQueue.add_move()` places the move object on the "look-ahead"
   queue.
-  * `MoveQueue.flush()` determines the start and end velocities of each
+  - `MoveQueue.flush()` determines the start and end velocities of each
   move.
-  * `Move.set_junction()` implements the "trapezoid generator" on a
+  - `Move.set_junction()` implements the "trapezoid generator" on a
   move. The "trapezoid generator" breaks every move into three parts:
   a constant acceleration phase, followed by a constant velocity
   phase, followed by a constant deceleration phase. Every move
   contains these three phases in this order, but some phases may be of
   zero duration.
-  * When `ToolHead._process_moves()` is called, everything about the
+  - When `ToolHead._process_moves()` is called, everything about the
   move is known - its start location, its end location, its
   acceleration, its start/cruising/end velocity, and distance traveled
   during acceleration/cruising/deceleration. All the information is
   stored in the `Move()` class and is in cartesian space in units of
   millimeters and seconds.
 
-* Klipper uses an
+- Klipper uses an
   [iterative solver](https://en.wikipedia.org/wiki/Root-finding_algorithm)
   to generate the step times for each stepper. For efficiency reasons,
   the stepper pulse times are generated in C code. The moves are first
@@ -179,14 +180,14 @@ provides further information on the mechanics of moves.
   formulas are located in the klippy/chelper/ directory (eg,
   kin_cart.c, kin_corexy.c, kin_delta.c, kin_extruder.c).
 
-* Note that the extruder is handled in its own kinematic class:
+- Note that the extruder is handled in its own kinematic class:
   `ToolHead._process_moves() -> PrinterExtruder.move()`. Since
   the `Move()` class specifies the exact movement time and since step
   pulses are sent to the micro-controller with specific timing,
   stepper movements produced by the extruder class will be in sync
   with head movement even though the code is kept separate.
 
-* After the iterative solver calculates the step times they are added
+- After the iterative solver calculates the step times they are added
   to an array: `itersolve_gen_steps_range() -> stepcompress_append()`
   (in klippy/chelper/stepcompress.c). The array (`struct
   stepcompress.queue`) stores the corresponding micro-controller clock
@@ -195,7 +196,7 @@ provides further information on the mechanics of moves.
   hardware counter - it is relative to when the micro-controller was
   last powered up.
 
-* The next major step is to compress the steps: `stepcompress_flush()
+- The next major step is to compress the steps: `stepcompress_flush()
   -> compress_bisect_add()` (in klippy/chelper/stepcompress.c). This
   code generates and encodes a series of micro-controller "queue_step"
   commands that correspond to the list of stepper step times built in
@@ -203,7 +204,7 @@ provides further information on the mechanics of moves.
   prioritized, and sent to the micro-controller (via
   stepcompress.c:`steppersync` and serialqueue.c:`serialqueue`).
 
-* Processing of the queue_step commands on the micro-controller starts
+- Processing of the queue_step commands on the micro-controller starts
   in src/command.c which parses the command and calls
   src/stepper.c) just appends the parameters of each queue_step
   `command_queue_step()`. The `command_queue_step()` code (in
@@ -238,13 +239,13 @@ reference - see **klippy/extras/servo.py** as an example.
 
 The following may also be useful:
 
-* Execution of the module starts in the module level `load_config()`
+- Execution of the module starts in the module level `load_config()`
   function (for config sections of the form [my_module]) or in
   `load_config_prefix()` (for config sections of the form
   [my_module my_name]). This function is passed a "config" object and
   it must return a new "printer object" associated with the given
   config section.
-* During the process of instantiating a new printer object, the config
+- During the process of instantiating a new printer object, the config
   object can be used to read parameters from the given config
   section. This is done using `config.get()`, `config.getfloat()`,
   `config.getint()`, etc. methods. Be sure to read all values from the
@@ -252,7 +253,7 @@ The following may also be useful:
   specifies a config parameter that is not read during this phase then
   it will be assumed it is a typo in the config and an error will be
   raised.
-* Use the `config.get_printer()` method to obtain a reference to the
+- Use the `config.get_printer()` method to obtain a reference to the
   main "printer" class. This "printer" class stores references to all
   the "printer objects" that have been instantiated. Use the
   `printer.lookup_object()` method to find references to other printer
@@ -262,7 +263,7 @@ The following may also be useful:
   will have been instantiated. The "gcode" and "pins" modules will
   always be available, but for other modules it is a good idea to
   defer the lookup.
-* Register event handlers using the `printer.register_event_handler()`
+- Register event handlers using the `printer.register_event_handler()`
   method if the code needs to be called during "events" raised by
   other printer objects. Each event name is a string, and by
   convention it is the name of the main source module that raises the
@@ -270,38 +271,38 @@ The following may also be useful:
   "`klippy:connect`"). The parameters passed to each event handler are
   specific to the given event (as are exception handling and execution
   context). Two common startup events are:
-  * `klippy:connect` - This event is generated after all printer objects
+  - `klippy:connect` - This event is generated after all printer objects
     are instantiated. It is commonly used to lookup other printer
     objects, to verify config settings, and to perform an initial
     "handshake" with printer hardware.
-  * `klippy:ready` - This event is generated after all connect handlers
+  - `klippy:ready` - This event is generated after all connect handlers
     have completed successfully. It indicates the printer is
     transitioning to a state ready to handle normal operations. Do not
     raise an error in this callback.
-* If there is an error in the user's config, be sure to raise it
+- If there is an error in the user's config, be sure to raise it
   during the `load_config()` or "connect event" phases. Use either
   `raise config.error("my error")` or `raise printer.config_error("my
   error")` to report the error.
-* Use the "pins" module to configure a pin on a micro-controller. This
+- Use the "pins" module to configure a pin on a micro-controller. This
   is typically done with something similar to
   `printer.lookup_object("pins").setup_pin("pwm",
   config.get("my_pin"))`. The returned object can then be commanded at
   run-time.
-* If the module needs access to system timing or external file
+- If the module needs access to system timing or external file
   descriptors then use `printer.get_reactor()` to obtain access to the
   global "event reactor" class. This reactor class allows one to
   schedule timers, wait for input on file descriptors, and to "sleep"
   the host code.
-* Do not use global variables. All state should be stored in the
+- Do not use global variables. All state should be stored in the
   printer object returned from the `load_config()` function. This is
   important as otherwise the RESTART command may not perform as
   expected. Also, for similar reasons, if any external files (or
   sockets) are opened then be sure to register a "klippy:disconnect"
   event handler and close them from that callback.
-* Avoid accessing the internal member variables (or calling methods
+- Avoid accessing the internal member variables (or calling methods
   that start with an underscore) of other printer objects. Observing
   this convention makes it easier to manage future changes.
-* If submitting the module for inclusion in the main Klipper code, be
+- If submitting the module for inclusion in the main Klipper code, be
   sure to place a copyright notice at the top of the module. See the
   existing modules for the preferred format.
 
@@ -494,14 +495,14 @@ the handling of time within Klipper is critical to correct operation.
 There are three types of times tracked internally in the Klipper host
 software:
 
-* System time. The system time uses the system's monotonic clock - it
+- System time. The system time uses the system's monotonic clock - it
   is a floating point number stored as seconds and it is (generally)
   relative to when the host computer was last started. System times
   have limited use in the software - they are primarily used when
   interacting with the operating system. Within the host code, system
   times are frequently stored in variables named *eventtime* or
   *curtime*.
-* Print time. The print time is synchronized to the main
+- Print time. The print time is synchronized to the main
   micro-controller clock (the micro-controller defined in the "[mcu]"
   config section). It is a floating point number stored as seconds and
   is relative to when the main mcu was last restarted. It is possible
@@ -511,7 +512,7 @@ software:
   to calculate almost all physical actions (eg, head movement, heater
   changes, etc.). Within the host code, print times are generally
   stored in variables named *print_time* or *move_time*.
-* MCU clock. This is the hardware clock counter on each
+- MCU clock. This is the hardware clock counter on each
   micro-controller. It is stored as an integer and its update rate is
   relative to the frequency of the given micro-controller. The host
   software translates its internal times to clocks before transmission
@@ -526,7 +527,7 @@ in the **klippy/clocksync.py** code.
 
 Some things to be aware of when reviewing the code:
 
-* 32bit and 64bit clocks: To reduce bandwidth and to improve
+- 32bit and 64bit clocks: To reduce bandwidth and to improve
   micro-controller efficiency, clocks on the micro-controller are
   tracked as 32bit integers. When comparing two clocks in the mcu
   code, the `timer_is_before()` function must always be used to ensure
@@ -539,7 +540,7 @@ Some things to be aware of when reviewing the code:
   there is no ambiguity in this conversion, the
   **klippy/chelper/serialqueue.c** code will buffer messages until
   they are within 2^31 clock ticks of their target time.
-* Multiple micro-controllers: The host software supports using
+- Multiple micro-controllers: The host software supports using
   multiple micro-controllers on a single printer. In this case, the
   "MCU clock" of each micro-controller is tracked separately. The
   clocksync.py code handles clock drift between micro-controllers by

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -106,7 +106,7 @@ commands to be executed on the micro-controller (as declared via the
 DECL_COMMAND macro in the micro-controller code).
 
 There are four threads in the Klippy host code. The main thread
-handles incoming gcode commands. A second thread (which resides
+handles incoming G-Code commands. A second thread (which resides
 entirely in the **klippy/chelper/serialqueue.c** C code) handles
 low-level IO with the serial port. The third thread is used to process
 response messages from the micro-controller in the Python code (see
@@ -337,9 +337,9 @@ Useful steps:
    functions are typically used to provide kinematic specific checks.
    However, at the start of development one can use boiler-plate code
    here.
-6. Implement test cases. Create a g-code file with a series of moves
+6. Implement test cases. Create a G-Code file with a series of moves
    that can test important cases for the given kinematics. Follow the
-   [debugging documentation](Debugging.md) to convert this g-code file
+   [debugging documentation](Debugging.md) to convert this G-Code file
    to micro-controller commands. This is useful to exercise corner
    cases and to check for regressions.
 
@@ -461,20 +461,20 @@ stepper motor drivers).
 The "gcode" position is the last requested position from a `G1` (or
 `G0`) command in cartesian coordinates relative to the coordinate
 system specified in the config file. This may differ from the
-"toolhead" position if a g-code transformation (eg, bed_mesh,
+"toolhead" position if a G-Code transformation (eg, bed_mesh,
 bed_tilt, skew_correction) is in effect. This may differ from the
-actual coordinates specified in the last `G1` command if the g-code
+actual coordinates specified in the last `G1` command if the G-Code
 origin has been changed (eg, `G92`, `SET_GCODE_OFFSET`, `M221`). The
 `M114` command (`gcode_move.get_status()['gcode_position']`) will
-report the last g-code position relative to the current g-code
+report the last G-Code position relative to the current G-Code
 coordinate system.
 
-The "gcode base" is the location of the g-code origin in cartesian
+The "G-Code base" is the location of the G-Code origin in cartesian
 coordinates relative to the coordinate system specified in the config
 file. Commands such as `G92`, `SET_GCODE_OFFSET`, and `M221` alter
 this value.
 
-The "gcode homing" is the location to use for the g-code origin (in
+The "G-Code homing" is the location to use for the G-Code origin (in
 cartesian coordinates relative to the coordinate system specified in
 the config file) after a `G28` home command. The `SET_GCODE_OFFSET`
 command can alter this value.

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -135,29 +135,29 @@ provides further information on the mechanics of moves.
   the timing of printing actions. The main codepath for a move is:
   `ToolHead.move() -> MoveQueue.add_move() -> MoveQueue.flush() ->
   Move.set_junction() -> ToolHead._process_moves()`.
-  * ToolHead.move() creates a Move() object with the parameters of the
+  * `ToolHead.move()` creates a `Move()` object with the parameters of the
   move (in cartesian space and in units of seconds and millimeters).
   * The kinematics class is given the opportunity to audit each move
   (`ToolHead.move() -> kin.check_move()`). The kinematics classes are
-  located in the klippy/kinematics/ directory. The check_move() code
-  may raise an error if the move is not valid. If check_move()
+  located in the klippy/kinematics/ directory. The `check_move()` code
+  may raise an error if the move is not valid. If `check_move()`
   completes successfully then the underlying kinematics must be able
   to handle the move.
-  * MoveQueue.add_move() places the move object on the "look-ahead"
+  * `MoveQueue.add_move()` places the move object on the "look-ahead"
   queue.
-  * MoveQueue.flush() determines the start and end velocities of each
+  * `MoveQueue.flush()` determines the start and end velocities of each
   move.
-  * Move.set_junction() implements the "trapezoid generator" on a
+  * `Move.set_junction()` implements the "trapezoid generator" on a
   move. The "trapezoid generator" breaks every move into three parts:
   a constant acceleration phase, followed by a constant velocity
   phase, followed by a constant deceleration phase. Every move
   contains these three phases in this order, but some phases may be of
   zero duration.
-  * When ToolHead._process_moves() is called, everything about the
+  * When `ToolHead._process_moves()` is called, everything about the
   move is known - its start location, its end location, its
   acceleration, its start/cruising/end velocity, and distance traveled
   during acceleration/cruising/deceleration. All the information is
-  stored in the Move() class and is in cartesian space in units of
+  stored in the `Move()` class and is in cartesian space in units of
   millimeters and seconds.
 
 * Klipper uses an
@@ -181,15 +181,15 @@ provides further information on the mechanics of moves.
 
 * Note that the extruder is handled in its own kinematic class:
   `ToolHead._process_moves() -> PrinterExtruder.move()`. Since
-  the Move() class specifies the exact movement time and since step
+  the `Move()` class specifies the exact movement time and since step
   pulses are sent to the micro-controller with specific timing,
   stepper movements produced by the extruder class will be in sync
   with head movement even though the code is kept separate.
 
 * After the iterative solver calculates the step times they are added
   to an array: `itersolve_gen_steps_range() -> stepcompress_append()`
-  (in klippy/chelper/stepcompress.c). The array (struct
-  stepcompress.queue) stores the corresponding micro-controller clock
+  (in klippy/chelper/stepcompress.c). The array (`struct
+  stepcompress.queue`) stores the corresponding micro-controller clock
   counter times for every step. Here the "micro-controller clock
   counter" value directly corresponds to the micro-controller's
   hardware counter - it is relative to when the micro-controller was
@@ -201,21 +201,21 @@ provides further information on the mechanics of moves.
   commands that correspond to the list of stepper step times built in
   the previous stage. These "queue_step" commands are then queued,
   prioritized, and sent to the micro-controller (via
-  stepcompress.c:steppersync and serialqueue.c:serialqueue).
+  stepcompress.c:`steppersync` and serialqueue.c:`serialqueue`).
 
 * Processing of the queue_step commands on the micro-controller starts
   in src/command.c which parses the command and calls
-  `command_queue_step()`. The command_queue_step() code (in
   src/stepper.c) just appends the parameters of each queue_step
+  `command_queue_step()`. The `command_queue_step()` code (in
   command to a per stepper queue. Under normal operation the
   queue_step command is parsed and queued at least 100ms before the
   time of its first step. Finally, the generation of stepper events is
   done in `stepper_event()`. It's called from the hardware timer
   interrupt at the scheduled time of the first step. The
-  stepper_event() code generates a step pulse and then reschedules
+  `stepper_event()` code generates a step pulse and then reschedules
   itself to run at the time of the next step pulse for the given
   queue_step parameters. The parameters for each queue_step command
-  are "interval", "count", and "add". At a high-level, stepper_event()
+  are "interval", "count", and "add". At a high-level, `stepper_event()`
   runs the following, 'count' times: `do_step(); next_wake_time =
   last_wake_time + interval; interval += add;`
 
@@ -237,6 +237,7 @@ The easiest way to add a new module is to use an existing module as a
 reference - see **klippy/extras/servo.py** as an example.
 
 The following may also be useful:
+
 * Execution of the module starts in the module level `load_config()`
   function (for config sections of the form [my_module]) or in
   `load_config_prefix()` (for config sections of the form
@@ -266,14 +267,14 @@ The following may also be useful:
   other printer objects. Each event name is a string, and by
   convention it is the name of the main source module that raises the
   event along with a short name for the action that is occurring (eg,
-  "klippy:connect"). The parameters passed to each event handler are
+  "`klippy:connect`"). The parameters passed to each event handler are
   specific to the given event (as are exception handling and execution
   context). Two common startup events are:
-  * klippy:connect - This event is generated after all printer objects
+  * `klippy:connect` - This event is generated after all printer objects
     are instantiated. It is commonly used to lookup other printer
     objects, to verify config settings, and to perform an initial
     "handshake" with printer hardware.
-  * klippy:ready - This event is generated after all connect handlers
+  * `klippy:ready` - This event is generated after all connect handlers
     have completed successfully. It indicates the printer is
     transitioning to a state ready to handle normal operations. Do not
     raise an error in this callback.
@@ -376,7 +377,7 @@ Useful steps:
    returns the current system clock) in this phase, but it is not
    necessary to fully support timer irq handling.
 4. Get familiar with the the console.py tool (as described in the
-   [debugging document](Debugging.md)) and verify connectivity to the
+   [Debugging document](Debugging.md)) and verify connectivity to the
    micro-controller with it. This tool translates the low-level
    micro-controller communication protocol to a human readable form.
 5. Add support for timer dispatch from hardware interrupts. See

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -182,6 +182,7 @@ at the time that the macro is evaluated, which may be a significant
 amount of time before the generated G-Code commands are executed.
 
 Available "action" commands:
+
 - `action_respond_info(msg)`: Write the given `msg` to the
   /tmp/printer pseudo-terminal. Each line of `msg` will be sent with a
   "// " prefix.
@@ -289,12 +290,14 @@ then it is possible to customize the menu with
 [menu](Config_Reference.md#menu) config sections.
 
 The following read-only attributes are available in menu templates:
+
 * `menu.width` - element width (number of display columns)
 * `menu.ns` - element namespace
 * `menu.event` - name of the event that triggered the script
 * `menu.input` - input value, only available in input script context
 
 The following actions are available in menu templates:
+
 * `menu.back(force, update)`: will execute menu back command, optional
   boolean parameters `<force>` and `<update>`.
   * When `<force>` is set True then it will also stop editing. Default

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -291,22 +291,22 @@ then it is possible to customize the menu with
 
 The following read-only attributes are available in menu templates:
 
-* `menu.width` - element width (number of display columns)
-* `menu.ns` - element namespace
-* `menu.event` - name of the event that triggered the script
-* `menu.input` - input value, only available in input script context
+- `menu.width` - element width (number of display columns)
+- `menu.ns` - element namespace
+- `menu.event` - name of the event that triggered the script
+- `menu.input` - input value, only available in input script context
 
 The following actions are available in menu templates:
 
-* `menu.back(force, update)`: will execute menu back command, optional
+- `menu.back(force, update)`: will execute menu back command, optional
   boolean parameters `<force>` and `<update>`.
-  * When `<force>` is set True then it will also stop editing. Default
+  - When `<force>` is set True then it will also stop editing. Default
     value is False.
-  * When `<update>` is set False then parent container items are not
+  - When `<update>` is set False then parent container items are not
     updated. Default value is True.
-* `menu.exit(force)` - will execute menu exit command, optional
+- `menu.exit(force)` - will execute menu exit command, optional
   boolean parameter `<force>` default value False.
-  * When `<force>` is set True then it will also stop editing. Default
+  - When `<force>` is set True then it will also stop editing. Default
     value is False.
 
 ## Save Variables to disk

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -55,7 +55,7 @@ The standard mechanism to move the toolhead is via the `G1` command
 (the `G0` command is an alias for `G1` and it can be used
 interchangeably with it). However, this command relies on the "G-Code
 parsing state" setup by `M82`, `M83`, `G90`, `G91`, `G92`, and
-previous `G1` commands.  When creating a G-Code macro it is a good
+previous `G1` commands. When creating a G-Code macro it is a good
 idea to always explicitly set the G-Code parsing state prior to
 issuing a `G1` command. (Otherwise, there is a risk the `G1` command
 will make an undesirable request.)
@@ -179,7 +179,7 @@ There are some commands available that can alter the state of the
 printer. For example, `{ action_emergency_stop() }` would cause the
 printer to go into a shutdown state. Note that these actions are taken
 at the time that the macro is evaluated, which may be a significant
-amount of time before the generated g-code commands are executed.
+amount of time before the generated G-Code commands are executed.
 
 Available "action" commands:
 - `action_respond_info(msg)`: Write the given `msg` to the
@@ -193,7 +193,7 @@ Available "action" commands:
   state. The `msg` parameter is optional, it may be useful to describe
   the reason for the shutdown.
 - `action_call_remote_method(method_name)`: Calls a method registered
-  by a remote client.  If the method takes parameters they should
+  by a remote client. If the method takes parameters they should
   be provided via keyword arguments, ie:
   `action_call_remote_method("print_stuff", my_arg="hello_world")`
 
@@ -225,10 +225,10 @@ gcode:
 Be sure to take the timing of macro evaluation and command execution
 into account when using SET_GCODE_VARIABLE.
 
-## Delayed Gcodes
+## Delayed G-Codes
 
 The [delayed_gcode] configuration option can be used to execute a delayed
-gcode sequence:
+G-Code sequence:
 
 ```cfg
 [delayed_gcode clear_display]
@@ -246,13 +246,13 @@ gcode:
 ```
 
 When the `load_filament` macro above executes, it will display a
-"Load Complete!" message after the extrusion is finished.  The
-last line of gcode enables the "clear_display" delayed_gcode, set
+"Load Complete!" message after the extrusion is finished. The
+last line of G-Code enables the "clear_display" delayed_gcode, set
 to execute in 10 seconds.
 
 The `initial_duration` config option can be set to execute the
-delayed_gcode on printer startup.  The countdown begins when the
-printer enters the "ready" state.  For example, the below delayed_gcode
+delayed_gcode on printer startup. The countdown begins when the
+printer enters the "ready" state. For example, the below delayed_gcode
 will execute 5 seconds after the printer is ready, initializing
 the display with a "Welcome!" message:
 
@@ -263,7 +263,7 @@ gcode:
   M117 Welcome!
 ```
 
-Its possible for a delayed gcode to repeat by updating itself in
+Its possible for a delayed G-Code to repeat by updating itself in
 the gcode option:
 
 ```cfg
@@ -275,7 +275,7 @@ gcode:
 ```
 
 The above delayed_gcode will send "// Extruder Temp: [ex0_temp]" to
-Octoprint every 2 seconds.  This can be canceled with the following
+Octoprint every 2 seconds. This can be canceled with the following
 gcode:
 
 ```gcode
@@ -315,7 +315,7 @@ has been enabled, `SAVE_VARIABLE VARIABLE=<name> VALUE=<value>` can be
 used to save the variable to disk so that it can be used across
 restarts. All stored variables are loaded into the
 `printer.save_variables.variables` dict at startup and can be used in
-gcode macros. to avoid overly long lines you can add the following at
+G-Code macros. to avoid overly long lines you can add the following at
 the top of the macro:
 
 ```text

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -5,11 +5,11 @@ sequences in gcode_macro (and similar) config sections.
 
 ## G-Code Macro Naming
 
-Case is not important for the G-Code macro name - MY_MACRO and
-my_macro will evaluate the same and may be called in either upper or
+Case is not important for the G-Code macro name - `MY_MACRO` and
+`my_macro` will evaluate the same and may be called in either upper or
 lower case. If any numbers are used in the macro name then they must
-all be at the end of the name (eg, TEST_MACRO25 is valid, but
-MACRO25_TEST3 is not).
+all be at the end of the name (eg, `TEST_MACRO25` is valid, but
+`MACRO25_TEST3` is not).
 
 ## Formatting of G-Code in the config
 

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -17,7 +17,7 @@ Indentation is important when defining a macro in the config file. To
 specify a multi-line G-Code sequence it is important for each line to
 have proper indentation. For example:
 
-```
+```cfg
 [gcode_macro blink_led]
 gcode:
   SET_PIN PIN=my_led VALUE=1
@@ -36,7 +36,7 @@ Add `description:` with a short text to describe the functionality.
 Default is "G-Code macro" if not specified.
 For example:
 
-```
+```cfg
 [gcode_macro blink_led]
 description: Blink my_led one time
 gcode:
@@ -63,7 +63,7 @@ will make an undesirable request.)
 A common way to accomplish that is to wrap the `G1` moves in
 `SAVE_GCODE_STATE`, `G91`, and `RESTORE_GCODE_STATE`. For example:
 
-```
+```cfg
 [gcode_macro MOVE_UP]
 gcode:
   SAVE_GCODE_STATE NAME=my_move_up_state
@@ -88,7 +88,8 @@ wrapped in `{% %}`. See the
 for further information on the syntax.
 
 An example of a complex macro:
-```
+
+```cfg
 [gcode_macro clean_nozzle]
 gcode:
   {% set wipe_count = 8 %}
@@ -109,7 +110,7 @@ It is often useful to inspect parameters passed to the macro when
 it is called. These parameters are available via the `params`
 pseudo-variable. For example, if the macro:
 
-```
+```cfg
 [gcode_macro SET_PERCENT]
 gcode:
   M117 Now at { params.VALUE|float * 100 }%
@@ -123,7 +124,7 @@ math then they must be explicitly converted to integers or floats.
 It's common to use the Jinja2 `set` directive to use a default
 parameter and assign the result to a local name. For example:
 
-```
+```cfg
 [gcode_macro SET_BED_TEMPERATURE]
 gcode:
   {% set bed_temp = params.TEMPERATURE|default(40)|float %}
@@ -135,7 +136,7 @@ gcode:
 It is possible to inspect (and alter) the current state of the printer
 via the `printer` pseudo-variable. For example:
 
-```
+```cfg
 [gcode_macro slow_fan]
 gcode:
   M106 S{ printer.fan.speed * 0.9 * 255}
@@ -163,7 +164,8 @@ access it via the `[ ]` accessor - for example:
 Note that the Jinja2 `set` directive can assign a local name to an
 object in the `printer` hierarchy. This can make macros more readable
 and reduce typing. For example:
-```
+
+```cfg
 [gcode_macro QUERY_HTU21D]
 gcode:
     {% set sensor = printer["htu21d my_sensor"] %}
@@ -201,7 +203,7 @@ The SET_GCODE_VARIABLE command may be useful for saving state between
 macro calls. Variable names may not contain any upper case characters.
 For example:
 
-```
+```cfg
 [gcode_macro start_probe]
 variable_bed_temp: 0
 gcode:
@@ -228,7 +230,7 @@ into account when using SET_GCODE_VARIABLE.
 The [delayed_gcode] configuration option can be used to execute a delayed
 gcode sequence:
 
-```
+```cfg
 [delayed_gcode clear_display]
 gcode:
   M117
@@ -254,7 +256,7 @@ printer enters the "ready" state.  For example, the below delayed_gcode
 will execute 5 seconds after the printer is ready, initializing
 the display with a "Welcome!" message:
 
-```
+```cfg
 [delayed_gcode welcome]
 initial_duration: 5.
 gcode:
@@ -264,7 +266,7 @@ gcode:
 Its possible for a delayed gcode to repeat by updating itself in
 the gcode option:
 
-```
+```cfg
 [delayed_gcode report_temp]
 initial_duration: 2.
 gcode:
@@ -276,8 +278,7 @@ The above delayed_gcode will send "// Extruder Temp: [ex0_temp]" to
 Octoprint every 2 seconds.  This can be canceled with the following
 gcode:
 
-
-```
+```gcode
 UPDATE_DELAYED_GCODE ID=report_temp DURATION=0
 ```
 
@@ -316,7 +317,8 @@ restarts. All stored variables are loaded into the
 `printer.save_variables.variables` dict at startup and can be used in
 gcode macros. to avoid overly long lines you can add the following at
 the top of the macro:
-```
+
+```text
 {% set svv = printer.save_variables.variables %}
 ```
 
@@ -324,7 +326,7 @@ As an example, it could be used to save the state of 2-in-1-out hotend
 and when starting a print ensure that the active extruder is used,
 instead of T0:
 
-```
+```cfg
 [gcode_macro T1]
 gcode:
   ACTIVATE_EXTRUDER extruder=extruder1

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -18,7 +18,7 @@ toolhead to a valid position immediately after homing.
 have been renamed from PE0/PE1 to PE2/PE3.
 
 20210720: A controller_fan section now monitors all stepper motors by
-default (not just the kinematic stepper motors).  If the previous
+default (not just the kinematic stepper motors). If the previous
 behavior is desired, see the `stepper` config option in the
 [config reference](Config_Reference.md#controller_fan).
 
@@ -26,13 +26,13 @@ behavior is desired, see the `stepper` config option in the
 bus it is configuring via the `sercom` option.
 
 20210612: The `pid_integral_max` config option in heater and
-temperature_fan sections is deprecated.  The option will be removed in
+temperature_fan sections is deprecated. The option will be removed in
 the near future.
 
 20210503: The gcode_macro `default_parameter_<name>` config option is
-deprecated.  Use the `params` pseudo-variable to access macro
-parameters.  Other methods for accessing macro parameters will be
-removed in the near future.  See the
+deprecated. Use the `params` pseudo-variable to access macro
+parameters. Other methods for accessing macro parameters will be
+removed in the near future. See the
 [Command Templates document](Command_Templates.md#macro-parameters)
 for examples.
 
@@ -59,10 +59,10 @@ not be contacted or if the driver reports an error, then Klipper will
 transition to a shutdown state.
 
 20210219: The `rpi_temperature` module has been renamed to
-`temperature_host`.  Replace any occurrences of `sensor_type:
-rpi_temperature` with `sensor_type: temperature_host`.  The path to
+`temperature_host`. Replace any occurrences of `sensor_type:
+rpi_temperature` with `sensor_type: temperature_host`. The path to
 the temperature file may be specified in the `sensor_path` config
-variable.  The `rpi_temperature` name is deprecated and will be
+variable. The `rpi_temperature` name is deprecated and will be
 removed in the near future.
 
 20210201: The `TEST_RESONANCES` command will now disable input shaping
@@ -75,8 +75,8 @@ of the accelerometer chip to the output file name if the chip was given
 a name in the corresponding adxl345 section of the printer.cfg.
 
 20201222: The `step_distance` setting in the stepper config sections
-is deprecated.  It is advised to update the config to use the
-[`rotation_distance`](Rotation_Distance.md) setting.  Support for
+is deprecated. It is advised to update the config to use the
+[`rotation_distance`](Rotation_Distance.md) setting. Support for
 `step_distance` will be removed in the near future.
 
 20201218: The `endstop_phase` setting in the endstop_phase module has
@@ -87,23 +87,23 @@ endstop phases by running the ENDSTOP_PHASE_CALIBRATE command.
 
 20201218: Rotary delta and polar printers must now specify a
 `gear_ratio` for their rotary steppers, and they may no longer specify
-a `step_distance` parameter.  See the
+a `step_distance` parameter. See the
 [config reference](Config_Reference.md#stepper) for the format of the
 new gear_ratio paramter.
 
 20201213: It is not valid to specify a Z "position_endstop" when using
-"probe:z_virtual_endstop".  An error will now be raised if a Z
+"probe:z_virtual_endstop". An error will now be raised if a Z
 "position_endstop" is specified with "probe:z_virtual_endstop".
 Remove the Z "position_endstop" definition to fix the error.
 
 20201120: The `[board_pins]` config section now specifies the mcu name
-in an explicit `mcu:` parameter.  If using board_pins for a secondary
-mcu, then the config must be updated to specify that name.  See the
+in an explicit `mcu:` parameter. If using board_pins for a secondary
+mcu, then the config must be updated to specify that name. See the
 [config reference](Config_Reference.md#board_pins) for further
 details.
 
 20201112: The time reported by `print_stats.print_duration` has
-changed.  The duration prior to the first detected extrusion is
+changed. The duration prior to the first detected extrusion is
 now excluded.
 
 20201029: The neopixel `color_order_GRB` config option has been
@@ -111,21 +111,21 @@ removed. If necessary, update the config to set the new `color_order`
 option to RGB, GRB, RGBW, or GRBW.
 
 20201029: The serial option in the mcu config section no longer
-defaults to /dev/ttyS0.  In the rare situation where /dev/ttyS0 is the
+defaults to /dev/ttyS0. In the rare situation where /dev/ttyS0 is the
 desired serial port, it must be specified explicitly.
 
 20201020: Klipper v0.9.0 released.
 
 20200902: The RTD resistance-to-temperature calculation for MAX31865
-converters has been corrected to not read low.  If you are using such a
+converters has been corrected to not read low. If you are using such a
 device, you should recalibrate your print temperature and PID settings.
 
 20200816: The gcode macro `printer.gcode` object has been renamed to
-`printer.gcode_move`.  Several undocumented variables in
-`printer.toolhead` and `printer.gcode` have been removed.  See
+`printer.gcode_move`. Several undocumented variables in
+`printer.toolhead` and `printer.gcode` have been removed. See
 docs/Command_Templates.md for a list of available template variables.
 
-20200816: The gcode macro "action_" system has changed.  Replace any
+20200816: The G-Code macro "action_" system has changed. Replace any
 calls to `printer.gcode.action_emergency_stop()` with
 `action_emergency_stop()`, `printer.gcode.action_respond_info()` with
 `action_respond_info()`, and `printer.gcode.action_respond_error()`
@@ -137,27 +137,27 @@ configuration. See config/example-menu.cfg for configuration details
 and see klippy/extras/display/menu.cfg for examples.
 
 20200731:  The behavior of the `progress` attribute reported by
-the `virtual_sdcard` printer object has changed.  Progress is no
-longer reset to 0 when a print is paused.  It will now always report
+the `virtual_sdcard` printer object has changed. Progress is no
+longer reset to 0 when a print is paused. It will now always report
 progress based on the internal file position, or 0 if no file is
 currently loaded.
 
 20200725: The servo `enable` config parameter and the SET_SERVO
-`ENABLE` parameter have been removed.  Update any macros to use
+`ENABLE` parameter have been removed. Update any macros to use
 `SET_SERVO SERVO=my_servo WIDTH=0` to disable a servo.
 
 20200608: The LCD display support has changed the name of some
-internal "glyphs".  If a custom display layout was implemented it may
+internal "glyphs". If a custom display layout was implemented it may
 be necessary to update to the latest glyph names (see
 klippy/extras/display/display.cfg for a list of available glyphs).
 
 20200606: The pin names on linux mcu have changed. Pins now have names
-of the form `gpiochip<chipid>/gpio<gpio>`.  For gpiochip0 you can also
-use a short `gpio<gpio>`.  For example, what was previously referred
+of the form `gpiochip<chipid>/gpio<gpio>`. For gpiochip0 you can also
+use a short `gpio<gpio>`. For example, what was previously referred
 to as `P20` now becomes `gpio20` or `gpiochip0/gpio20`.
 
 20200603: The default 16x4 LCD layout will no longer show the
-estimated time remaining in a print.  (Only the elapsed time will be
+estimated time remaining in a print. (Only the elapsed time will be
 shown.)  If the old behavior is desired one can customize the menu
 display with that information (see the description of display_data in
 config/example-extras.cfg for details).
@@ -174,8 +174,8 @@ new ids may appear in system logs.
 was renamed to `printer.heaters`.
 
 20200313: The default lcd layout for multi-extruder printers with a
-16x4 screen has changed.  The single extruder screen layout is now the
-default and it will show the currently active extruder.  To use the
+16x4 screen has changed. The single extruder screen layout is now the
+default and it will show the currently active extruder. To use the
 previous display layout set "display_group: _multiextruder_16x4" in
 the [display] section of the printer.cfg file.
 
@@ -188,53 +188,53 @@ customize the layout of an lcd screen use the new display_data config
 sections (see config/example-extras.cfg for the details).
 
 20200109:  The bed_mesh module now references the probe's location
-in for the mesh configuration.  As such, some configuration options
+in for the mesh configuration. As such, some configuration options
 have been renamed to more accurately reflect their intended
-functionality.  For rectangular beds, `min_point` and `max_point`
-have been renamed to `mesh_min` and `mesh_max` respectively.  For
-round beds, `bed_radius` has been renamed to `mesh_radius`.  A new
-`mesh_origin` option has also been added for round beds.  Note that
+functionality. For rectangular beds, `min_point` and `max_point`
+have been renamed to `mesh_min` and `mesh_max` respectively. For
+round beds, `bed_radius` has been renamed to `mesh_radius`. A new
+`mesh_origin` option has also been added for round beds. Note that
 these changes are also incompatible with previously saved mesh profiles.
 If an incompatible profile is detected it will be ignored and scheduled
-for removal.  The removal process can be completed by issuing the
+for removal. The removal process can be completed by issuing the
 SAVE_CONFIG command. The user will need to re-calibrate each profile.
 
 20191218: The display config section no longer supports "lcd_type:
-st7567".  Use the "uc1701" display type instead - set "lcd_type:
-uc1701" and change the "rs_pin: some_pin" to "rst_pin: some_pin".  It
+st7567". Use the "uc1701" display type instead - set "lcd_type:
+uc1701" and change the "rs_pin: some_pin" to "rst_pin: some_pin". It
 may also be necessary to add a "contrast: 60" config setting.
 
-20191210: The builtin T0, T1, T2, ... commands have been removed.  The
+20191210: The builtin T0, T1, T2, ... commands have been removed. The
 extruder activate_gcode and deactivate_gcode config options have been
-removed.  If these commands (and scripts) are needed then define
+removed. If these commands (and scripts) are needed then define
 individual [gcode_macro T0] style macros that call the
-ACTIVATE_EXTRUDER command.  See the config/sample-idex.cfg and
+ACTIVATE_EXTRUDER command. See the config/sample-idex.cfg and
 sample-multi-extruder.cfg files for examples.
 
-20191210: Support for the M206 command has been removed.  Replace with
-calls to SET_GCODE_OFFSET.  If support for M206 is needed, add a
-[gcode_macro M206] config section that calls SET_GCODE_OFFSET.  (For
+20191210: Support for the M206 command has been removed. Replace with
+calls to SET_GCODE_OFFSET. If support for M206 is needed, add a
+[gcode_macro M206] config section that calls SET_GCODE_OFFSET. (For
 example "SET_GCODE_OFFSET Z=-{params.Z}".)
 
 20191202: Support for the undocumented "S" parameter of the "G4"
-command has been removed.  Replace any occurrences of S with the
+command has been removed. Replace any occurrences of S with the
 standard "P" parameter (the delay specified in milliseconds).
 
 20191126: The USB names have changed on micro-controllers with native
-USB support.  They now use a unique chip id by default (where
-available).  If an "mcu" config section uses a "serial" setting that
+USB support. They now use a unique chip id by default (where
+available). If an "mcu" config section uses a "serial" setting that
 starts with "/dev/serial/by-id/" then it may be necessary to update
-the config.  Run "ls /dev/serial/by-id/*" in an ssh terminal to
+the config. Run "ls /dev/serial/by-id/*" in an ssh terminal to
 determine the new id.
 
 20191121: The pressure_advance_lookahead_time parameter has been
-removed.  See example.cfg for alternate configuration settings.
+removed. See example.cfg for alternate configuration settings.
 
 20191112: The tmc stepper driver virtual enable capability is now
 automatically enabled if the stepper does not have a dedicated stepper
-enable pin.  Remove references to tmcXXXX:virtual_enable from the
-config.  The ability to control multiple pins in the stepper
-enable_pin config has been removed.  If multiple pins are needed then
+enable pin. Remove references to tmcXXXX:virtual_enable from the
+config. The ability to control multiple pins in the stepper
+enable_pin config has been removed. If multiple pins are needed then
 use a multi_pin config section.
 
 20191107: The primary extruder config section must be specified as
@@ -245,7 +245,7 @@ command templates that query the extruder status are now accessed via
 20191021: Klipper v0.8.0 released
 
 20191003: The move_to_previous option in [safe_z_homing] now defaults
-to False.  (It was effectively False prior to 20190918.)
+to False. (It was effectively False prior to 20190918.)
 
 20190918: The zhop option in [safe_z_homing] is always re-applied
 after Z axis homing completed. This might need users to update custom
@@ -266,8 +266,8 @@ changed. It may be necessary to update any macros or scripts that use
 that command.
 
 20190628: All configuration options have been removed from the
-[skew_correction] section.  Configuration for skew_correction
-is now done via the SET_SKEW gcode.  See skew_correction.md
+[skew_correction] section. Configuration for skew_correction
+is now done via the SET_SKEW gcode. See skew_correction.md
 for recommended usage.
 
 20190607: The "variable_X" parameters of gcode_macro (along with the
@@ -284,7 +284,7 @@ config sections.
 20190528: The magic "status" variable in gcode_macro template
 evaluation has been renamed to "printer".
 
-20190520: The SET_GCODE_OFFSET command has changed; update any g-code
+20190520: The SET_GCODE_OFFSET command has changed; update any G-Code
 macros accordingly. The command will no longer apply the requested
 offset to the next G1 command. The old behavior may be approximated by
 using the new "MOVE=1" parameter.
@@ -322,8 +322,8 @@ several of the driver_XXX parameters has changed.
 20190228: Users of SPI or I2C on SAMD21 boards must now specify the
 bus pins via a [samd_sercom] config section.
 
-20190224: The bed_shape option has been removed from bed_mesh.  The
-radius option has been renamed to bed_radius.  Users with round beds
+20190224: The bed_shape option has been removed from bed_mesh. The
+radius option has been renamed to bed_radius. Users with round beds
 should supply the bed_radius and round_probe_count options.
 
 20190107: The i2c_address parameter in the mcp4451 config section

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -176,7 +176,7 @@ was renamed to `printer.heaters`.
 20200313: The default lcd layout for multi-extruder printers with a
 16x4 screen has changed. The single extruder screen layout is now the
 default and it will show the currently active extruder. To use the
-previous display layout set "display_group: _multiextruder_16x4" in
+previous display layout set `display_group: _multiextruder_16x4` in
 the [display] section of the printer.cfg file.
 
 20200308: The default `__test` menu item was removed. If the config

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -156,7 +156,7 @@ endstop_pin:
 #   the X, Y, and Z steppers on cartesian style printers.
 #position_min: 0
 #   Minimum valid distance (in mm) the user may command the stepper to
-#   move to.  The default is 0mm.
+#   move to. The default is 0mm.
 position_endstop:
 #   Location of the endstop (in mm). This parameter must be provided
 #   for the X, Y, and Z steppers on cartesian style printers.
@@ -286,7 +286,7 @@ arm_length:
 [stepper_c]
 
 # The delta_calibrate section enables a DELTA_CALIBRATE extended
-# g-code command that can calibrate the tower endstop positions and
+# G-Code command that can calibrate the tower endstop positions and
 # angles.
 [delta_calibrate]
 radius:
@@ -503,7 +503,7 @@ max_z_velocity:
 #   max_velocity for max_z_velocity.
 #minimum_z_position: 0
 #   The minimum Z position that the user may command the head to move
-#   to.  The default is 0.
+#   to. The default is 0.
 shoulder_radius:
 #   Radius (in mm) of the horizontal circle formed by the three
 #   shoulder joints, minus the radius of the circle formed by the
@@ -555,7 +555,7 @@ lower_arm_length:
 [stepper_c]
 
 # The delta_calibrate section enables a DELTA_CALIBRATE extended
-# g-code command that can calibrate the shoulder endstop positions.
+# G-Code command that can calibrate the shoulder endstop positions.
 [delta_calibrate]
 radius:
 #   Radius (in mm) of the area that may be probed. This is the radius
@@ -835,10 +835,10 @@ Visual Examples:
 #   points to probe along each axis. This value must be an odd number.
 #   Default is 5.
 #fade_start: 1.0
-#   The gcode z position in which to start phasing out z-adjustment
+#   The G-Code z position in which to start phasing out z-adjustment
 #   when fade is enabled. Default is 1.0.
 #fade_end: 0.0
-#   The gcode z position in which phasing out completes. When set to a
+#   The G-Code z position in which phasing out completes. When set to a
 #   value below fade_start, fade is disabled. It should be noted that
 #   fade may add unwanted scaling along the z-axis of a print. If a
 #   user wishes to enable fade, a value of 10.0 is recommended.
@@ -876,8 +876,8 @@ Visual Examples:
 #   at the provided index.
 #faulty_region_1_min:
 #faulty_region_1_max:
-#   Optional points that define a faulty region.  See docs/Bed_Mesh.md
-#   for details on faulty regions.  Up to 99 faulty regions may be added.
+#   Optional points that define a faulty region. See docs/Bed_Mesh.md
+#   for details on faulty regions. Up to 99 faulty regions may be added.
 #   By default no faulty regions are set.
 ```
 
@@ -902,7 +902,7 @@ information.
 #   The amount to add to the Z height when the nozzle is nominally at
 #   0,0. The default is 0.
 # The remaining parameters control a BED_TILT_CALIBRATE extended
-# g-code command that may be used to calibrate appropriate x and y
+# G-Code command that may be used to calibrate appropriate x and y
 # adjustment parameters.
 #points:
 #   A list of X,Y coordinates (one per line; subsequent lines
@@ -921,7 +921,7 @@ information.
 ### [bed_screws]
 
 Tool to help adjust bed leveling screws. One may define a [bed_screws]
-config section to enable a BED_SCREWS_ADJUST g-code command.
+config section to enable a BED_SCREWS_ADJUST G-Code command.
 
 See the
 [leveling guide](Manual_Level.md#adjusting-bed-leveling-screws) and
@@ -967,7 +967,7 @@ information.
 
 Tool to help adjust bed screws tilt using Z probe. One may define a
 screws_tilt_adjust config section to enable a SCREWS_TILT_CALCULATE
-g-code command.
+G-Code command.
 
 See the
 [leveling guide](Manual_Level.md#adjusting-bed-leveling-screws-using-the-bed-probe)
@@ -1104,7 +1104,7 @@ Where x is the (0,0) point on the bed
 Printer Skew Correction. It is possible to use software to correct
 printer skew across 3 planes, xy, xz, yz. This is done by printing a
 calibration model along a plane and measuring three lengths. Due to
-the nature of skew correction these lengths are set via gcode. See
+the nature of skew correction these lengths are set via G-Code. See
 [skew correction](skew_correction.md) and
 [command reference](G-Codes.md#skew-correction) for details.
 
@@ -1145,8 +1145,8 @@ home_xy_position:
 
 ### [homing_override]
 
-Homing override. One may use this mechanism to run a series of g-code
-commands in place of a G28 found in the normal g-code input. This may
+Homing override. One may use this mechanism to run a series of G-Code
+commands in place of a G28 found in the normal G-Code input. This may
 be useful on printers that require a specific procedure to home the
 machine.
 
@@ -1154,7 +1154,7 @@ machine.
 [homing_override]
 gcode:
 #   A list of G-Code commands to execute in place of G28 commands
-#   found in the normal g-code input. See docs/Command_Templates.md
+#   found in the normal G-Code input. See docs/Command_Templates.md
 #   for G-Code format. If a G28 is contained in this list of commands
 #   then it will invoke the normal homing procedure for the printer.
 #   The commands listed here must home all axes. This parameter must
@@ -1169,7 +1169,7 @@ gcode:
 #set_position_y:
 #set_position_z:
 #   If specified, the printer will assume the axis is at the specified
-#   position prior to running the above g-code commands. Setting this
+#   position prior to running the above G-Code commands. Setting this
 #   disables homing checks for that axis. This may be useful if the
 #   head must move prior to invoking the normal G28 mechanism for an
 #   axis. The default is to not force a position for an axis.
@@ -1231,7 +1231,7 @@ G-Code macros (one may define any number of sections with a
 #   The given variable name will be assigned the given value (parsed
 #   as a Python literal) and will be available during macro expansion.
 #   For example, a config with "variable_fan_speed = 75" might have
-#   gcode commands containing "M106 S{ fan_speed * 255 }". Variables
+#   G-Code commands containing "M106 S{ fan_speed * 255 }". Variables
 #   can be changed at run-time using the SET_GCODE_VARIABLE command
 #   (see docs/Command_Templates.md for details). Variable names may
 #   not use upper case characters.
@@ -1249,7 +1249,7 @@ G-Code macros (one may define any number of sections with a
 
 ### [delayed_gcode]
 
-Execute a gcode on a set delay. See the
+Execute a G-Code on a set delay. See the
 [command template guide](Command_Templates.md#delayed-gcodes) and
 [command reference](G-Codes.md#delayed-gcode) for more information.
 
@@ -1304,14 +1304,14 @@ explicit idle_timeout config section to change the default settings.
 
 A virtual sdcard may be useful if the host machine is not fast enough
 to run OctoPrint well. It allows the Klipper host software to directly
-print gcode files stored in a directory on the host using standard
+print G-Code files stored in a directory on the host using standard
 sdcard G-Code commands (eg, M24).
 
 ```cfg
 [virtual_sdcard]
 path:
 #   The path of the local directory on the host machine to look for
-#   g-code files. This is a read-only directory (sdcard file writes
+#   G-Code files. This is a read-only directory (sdcard file writes
 #   are not supported). One may point this to OctoPrint's upload
 #   directory (generally ~/.octoprint/uploads/ ). This parameter must
 #   be provided.
@@ -1383,7 +1383,7 @@ allowing per-filament settings and runtime tuning.
 
 ### [gcode_arcs]
 
-Support for gcode arc (G2/G3) commands.
+Support for G-Code arc (G2/G3) commands.
 
 ```cfg
 [gcode_arcs]
@@ -1603,7 +1603,7 @@ pins:
 
 Z height probe. One may define this section to enable Z height probing
 hardware. When this section is enabled, PROBE and QUERY_PROBE extended
-[g-code commands](G-Codes.md#probe) become available. Also, see the
+[G-Code commands](G-Codes.md#probe) become available. Also, see the
 [probe calibrate guide](Probe_Calibrate.md). The probe section also
 creates a virtual "probe:z_virtual_endstop" pin. One may set the
 stepper_z endstop_pin to this virtual pin on cartesian style printers
@@ -1616,7 +1616,7 @@ stepper_z config section.
 pin:
 #   Probe detection pin. This parameter must be provided.
 #deactivate_on_each_sample: True
-#   This determines if Klipper should execute deactivation gcode
+#   This determines if Klipper should execute deactivation G-Code
 #   between each probe attempt when performing a multiple probe
 #   sequence. The default is True.
 #x_offset: 0.0
@@ -1780,7 +1780,7 @@ for an example configuration.
 
 Support for cartesian printers with dual carriages on a single
 axis. The active carriage is set via the SET_DUAL_CARRIAGE extended
-g-code command. The "SET_DUAL_CARRIAGE CARRIAGE=1" command will
+G-Code command. The "SET_DUAL_CARRIAGE CARRIAGE=1" command will
 activate the carriage defined in this section (CARRIAGE=0 will return
 activation to the primary carriage). Dual carriage support is
 typically combined with extra extruders - the SET_DUAL_CARRIAGE
@@ -1834,7 +1834,7 @@ more information.
 
 Manual steppers (one may define any number of sections with a
 "manual_stepper" prefix). These are steppers that are controlled by
-the MANUAL_STEPPER g-code command. For example: "MANUAL_STEPPER
+the MANUAL_STEPPER G-Code command. For example: "MANUAL_STEPPER
 STEPPER=my_stepper MOVE=10 SPEED=5". See
 [G-Codes](G-Codes.md#manual-stepper-commands) file for a description
 of the MANUAL_STEPPER command. The steppers are not connected to the
@@ -2475,8 +2475,8 @@ additional information.
 
 Manually controlled fan (one may define any number of sections with a
 "fan_generic" prefix). The speed of a manually controlled fan is set
-with the SET_FAN_SPEED
-[gcode command](G-Codes.md#manually-controlled-fans-commands).
+with the `SET_FAN_SPEED`
+[G-Code command](G-Codes.md#manually-controlled-fans-commands).
 
 ```cfg
 [fan_generic extruder_partfan]
@@ -2531,7 +2531,7 @@ pin:
 Neopixel (aka WS2812) LED support (one may define any number of
 sections with a "neopixel" prefix). One may set the LED color via
 "SET_LED LED=my_neopixel RED=0.1 GREEN=0.1 BLUE=0.1" type extended
-[g-code commands](G-Codes.md#neopixel-and-dotstar-commands).
+[G-Code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
 ```cfg
 [neopixel my_neopixel]
@@ -2559,7 +2559,7 @@ pin:
 Dotstar (aka APA102) LED support (one may define any number of
 sections with a "dotstar" prefix). One may set the LED color via
 "SET_LED LED=my_dotstar RED=0.1 GREEN=0.1 BLUE=0.1" type extended
-[g-code commands](G-Codes.md#neopixel-and-dotstar-commands).
+[G-Code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
 ```cfg
 [dotstar my_dotstar]
@@ -2602,7 +2602,7 @@ PCA9533 LED support. The PCA9533 is used on the mightyboard.
 
 ### [gcode_button]
 
-Execute gcode when a button is pressed or released (or when a pin
+Execute G-Code when a button is pressed or released (or when a pin
 changes state). You can check the state of the button by using
 `QUERY_BUTTON button=my_gcode_button`.
 
@@ -2634,7 +2634,7 @@ Run-time configurable output pins (one may define any number of
 sections with an "output_pin" prefix). Pins configured here will be
 setup as output pins and one may modify them at run-time using
 "SET_PIN PIN=my_pin VALUE=.1" type extended
-[g-code commands](G-Codes.md#custom-pin-commands).
+[G-Code commands](G-Codes.md#custom-pin-commands).
 
 ```cfg
 [output_pin my_pin]
@@ -3443,7 +3443,7 @@ lcd_type:
 #   a "smearing" effect on some OLED displays. The value may range
 #   from 0 to 63. Default is 0.
 #invert: False
-#   TRUE inverts the pixels on certain OLED displays.  The default is
+#   TRUE inverts the pixels on certain OLED displays. The default is
 #   False.
 #x_offset: 0
 #   Set the horizontal offset value on SH1106 displays. The default is
@@ -3572,7 +3572,7 @@ information on menu attributes available during template rendering.
 #       input   - same like 'command' but has value changing capabilities.
 #                 Press will start/stop edit mode.
 #       list    - it allows for menu items to be grouped together in a
-#                 scrollable list.  Add to the list by creating menu
+#                 scrollable list. Add to the list by creating menu
 #                 configurations using "some_list" as a prefix - for
 #                 example: [menu some_list some_item_in_the_list]
 #       vsdlist - same as 'list' but will append files from virtual sdcard
@@ -3619,7 +3619,7 @@ information on menu attributes available during template rendering.
 #   rate step is same input_step.
 #realtime:
 #   This attribute accepts static boolean value. When enabled then
-#   gcode script is run after each value change. The default is False.
+#   G-Code script is run after each value change. The default is False.
 #gcode:
 #   Script to run on button click, long click or value change.
 #   Evaluated as a template. The button click will trigger the edit
@@ -3773,7 +3773,7 @@ adc2:
 Configure an SX1509 I2C to GPIO expander. Due to the delay incurred by
 I2C communication you should NOT use SX1509 pins as stepper enable,
 step or dir pins or any other pin that requires fast bit-banging. They
-are best used as static or gcode controlled digital outputs or
+are best used as static or G-Code controlled digital outputs or
 hardware-pwm pins for e.g. fans. One may define any number of sections
 with an "sx1509" prefix. Each expander provides a set of 16 pins
 (sx1509_my_sx1509:PIN_0 to sx1509_my_sx1509:PIN_15) which can be used
@@ -3856,7 +3856,7 @@ vssa_pin:
 
 ### [replicape]
 
-Replicape support - see the [beaglebone guide](beaglebone.md) and the
+Replicape support - see the [Beaglebone guide](beaglebone.md) and the
 [generic-replicape.cfg](../config/generic-replicape.cfg) file for an
 example.
 
@@ -3934,7 +3934,7 @@ If you use this module, do not use the Palette 2 plugin for
 Octoprint as they will conflict, and 1 will fail to initialize
 properly likely aborting your print.
 
-If you use Octoprint and stream gcode over the serial port instead of
+If you use Octoprint and stream G-Code over the serial port instead of
 printing from virtual_sd, then remo **M1** and **M0** from *Pausing commands*
 in *Settings > Serial Connection > Firmware & protocol* will prevent
 the need to start print on the Palette 2 and unpausing in Octoprint

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1457,7 +1457,7 @@ the [command reference](G-Codes.md#resonance-compensation).
 
 Support for ADXL345 accelerometers. This support allows one to query
 accelerometer measurements from the sensor. This enables an
-ACCELEROMETER_MEASURE command (see
+`ACCELEROMETER_MEASURE` command (see
 [G-Codes](G-Codes.md#adxl345-accelerometer-commands) for more
 information). The default chip name is "default", but one may specify
 an explicit name (eg, [adxl345 my_chip_name]).
@@ -1602,7 +1602,7 @@ pins:
 ### [probe]
 
 Z height probe. One may define this section to enable Z height probing
-hardware. When this section is enabled, PROBE and QUERY_PROBE extended
+hardware. When this section is enabled, `PROBE` and `QUERY_PROBE` extended
 [G-Code commands](G-Codes.md#probe) become available. Also, see the
 [probe calibrate guide](Probe_Calibrate.md). The probe section also
 creates a virtual "probe:z_virtual_endstop" pin. One may set the
@@ -1992,7 +1992,7 @@ section.
 
 Generic heaters (one may define any number of sections with a
 "heater_generic" prefix). These heaters behave similarly to standard
-heaters (extruders, heated beds). Use the SET_HEATER_TEMPERATURE
+heaters (extruders, heated beds). Use the `SET_HEATER_TEMPERATURE`
 command (see [G-Codes](G-Codes.md) for details) to set the target
 temperature.
 
@@ -2498,9 +2498,9 @@ with the `SET_FAN_SPEED`
 ### [servo]
 
 Servos (one may define any number of sections with a "servo"
-prefix). The servos may be controlled using the SET_SERVO
-[g-code command](G-Codes.md#servo-commands). For example: SET_SERVO
-SERVO=my_servo ANGLE=180
+prefix). The servos may be controlled using the `SET_SERVO`
+[G-Code command](G-Codes.md#servo-commands). For example: `SET_SERVO
+SERVO=my_servo ANGLE=180`
 
 ```cfg
 [servo my_servo]
@@ -2530,7 +2530,7 @@ pin:
 
 Neopixel (aka WS2812) LED support (one may define any number of
 sections with a "neopixel" prefix). One may set the LED color via
-"SET_LED LED=my_neopixel RED=0.1 GREEN=0.1 BLUE=0.1" type extended
+`SET_LED LED=my_neopixel RED=0.1 GREEN=0.1 BLUE=0.1` type extended
 [G-Code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
 ```cfg
@@ -2558,7 +2558,7 @@ pin:
 
 Dotstar (aka APA102) LED support (one may define any number of
 sections with a "dotstar" prefix). One may set the LED color via
-"SET_LED LED=my_dotstar RED=0.1 GREEN=0.1 BLUE=0.1" type extended
+`SET_LED LED=my_dotstar RED=0.1 GREEN=0.1 BLUE=0.1` type extended
 [G-Code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
 ```cfg
@@ -2633,7 +2633,7 @@ pin:
 Run-time configurable output pins (one may define any number of
 sections with an "output_pin" prefix). Pins configured here will be
 setup as output pins and one may modify them at run-time using
-"SET_PIN PIN=my_pin VALUE=.1" type extended
+`SET_PIN PIN=my_pin VALUE=.1` type extended
 [G-Code commands](G-Codes.md#custom-pin-commands).
 
 ```cfg

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -31,7 +31,7 @@ config file before any sections using those pins.
 
 Configuration of the primary micro-controller.
 
-```
+```cfg
 [mcu]
 serial:
 #   The serial port to connect to the MCU. If unsure (or if it
@@ -69,7 +69,7 @@ etc.. For example, if an "[mcu extra_mcu]" section is introduced, then
 pins such as "extra_mcu:ar9" may then be used elsewhere in the config
 (where "ar9" is a hardware pin name or alias name on the given mcu).
 
-```
+```cfg
 [mcu my_extra_mcu]
 # See the "mcu" section for configuration parameters.
 ```
@@ -80,7 +80,7 @@ pins such as "extra_mcu:ar9" may then be used elsewhere in the config
 
 The printer section controls high level printer settings.
 
-```
+```cfg
 [printer]
 kinematics:
 #   The type of printer in use. This option may be one of: cartesian,
@@ -121,7 +121,7 @@ Below are common stepper definitions.
 See the [rotation distance document](Rotation_Distance.md) for
 information on calculating the `rotation_distance` parameter.
 
-```
+```cfg
 [stepper_x]
 step_pin:
 #   Step GPIO pin (triggered high). This parameter must be provided.
@@ -195,7 +195,7 @@ Only parameters specific to cartesian printers are described here -
 see [common kinematic settings](#common-kinematic-settings) for
 available parameters.
 
-```
+```cfg
 [printer]
 kinematics: cartesian
 max_z_velocity:
@@ -232,7 +232,7 @@ Only parameters specific to linear delta printers are described here -
 see [common kinematic settings](#common-kinematic-settings) for
 available parameters.
 
-```
+```cfg
 [printer]
 kinematics: delta
 max_z_velocity:
@@ -311,7 +311,7 @@ Only parameters specific to corexy printers are described here - see
 [common kinematic settings](#common-kinematic-settings) for available
 parameters.
 
-```
+```cfg
 [printer]
 kinematics: corexy
 max_z_velocity:
@@ -346,7 +346,7 @@ Only parameters specific to corexz printers are described here - see
 [common kinematic settings](#common-kinematic-settings) for available
 parameters.
 
-```
+```cfg
 [printer]
 kinematics: corexz
 max_z_velocity:
@@ -380,7 +380,7 @@ Only parameters specific to hybrid corexy printers are described here
 see [common kinematic settings](#common-kinematic-settings) for available
 parameters.
 
-```
+```cfg
 [printer]
 kinematics: hybrid_corexy
 max_z_velocity:
@@ -414,7 +414,7 @@ Only parameters specific to hybrid corexy printers are described here
 see [common kinematic settings](#common-kinematic-settings) for available
 parameters.
 
-```
+```cfg
 [printer]
 kinematics: hybrid_corexz
 max_z_velocity:
@@ -449,7 +449,7 @@ parameters.
 POLAR KINEMATICS ARE A WORK IN PROGRESS. Moves around the `0,0`
 position are known to not work properly.
 
-```
+```cfg
 [printer]
 kinematics: polar
 
@@ -492,7 +492,7 @@ available parameters.
 ROTARY DELTA KINEMATICS ARE A WORK IN PROGRESS. Homing moves may
 timeout and some boundary checks are not implemented.
 
-```
+```cfg
 [printer]
 kinematics: rotary_delta
 max_z_velocity:
@@ -584,7 +584,7 @@ cable winch kinematics. In order to home the printer, manually send
 movement commands until the toolhead is at 0,0,0 and then issue a
 `G28` command.
 
-```
+```cfg
 [printer]
 kinematics: winch
 
@@ -609,7 +609,7 @@ It is possible to define a special "none" kinematics to disable
 kinematic support in Klipper. This may be useful for controlling
 devices that are not typical 3d-printers or for debugging purposes.
 
-```
+```cfg
 [printer]
 kinematics: none
 max_velocity: 1
@@ -627,7 +627,7 @@ the printer extruder and the heater parameters for the nozzle. See the
 [pressure advance guide](Pressure_Advance.md) for information on
 tuning pressure advance.
 
-```
+```cfg
 [extruder]
 step_pin:
 dir_pin:
@@ -749,7 +749,7 @@ max_temp:
 The heater_bed section describes a heated bed. It uses the same heater
 settings described in the "extruder" section.
 
-```
+```cfg
 [heater_bed]
 heater_pin:
 sensor_type:
@@ -775,7 +775,8 @@ See the [bed mesh guide](Bed_Mesh.md) and
 information.
 
 Visual Examples:
-```
+
+```text
  rectangular bed, probe_count = 3,3:
              x---x---x (max_point)
              |
@@ -795,7 +796,7 @@ Visual Examples:
                 x  (0,-r) start
 ```
 
-```
+```cfg
 [bed_mesh]
 #speed: 50
 #   The speed (in mm/s) of non-probing moves during the calibration.
@@ -889,7 +890,7 @@ bed_mesh and bed_tilt are incompatible; both cannot be defined.
 See the [command reference](G-Codes.md#bed-tilt) for additional
 information.
 
-```
+```cfg
 [bed_tilt]
 #x_adjust: 0
 #   The amount to add to each move's Z height for each mm on the X
@@ -927,7 +928,7 @@ See the
 [command reference](G-Codes.md#bed-screws-helper) for additional
 information.
 
-```
+```cfg
 [bed_screws]
 #screw1:
 #   The X,Y coordinate of the first bed leveling screw. This is a
@@ -973,7 +974,7 @@ See the
 and [command reference](G-Codes.md#bed-screws-tilt-adjust-helper) for
 additional information.
 
-```
+```cfg
 [screws_tilt_adjust]
 #screw1:
 #   The X,Y coordinate of the first bed leveling screw. This is a
@@ -1012,7 +1013,7 @@ adjustment of multiple z steppers (see the "stepper_z1" section) to
 adjust for tilt. If this section is present then a Z_TILT_ADJUST
 extended [G-Code command](G-Codes.md#z-tilt) becomes available.
 
-```
+```cfg
 [z_tilt]
 #z_positions:
 #   A list of X,Y coordinates (one per line; subsequent lines
@@ -1055,7 +1056,8 @@ WARNING: Using this on a moving bed may lead to undesirable results.
 If this section is present then a QUAD_GANTRY_LEVEL extended G-Code
 command becomes available. This routine assumes the following Z motor
 configuration:
-```
+
+```text
  ----------------
  |Z1          Z2|
  |  ---------   |
@@ -1065,9 +1067,10 @@ configuration:
  |Z           Z3|
  ----------------
 ```
+
 Where x is the (0,0) point on the bed
 
-```
+```cfg
 [quad_gantry_level]
 #gantry_corners:
 #   A newline separated list of X,Y coordinates describing the two
@@ -1105,7 +1108,7 @@ the nature of skew correction these lengths are set via gcode. See
 [skew correction](skew_correction.md) and
 [command reference](G-Codes.md#skew-correction) for details.
 
-```
+```cfg
 [skew_correction]
 ```
 
@@ -1117,7 +1120,7 @@ Safe Z homing. One may use this mechanism to home the Z axis at a
 specific XY coordinate. This is useful if the toolhead, for example
 has to move to the center of the bed before Z can be homed.
 
-```
+```cfg
 [safe_z_home]
 home_xy_position:
 #   A X,Y coordinate (e.g. 100,100) where the Z homing should be
@@ -1147,7 +1150,7 @@ commands in place of a G28 found in the normal g-code input. This may
 be useful on printers that require a specific procedure to home the
 machine.
 
-```
+```cfg
 [homing_override]
 gcode:
 #   A list of G-Code commands to execute in place of G28 commands
@@ -1185,7 +1188,7 @@ See the [endstop phases guide](Endstop_Phase.md) and
 [command reference](G-Codes.md#endstop-adjustments-by-stepper-phase)
 for additional information.
 
-```
+```cfg
 [endstop_phase stepper_z]
 #endstop_accuracy:
 #   Sets the expected accuracy (in mm) of the endstop. This represents
@@ -1217,7 +1220,7 @@ G-Code macros (one may define any number of sections with a
 "gcode_macro" prefix). See the
 [command template guide](Command_Templates.md) for more information.
 
-```
+```cfg
 [gcode_macro my_cmd]
 #gcode:
 #   A list of G-Code commands to execute in place of "my_cmd". See
@@ -1250,7 +1253,7 @@ Execute a gcode on a set delay. See the
 [command template guide](Command_Templates.md#delayed-gcodes) and
 [command reference](G-Codes.md#delayed-gcode) for more information.
 
-```
+```cfg
 [delayed_gcode my_delayed_gcode]
 gcode:
 #   A list of G-Code commands to execute when the delay duration has
@@ -1272,7 +1275,7 @@ restarts. See
 [command templates](Command_Templates.md#save-variables-to-disk) and
 [G-Code reference](G-Codes.md#save-variables) for further information.
 
-```
+```cfg
 [save_variables]
 filename:
 #   Required - provide a filename that would be used to save the
@@ -1284,7 +1287,7 @@ filename:
 Idle timeout. An idle timeout is automatically enabled - add an
 explicit idle_timeout config section to change the default settings.
 
-```
+```cfg
 [idle_timeout]
 #gcode:
 #   A list of G-Code commands to execute on an idle timeout. See
@@ -1304,7 +1307,7 @@ to run OctoPrint well. It allows the Klipper host software to directly
 print gcode files stored in a directory on the host using standard
 sdcard G-Code commands (eg, M24).
 
-```
+```cfg
 [virtual_sdcard]
 path:
 #   The path of the local directory on the host machine to look for
@@ -1325,7 +1328,7 @@ See the [command reference](G-Codes.md#sdcard-loop) for supported
 commands. See the [sample-macros.cfg](../config/sample-macros.cfg)
 file for a Marlin compatible M808 G-Code macro.
 
-```
+```cfg
 [sdcard_loop]
 ```
 
@@ -1335,7 +1338,7 @@ Support manually moving stepper motors for diagnostic purposes. Note,
 using this feature may place the printer in an invalid state - see the
 [command reference](G-Codes.md#force-movement) for important details.
 
-```
+```cfg
 [force_move]
 #enable_force_move: False
 #   Set to true to enable FORCE_MOVE and SET_KINEMATIC_POSITION
@@ -1348,7 +1351,7 @@ Pause/Resume functionality with support of position capture and
 restore. See the [command reference](G-Codes.md#pause-resume) for more
 information.
 
-```
+```cfg
 [pause_resume]
 #recover_velocity: 50.
 #   When capture/restore is enabled, the speed at which to return to
@@ -1363,7 +1366,7 @@ below provide startup defaults, although the values can be adjusted
 via the SET_RETRACTION [command](G-Codes.md#firmware-retraction)),
 allowing per-filament settings and runtime tuning.
 
-```
+```cfg
 [firmware_retraction]
 #retract_length: 0
 #   The length of filament (in mm) to retract when G10 is activated,
@@ -1382,7 +1385,7 @@ allowing per-filament settings and runtime tuning.
 
 Support for gcode arc (G2/G3) commands.
 
-```
+```cfg
 [gcode_arcs]
 #resolution: 1.0
 #   An arc will be split into segments. Each segment's length will
@@ -1397,7 +1400,7 @@ Support for gcode arc (G2/G3) commands.
 Enable the "M118" and "RESPOND" extended
 [commands](G-Codes.md#send-message-respond-to-host).
 
-```
+```cfg
 [respond]
 #default_type: echo
 #   Sets the default prefix of the "M118" and "RESPOND" output to one
@@ -1417,7 +1420,7 @@ Enable the "M118" and "RESPOND" extended
 Enables [resonance compensation](Resonance_Compensation.md). Also see
 the [command reference](G-Codes.md#resonance-compensation).
 
-```
+```cfg
 [input_shaper]
 #shaper_freq_x: 0
 #   A frequency (in Hz) of the input shaper for X axis. This is
@@ -1459,7 +1462,7 @@ ACCELEROMETER_MEASURE command (see
 information). The default chip name is "default", but one may specify
 an explicit name (eg, [adxl345 my_chip_name]).
 
-```
+```cfg
 [adxl345]
 cs_pin:
 #   The SPI enable pin for the sensor. This parameter must be provided.
@@ -1498,7 +1501,7 @@ information. See the [Max smoothing](Measuring_Resonances.md#max-smoothing)
 section of the measuring resonances guide for more information on
 `max_smoothing` parameter and its use.
 
-```
+```cfg
 [resonance_tester]
 #probe_points:
 #   A list of X,Y,Z coordinates of points (one point per line) to test
@@ -1553,7 +1556,7 @@ Board pin aliases (one may define any number of sections with a
 "board_pins" prefix). Use this to define aliases for the pins on a
 micro-controller.
 
-```
+```cfg
 [board_pins my_aliases]
 mcu: mcu
 #   A comma separated list of micro-controllers that may use the
@@ -1574,7 +1577,7 @@ Include file support. One may include additional config file from the
 main printer config file. Wildcards may also be used (eg,
 "configs/*.cfg").
 
-```
+```cfg
 [include my_other_config.cfg]
 ```
 
@@ -1586,7 +1589,7 @@ for diagnostic and debugging purposes. This section is not needed
 where Klipper supports using the same pin multiple times, and using
 this override may cause confusing and unexpected results.
 
-```
+```cfg
 [duplicate_pin_override]
 pins:
 #   A comma separated list of pins that may be used multiple times in
@@ -1608,7 +1611,7 @@ that use the probe in place of a z endstop. If using
 "probe:z_virtual_endstop" then do not define a position_endstop in the
 stepper_z config section.
 
-```
+```cfg
 [probe]
 pin:
 #   Probe detection pin. This parameter must be provided.
@@ -1673,7 +1676,7 @@ and [command reference](G-Codes.md#bltouch) for further information. A
 virtual "probe:z_virtual_endstop" pin is also created (see the "probe"
 section for the details).
 
-```
+```cfg
 [bltouch]
 sensor_pin:
 #   Pin connected to the BLTouch sensor pin. Most BLTouch devices
@@ -1732,7 +1735,7 @@ steppers that should be stepped in concert with the primary stepper.
 One may define any number of sections with a numeric suffix starting
 at 1 (for example, "stepper_z1", "stepper_z2", etc.).
 
-```
+```cfg
 [stepper_z1]
 #step_pin:
 #dir_pin:
@@ -1757,7 +1760,7 @@ named "extruder1", "extruder2", "extruder3", and so on. See the
 See [sample-multi-extruder.cfg](../config/sample-multi-extruder.cfg)
 for an example configuration.
 
-```
+```cfg
 [extruder1]
 #step_pin:
 #dir_pin:
@@ -1787,7 +1790,7 @@ command. Be sure to park the carriages during deactivation.
 See [sample-idex.cfg](../config/sample-idex.cfg) for an example
 configuration.
 
-```
+```cfg
 [dual_carriage]
 axis:
 #   The axis this extra carriage is on (either x or y). This parameter
@@ -1813,7 +1816,7 @@ extruder (one may define any number of sections with an
 See the [command reference](G-Codes.md#extruder-stepper-commands) for
 more information.
 
-```
+```cfg
 [extruder_stepper my_extra_stepper]
 #extruder: extruder
 #   The extruder this stepper is synchronized to. The default is
@@ -1837,7 +1840,7 @@ STEPPER=my_stepper MOVE=10 SPEED=5". See
 of the MANUAL_STEPPER command. The steppers are not connected to the
 normal printer kinematics.
 
-```
+```cfg
 [manual_stepper my_stepper]
 #step_pin:
 #dir_pin:
@@ -1868,7 +1871,7 @@ Heater and temperature sensor verification. Heater verification is
 automatically enabled for each heater that is configured on the
 printer. Use verify_heater sections to change the default settings.
 
-```
+```cfg
 [verify_heater heater_config_name]
 #max_error: 120
 #   The maximum "cumulative temperature error" before raising an
@@ -1904,7 +1907,7 @@ printer. Use verify_heater sections to change the default settings.
 
 Tool to disable heaters when homing or probing an axis.
 
-```
+```cfg
 [homing_heaters]
 #steppers:
 #   A comma separated list of steppers that should cause heaters to be
@@ -1927,7 +1930,7 @@ defines a "[thermistor my_thermistor]" section then one may use a
 the thermistor section in the config file above its first use in a
 heater section.
 
-```
+```cfg
 [thermistor my_thermistor]
 #temperature1:
 #resistance1:
@@ -1960,7 +1963,7 @@ defines a "[adc_temperature my_sensor]" section then one may use a
 sensor section in the config file above its first use in a heater
 section.
 
-```
+```cfg
 [adc_temperature my_sensor]
 #temperature1:
 #voltage1:
@@ -1993,7 +1996,7 @@ heaters (extruders, heated beds). Use the SET_HEATER_TEMPERATURE
 command (see [G-Codes](G-Codes.md) for details) to set the target
 temperature.
 
-```
+```cfg
 [heater_generic my_generic_heater]
 #gcode_id:
 #   The id to use when reporting the temperature in the M105 command.
@@ -2019,7 +2022,7 @@ temperature.
 Generic temperature sensors. One can define any number of additional
 temperature sensors that are reported via the M105 command.
 
-```
+```cfg
 [temperature_sensor my_sensor]
 #sensor_type:
 #sensor_pin:
@@ -2044,7 +2047,7 @@ section).
 Common thermistors. The following parameters are available in heater
 sections that use one of these sensors.
 
-```
+```cfg
 sensor_type:
 #   One of "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2",
 #   "NTC 100K beta 3950", "Honeywell 100K 135-104LAG-J01",
@@ -2067,7 +2070,7 @@ sensor_pin:
 Common temperature amplifiers. The following parameters are available
 in heater sections that use one of these sensors.
 
-```
+```cfg
 sensor_type:
 #   One of "PT100 INA826", "AD595", "AD597", "AD8494", "AD8495",
 #   "AD8496", or "AD8497".
@@ -2085,7 +2088,7 @@ sensor_pin:
 Directly connected PT1000 sensor. The following parameters are
 available in heater sections that use one of these sensors.
 
-```
+```cfg
 sensor_type: PT1000
 sensor_pin:
 #   Analog input pin connected to the sensor. This parameter must be
@@ -2101,7 +2104,7 @@ MAXxxxxx serial peripheral interface (SPI) temperature based
 sensors. The following parameters are available in heater sections
 that use one of these sensor types.
 
-```
+```cfg
 sensor_type:
 #   One of "MAX6675", "MAX31855", "MAX31856", or "MAX31865".
 sensor_pin:
@@ -2141,7 +2144,7 @@ See [sample-macros.cfg](../config/sample-macros.cfg) for a gcode_macro
 that may be used to report pressure and humidity in addition to
 temperature.
 
-```
+```cfg
 sensor_type: BME280
 #i2c_address:
 #   Default is 118 (0x76). Some BME280 sensors have an address of 119
@@ -2162,7 +2165,7 @@ humidity. See [sample-macros.cfg](../config/sample-macros.cfg) for a
 gcode_macro that may be used to report humidity in addition to
 temperature.
 
-```
+```cfg
 sensor_type:
 #   Must be "HTU21D" , "SI7013", "SI7020", "SI7021" or "SHT21"
 #i2c_address:
@@ -2194,7 +2197,7 @@ LM75/LM75A two wire (I2C) connected temperature sensors. These sensors
 have range up to 125 C, so are usable for e.g. chamber temperature
 monitoring. They can also function as simple fan/heater controllers.
 
-```
+```cfg
 sensor_type: lm75
 #i2c_address:
 #   Default is 72 (0x48). Normal range is 72-79 (0x48-0x4F) and the 3
@@ -2216,7 +2219,7 @@ The atsam, atsamd, and stm32 micro-controllers contain an internal
 temperature sensor. One can use the "temperature_mcu" sensor to
 monitor these temperatures.
 
-```
+```cfg
 sensor_type: temperature_mcu
 #sensor_mcu: mcu
 #   The micro-controller to read from. The default is "mcu".
@@ -2248,7 +2251,7 @@ sensor_type: temperature_mcu
 
 Temperature from the machine (eg Raspberry Pi) running the host software.
 
-```
+```cfg
 sensor_type: temperature_host
 #sensor_path:
 #   The path to temperature system file. The default is
@@ -2260,7 +2263,7 @@ sensor_type: temperature_host
 
 DS18B20 is a 1-wire (w1) digital temperature sensor. Note that this sensor is not intended for use with extruders and heater beds, but rather for monitoring ambient temperature (C). These sensors have range up to 125 C, so are usable for e.g. chamber temperature monitoring. They can also function as simple fan/heater controllers. DS18B20 sensors are only supported on the "host mcu", e.g. the Raspberry Pi. The w1-gpio Linux kernel module must be installed.
 
-```
+```cfg
 sensor_type: DS18B20
 serial_no:
 #   Each 1-wire device has a unique serial number used to identify the device,
@@ -2279,7 +2282,7 @@ serial_no:
 
 Print cooling fan.
 
-```
+```cfg
 [fan]
 pin:
 #   Output pin controlling the fan. This parameter must be provided.
@@ -2347,7 +2350,7 @@ Heater cooling fans (one may define any number of sections with a
 whenever its associated heater is active. By default, a heater_fan has
 a shutdown_speed equal to max_power.
 
-```
+```cfg
 [heater_fan my_nozzle_fan]
 #pin:
 #max_power:
@@ -2383,7 +2386,7 @@ driver is active. The fan will stop whenever an idle_timeout is
 reached to ensure no overheating will occur after deactivating a
 watched component.
 
-```
+```cfg
 [controller_fan my_controller_fan]
 #pin:
 #max_power:
@@ -2428,7 +2431,7 @@ to max_power.
 See the [command reference](G-Codes.md#temperature-fan-commands) for
 additional information.
 
-```
+```cfg
 [temperature_fan my_temp_fan]
 #pin:
 #max_power:
@@ -2475,7 +2478,7 @@ Manually controlled fan (one may define any number of sections with a
 with the SET_FAN_SPEED
 [gcode command](G-Codes.md#manually-controlled-fans-commands).
 
-```
+```cfg
 [fan_generic extruder_partfan]
 #pin:
 #max_power:
@@ -2499,7 +2502,7 @@ prefix). The servos may be controlled using the SET_SERVO
 [g-code command](G-Codes.md#servo-commands). For example: SET_SERVO
 SERVO=my_servo ANGLE=180
 
-```
+```cfg
 [servo my_servo]
 pin:
 #   PWM output pin controlling the servo. This parameter must be
@@ -2530,7 +2533,7 @@ sections with a "neopixel" prefix). One may set the LED color via
 "SET_LED LED=my_neopixel RED=0.1 GREEN=0.1 BLUE=0.1" type extended
 [g-code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
-```
+```cfg
 [neopixel my_neopixel]
 pin:
 #   The pin connected to the neopixel. This parameter must be
@@ -2558,7 +2561,7 @@ sections with a "dotstar" prefix). One may set the LED color via
 "SET_LED LED=my_dotstar RED=0.1 GREEN=0.1 BLUE=0.1" type extended
 [g-code commands](G-Codes.md#neopixel-and-dotstar-commands).
 
-```
+```cfg
 [dotstar my_dotstar]
 data_pin:
 #   The pin connected to the data line of the dotstar. This parameter
@@ -2577,7 +2580,7 @@ clock_pin:
 
 PCA9533 LED support. The PCA9533 is used on the mightyboard.
 
-```
+```cfg
 [pca9533 my_pca9533]
 #i2c_address: 98
 #   The i2c address that the chip is using on the i2c bus. Use 98 for
@@ -2603,7 +2606,7 @@ Execute gcode when a button is pressed or released (or when a pin
 changes state). You can check the state of the button by using
 `QUERY_BUTTON button=my_gcode_button`.
 
-```
+```cfg
 [gcode_button my_gcode_button]
 pin:
 #   The pin on which the button is connected. This parameter must be
@@ -2633,7 +2636,7 @@ setup as output pins and one may modify them at run-time using
 "SET_PIN PIN=my_pin VALUE=.1" type extended
 [g-code commands](G-Codes.md#custom-pin-commands).
 
-```
+```cfg
 [output_pin my_pin]
 pin:
 #   The pin to configure as an output. This parameter must be
@@ -2689,7 +2692,7 @@ of sections with a "static_digital_output" prefix). Pins configured
 here will be setup as a GPIO output during MCU configuration. They can
 not be changed at run-time.
 
-```
+```cfg
 [static_digital_output my_output_pins]
 pins:
 #   A comma separated list of pins to be set as GPIO output pins. The
@@ -2707,7 +2710,7 @@ containing two pins and then set "pin=multi_pin:my_fan" in the "[fan]"
 section - on each fan change both output pins would be updated. These
 aliases may not be used with stepper motor pins.
 
-```
+```cfg
 [multi_pin my_multi_pin]
 pins:
 #   A comma separated list of pins associated with this alias. This
@@ -2727,7 +2730,7 @@ feature, define a config section with a "tmc2130" prefix followed by
 the name of the corresponding stepper config section (for example,
 "[tmc2130 stepper_x]").
 
-```
+```cfg
 [tmc2130 stepper_x]
 cs_pin:
 #   The pin corresponding to the TMC2130 chip select line. This pin
@@ -2798,7 +2801,7 @@ UART. To use this feature, define a config section with a "tmc2208"
 prefix followed by the name of the corresponding stepper config
 section (for example, "[tmc2208 stepper_x]").
 
-```
+```cfg
 [tmc2208 stepper_x]
 uart_pin:
 #   The pin connected to the TMC2208 PDN_UART line. This parameter
@@ -2856,7 +2859,7 @@ this feature, define a config section with a "tmc2209" prefix followed
 by the name of the corresponding stepper config section (for example,
 "[tmc2209 stepper_x]").
 
-```
+```cfg
 [tmc2209 stepper_x]
 uart_pin:
 #tx_pin:
@@ -2906,7 +2909,7 @@ feature, define a config section with a tmc2660 prefix followed by the
 name of the corresponding stepper config section (for example,
 "[tmc2660 stepper_x]").
 
-```
+```cfg
 [tmc2660 stepper_x]
 cs_pin:
 #   The pin corresponding to the TMC2660 chip select line. This pin
@@ -2976,7 +2979,7 @@ feature, define a config section with a "tmc5160" prefix followed by
 the name of the corresponding stepper config section (for example,
 "[tmc5160 stepper_x]").
 
-```
+```cfg
 [tmc5160 stepper_x]
 cs_pin:
 #   The pin corresponding to the TMC5160 chip select line. This pin
@@ -3065,7 +3068,7 @@ run_current:
 Statically configured AD5206 digipots connected via SPI bus (one may
 define any number of sections with an "ad5206" prefix).
 
-```
+```cfg
 [ad5206 my_digipot]
 enable_pin:
 #   The pin corresponding to the AD5206 chip select line. This pin
@@ -3105,7 +3108,7 @@ enable_pin:
 Statically configured MCP4451 digipot connected via I2C bus (one may
 define any number of sections with an "mcp4451" prefix).
 
-```
+```cfg
 [mcp4451 my_digipot]
 i2c_address:
 #   The i2c address that the chip is using on the i2c bus. This
@@ -3141,7 +3144,7 @@ Statically configured MCP4728 digital-to-analog converter connected
 via I2C bus (one may define any number of sections with an "mcp4728"
 prefix).
 
-```
+```cfg
 [mcp4728 my_dac]
 #i2c_address: 96
 #   The i2c address that the chip is using on the i2c bus. The default
@@ -3178,7 +3181,7 @@ Statically configured MCP4018 digipot connected via two gpio "bit
 banging" pins (one may define any number of sections with an "mcp4018"
 prefix).
 
-```
+```cfg
 [mcp4018 my_digipot]
 scl_pin:
 #   The SCL "clock" pin. This parameter must be provided.
@@ -3207,7 +3210,7 @@ wiper:
 
 Support for a display attached to the micro-controller.
 
-```
+```cfg
 [display]
 lcd_type:
 #   The type of LCD chip in use. This may be "hd44780", "hd44780_spi",
@@ -3287,7 +3290,7 @@ lcd_type:
 Information on configuring hd44780 displays (which is used in
 "RepRapDiscount 2004 Smart Controller" type displays).
 
-```
+```cfg
 [display]
 lcd_type: hd44780
 #   Set to "hd44780" for hd44780 displays.
@@ -3316,7 +3319,7 @@ Information on configuring an hd44780_spi display - a 20x04 display
 controlled via a hardware "shift register" (which is used in
 mightyboard based printers).
 
-```
+```cfg
 [display]
 lcd_type: hd44780_spi
 #   Set to "hd44780_spi" for hd44780_spi displays.
@@ -3345,7 +3348,7 @@ spi_software_miso_pin:
 Information on configuring st7920 displays (which is used in
 "RepRapDiscount 12864 Full Graphic Smart Controller" type displays).
 
-```
+```cfg
 [display]
 lcd_type: st7920
 #   Set to "st7920" for st7920 displays.
@@ -3362,7 +3365,7 @@ sid_pin:
 Information on configuring an emulated st7920 display - found in some
 "2.4 inch touchscreen devices" and similar.
 
-```
+```cfg
 [display]
 lcd_type: emulated_st7920
 #   Set to "emulated_st7920" for emulated_st7920 displays.
@@ -3385,7 +3388,7 @@ spi_software_miso_pin:
 Information on configuring uc1701 displays (which is used in "MKS Mini
 12864" type displays).
 
-```
+```cfg
 [display]
 lcd_type: uc1701
 #   Set to "uc1701" for uc1701 displays.
@@ -3407,7 +3410,7 @@ a0_pin:
 
 Information on configuring ssd1306 and sh1106 displays.
 
-```
+```cfg
 [display]
 lcd_type:
 #   Set to either "ssd1306" or "sh1106" for the given display type.
@@ -3462,7 +3465,7 @@ are automatically created. One can replace or extend these
 display_data items by overriding the defaults in the main printer.cfg
 config file.
 
-```
+```cfg
 [display_data my_group_name my_data_name]
 position:
 #   Comma separated row and column of the display position that should
@@ -3484,7 +3487,7 @@ template. For example, if one were to define `[display_template
 my_template]` then one could use `{ render('my_template') }` in a
 display_data section.
 
-```
+```cfg
 [display_template my_template_name]
 #param_<name>:
 #   One may specify any number of options with a "param_" prefix. The
@@ -3511,7 +3514,7 @@ symbols i.e. `~my_display_glyph~`
 See [sample-glyphs.cfg](../config/sample-glyphs.cfg) for some
 examples.
 
-```
+```cfg
 [display_glyph my_display_glyph]
 #data:
 #   The display data, stored as 16 lines consisting of 16 bits (1 per
@@ -3538,7 +3541,7 @@ shown above it is possible to define multiple auxiliary displays. Note
 that auxiliary displays do not currently support menu functionality,
 thus they do not support the "menu" options or button configuration.
 
-```
+```cfg
 [display my_extra_display]
 # See the "display" section for available parameters.
 ```
@@ -3555,7 +3558,7 @@ See the
 [command template document](Command_Templates.md#menu-templates) for
 information on menu attributes available during template rendering.
 
-```
+```cfg
 # Common parameters available for all menu config sections.
 #[menu __some_list __some_name]
 #type: disabled
@@ -3633,7 +3636,7 @@ detection using a switch sensor, such as an endstop switch.
 See the [command reference](G-Codes.md#filament-sensor) for more
 information.
 
-```
+```cfg
 [filament_switch_sensor my_sensor]
 #pause_on_runout: True
 #   When set to True, a PAUSE will execute immediately after a runout
@@ -3673,7 +3676,7 @@ movement through the sensor.
 See the [command reference](G-Codes.md#filament-sensor) for more
 information.
 
-```
+```cfg
 [filament_motion_sensor my_sensor]
 detection_length: 7.0
 #   The minimum length of filament pulled through the sensor to trigger
@@ -3697,7 +3700,7 @@ switch_pin:
 TSLl401CL Based Filament Width Sensor. See the
 [guide](TSL1401CL_Filament_Width_Sensor.md) for more information.
 
-```
+```cfg
 [tsl1401cl_filament_width_sensor]
 #pin:
 #default_nominal_filament_diameter: 1.75 # (mm)
@@ -3712,7 +3715,7 @@ TSLl401CL Based Filament Width Sensor. See the
 Hall filament width sensor (see
 [Hall Filament Width Sensor](HallFilamentWidthSensor.md)).
 
-```
+```cfg
 [hall_filament_width_sensor]
 adc1:
 adc2:
@@ -3779,7 +3782,7 @@ in the printer configuration.
 See the [generic-duet2-duex.cfg](../config/generic-duet2-duex.cfg)
 file for an example.
 
-```
+```cfg
 [sx1509 my_sx1509]
 i2c_address:
 #   I2C address used by this expander. Depending on the hardware
@@ -3804,7 +3807,7 @@ prefix. Each SERCOM must be configured prior to using it as SPI or I2C
 peripheral. Place this config section above any other section that
 makes use of SPI or I2C buses.
 
-```
+```cfg
 [samd_sercom my_sercom]
 sercom:
 #   The name of the sercom bus to configure in the micro-controller.
@@ -3837,7 +3840,7 @@ See the
 [generic-duet2-maestro.cfg](../config/generic-duet2-maestro.cfg) file
 for an example.
 
-```
+```cfg
 [adc_scaled my_name]
 vref_pin:
 #   The ADC pin to use for VREF monitoring. This parameter must be
@@ -3857,7 +3860,7 @@ Replicape support - see the [beaglebone guide](beaglebone.md) and the
 [generic-replicape.cfg](../config/generic-replicape.cfg) file for an
 example.
 
-```
+```cfg
 # The "replicape" config section adds "replicape:stepper_x_enable"
 # virtual stepper enable pins (for steppers x, y, z, e, and h) and
 # "replicape:power_x" PWM output pins (for hotbed, e, h, fan0, fan1,
@@ -3937,7 +3940,7 @@ in *Settings > Serial Connection > Firmware & protocol* will prevent
 the need to start print on the Palette 2 and unpausing in Octoprint
 for your print to begin.
 
-```
+```cfg
 [palette2]
 serial:
 #   The serial port to connect to the Palette 2.
@@ -3960,7 +3963,7 @@ serial:
 The following parameters are generally available for devices using an
 SPI bus.
 
-```
+```cfg
 #spi_speed:
 #   The SPI speed (in hz) to use when communicating with the device.
 #   The default depends on the type of device.
@@ -3982,7 +3985,7 @@ SPI bus.
 The following parameters are generally available for devices using an
 I2C bus.
 
-```
+```cfg
 #i2c_address:
 #   The i2c address of the device. This must specified as a decimal
 #   number (not in hex). The default depends on the type of device.

--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -1,7 +1,7 @@
 # Configuration checks
 
 This document provides a list of steps to help confirm the pin
-settings in the Klipper printer.cfg file.  It is a good idea to run
+settings in the Klipper printer.cfg file. It is a good idea to run
 through these steps after following the steps in the
 [installation document](Installation.md).
 
@@ -113,7 +113,7 @@ best to test the extruder motor separately (see the next section).
 
 After verifying all endstops and verifying all stepper motors the
 homing mechanism should be tested. Issue a G28 command to home all
-axes.  Remove power from the printer if it does not home properly.
+axes. Remove power from the printer if it does not home properly.
 Rerun the endstop and stepper motor verification steps if necessary.
 
 ## Verify extruder motor

--- a/docs/Contact.md
+++ b/docs/Contact.md
@@ -64,6 +64,7 @@ Do not open a Klipper GitHub issue to request a feature.
 Unfortunately, we receive many more requests for help than we could
 possibly answer. Most problem reports we see are eventually tracked
 down to:
+
 1. Subtle errors in the hardware, or
 2. Not following all the steps described in the Klipper documentation.
 
@@ -97,6 +98,7 @@ diagnose errors in the software.
 
 There is important information that will be needed in order to fix a
 bug. Please follow these steps:
+
 1. Be sure the bug is in the Klipper software. If you are thinking
    "there is a problem, I can't figure out why, and therefore it is a
    Klipper bug", then **do not** open a GitHub issue. In that case,

--- a/docs/Contact.md
+++ b/docs/Contact.md
@@ -46,7 +46,7 @@ experiencing general printing problems, then you will likely get a
 better response by asking in a general 3d-printing forum or a forum
 dedicated to your printer hardware.
 
-Do not open a Klipper github issue to ask a question.
+Do not open a Klipper GitHub issue to ask a question.
 
 ## I have a feature request
 
@@ -57,7 +57,7 @@ feature, you can search for ongoing developments in the
 [Klipper Discord Chat](#discord-chat) for discussions between
 collaborators.
 
-Do not open a Klipper github issue to request a feature.
+Do not open a Klipper GitHub issue to request a feature.
 
 ## Help! It doesn't work!
 
@@ -88,7 +88,7 @@ other Klipper users then you can join the
 [Klipper Discord Chat](#discord-chat). Both are communities where
 Klipper users can discuss Klipper with other users.
 
-Do not open a Klipper github issue to request help.
+Do not open a Klipper GitHub issue to request help.
 
 ## I have diagnosed a defect in the Klipper software
 
@@ -99,7 +99,7 @@ There is important information that will be needed in order to fix a
 bug. Please follow these steps:
 1. Be sure the bug is in the Klipper software. If you are thinking
    "there is a problem, I can't figure out why, and therefore it is a
-   Klipper bug", then **do not** open a github issue. In that case,
+   Klipper bug", then **do not** open a GitHub issue. In that case,
    someone interested and able will need to first research and
    diagnose the root cause of the problem. If you would like to share
    the results of your research or check if other users are
@@ -138,7 +138,7 @@ bug. Please follow these steps:
       necessary information.
    5. If the log file is very large (eg, greater than 2MB) then one
       may need to compress the log with zip or gzip.
-5. Open a new github issue at
+5. Open a new GitHub issue at
    [https://github.com/KevinOConnor/klipper/issues](https://github.com/KevinOConnor/klipper/issues)
    and provide a clear description of the problem. The Klipper
    developers need to understand what steps were taken, what the
@@ -152,7 +152,7 @@ bug. Please follow these steps:
 Klipper is open-source software and we appreciate new contributions.
 
 New contributions (for both code and documentation) are submitted via
-Github Pull Requests. See the [CONTRIBUTING document](CONTRIBUTING.md)
+GitHub Pull Requests. See the [CONTRIBUTING document](CONTRIBUTING.md)
 for important information.
 
 There are several
@@ -160,6 +160,6 @@ There are several
 you have questions on the code then you can also ask in the
 [Klipper Community Forum](#community-forum) or on the
 [Klipper Community Discord](#discord-chat). If you would like to
-provide an update on your current progress then you can open a Github
+provide an update on your current progress then you can open a GitHub
 issue with the location of your code, an overview of the changes, and
 a description of its current status.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -4,7 +4,7 @@ This document describes some of the Klipper debugging tools.
 
 ## Running the regression tests
 
-The main Klipper GitHub repository uses "github actions" to run a
+The main Klipper GitHub repository uses "GitHub actions" to run a
 series of regression tests. It can be useful to run some of these
 tests locally.
 
@@ -16,7 +16,7 @@ The source code "whitespace check" can be run with:
 
 The Klippy regression test suite requires "data dictionaries" from
 many platforms. The easiest way to obtain them is to
-[download them from github](https://github.com/KevinOConnor/klipper/issues/1438).
+[download them from GitHub](https://github.com/KevinOConnor/klipper/issues/1438).
 Once the data dictionaries are downloaded, use the following to run
 the regression suite:
 
@@ -27,7 +27,7 @@ tar xfz klipper-dict-20??????.tar.gz
 
 ## Manually sending commands to the micro-controller
 
-Normally, the host klippy.py process would be used to translate gcode
+Normally, the host klippy.py process would be used to translate G-Code
 commands to Klipper micro-controller commands. However, it's also
 possible to manually send these MCU commands (functions marked with
 the DECL_COMMAND() macro in the Klipper source code). To do so, run:
@@ -42,10 +42,10 @@ functionality.
 Some command-line options are available. For more information run:
 `~/klippy-env/bin/python ./klippy/console.py --help`
 
-## Translating gcode files to micro-controller commands
+## Translating G-Code files to micro-controller commands
 
 The Klippy host code can run in a batch mode to produce the low-level
-micro-controller commands associated with a gcode file. Inspecting
+micro-controller commands associated with a G-Code file. Inspecting
 these low-level commands is useful when trying to understand the
 actions of the low-level hardware. It can also be useful to compare
 the difference in micro-controller commands after a code change.
@@ -61,7 +61,7 @@ make
 ```
 
 Once the above is done it is possible to run Klipper in batch mode
-(see [installation](Installation.md) for the steps necessary to build
+(see [Installation](Installation.md) for the steps necessary to build
 the python virtual environment and a printer.cfg file):
 
 ```bash
@@ -132,7 +132,7 @@ and effect scenarios.
 
 The [simulavr](http://www.nongnu.org/simulavr/) tool enables one to
 simulate an Atmel ATmega micro-controller. This section describes how
-one can run test gcode files through simulavr. It is recommended to
+one can run test G-Code files through simulavr. It is recommended to
 run this on a desktop class machine (not a Raspberry Pi) as it does
 require significant cpu to run efficiently.
 
@@ -169,7 +169,7 @@ PYTHONPATH=/path/to/simulavr/src/python/ ./scripts/avrsim.py -m atmega644 -s 200
 ```
 
 Then, with simulavr running in another window, one can run the
-following to read gcode from a file (eg, "test.gcode"), process it
+following to read G-Code from a file (eg, "test.gcode"), process it
 with Klippy, and send it to Klipper running in simulavr (see
 [installation](Installation.md) for the steps necessary to build the
 python virtual environment):

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -9,7 +9,8 @@ series of regression tests. It can be useful to run some of these
 tests locally.
 
 The source code "whitespace check" can be run with:
-```
+
+```bash
 ./scripts/check_whitespace.sh
 ```
 
@@ -18,7 +19,8 @@ many platforms. The easiest way to obtain them is to
 [download them from github](https://github.com/KevinOConnor/klipper/issues/1438).
 Once the data dictionaries are downloaded, use the following to run
 the regression suite:
-```
+
+```bash
 tar xfz klipper-dict-20??????.tar.gz
 ~/klippy-env/bin/python ~/klipper/scripts/test_klippy.py -d dict/ ~/klipper/test/klippy/*.test
 ```
@@ -30,7 +32,7 @@ commands to Klipper micro-controller commands. However, it's also
 possible to manually send these MCU commands (functions marked with
 the DECL_COMMAND() macro in the Klipper source code). To do so, run:
 
-```
+```bash
 ~/klippy-env/bin/python ./klippy/console.py /tmp/pseudoserial
 ```
 
@@ -53,7 +55,7 @@ to generate the micro-controller "data dictionary". This is done by
 compiling the micro-controller code to obtain the **out/klipper.dict**
 file:
 
-```
+```bash
 make menuconfig
 make
 ```
@@ -62,14 +64,14 @@ Once the above is done it is possible to run Klipper in batch mode
 (see [installation](Installation.md) for the steps necessary to build
 the python virtual environment and a printer.cfg file):
 
-```
+```bash
 ~/klippy-env/bin/python ./klippy/klippy.py ~/printer.cfg -i test.gcode -o test.serial -v -d out/klipper.dict
 ```
 
 The above will produce a file **test.serial** with the binary serial
 output. This output can be translated to readable text with:
 
-```
+```bash
 ~/klippy-env/bin/python ./klippy/parsedump.py out/klipper.dict test.serial > test.txt
 ```
 
@@ -91,14 +93,14 @@ these statistics after a print.
 To generate a graph, a one time step is necessary to install the
 "matplotlib" package:
 
-```
+```bash
 sudo apt-get update
 sudo apt-get install python-matplotlib
 ```
 
 Then graphs can be produced with:
 
-```
+```bash
 ~/klipper/scripts/graphstats.py /tmp/klippy.log -o loadgraph.png
 ```
 
@@ -114,7 +116,7 @@ information. There is a logextract.py script that may be useful when
 analyzing a micro-controller shutdown or similar problem. It is
 typically run with something like:
 
-```
+```bash
 mkdir work_directory
 cd work_directory
 cp /tmp/klippy.log .
@@ -137,7 +139,7 @@ require significant cpu to run efficiently.
 To use simulavr, download the simulavr package and compile with python
 support:
 
-```
+```bash
 git clone git://git.savannah.nongnu.org/simulavr.git
 cd simulavr
 ./bootstrap
@@ -152,7 +154,7 @@ compilation.
 
 To compile Klipper for use in simulavr, run:
 
-```
+```bash
 cd /patch/to/klipper
 make menuconfig
 ```
@@ -162,7 +164,7 @@ the MCU frequency to 20Mhz, and select SIMULAVR software emulation
 support. Then one can compile Klipper (run `make`) and then start the
 simulation with:
 
-```
+```bash
 PYTHONPATH=/path/to/simulavr/src/python/ ./scripts/avrsim.py -m atmega644 -s 20000000 -b 250000 out/klipper.elf
 ```
 
@@ -172,7 +174,7 @@ with Klippy, and send it to Klipper running in simulavr (see
 [installation](Installation.md) for the steps necessary to build the
 python virtual environment):
 
-```
+```bash
 ~/klippy-env/bin/python ./klippy/klippy.py config/generic-simulavr.cfg -i test.gcode -v
 ```
 
@@ -183,7 +185,7 @@ generation files with the exact timing of events. To do this, follow
 the directions above, but run avrsim.py with a command-line like the
 following:
 
-```
+```bash
 PYTHONPATH=/path/to/simulavr/src/python/ ./scripts/avrsim.py -m atmega644 -s 20000000 -b 250000 out/klipper.elf -t PORTA.PORT,PORTC.PORT
 ```
 
@@ -191,6 +193,6 @@ The above would create a file **avrsim.vcd** with information on each
 change to the GPIOs on PORTA and PORTB. This could then be viewed
 using gtkwave with:
 
-```
+```bash
 gtkwave avrsim.vcd
 ```

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -36,11 +36,14 @@ the DECL_COMMAND() macro in the Klipper source code). To do so, run:
 ~/klippy-env/bin/python ./klippy/console.py /tmp/pseudoserial
 ```
 
-See the "HELP" command within the tool for more information on its
+See the `HELP` command within the tool for more information on its
 functionality.
 
 Some command-line options are available. For more information run:
-`~/klippy-env/bin/python ./klippy/console.py --help`
+
+```bash
+~/klippy-env/bin/python ./klippy/console.py --help
+```
 
 ## Translating G-Code files to micro-controller commands
 

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -94,7 +94,8 @@ later analyzed. To use this feature, Klipper must be started with the
 [API Server](API_Server.md) enabled.
 
 Data logging is enabled with the `data_logger.py` tool. For example:
-```
+
+```bash
 ~/klipper/scripts/motan/data_logger.py /tmp/klippy_uds mylog
 ```
 
@@ -109,10 +110,12 @@ from the `data_logger.py` tool.
 The resulting files can be read and graphed using the `motan_graph.py`
 tool. To generate graphs on a Raspberry Pi, a one time step is
 necessary to install the "matplotlib" package:
-```
+
+```bash
 sudo apt-get update
 sudo apt-get install python-matplotlib
 ```
+
 However, it may be more convenient to copy the data files to a desktop
 class machine along with the Python code in the `scripts/motan/`
 directory. The motion analysis scripts should run on any machine with
@@ -120,27 +123,32 @@ a recent version of [Python](https://python.org) and
 [Matplotlib](https://matplotlib.org/) installed.
 
 Graphs can be generated with a command like the following:
-```
+
+```bash
 ~/klipper/scripts/motan/motan_graph.py mylog -o mygraph.png
 ```
 
 One can use the `-g` option to specify the datasets to graph (it takes
 a Python literal containing a list of lists). For example:
-```
+
+```bash
 ~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq:toolhead:velocity"], ["trapq:toolhead:accel"]]'
 ```
 
 The list of available datasets can be found using the `-l` option -
 for example:
-```
+
+```bash
 ~/klipper/scripts/motan/motan_graph.py -l
 ```
 
 It is also possible to specify matplotlib plot options for each
 dataset:
-```
+
+```bash
 ~/klipper/scripts/motan/motan_graph.py mylog -g '[["trapq:toolhead:velocity?color=red"]]'
 ```
+
 Many matplotlib options are available; some examples are "color",
 "label", "alpha", and "linestyle".
 

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -99,8 +99,8 @@ This calibration procedure requires printing a test object and
 measuring parts of that test object with digital calipers.
 
 Prior to running an enhanced delta calibration one must run the basic
-delta calibration (via the DELTA_CALIBRATE command) and save the
-results (via the SAVE_CONFIG command).
+delta calibration (via the `DELTA_CALIBRATE` command) and save the
+results (via the `SAVE_CONFIG` command).
 
 Use a slicer to generate G-Code from the
 [docs/prints/calibrate_size.stl](prints/calibrate_size.stl) file.
@@ -115,7 +115,7 @@ print size.
 
 Print the test object and wait for it to fully cool. The commands
 described below must be run with the same printer settings used to
-print the calibration object (don't run DELTA_CALIBRATE between
+print the calibration object (don't run `DELTA_CALIBRATE` between
 printing and measuring, or do something that would otherwise change
 the printer configuration).
 
@@ -213,35 +213,35 @@ DELTA_ANALYZE CALIBRATE=extended
 
 This command can take several minutes to complete. After completion it
 will calculate updated delta parameters (delta radius, tower angles,
-endstop positions, and arm lengths). Use the SAVE_CONFIG command to
+endstop positions, and arm lengths). Use the `SAVE_CONFIG` command to
 save and apply the settings:
 
 ```gcode
 SAVE_CONFIG
 ```
 
-The SAVE_CONFIG command will save both the updated delta parameters
-and information from the distance measurements. Future DELTA_CALIBRATE
+The `SAVE_CONFIG` command will save both the updated delta parameters
+and information from the distance measurements. Future `DELTA_CALIBRATE`
 commands will also utilize this distance information. Do not attempt
-to reenter the raw distance measurements after running SAVE_CONFIG, as
+to reenter the raw distance measurements after running `SAVE_CONFIG`, as
 this command changes the printer configuration and the raw
 measurements no longer apply.
 
 ### Additional notes
 
-* If the delta printer has good dimensional accuracy then the distance
+- If the delta printer has good dimensional accuracy then the distance
   between any two pillars should be around 74mm and the width of every
   pillar should be around 9mm. (Specifically, the goal is for the
   distance between any two pillars minus the width of one of the
   pillars to be exactly 65mm.) Should there be a dimensional
-  inaccuracy in the part then the DELTA_ANALYZE routine will calculate
+  inaccuracy in the part then the `DELTA_ANALYZE` routine will calculate
   new delta parameters using both the distance measurements and the
-  previous height measurements from the last DELTA_CALIBRATE command.
+  previous height measurements from the last `DELTA_CALIBRATE` command.
 
-* DELTA_ANALYZE may produce delta parameters that are surprising. For
+- `DELTA_ANALYZE` may produce delta parameters that are surprising. For
   example, it may suggest arm lengths that do not match the printer's
   actual arm lengths. Despite this, testing has shown that
-  DELTA_ANALYZE often produces superior results. It is believed that
+  `DELTA_ANALYZE` often produces superior results. It is believed that
   the calculated delta parameters are able to account for slight
   errors elsewhere in the hardware. For example, small differences in
   arm length may result in a tilt to the effector and some of that
@@ -256,4 +256,4 @@ confusing and poor results.
 
 Note that performing delta calibration will invalidate any previously
 obtained bed mesh. After performing a new delta calibration be sure to
-rerun BED_MESH_CALIBRATE.
+rerun `BED_MESH_CALIBRATE`.

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -40,7 +40,7 @@ then be sure to rerun probe calibration after any delta calibration.
 
 ## Basic delta calibration
 
-Klipper has a DELTA_CALIBRATE command that can perform basic delta
+Klipper has a `DELTA_CALIBRATE` command that can perform basic delta
 calibration. This command probes seven different points on the bed and
 calculates new values for the tower angles, tower endstops, and delta
 radius.
@@ -49,7 +49,7 @@ In order to perform this calibration the initial delta parameters (arm
 lengths, radius, and endstop positions) must be provided and they
 should have an accuracy to within a few millimeters. Most delta
 printer kits will provide these parameters - configure the printer
-with these initial defaults and then go on to run the DELTA_CALIBRATE
+with these initial defaults and then go on to run the `DELTA_CALIBRATE`
 command as described below. If no defaults are available then search
 online for a delta calibration guide that can provide a basic starting
 point.
@@ -74,8 +74,9 @@ To perform the basic probe, make sure the config has a
 G28
 DELTA_CALIBRATE METHOD=manual
 ```
+
 After probing the seven points new delta parameters will be
-calculated.  Save and apply these parameters by running:
+calculated. Save and apply these parameters by running:
 
 ```gcode
 SAVE_CONFIG
@@ -209,6 +210,7 @@ Finally, perform the enhanced delta calibration by running:
 ```gcode
 DELTA_ANALYZE CALIBRATE=extended
 ```
+
 This command can take several minutes to complete. After completion it
 will calculate updated delta parameters (delta radius, tower angles,
 endstop positions, and arm lengths). Use the SAVE_CONFIG command to

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -115,9 +115,9 @@ print size.
 
 Print the test object and wait for it to fully cool. The commands
 described below must be run with the same printer settings used to
-print the calibration object (don't run `DELTA_CALIBRATE` between
+print the calibration object (**don't run `DELTA_CALIBRATE` between
 printing and measuring, or do something that would otherwise change
-the printer configuration).
+the printer configuration**).
 
 If possible, perform the measurements described below while the object
 is still attached to the print bed, but don't worry if the part

--- a/docs/Delta_Calibrate.md
+++ b/docs/Delta_Calibrate.md
@@ -69,13 +69,15 @@ actual distance between the nozzle and bed at the given location.
 
 To perform the basic probe, make sure the config has a
 [delta_calibrate] section defined and then run the tool:
-```
+
+```gcode
 G28
 DELTA_CALIBRATE METHOD=manual
 ```
 After probing the seven points new delta parameters will be
 calculated.  Save and apply these parameters by running:
-```
+
+```gcode
 SAVE_CONFIG
 ```
 
@@ -135,9 +137,11 @@ from C label, distance from center to pillar with B label, etc.).
 
 Enter these parameters into Klipper with a comma separated list of
 floating point numbers:
-```
+
+```gcode
 DELTA_ANALYZE CENTER_DISTS=<a_dist>,<far_c_dist>,<b_dist>,<far_a_dist>,<c_dist>,<far_b_dist>
 ```
+
 Provide the values without spaces between them.
 
 Then measure the distance between the A pillar and the pillar across
@@ -152,7 +156,8 @@ the pillar across from A, and so on.
 ![delta_cal_e_step2](img/delta_cal_e_step2.png)
 
 Enter these parameters into Klipper:
-```
+
+```gcode
 DELTA_ANALYZE OUTER_DISTS=<a_to_far_c>,<far_c_to_b>,<b_to_far_a>,<far_a_to_c>,<c_to_far_b>,<far_b_to_a>
 ```
 
@@ -166,7 +171,8 @@ spoke.
 ![delta_cal_e_step3](img/delta_cal_e_step3.png)
 
 Enter them into Klipper:
-```
+
+```gcode
 DELTA_ANALYZE CENTER_PILLAR_WIDTHS=<a>,<b>,<c>
 ```
 
@@ -183,27 +189,32 @@ pillar across from A, etc.).
 ![delta_cal_e_step4](img/delta_cal_e_step4.png)
 
 And enter them into Klipper:
-```
+
+```gcode
 DELTA_ANALYZE OUTER_PILLAR_WIDTHS=<a>,<far_c>,<b>,<far_a>,<c>,<far_b>
 ```
 
 If the object was scaled to a smaller or larger size then provide the
 scale factor that was used when slicing the object:
-```
+
+```gcode
 DELTA_ANALYZE SCALE=1.0
 ```
+
 (A scale value of 2.0 would mean the object is twice its original
 size, 0.5 would be half its original size.)
 
 Finally, perform the enhanced delta calibration by running:
-```
+
+```gcode
 DELTA_ANALYZE CALIBRATE=extended
 ```
 This command can take several minutes to complete. After completion it
 will calculate updated delta parameters (delta radius, tower angles,
 endstop positions, and arm lengths). Use the SAVE_CONFIG command to
 save and apply the settings:
-```
+
+```gcode
 SAVE_CONFIG
 ```
 

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -38,7 +38,7 @@ drivers - see below for details.)
 
 If using Trinamic stepper motor drivers with run-time configuration
 then one can calibrate the endstop phases using the
-ENDSTOP_PHASE_CALIBRATE command. Start by adding the following to the
+`ENDSTOP_PHASE_CALIBRATE` command. Start by adding the following to the
 config file:
 
 ```cfg

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -76,7 +76,7 @@ SAVE_CONFIG
 
 ### Additional notes
 
-* This feature is most useful on delta printers and on the Z endstop
+- This feature is most useful on delta printers and on the Z endstop
   of cartesian/corexy printers. It is possible to use this feature on
   the XY endstops of cartesian printers, but that isn't particularly
   useful as a minor error in X/Y endstop position is unlikely to
@@ -87,12 +87,12 @@ SAVE_CONFIG
   the stepper phase is only stable if the endstop is at a static
   location on a rail).
 
-* After calibrating the endstop phase, if the endstop is later moved
+- After calibrating the endstop phase, if the endstop is later moved
   or adjusted then it will be necessary to recalibrate the endstop.
   Remove the calibration data from the config file and rerun the steps
   above.
 
-* In order to use this system the endstop must be accurate enough to
+- In order to use this system the endstop must be accurate enough to
   identify the stepper position within two "full steps". So, for
   example, if a stepper is using 16 micro-steps with a step distance
   of 0.005mm then the endstop must have an accuracy of at least
@@ -101,7 +101,7 @@ SAVE_CONFIG
   accurate. If recalibration does not help then disable endstop phase
   adjustments by removing them from the config file.
 
-* If one is using a traditional stepper controlled Z axis (as on a
+- If one is using a traditional stepper controlled Z axis (as on a
   cartesian or corexy printer) along with traditional bed leveling
   screws then it is also possible to use this system to arrange for
   each print layer to be performed on a "full step" boundary. To
@@ -111,7 +111,7 @@ SAVE_CONFIG
   (see [config reference](Config_Reference.md#endstop_phase) for
   further details), and then re-level the bed screws.
 
-* It is possible to use this system with traditional (non-Trinamic)
+- It is possible to use this system with traditional (non-Trinamic)
   stepper motor drivers. However, doing this requires making sure that
   the stepper motor drivers are reset every time the micro-controller
   is reset. (If the two are always reset together then Klipper can

--- a/docs/Endstop_Phase.md
+++ b/docs/Endstop_Phase.md
@@ -40,7 +40,8 @@ If using Trinamic stepper motor drivers with run-time configuration
 then one can calibrate the endstop phases using the
 ENDSTOP_PHASE_CALIBRATE command. Start by adding the following to the
 config file:
-```
+
+```cfg
 [endstop_phase]
 ```
 
@@ -59,7 +60,8 @@ little later.)
 
 To save the endstop phase for a particular stepper motor, run
 something like the following:
-```
+
+```gcode
 ENDSTOP_PHASE_CALIBRATE STEPPER=stepper_z
 ```
 
@@ -67,7 +69,8 @@ Run the above for all the steppers one wishes to save. Typically, one
 would use this on stepper_z for cartesian and corexy printers, and for
 stepper_a, stepper_b, and stepper_c on delta printers. Finally, run
 the following to update the configuration file with the data:
-```
+
+```gcode
 SAVE_CONFIG
 ```
 

--- a/docs/Example_Configs.md
+++ b/docs/Example_Configs.md
@@ -1,7 +1,7 @@
 # Example configurations
 
 This document contains guidelines for contributing an example Klipper
-configuration to the Klipper github repository (located in the
+configuration to the Klipper GitHub repository (located in the
 [config directory](../config/)).
 
 Note that the
@@ -59,7 +59,7 @@ is also a useful resource for finding and sharing config files.
       hardware. For example, do not specify `[virtual_sdcard]` nor
       `[temperature_host]` config sections.
    4. Only define macros that utilize functionality specific to the
-      given printer or to define g-codes that are commonly emitted by
+      given printer or to define G-Codes that are commonly emitted by
       slicers configured for the given printer.
 6. Where possible, it is best to use the same wording, phrasing,
    indentation, and section ordering as the existing config files.
@@ -99,6 +99,6 @@ is also a useful resource for finding and sharing config files.
    `max_extrude_cross_section`. Do not enable debugging features. For
    example there should not be a `force_move` config section.
 
-Example config files are submitted by creating a github "pull
+Example config files are submitted by creating a GitHub "pull
 request". Please also follow the directions in the
 [contributing document](CONTRIBUTING.md).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -39,20 +39,24 @@ See the [rotation distance document](Rotation_Distance.md).
 The general way to find a USB serial port is to run `ls
 /dev/serial/by-id/*` from an ssh terminal on the host machine. It will
 likely produce output similar to the following:
-```
+
+```bash
 /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
 
 The name found in the above command is stable and it is possible to
 use it in the config file and while flashing the micro-controller
 code. For example, a flash command might look similar to:
-```
+
+```bash
 sudo service klipper stop
 make flash FLASH_DEVICE=/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 sudo service klipper start
 ```
+
 and the updated config might look like:
-```
+
+```cfg
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
@@ -107,7 +111,8 @@ flashed to the micro-controller. The Klipper printer.cfg file will
 also need to be updated to match that baud rate (see the
 [config reference](Config_Reference.md#mcu) for details).  For
 example:
-```
+
+```cfg
 [mcu]
 baud: 250000
 ```
@@ -169,13 +174,16 @@ package.
 It is possible to run multiple instances of the Klipper host software,
 but doing so requires Linux admin knowledge. The Klipper installation
 scripts ultimately cause the following Unix command to be run:
-```
+
+```bash
 ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer.cfg -l /tmp/klippy.log
 ```
+
 One can run multiple instances of the above command as long as each
 instance has its own printer config file, its own log file, and its
 own pseudo-tty. For example:
-```
+
+```bash
 ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer2.cfg -l /tmp/klippy2.log -I /tmp/printer2
 ```
 
@@ -261,6 +269,7 @@ Klipper in mid-March of 2020.
 
 This is commonly caused by hardware errors on the USB connection
 between the host machine and the micro-controller. Things to look for:
+
 - Use a good quality USB cable between the host machine and
   micro-controller. Make sure the plugs are secure.
 - If using a Raspberry Pi, use a
@@ -463,7 +472,7 @@ prior to upgrading.
 When ready to upgrade, the general method is to ssh into the Raspberry
 Pi and run:
 
-```
+```bash
 cd ~/klipper
 git pull
 ~/klipper/scripts/install-octopi.sh
@@ -472,7 +481,7 @@ git pull
 Then one can recompile and flash the micro-controller code. For
 example:
 
-```
+```bash
 make menuconfig
 make clean
 make
@@ -485,7 +494,7 @@ sudo service klipper start
 However, it's often the case that only the host software changes. In
 this case, one can update and restart just the host software with:
 
-```
+```bash
 cd ~/klipper
 git pull
 sudo service klipper restart
@@ -511,7 +520,8 @@ flashing directions for the new firmware.
 On the raspberry pi end, an uninstall script is available in
 [scripts/klipper-uninstall.sh](../scripts/klipper-uninstall.sh). For
 example:
-```
+
+```bash
 sudo ~/klipper/scripts/klipper-uninstall.sh
 rm -rf ~/klippy-env ~/klipper
 ```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -23,7 +23,7 @@
 21. [Can I find out whether the printer has lost steps?](#can-i-find-out-whether-the-printer-has-lost-steps)
 22. [Why does Klipper report errors? I lost my print!](#why-does-klipper-report-errors-i-lost-my-print)
 23. [How do I upgrade to the latest software?](#how-do-i-upgrade-to-the-latest-software)
-24. [How do I uninstall klipper?](#how-do-i-uninstall-klipper)
+24. [How do I uninstall Klipper ?](#how-do-i-uninstall-klipper)
 
 ## How can I donate to the project?
 
@@ -109,7 +109,7 @@ need to be configured in the micro-controller (during **make
 menuconfig**) and that updated code will need to be compiled and
 flashed to the micro-controller. The Klipper printer.cfg file will
 also need to be updated to match that baud rate (see the
-[config reference](Config_Reference.md#mcu) for details).  For
+[Config Reference](Config_Reference.md#mcu) for details). For
 example:
 
 ```cfg
@@ -219,7 +219,7 @@ you. It's configured in OctoPrint via a web browser under:
 Settings->GCODE Scripts
 
 If you want to move the head after a print finishes, consider adding
-the desired movement to the "custom g-code" section of your slicer.
+the desired movement to the "custom G-Code" section of your slicer.
 
 If the printer requires some additional movement as part of the homing
 process itself (or fundamentally does not have a homing process) then
@@ -410,7 +410,7 @@ the terminal box. The M112 command will cause Klipper to enter into a
 Klipper. Navigate to the OctoPrint connection area and click on
 "Connect" to cause OctoPrint to reconnect. Navigate back to the
 terminal tab and issue a FIRMWARE_RESTART command to clear the Klipper
-error state.  After completing this sequence, the previous heating
+error state. After completing this sequence, the previous heating
 request will be canceled and a new print may be started.
 
 ## Can I find out whether the printer has lost steps?
@@ -508,7 +508,7 @@ If any errors persist then double check the
 [config changes](Config_Changes.md) document, as you may need to
 modify the printer configuration.
 
-Note that the RESTART and FIRMWARE_RESTART g-code commands do not load
+Note that the RESTART and FIRMWARE_RESTART G-Code commands do not load
 new software - the above "sudo service klipper restart" and "make
 flash" commands are needed for a software change to take effect.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -82,10 +82,10 @@ methods, so the "make flash" command may not work on all boards.
 
 If you're having an intermittent failure or you do have a standard
 setup, then double check that Klipper isn't running when flashing
-(sudo service klipper stop), make sure OctoPrint isn't trying to
+(`sudo service klipper stop`), make sure OctoPrint isn't trying to
 connect directly to the device (open the Connection tab in the web
 page and click Disconnect if the Serial Port is set to the device),
-and make sure FLASH_DEVICE is set correctly for your board (see the
+and make sure `FLASH_DEVICE` is set correctly for your board (see the
 [question above](#wheres-my-serial-port)).
 
 However, if "make flash" just doesn't work for your board, then you
@@ -209,7 +209,7 @@ can be configured to use "/tmp/printer" for the printer serial port.
 The code does this to reduce the chance of accidentally commanding the
 head into the bed or a wall. Once the printer is homed the software
 attempts to verify each move is within the position_min/max defined in
-the config file. If the motors are disabled (via an M84 or M18
+the config file. If the motors are disabled (via an `M84` or `M18`
 command) then the motors will need to be homed again prior to
 movement.
 
@@ -324,7 +324,7 @@ seconds. If the micro-controller does not receive a confirmation every
 5 seconds it goes into a "shutdown" state which is designed to turn
 off all heaters and stepper motors.
 
-See the "config_digital_out" command in the
+See the `config_digital_out` command in the
 [MCU commands](MCU_Commands.md) document for further details.
 
 In addition, the micro-controller software is configured with a

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -82,7 +82,7 @@ Klipper supports many standard 3d printer features:
   a regular web-browser. The same Raspberry Pi that runs Klipper can
   also run Octoprint.
 
-* Standard G-Code support. Common g-code commands that are produced by
+* Standard G-Code support. Common G-Code commands that are produced by
   typical "slicers" are supported. One may continue to use Slic3r,
   Cura, etc. with Klipper.
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -2,7 +2,7 @@
 
 Klipper has several compelling features:
 
-* High precision stepper movement. Klipper utilizes an application
+- High precision stepper movement. Klipper utilizes an application
   processor (such as a low-cost Raspberry Pi) when calculating printer
   movements. The application processor determines when to step each
   stepper motor, it compresses those events, transmits them to the
@@ -14,7 +14,7 @@ Klipper has several compelling features:
   and the physics of the machine kinematics. More precise stepper
   movement translates to quieter and more stable printer operation.
 
-* Best in class performance. Klipper is able to achieve high stepping
+- Best in class performance. Klipper is able to achieve high stepping
   rates on both new and old micro-controllers. Even old 8bit
   micro-controllers can obtain rates over 175K steps per second. On
   more recent micro-controllers, rates over 500K steps per second are
@@ -22,7 +22,7 @@ Klipper has several compelling features:
   stepper event timing remains precise even at high speeds which
   improves overall stability.
 
-* Klipper supports printers with multiple micro-controllers. For
+- Klipper supports printers with multiple micro-controllers. For
   example, one micro-controller could be used to control an extruder,
   while another controls the printer's heaters, while a third controls
   the rest of the printer. The Klipper host software implements clock
@@ -31,45 +31,45 @@ Klipper has several compelling features:
   micro-controllers - it just requires a few extra lines in the config
   file.
 
-* Configuration via simple config file. There's no need to reflash the
+- Configuration via simple config file. There's no need to reflash the
   micro-controller to change a setting. All of Klipper's configuration
   is stored in a standard config file which can be easily edited. This
   makes it easier to setup and maintain the hardware.
 
-* Klipper supports "Smooth Pressure Advance" - a mechanism to account
+- Klipper supports "Smooth Pressure Advance" - a mechanism to account
   for the effects of pressure within an extruder. This reduces
   extruder "ooze" and improves the quality of print corners. Klipper's
   implementation does not introduce instantaneous extruder speed
   changes, which improves overall stability and robustness.
 
-* Klipper supports "Input Shaping" to reduce the impact of vibrations
+- Klipper supports "Input Shaping" to reduce the impact of vibrations
   on print quality. This can reduce or eliminate "ringing" (also known
   as "ghosting", "echoing", or "rippling") in prints. It may also
   allow one to obtain faster printing speeds while still maintaining
   high print quality.
 
-* Klipper uses an "iterative solver" to calculate precise step times
+- Klipper uses an "iterative solver" to calculate precise step times
   from simple kinematic equations. This makes porting Klipper to new
   types of robots easier and it keeps timing precise even with complex
   kinematics (no "line segmentation" is needed).
 
-* Portable code. Klipper works on ARM, AVR, and PRU based
+- Portable code. Klipper works on ARM, AVR, and PRU based
   micro-controllers. Existing "reprap" style printers can run Klipper
   without hardware modification - just add a Raspberry Pi. Klipper's
   internal code layout makes it easier to support other
   micro-controller architectures as well.
 
-* Simpler code. Klipper uses a very high level language (Python) for
+- Simpler code. Klipper uses a very high level language (Python) for
   most code. The kinematics algorithms, the G-code parsing, the
   heating and thermistor algorithms, etc. are all written in Python.
   This makes it easier to develop new functionality.
 
-* Custom programmable macros. New G-Code commands can be defined in
+- Custom programmable macros. New G-Code commands can be defined in
   the printer config file (no code changes are necessary). Those
   commands are programmable - allowing them to produce different
   actions depending on the state of the printer.
 
-* Builtin API server. In addition to the standard G-Code interface,
+- Builtin API server. In addition to the standard G-Code interface,
   Klipper supports a rich JSON based application interface. This
   enables programmers to build external applications with detailed
   control of the printer.
@@ -78,69 +78,69 @@ Klipper has several compelling features:
 
 Klipper supports many standard 3d printer features:
 
-* Works with Octoprint. This allows the printer to be controlled using
+- Works with Octoprint. This allows the printer to be controlled using
   a regular web-browser. The same Raspberry Pi that runs Klipper can
   also run Octoprint.
 
-* Standard G-Code support. Common G-Code commands that are produced by
+- Standard G-Code support. Common G-Code commands that are produced by
   typical "slicers" are supported. One may continue to use Slic3r,
   Cura, etc. with Klipper.
 
-* Support for multiple extruders. Extruders with shared heaters and
+- Support for multiple extruders. Extruders with shared heaters and
   extruders on independent carriages (IDEX) are also supported.
 
-* Support for cartesian, delta, corexy, corexz, rotary delta, polar,
+- Support for cartesian, delta, corexy, corexz, rotary delta, polar,
   and cable winch style printers.
 
-* Automatic bed leveling support. Klipper can be configured for basic
+- Automatic bed leveling support. Klipper can be configured for basic
   bed tilt detection or full mesh bed leveling. If the bed uses
   multiple Z steppers then Klipper can also level by independently
   manipulating the Z steppers. Most Z height probes are supported,
   including BL-Touch probes and servo activated probes.
 
-* Automatic delta calibration support. The calibration tool can
+- Automatic delta calibration support. The calibration tool can
   perform basic height calibration as well as an enhanced X and Y
   dimension calibration. The calibration can be done with a Z height
   probe or via manual probing.
 
-* Support for common temperature sensors (eg, common thermistors,
+- Support for common temperature sensors (eg, common thermistors,
   AD595, AD597, AD849x, PT100, PT1000, MAX6675, MAX31855, MAX31856,
   MAX31865, BME280, HTU21D, and LM75). Custom thermistors and custom
   analog temperature sensors can also be configured.
 
-* Basic thermal heater protection enabled by default.
+- Basic thermal heater protection enabled by default.
 
-* Support for standard fans, nozzle fans, and temperature controlled
+- Support for standard fans, nozzle fans, and temperature controlled
   fans. No need to keep fans running when the printer is idle.
 
-* Support for run-time configuration of TMC2130, TMC2208/TMC2224,
+- Support for run-time configuration of TMC2130, TMC2208/TMC2224,
   TMC2209, TMC2660, and TMC5160 stepper motor drivers. There is also
   support for current control of traditional stepper drivers via
   AD5206, MCP4451, MCP4728, MCP4018, and PWM pins.
 
-* Support for common LCD displays attached directly to the printer. A
+- Support for common LCD displays attached directly to the printer. A
   default menu is also available. The contents of the display and menu
   can be fully customized via the config file.
 
-* Constant acceleration and "look-ahead" support. All printer moves
+- Constant acceleration and "look-ahead" support. All printer moves
   will gradually accelerate from standstill to cruising speed and then
   decelerate back to a standstill. The incoming stream of G-Code
   movement commands are queued and analyzed - the acceleration between
   movements in a similar direction will be optimized to reduce print
   stalls and improve overall print time.
 
-* Klipper implements a "stepper phase endstop" algorithm that can
+- Klipper implements a "stepper phase endstop" algorithm that can
   improve the accuracy of typical endstop switches. When properly
   tuned it can improve a print's first layer bed adhesion.
 
-* Support for measuring and recording acceleration using an adxl345
+- Support for measuring and recording acceleration using an adxl345
   accelerometer.
 
-* Support for limiting the top speed of short "zigzag" moves to reduce
+- Support for limiting the top speed of short "zigzag" moves to reduce
   printer vibration and noise. See the [kinematics](Kinematics.md)
   document for more information.
 
-* Sample configuration files are available for many common printers.
+- Sample configuration files are available for many common printers.
   Check the [config directory](../config/) for a list.
 
 To get started with Klipper, read the [installation](Installation.md)

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -280,7 +280,7 @@ The following command is available when a
 enabled:
 
 - `SET_FAN_SPEED FAN=config_name SPEED=<speed>` This command sets
-  the speed of a fan. <speed> must be between 0.0 and 1.0.
+  the speed of a fan. \<speed\> must be between 0.0 and 1.0.
 
 ### Neopixel and Dotstar Commands
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -73,8 +73,8 @@ In addition, the following extended commands are availble when the
 The following standard G-Code commands are available if a
 [gcode_arcs config section](Config_Reference.md#gcode_arcs) is
 enabled:
-- Controlled Arc Move (G2 or G3): `G2 [X<pos>] [Y<pos>] [Z<pos>]
-  [E<pos>] [F<speed>] I<value> J<value>`
+- Controlled Arc Move (G2 or G3):
+  `G2 [X<pos>] [Y<pos>] [Z<pos>][E<pos>] [F<speed>] I<value> J<value>`
 
 ### G-Code firmware retraction
 
@@ -95,12 +95,12 @@ The following standard G-Code commands are available if a
 
 The following standard G-Code commands are currently available, but
 using them is not recommended:
-- Get Endstop Status: `M119` (Use QUERY_ENDSTOPS instead.)
+- Get Endstop Status: `M119` (Use `QUERY_ENDSTOPS` instead.)
 
 ## Extended G-Code Commands
 
 Klipper uses "extended" G-Code commands for general configuration and
-status.  These extended commands all follow a similar format - they
+status. These extended commands all follow a similar format - they
 start with a command name and may be followed by one or more
 parameters. For example: `SET_SERVO SERVO=myservo ANGLE=5.3`. In this
 document, the commands and parameters are shown in uppercase, however
@@ -123,11 +123,11 @@ The following standard commands are supported:
   [MOVE=1 [MOVE_SPEED=<speed>]]`: Set a positional offset to apply to
   future G-Code commands. This is commonly used to virtually change
   the Z bed offset or to set nozzle XY offsets when switching
-  extruders. For example, if "SET_GCODE_OFFSET Z=0.2" is sent, then
+  extruders. For example, if `SET_GCODE_OFFSET Z=0.2` is sent, then
   future G-Code moves will have 0.2mm added to their Z height. If the
   X_ADJUST style parameters are used, then the adjustment will be
-  added to any existing offset (eg, "SET_GCODE_OFFSET Z=-0.2" followed
-  by "SET_GCODE_OFFSET Z_ADJUST=0.3" would result in a total Z offset
+  added to any existing offset (eg, `SET_GCODE_OFFSET Z=-0.2` followed
+  by `SET_GCODE_OFFSET Z_ADJUST=0.3` would result in a total Z offset
   of 0.1). If "MOVE=1" is specified then a toolhead move will be
   issued to apply the given offset (otherwise the offset will take
   effect on the next absolute G-Code move that specifies the given
@@ -135,11 +135,11 @@ The following standard commands are supported:
   performed with the given speed (in mm/s); otherwise the toolhead
   move will use the last specified G-Code speed.
 - `SAVE_GCODE_STATE [NAME=<state_name>]`: Save the current
-  g-code coordinate parsing state. Saving and restoring the g-code
+  G-Code coordinate parsing state. Saving and restoring the G-Code
   state is useful in scripts and macros. This command saves the
-  current g-code absolute coordinate mode (G90/G91), absolute extrude
-  mode (M82/M83), origin (G92), offset (SET_GCODE_OFFSET), speed
-  override (M220), extruder override (M221), move speed, current XYZ
+  current G-Code absolute coordinate mode (`G90`/`G91`), absolute extrude
+  mode (`M82`/`M83`), origin (`G92`), offset (`SET_GCODE_OFFSET`), speed
+  override (`M220`), extruder override (`M221`), move speed, current XYZ
   position, and relative extruder "E" position. If NAME is provided it
   allows one to name the saved state to the given string. If NAME is
   not provided it defaults to "default".
@@ -149,7 +149,7 @@ The following standard commands are supported:
   be issued to move back to the previous XYZ position. If "MOVE_SPEED"
   is specified then the toolhead move will be performed with the given
   speed (in mm/s); otherwise the toolhead move will use the restored
-  g-code speed.
+  G-Code speed.
 - `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
   [WRITE_FILE=1]`: Perform a PID calibration test. The specified
   heater will be enabled until the specified target temperature is
@@ -208,10 +208,10 @@ The following standard commands are supported:
   for calibrating a Z position_endstop config setting. See the
   MANUAL_PROBE command for details on the parameters and the
   additional commands available while the tool is active.
-- `Z_OFFSET_APPLY_ENDSTOP`: Take the current Z Gcode offset (aka,
+- `Z_OFFSET_APPLY_ENDSTOP`: Take the current Z G-Code offset (aka,
   babystepping), and subtract it from the stepper_z endstop_position.
   This acts to take a frequently used babystepping value, and "make
-  it permanent".  Requires a `SAVE_CONFIG` to take effect.
+  it permanent". Requires a `SAVE_CONFIG` to take effect.
 - `TUNING_TOWER COMMAND=<command> PARAMETER=<name> START=<value>
   FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
   each Z height during a print. The tool will run the given COMMAND
@@ -224,7 +224,7 @@ The following standard commands are supported:
   active display group of an lcd display. This allows to define
   multiple display data groups in the config,
   e.g. `[display_data <group> <elementname>]` and switch between them
-  using this extended gcode command. If DISPLAY is not specified it
+  using this extended G-Code command. If DISPLAY is not specified it
   defaults to "display" (the primary display).
 - `SET_IDLE_TIMEOUT [TIMEOUT=<timeout>]`:  Allows the user to set the
   idle timeout (in seconds).
@@ -362,10 +362,10 @@ the [probe calibrate guide](Probe_Calibrate.md)):
   additional commands available while the tool is active. Please note,
   the PROBE_CALIBRATE command uses the speed variable
   to move in XY direction as well as Z.
-- `Z_OFFSET_APPLY_PROBE`: Take the current Z Gcode offset (aka,
+- `Z_OFFSET_APPLY_PROBE`: Take the current Z G-Code offset (aka,
   babystepping), and subtract if from the probe's z_offset.
   This acts to take a frequently used babystepping value, and "make
-  it permanent".  Requires a `SAVE_CONFIG` to take effect.
+  it permanent". Requires a `SAVE_CONFIG` to take effect.
 
 ### BLTouch
 
@@ -425,26 +425,26 @@ The following commands are available when the
   MANUAL_PROBE command above for details on the additional commands
   available while this tool is active.
 - `BED_MESH_OUTPUT PGP=[<0:1>]`: This command outputs the current probed
-  z values and current mesh values to the terminal.  If PGP=1 is specified
+  z values and current mesh values to the terminal. If PGP=1 is specified
   the x,y coordinates generated by bed_mesh, along with their associated
   indices, will be output to the terminal.
 - `BED_MESH_MAP`: Like to BED_MESH_OUTPUT, this command prints the current
-  state of the mesh to the terminal.  Instead of printing the values in a
+  state of the mesh to the terminal. Instead of printing the values in a
   human readable format, the state is serialized in json format. This allows
-  octoprint plugins to easily capture the data and generate height maps
+  Octoprint plugins to easily capture the data and generate height maps
   approximating the bed's surface.
 - `BED_MESH_CLEAR`: This command clears the mesh and removes all
-  z adjustment.  It is recommended to put this in your end-gcode.
+  z adjustment. It is recommended to put this in your end G-Code.
 - `BED_MESH_PROFILE LOAD=<name> SAVE=<name> REMOVE=<name>`: This
-  command provides profile management for mesh state.  LOAD will
+  command provides profile management for mesh state. LOAD will
   restore the mesh state from the profile matching the supplied name.
   SAVE will save the current mesh state to a profile matching the
-  supplied name.  Remove will delete the profile matching the
-  supplied name from persistent memory.  Note that after SAVE or
-  REMOVE operations have been run the SAVE_CONFIG gcode must be run
+  supplied name. Remove will delete the profile matching the
+  supplied name from persistent memory. Note that after SAVE or
+  REMOVE operations have been run the SAVE_CONFIG G-Code must be run
   to make the changes to peristent memory permanent.
 - `BED_MESH_OFFSET [X=<value>] [Y=<value>]`:  Applies X and/or Y
-  offsets to the mesh lookup.  This is useful for printers with
+  offsets to the mesh lookup. This is useful for printers with
   independent extruders, as an offset is necessary to produce
   correct Z adjustment after a tool change.
 
@@ -591,12 +591,12 @@ enabled:
 - `PAUSE`: Pauses the current print. The current position is captured
   for restoration upon resume.
 - `RESUME [VELOCITY=<value>]`: Resumes the print from a pause, first
-  restoring the previously captured position.  The VELOCITY parameter
+  restoring the previously captured position. The VELOCITY parameter
   determines the speed at which the tool should return to the original
   captured position.
 - `CLEAR_PAUSE`: Clears the current paused state without resuming the
   print. This is useful if one decides to cancel a print after a
-  PAUSE. It is recommended to add this to your start gcode to make
+  PAUSE. It is recommended to add this to your start G-Code to make
   sure the paused state is fresh for each print.
 - `CANCEL_PRINT`: Cancels the current print.
 
@@ -653,7 +653,7 @@ is enabled (also see the [skew correction guide](skew_correction.md)):
   then all skew correction will be disabled.
 - `GET_CURRENT_SKEW`: Reports the current printer skew for each plane
   in both radians and degrees. The skew is calculated based on
-  parameters provided via the `SET_SKEW` gcode.
+  parameters provided via the `SET_SKEW` G-Code.
 - `CALC_MEASURED_SKEW [AC=<ac_length>] [BD=<bd_length>]
   [AD=<ad_length>]`: Calculates and reports the skew (in radians and
   degrees) based on a measured print. This can be useful for
@@ -667,10 +667,10 @@ is enabled (also see the [skew correction guide](skew_correction.md)):
   skew state to a profile matching the supplied name. Remove will
   delete the profile matching the supplied name from persistent
   memory. Note that after SAVE or REMOVE operations have been run the
-  SAVE_CONFIG gcode must be run to make the changes to peristent
+  SAVE_CONFIG G-Code must be run to make the changes to peristent
   memory permanent.
 
-### Delayed GCode
+### Delayed G-Code
 
 The following command is enabled if a
 [delayed_gcode config section](Config_Reference.md#delayed_gcode) has
@@ -678,7 +678,7 @@ been enabled (also see the
 [template guide](Command_Templates.md#delayed-gcodes)):
 - `UPDATE_DELAYED_GCODE [ID=<name>] [DURATION=<seconds>]`:  Updates the
   delay duration for the identified [delayed_gcode] and starts the timer
-  for gcode execution.  A value of 0 will cancel a pending delayed gcode
+  for G-Code execution. A value of 0 will cancel a pending delayed G-Code
   from executing.
 
 ### Save Variables
@@ -689,7 +689,7 @@ has been enabled:
 - `SAVE_VARIABLE VARIABLE=<name> VALUE=<value>`: Saves the variable to
   disk so that it can be used across restarts. All stored variables
   are loaded into the `printer.save_variables.variables` dict at
-  startup and can be used in gcode macros. The provided VALUE is
+  startup and can be used in G-Code macros. The provided VALUE is
   parsed as a Python literal.
 
 ### Resonance compensation
@@ -821,6 +821,6 @@ is enabled:
   is complete.
 
 Palette prints work by embedding special OCodes (Omega Codes)
-in the GCode file:
-- `O1`...`O32`: These codes are read from the GCode stream and processed
+in the G-Code file:
+- `O1`...`O32`: These codes are read from the G-Code stream and processed
   by this module and passed to the Palette 2 device.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -224,10 +224,10 @@ The following standard commands are supported:
   FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
   each Z height during a print. The tool will run the given COMMAND
   with the given PARAMETER assigned to the value using the formula
-  $value = start + factor \times z_{height}$. If BAND is provided then the
+  `value = start + factor * z_height`. If BAND is provided then the
   adjustment will only be made every BAND millimeters of z height - in
-  that case the formula used is $value = start + factor \times
-  (\lfloor{\frac{z_{height}}{band}}\rfloor + .5) \times band$.
+  that case the formula used is `value = start + factor *
+  ((floor(z_height / band) + .5) * band)`.
 - `SET_DISPLAY_GROUP [DISPLAY=<display>] GROUP=<group>`: Set the
   active display group of an lcd display. This allows to define
   multiple display data groups in the config,

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -145,7 +145,7 @@ The following standard commands are supported:
   not provided it defaults to "default".
 - `RESTORE_GCODE_STATE [NAME=<state_name>]
   [MOVE=1 [MOVE_SPEED=<speed>]]`: Restore a state previously saved via
-  SAVE_GCODE_STATE. If "MOVE=1" is specified then a toolhead move will
+  `SAVE_GCODE_STATE`. If "MOVE=1" is specified then a toolhead move will
   be issued to move back to the previous XYZ position. If "MOVE_SPEED"
   is specified then the toolhead move will be performed with the given
   speed (in mm/s); otherwise the toolhead move will use the restored
@@ -193,7 +193,7 @@ The following standard commands are supported:
   diagnostic tool to help verify stepper connectivity.
 - `MANUAL_PROBE [SPEED=<speed>]`: Run a helper script useful for
   measuring the height of the nozzle at a given location. If SPEED is
-  specified, it sets the speed of TESTZ commands (the default is
+  specified, it sets the speed of `TESTZ` commands (the default is
   5mm/s). During a manual probe, the following additional commands are
   available:
   - `ACCEPT`: This command accepts the current Z position and
@@ -206,7 +206,7 @@ The following standard commands are supported:
     nozzle up or down an amount relative to previous attempts.
 - `Z_ENDSTOP_CALIBRATE [SPEED=<speed>]`: Run a helper script useful
   for calibrating a Z position_endstop config setting. See the
-  MANUAL_PROBE command for details on the parameters and the
+  `MANUAL_PROBE` command for details on the parameters and the
   additional commands available while the tool is active.
 - `Z_OFFSET_APPLY_ENDSTOP`: Take the current Z G-Code offset (aka,
   babystepping), and subtract it from the stepper_z endstop_position.
@@ -230,10 +230,10 @@ The following standard commands are supported:
   idle timeout (in seconds).
 - `RESTART`: This will cause the host software to reload its config
   and perform an internal reset. This command will not clear error
-  state from the micro-controller (see FIRMWARE_RESTART) nor will it
+  state from the micro-controller (see `FIRMWARE_RESTART`) nor will it
   load new software (see
   [the FAQ](FAQ.md#how-do-i-upgrade-to-the-latest-software)).
-- `FIRMWARE_RESTART`: This is similar to a RESTART command, but it
+- `FIRMWARE_RESTART`: This is similar to a `RESTART` command, but it
   also clears any error state from the micro-controller.
 - `SAVE_CONFIG`: This command will overwrite the main printer config
   file and restart the host software. This command is used in
@@ -284,10 +284,10 @@ The following command is available when a
   the given chip (1 for the first chip, 2 for the second, etc.). If
   INDEX is not provided then all LEDs in the daisy-chain will be set
   to the provided color. If TRANSMIT=0 is specified then the color
-  change will only be made on the next SET_LED command that does not
+  change will only be made on the next `SET_LED` command that does not
   specify TRANSMIT=0; this may be useful in combination with the INDEX
   parameter to batch multiple updates in a daisy-chain. By default, the
-  SET_LED command will sync it's changes with other ongoing gcode commands.
+  `SET_LED` command will sync it's changes with other ongoing G-Code commands.
   This can lead to undesirable behavior if LEDs are being set while the
   printer is not printing as it will reset the idle timeout. If careful
   timing is not needed, the optional SYNC=0 parameter can be specified to
@@ -310,7 +310,7 @@ enabled:
   [SET_POSITION=<pos>] [SPEED=<speed>] [ACCEL=<accel>]
   [MOVE=<pos> [STOP_ON_ENDSTOP=[1|2|-1|-2]] [SYNC=0]]`: This command
   will alter the state of the stepper. Use the ENABLE parameter to
-  enable/disable the stepper. Use the SET_POSITION parameter to force
+  enable/disable the stepper. Use the `SET_POSITION` parameter to force
   the stepper to think it is at the given position. Use the MOVE
   parameter to request a movement to the given position. If SPEED
   and/or ACCEL is specified then the given values will be used instead
@@ -358,9 +358,9 @@ the [probe calibrate guide](Probe_Calibrate.md)):
 - `PROBE_CALIBRATE [SPEED=<speed>] [<probe_parameter>=<value>]`: Run a
   helper script useful for calibrating the probe's z_offset. See the
   PROBE command for details on the optional probe parameters. See
-  the MANUAL_PROBE command for details on the SPEED parameter and the
+  the `MANUAL_PROBE` command for details on the SPEED parameter and the
   additional commands available while the tool is active. Please note,
-  the PROBE_CALIBRATE command uses the speed variable
+  the `PROBE_CALIBRATE` command uses the speed variable
   to move in XY direction as well as Z.
 - `Z_OFFSET_APPLY_PROBE`: Take the current Z G-Code offset (aka,
   babystepping), and subtract if from the probe's z_offset.
@@ -393,7 +393,7 @@ is enabled (also see the [delta calibrate guide](Delta_Calibrate.md)):
   endstop positions, tower angles, and radius. See the PROBE command
   for details on the optional probe parameters. If METHOD=manual is
   specified then the manual probing tool is activated - see the
-  MANUAL_PROBE command above for details on the additional commands
+  `MANUAL_PROBE` command above for details on the additional commands
   available while this tool is active.
 - `DELTA_ANALYZE`: This command is used during enhanced delta
   calibration. See [Delta Calibrate](Delta_Calibrate.md) for details.
@@ -404,10 +404,10 @@ The following commands are available when the
 [bed_tilt config section](Config_Reference.md#bed_tilt) is enabled:
 - `BED_TILT_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`:
   This command will probe the points specified in the config and then
-  recommend updated x and y tilt adjustments. See the PROBE command
-  for details on the optional probe parameters. If METHOD=manual is
+  recommend updated x and y tilt adjustments. See the `PROBE` command
+  for details on the optional probe parameters. If `METHOD=manual` is
   specified then the manual probing tool is activated - see the
-  MANUAL_PROBE command above for details on the additional commands
+  `MANUAL_PROBE` command above for details on the additional commands
   available while this tool is active.
 
 ### Mesh Bed Leveling
@@ -419,8 +419,8 @@ The following commands are available when the
   [<mesh_parameter>=<value>]`:
   This command probes the bed using generated points specified by the
   parameters in the config. After probing, a mesh is generated and
-  z-movement is adjusted according to the mesh. See the PROBE command
-  for details on the optional probe parameters. If METHOD=manual is
+  z-movement is adjusted according to the mesh. See the `PROBE` command
+  for details on the optional probe parameters. If `METHOD=manual` is
   specified then the manual probing tool is activated - see the
   MANUAL_PROBE command above for details on the additional commands
   available while this tool is active.
@@ -428,7 +428,7 @@ The following commands are available when the
   z values and current mesh values to the terminal. If PGP=1 is specified
   the x,y coordinates generated by bed_mesh, along with their associated
   indices, will be output to the terminal.
-- `BED_MESH_MAP`: Like to BED_MESH_OUTPUT, this command prints the current
+- `BED_MESH_MAP`: Like to `BED_MESH_OUTPUT`, this command prints the current
   state of the mesh to the terminal. Instead of printing the values in a
   human readable format, the state is serialized in json format. This allows
   Octoprint plugins to easily capture the data and generate height maps
@@ -438,10 +438,10 @@ The following commands are available when the
 - `BED_MESH_PROFILE LOAD=<name> SAVE=<name> REMOVE=<name>`: This
   command provides profile management for mesh state. LOAD will
   restore the mesh state from the profile matching the supplied name.
-  SAVE will save the current mesh state to a profile matching the
+  `SAVE` will save the current mesh state to a profile matching the
   supplied name. Remove will delete the profile matching the
-  supplied name from persistent memory. Note that after SAVE or
-  REMOVE operations have been run the SAVE_CONFIG G-Code must be run
+  supplied name from persistent memory. Note that after `SAVE` or
+  `REMOVE` operations have been run the SAVE_CONFIG G-Code must be run
   to make the changes to peristent memory permanent.
 - `BED_MESH_OFFSET [X=<value>] [Y=<value>]`:  Applies X and/or Y
   offsets to the mesh lookup. This is useful for printers with
@@ -524,7 +524,7 @@ enabled (also see the [endstop phase guide](Endstop_Phase.md)):
   endstop stepper phases during past homing operations. When a STEPPER
   parameter is provided it arranges for the given endstop phase
   setting to be written to the config file (in conjunction with the
-  SAVE_CONFIG command).
+  `SAVE_CONFIG` command).
 
 ### Force movement
 
@@ -540,17 +540,17 @@ enabled:
   kinematic updates are made; other parallel steppers on an axis will
   not be moved. Use caution as an incorrect command could cause
   damage! Using this command will almost certainly place the low-level
-  kinematics in an incorrect state; issue a G28 afterwards to reset
+  kinematics in an incorrect state; issue a `G28` afterwards to reset
   the kinematics. This command is intended for low-level diagnostics
   and debugging.
 - `SET_KINEMATIC_POSITION [X=<value>] [Y=<value>] [Z=<value>]`: Force
   the low-level kinematic code to believe the toolhead is at the given
   cartesian position. This is a diagnostic and debugging command; use
-  SET_GCODE_OFFSET and/or G92 for regular axis transformations. If an
+  `SET_GCODE_OFFSET` and/or `G92` for regular axis transformations. If an
   axis is not specified then it will default to the position that the
   head was last commanded to. Setting an incorrect or invalid position
   may lead to internal software errors. This command may invalidate
-  future boundary checks; issue a G28 afterwards to reset the
+  future boundary checks; issue a `G28` afterwards to reset the
   kinematics.
 
 ### SDcard loop
@@ -667,7 +667,7 @@ is enabled (also see the [skew correction guide](skew_correction.md)):
   skew state to a profile matching the supplied name. Remove will
   delete the profile matching the supplied name from persistent
   memory. Note that after SAVE or REMOVE operations have been run the
-  SAVE_CONFIG G-Code must be run to make the changes to peristent
+  `SAVE_CONFIG` G-Code must be run to make the changes to peristent
   memory permanent.
 
 ### Delayed G-Code

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -6,6 +6,7 @@ commands that one may enter into the OctoPrint terminal tab.
 ## G-Code commands
 
 Klipper supports the following standard G-Code commands:
+
 - Move (G0 or G1): `G1 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>] [F<speed>]`
 - Dwell: `G4 P<milliseconds>`
 - Move to origin: `G28 [X] [Y] [Z]`
@@ -55,6 +56,7 @@ example, one might use this to implement: `G12`, `G29`, `G30`, `G31`,
 Klipper also supports the following standard G-Code commands if the
 [virtual_sdcard config section](Config_Reference.md#virtual_sdcard) is
 enabled:
+
 - List SD card: `M20`
 - Initialize SD card: `M21`
 - Select SD file: `M23 <filename>`
@@ -65,6 +67,7 @@ enabled:
 
 In addition, the following extended commands are availble when the
 "virtual_sdcard" config section is enabled.
+
 - Load a file and start SD print: `SDCARD_PRINT_FILE FILENAME=<filename>`
 - Unload file and clear SD state: `SDCARD_RESET_FILE`
 
@@ -73,6 +76,7 @@ In addition, the following extended commands are availble when the
 The following standard G-Code commands are available if a
 [gcode_arcs config section](Config_Reference.md#gcode_arcs) is
 enabled:
+
 - Controlled Arc Move (G2 or G3):
   `G2 [X<pos>] [Y<pos>] [Z<pos>][E<pos>] [F<speed>] I<value> J<value>`
 
@@ -81,6 +85,7 @@ enabled:
 The following standard G-Code commands are available if a
 [firmware_retraction config section](Config_Reference.md#firmware_retraction)
 is enabled:
+
 - Retract: `G10`
 - Unretract: `G11`
 
@@ -88,6 +93,7 @@ is enabled:
 
 The following standard G-Code commands are available if a
 [display config section](Config_Reference.md#display) is enabled:
+
 - Display Message: `M117 <message>`
 - Set build percentage: `M73 P<percent>`
 
@@ -95,6 +101,7 @@ The following standard G-Code commands are available if a
 
 The following standard G-Code commands are currently available, but
 using them is not recommended:
+
 - Get Endstop Status: `M119` (Use `QUERY_ENDSTOPS` instead.)
 
 ## Extended G-Code Commands
@@ -108,6 +115,7 @@ they are not case sensitive. (So, "SET_SERVO" and "set_servo" both run
 the same command.)
 
 The following standard commands are supported:
+
 - `QUERY_ENDSTOPS`: Probe the axis endstops and report if they are
   "triggered" or in an "open" state. This command is typically used to
   verify that an endstop is working correctly.
@@ -248,6 +256,7 @@ The following command is available when a
 [gcode_macro config section](Config_Reference.md#gcode_macro) is
 enabled (also see the
 [command templates guide](Command_Templates.md)):
+
 - `SET_GCODE_VARIABLE MACRO=<macro_name> VARIABLE=<name>
   VALUE=<value>`: This command allows one to change the value of a
   gcode_macro variable at run-time. The provided VALUE is parsed as a
@@ -258,6 +267,7 @@ enabled (also see the
 The following command is available when an
 [output_pin config section](Config_Reference.md#output_pin) is
 enabled:
+
 - `SET_PIN PIN=config_name VALUE=<value> CYCLE_TIME=<cycle_time>`
 
 Note: Hardware PWM does not currently support the CYCLE_TIME parameter
@@ -268,6 +278,7 @@ and will use the cycle time defined in the config.
 The following command is available when a
 [fan_generic config section](Config_Reference.md#fan_generic) is
 enabled:
+
 - `SET_FAN_SPEED FAN=config_name SPEED=<speed>` This command sets
   the speed of a fan. <speed> must be between 0.0 and 1.0.
 
@@ -276,6 +287,7 @@ enabled:
 The following command is available when a
 [neopixel config section](Config_Reference.md#neopixel) or
 [dotstar config section](Config_Reference.md#dotstar) is enabled:
+
 - `SET_LED LED=<config_name> RED=<value> GREEN=<value> BLUE=<value>
   WHITE=<value> [INDEX=<index>] [TRANSMIT=0] [SYNC=1]`: This sets the LED
   output. Each color `<value>` must be between 0.0 and 1.0. The WHITE
@@ -297,6 +309,7 @@ The following command is available when a
 
 The following commands are available when a
 [servo config section](Config_Reference.md#servo) is enabled:
+
 - `SET_SERVO SERVO=config_name [ANGLE=<degrees> | WIDTH=<seconds>]`:
   Set the servo position to the given angle (in degrees) or pulse
   width (in seconds). Use `WIDTH=0` to disable the servo output.
@@ -306,6 +319,7 @@ The following commands are available when a
 The following command is available when a
 [manual_stepper config section](Config_Reference.md#manual_stepper) is
 enabled:
+
 - `MANUAL_STEPPER STEPPER=config_name [ENABLE=[0|1]]
   [SET_POSITION=<pos>] [SPEED=<speed>] [ACCEL=<accel>]
   [MOVE=<pos> [STOP_ON_ENDSTOP=[1|2|-1|-2]] [SYNC=0]]`: This command
@@ -330,6 +344,7 @@ enabled:
 The following command is available when an
 [extruder_stepper config section](Config_Reference.md#extruder_stepper)
 is enabled:
+
 - `SYNC_STEPPER_TO_EXTRUDER STEPPER=<extruder_stepper config_name>
   [EXTRUDER=<extruder config_name>]`: This command will cause the given
   STEPPER to become synchronized to the given EXTRUDER, overriding
@@ -340,6 +355,7 @@ is enabled:
 The following commands are available when a
 [probe config section](Config_Reference.md#probe) is enabled (also see
 the [probe calibrate guide](Probe_Calibrate.md)):
+
 - `PROBE [PROBE_SPEED=<mm/s>] [LIFT_SPEED=<mm/s>] [SAMPLES=<count>]
   [SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_TOLERANCE=<mm>]
   [SAMPLES_TOLERANCE_RETRIES=<count>]
@@ -372,6 +388,7 @@ the [probe calibrate guide](Probe_Calibrate.md)):
 The following command is available when a
 [bltouch config section](Config_Reference.md#bltouch) is enabled (also
 see the [BL-Touch guide](BLTouch.md)):
+
 - `BLTOUCH_DEBUG COMMAND=<command>`: This sends a command to the
   BLTouch. It may be useful for debugging. Available commands are:
   `pin_down`, `touch_mode`, `pin_up`, `self_test`, `reset`,
@@ -379,7 +396,6 @@ see the [BL-Touch guide](BLTouch.md)):
 
   *** Note that the commands marked by (*1) are solely supported
       by a BL-Touch V3.0 or V3.1(+)
-
 - `BLTOUCH_STORE MODE=<output_mode>`: This stores an output mode in the
   EEPROM of a BLTouch V3.1 Available output_modes are: `5V`, `OD`
 
@@ -388,6 +404,7 @@ see the [BL-Touch guide](BLTouch.md)):
 The following commands are available when the
 [delta_calibrate config section](Config_Reference.md#linear-delta-kinematics)
 is enabled (also see the [delta calibrate guide](Delta_Calibrate.md)):
+
 - `DELTA_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`: This
   command will probe seven points on the bed and recommend updated
   endstop positions, tower angles, and radius. See the PROBE command
@@ -402,6 +419,7 @@ is enabled (also see the [delta calibrate guide](Delta_Calibrate.md)):
 
 The following commands are available when the
 [bed_tilt config section](Config_Reference.md#bed_tilt) is enabled:
+
 - `BED_TILT_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`:
   This command will probe the points specified in the config and then
   recommend updated x and y tilt adjustments. See the `PROBE` command
@@ -415,6 +433,7 @@ The following commands are available when the
 The following commands are available when the
 [bed_mesh config section](Config_Reference.md#bed_mesh) is enabled
 (also see the [bed mesh guide](Bed_Mesh.md)):
+
 - `BED_MESH_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]
   [<mesh_parameter>=<value>]`:
   This command probes the bed using generated points specified by the
@@ -454,6 +473,7 @@ The following commands are available when the
 [bed_screws config section](Config_Reference.md#bed_screws) is enabled
 (also see the
 [manual level guide](Manual_Level.md#adjusting-bed-leveling-screws)):
+
 - `BED_SCREWS_ADJUST`: This command will invoke the bed screws
   adjustment tool. It will command the nozzle to different locations
   (as defined in the config file) and allow one to make adjustments to
@@ -466,6 +486,7 @@ The following commands are available when the
 [screws_tilt_adjust config section](Config_Reference.md#screws_tilt_adjust)
 is enabled (also see the
 [manual level guide](Manual_Level.md#adjusting-bed-leveling-screws-using-the-bed-probe)):
+
 - `SCREWS_TILT_CALCULATE [DIRECTION=CW|CCW] [<probe_parameter>=<value>]`:
   This command will invoke the bed screws adjustment tool. It will command the
   nozzle to different locations (as defined in the config file)
@@ -479,6 +500,7 @@ is enabled (also see the
 
 The following commands are available when the
 [z_tilt config section](Config_Reference.md#z_tilt) is enabled:
+
 - `Z_TILT_ADJUST [<probe_parameter>=<value>]`: This command will probe
   the points specified in the config and then make independent
   adjustments to each Z stepper to compensate for tilt. See the PROBE
@@ -489,6 +511,7 @@ The following commands are available when the
 The following command is available when the
 [dual_carriage config section](Config_Reference.md#dual_carriage) is
 enabled:
+
 - `SET_DUAL_CARRIAGE CARRIAGE=[0|1]`: This command will set the active
   carriage. It is typically invoked from the activate_gcode and
   deactivate_gcode fields in a multiple extruder configuration.
@@ -498,6 +521,7 @@ enabled:
 The following commands are available when any of the
 [tmcXXXX config sections](Config_Reference.md#tmc-stepper-driver-configuration)
 are enabled:
+
 - `DUMP_TMC STEPPER=<name>`: This command will read the TMC driver
   registers and report their values.
 - `INIT_TMC STEPPER=<name>`: This command will intitialize the TMC
@@ -519,6 +543,7 @@ are enabled:
 The following commands are available when an
 [endstop_phase config section](Config_Reference.md#endstop_phase) is
 enabled (also see the [endstop phase guide](Endstop_Phase.md)):
+
 - `ENDSTOP_PHASE_CALIBRATE [STEPPER=<config_name>]`: If no STEPPER
   parameter is provided then this command will reports statistics on
   endstop stepper phases during past homing operations. When a STEPPER
@@ -531,6 +556,7 @@ enabled (also see the [endstop phase guide](Endstop_Phase.md)):
 The following commands are available when the
 [force_move config section](Config_Reference.md#force_move) is
 enabled:
+
 - `FORCE_MOVE STEPPER=<config_name> DISTANCE=<value> VELOCITY=<value>
   [ACCEL=<value>]`: This command will forcibly move the given stepper
   the given distance (in mm) at the given constant velocity (in
@@ -557,6 +583,7 @@ enabled:
 
 When the [sdcard_loop config section](Config_Reference.md#sdcard_loop)
 is enabled, the following extended commands are available:
+
 - `SDCARD_LOOP_BEGIN COUNT=<count>`: Begin a looped section in the SD
   print. A count of 0 indicates that the section should be looped
   indefinately.
@@ -568,6 +595,7 @@ is enabled, the following extended commands are available:
 
 The following commands are availabe when the
 [respond config section](Config_Reference.md#respond) is enabled.
+
 - `M118 <message>`: echo the message prepended with the configured
   default prefix (or `echo: ` if no prefix is configured).
 - `RESPOND MSG="<message>"`: echo the message prepended with the
@@ -588,6 +616,7 @@ The following commands are availabe when the
 The following commands are available when the
 [pause_resume config section](Config_Reference.md#pause_resume) is
 enabled:
+
 - `PAUSE`: Pauses the current print. The current position is captured
   for restoration upon resume.
 - `RESUME [VELOCITY=<value>]`: Resumes the print from a pause, first
@@ -605,6 +634,7 @@ enabled:
 The following command is available when the
 [filament_switch_sensor or filament_motion_sensor config section](Config_Reference.md#filament_switch_sensor)
 is enabled.
+
 - `QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current
   status of the filament sensor. The data displayed on the terminal
   will depend on the sensor type defined in the confguration.
@@ -621,6 +651,7 @@ retraction feature available in many slicers, to reduce stringing
 during non-extrusion moves from one part of the print to another.
 Appropriately configuring pressure advance reduces the length of
 retraction required.
+
 - `SET_RETRACTION [RETRACT_LENGTH=<mm>] [RETRACT_SPEED=<mm/s>]
   [UNRETRACT_EXTRA_LENGTH=<mm>] [UNRETRACT_SPEED=<mm/s>]`: Adjust the
   parameters used by firmware retraction. RETRACT_LENGTH determines
@@ -645,6 +676,7 @@ retraction required.
 The following commands are available when the
 [skew_correction config section](Config_Reference.md#skew_correction)
 is enabled (also see the [skew correction guide](skew_correction.md)):
+
 - `SET_SKEW [XY=<ac_length,bd_length,ad_length>] [XZ=<ac,bd,ad>]
   [YZ=<ac,bd,ad>] [CLEAR=<0|1>]`: Configures the [skew_correction]
   module with measurements (in mm) taken from a calibration print.
@@ -676,6 +708,7 @@ The following command is enabled if a
 [delayed_gcode config section](Config_Reference.md#delayed_gcode) has
 been enabled (also see the
 [template guide](Command_Templates.md#delayed-gcodes)):
+
 - `UPDATE_DELAYED_GCODE [ID=<name>] [DURATION=<seconds>]`:  Updates the
   delay duration for the identified [delayed_gcode] and starts the timer
   for G-Code execution. A value of 0 will cancel a pending delayed G-Code
@@ -686,6 +719,7 @@ been enabled (also see the
 The following command is enabled if a
 [save_variables config section](Config_Reference.md#save_variables)
 has been enabled:
+
 - `SAVE_VARIABLE VARIABLE=<name> VALUE=<value>`: Saves the variable to
   disk so that it can be used across restarts. All stored variables
   are loaded into the `printer.save_variables.variables` dict at
@@ -698,6 +732,7 @@ The following command is enabled if an
 [input_shaper config section](Config_Reference.md#input_shaper) has
 been enabled (also see the
 [resonance compensation guide](Resonance_Compensation.md)):
+
 - `SET_INPUT_SHAPER [SHAPER_FREQ_X=<shaper_freq_x>]
   [SHAPER_FREQ_Y=<shaper_freq_y>]
   [DAMPING_RATIO_X=<damping_ratio_x>]
@@ -716,6 +751,7 @@ been enabled (also see the
 The following command is available when a
 [temperature_fan config section](Config_Reference.md#temperature_fan)
 is enabled:
+
 - `SET_TEMPERATURE_FAN_TARGET temperature_fan=<temperature_fan_name>
   [target=<target_temperature>] [min_speed=<min_speed>]  [max_speed=<max_speed>]`: Sets the target temperature for a
   temperature_fan. If a target is not supplied, it is set to the
@@ -725,6 +761,7 @@ is enabled:
 
 The following commands are available when an
 [adxl345 config section](Config_Reference.md#adxl345) is enabled:
+
 - `ACCELEROMETER_MEASURE [CHIP=<config_name>] [RATE=<value>]
   [NAME=<value>]`: Starts accelerometer measurements at the requested
   number of samples per second. If CHIP is not specified it defaults
@@ -760,6 +797,7 @@ The following commands are available when a
 [resonance_tester config section](Config_Reference.md#resonance_tester)
 is enabled (also see the
 [measuring resonances guide](Measuring_Resonances.md)):
+
 - `MEASURE_AXES_NOISE`: Measures and outputs the noise for all axes of
   all enabled accelerometer chips.
 - `TEST_RESONANCES AXIS=<axis> OUTPUT=<resonances,raw_data>
@@ -806,6 +844,7 @@ is enabled (also see the
 The following command is available when the
 [palette2 config section](Config_Reference.md#palette2)
 is enabled:
+
 - `PALETTE_CONNECT`: This command initializes the connection with
   the Palette 2.
 - `PALETTE_DISCONNECT`: This command disconnects from the Palette 2.
@@ -822,5 +861,6 @@ is enabled:
 
 Palette prints work by embedding special OCodes (Omega Codes)
 in the G-Code file:
+
 - `O1`...`O32`: These codes are read from the G-Code stream and processed
   by this module and passed to the Palette 2 device.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -224,10 +224,10 @@ The following standard commands are supported:
   FACTOR=<value> [BAND=<value>]`: A tool for tuning a parameter on
   each Z height during a print. The tool will run the given COMMAND
   with the given PARAMETER assigned to the value using the formula
-  `value = start + factor * z_height`. If BAND is provided then the
+  $value = start + factor \times z_{height}$. If BAND is provided then the
   adjustment will only be made every BAND millimeters of z height - in
-  that case the formula used is `value = start + factor *
-  ((floor(z_height / band) + .5) * band)`.
+  that case the formula used is $value = start + factor \times
+  (\lfloor{\frac{z_{height}}{band}}\rfloor + .5) \times band$.
 - `SET_DISPLAY_GROUP [DISPLAY=<display>] GROUP=<group>`: Set the
   active display group of an lcd display. This allows to define
   multiple display data groups in the config,

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -394,7 +394,7 @@ see the [BL-Touch guide](BLTouch.md)):
   `pin_down`, `touch_mode`, `pin_up`, `self_test`, `reset`,
   (*1): `set_5V_output_mode`, `set_OD_output_mode`, `output_mode_store`
 
-  *** Note that the commands marked by (*1) are solely supported
+  \*\*\* Note that the commands marked by (\*1) are solely supported
       by a BL-Touch V3.0 or V3.1(+)
 - `BLTOUCH_STORE MODE=<output_mode>`: This stores an output mode in the
   EEPROM of a BLTouch V3.1 Available output_modes are: `5V`, `OD`
@@ -597,16 +597,16 @@ The following commands are availabe when the
 [respond config section](Config_Reference.md#respond) is enabled.
 
 - `M118 <message>`: echo the message prepended with the configured
-  default prefix (or `echo: ` if no prefix is configured).
+  default prefix (or `echo:` if no prefix is configured).
 - `RESPOND MSG="<message>"`: echo the message prepended with the
-  configured default prefix (or `echo: ` if no prefix is configured).
+  configured default prefix (or `echo:` if no prefix is configured).
 - `RESPOND TYPE=echo MSG="<message>"`: echo the message prepended with
-  `echo: `.
+  `echo:`.
 - `RESPOND TYPE=command MSG="<message>"`: echo the message prepended
-  with `// `.  Octopint can be configured to respond to these messages
-  (e.g.  `RESPOND TYPE=command MSG=action:pause`).
+  with `//`. Octopint can be configured to respond to these messages
+  (e.g. `RESPOND TYPE=command MSG=action:pause`).
 - `RESPOND TYPE=error MSG="<message>"`: echo the message prepended
-  with `!! `.
+  with `!!`.
 - `RESPOND PREFIX=<prefix> MSG="<message>"`: echo the message
   prepended with `<prefix>`. (The `PREFIX` parameter will take
   priority over the `TYPE` parameter)

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -110,20 +110,17 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 
 ## Calibration procedure
 
-Insert first  calibration rod (1.5 mm size) get first  raw sensor value
-
-To get raw sensor value you can use menu item or  **QUERY_RAW_FILAMENT_WIDTH** command in terminal
-
-Insert second calibration rod (2.0 mm size) get second raw sensor value
-
-Save raw values in config
+1. Insert first  calibration rod (1.5 mm size) get first  raw sensor value
+2. To get raw sensor value you can use menu item or  **QUERY_RAW_FILAMENT_WIDTH** command in terminal
+3. Insert second calibration rod (2.0 mm size) get second raw sensor value
+4. Save raw values in config
 
 ## How to enable sensor
 
-After power on by default sensor disabled.
-Enable sensor in start g-code by command **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config
+After power on by default sensor disabled, enable sensor in start G-Code by command
+ **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config.
 
 ## Logging
 
-After power on by default diameter Logging disabled.
-Data to log added on every measurement interval (10 mm by default)
+After power on by default diameter Logging disabled, data to log added on every measurement interval
+ (10 mm by default).

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -5,6 +5,7 @@ This document describes Filament Width Sensor host module. Hardware used for dev
 [Hall based filament width sensor assembly video](https://www.youtube.com/watch?v=TDO9tME8vp4)
 
 ## How does it work?
+
 Sensor generates two analog output based on calculated filament width. Sum of output voltage always equals to detected filament width . Host module monitors voltage changes and adjusts extrusion multiplier. I use aux2 connector on ramps-like board analog11 and analog12 pins. You can use different pins and differenr boards
 
 ## Configuration
@@ -69,8 +70,8 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     #event_delay: 3.0
     #pause_delay: 0.5
 
-
 ## Commands
+
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 
 **RESET_FILAMENT_WIDTH_SENSOR** вЂ“ Clear all sensor readings. Can be used after filament change.
@@ -94,6 +95,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 **hall_filament_width_sensor.is_active** Sensor on or off
 
 ## Template for menu variables
+
     [menu __main __filament __width_current]
     type: command
     enable: {'hall_filament_width_sensor' in printer}
@@ -119,6 +121,8 @@ Save raw values in config
 After power on by default sensor disabled.
 Enable sensor in start g-code by command **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config
 
+
 ## Logging
 After power on by default diameter Logging disabled.
 Data to log added on every measurement interval (10 mm by default)
+

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -109,6 +109,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     index: 1
 
 ## Calibration procedure
+
 Insert first  calibration rod (1.5 mm size) get first  raw sensor value
 
 To get raw sensor value you can use menu item or  **QUERY_RAW_FILAMENT_WIDTH** command in terminal
@@ -118,11 +119,11 @@ Insert second calibration rod (2.0 mm size) get second raw sensor value
 Save raw values in config
 
 ## How to enable sensor
+
 After power on by default sensor disabled.
 Enable sensor in start g-code by command **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config
 
-
 ## Logging
+
 After power on by default diameter Logging disabled.
 Data to log added on every measurement interval (10 mm by default)
-

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -74,13 +74,13 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 
-**RESET_FILAMENT_WIDTH_SENSOR** вЂ“ Clear all sensor readings. Can be used after filament change.
+**RESET_FILAMENT_WIDTH_SENSOR** - Clear all sensor readings. Can be used after filament change.
 
-**DISABLE_FILAMENT_WIDTH_SENSOR** вЂ“ Turn off the filament width sensor and stop using it to do flow control
+**DISABLE_FILAMENT_WIDTH_SENSOR** - Turn off the filament width sensor and stop using it to do flow control
 
 **ENABLE_FILAMENT_WIDTH_SENSOR** - Turn on the filament width sensor and start using it to do flow control
 
-**QUERY_RAW_FILAMENT_WIDTH** Return the current ADC channel values and RAW sensor value for calibration points
+**QUERY_RAW_FILAMENT_WIDTH** - Return the current ADC channel values and RAW sensor value for calibration points
 
 **ENABLE_FILAMENT_WIDTH_LOG** - Turn on diameter logging
 
@@ -88,11 +88,11 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 
 ## Menu variables
 
-**hall_filament_width_sensor.Diameter** current measured filament width in mm
+**hall_filament_width_sensor.Diameter** - current measured filament width in mm
 
-**hall_filament_width_sensor.Raw** current raw measured filament width in units
+**hall_filament_width_sensor.Raw** - current raw measured filament width in units
 
-**hall_filament_width_sensor.is_active** Sensor on or off
+**hall_filament_width_sensor.is_active** - Sensor on or off
 
 ## Template for menu variables
 

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -1,6 +1,6 @@
 # Hall filament width sensor
 
-This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on Two Hall liniar sensors (ss49e for example). Sensors in the body are located opposite sides.  Principle of operation : two hall sensors work in differential mode, temperature drift same for sensor. Special temperature compensation not needed. You can find designs at [thingiverse.com](https://www.thingiverse.com/thing:4138933)
+This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on Two Hall liniar sensors (ss49e for example). Sensors in the body are located opposite sides. Principle of operation : two hall sensors work in differential mode, temperature drift same for sensor. Special temperature compensation not needed. You can find designs at [thingiverse.com](https://www.thingiverse.com/thing:4138933)
 
 [Hall based filament width sensor assembly video](https://www.youtube.com/watch?v=TDO9tME8vp4)
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -172,7 +172,7 @@ Klipper reports error messages via the OctoPrint terminal tab. The
 Klipper startup script also places a log in **/tmp/klippy.log** which
 provides more detailed information.
 
-In addition to common g-code commands, Klipper supports a few extended
+In addition to common G-Code commands, Klipper supports a few extended
 commands - "status" and "restart" are examples of these commands. Use
 the "help" command to get a list of other extended commands.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -29,7 +29,7 @@ other desktops (eg,
 ssh utility to connect to the Raspberry Pi (ssh pi@octopi -- password
 is "raspberry") and run the following commands:
 
-```
+```bash
 git clone https://github.com/KevinOConnor/klipper
 ./klipper/scripts/install-octopi.sh
 ```
@@ -44,7 +44,7 @@ minutes to complete.
 To compile the micro-controller code, start by running these commands
 on the Raspberry Pi:
 
-```
+```bash
 cd ~/klipper/
 make menuconfig
 ```
@@ -52,7 +52,7 @@ make menuconfig
 Select the appropriate micro-controller and review any other options
 provided. Once configured, run:
 
-```
+```bash
 make
 ```
 
@@ -60,13 +60,13 @@ It is necessary to determine the serial port connected to the
 micro-controller. For micro-controllers that connect via USB, run the
 following:
 
-```
+```bash
 ls /dev/serial/by-id/*
 ```
 
 It should report something similar to the following:
 
-```
+```bash
 /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
 
@@ -79,7 +79,7 @@ choose the line corresponding to the micro-controller (see the
 For common micro-controllers, the code can be flashed with something
 similar to:
 
-```
+```bash
 sudo service klipper stop
 make flash FLASH_DEVICE=/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 sudo service klipper start
@@ -139,7 +139,7 @@ config files as a starting point and save it as a file named
 Alternatively, one can also copy and edit the file directly on the
 Raspberry Pi via ssh - for example:
 
-```
+```bash
 cp ~/klipper/config/example-cartesian.cfg ~/printer.cfg
 nano ~/printer.cfg
 ```
@@ -153,7 +153,7 @@ the `ls /dev/serial/by-id/*` command and then update the config file
 with the unique name. For example, update the `[mcu]` section to look
 something similar to:
 
-```
+```cfg
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```

--- a/docs/Kinematics.md
+++ b/docs/Kinematics.md
@@ -28,9 +28,8 @@ inverse is not always true).
 
 Klipper implements constant acceleration. The key formula for constant
 acceleration is:
-```
-velocity(time) = start_velocity + accel*time
-```
+
+$\vec{v}(time) = \vec{v}_{start} + a \times t$
 
 ## Trapezoid generator
 
@@ -92,9 +91,8 @@ velocity"), and the junction speeds for other angles are derived from
 that.
 
 Key formula for look-ahead:
-```
-end_velocity^2 = start_velocity^2 + 2*accel*move_distance
-```
+
+$\vec{v}_{end}^2 = \vec{v}_{start}^2 + 2 \times a \times x_{move}$
 
 ### Smoothed look-ahead
 
@@ -148,21 +146,21 @@ these calculated times.
 
 The key formula to determine how far a move should travel under
 constant acceleration is:
-```
-move_distance = (start_velocity + .5 * accel * move_time) * move_time
-```
+
+$d_{move} = (\vec{v}_{start} + .5 \times a \times t_{move}) \times t_{move}$
+
 and the key formula for movement with constant velocity is:
-```
-move_distance = cruise_velocity * move_time
-```
+
+$d_{move} = \vec{v}_{cruise} \times t_{move}$
 
 The key formulas for determining the cartesian coordinate of a move
 given a move distance is:
-```
-cartesian_x_position = start_x + move_distance * total_x_movement / total_movement
-cartesian_y_position = start_y + move_distance * total_y_movement / total_movement
-cartesian_z_position = start_z + move_distance * total_z_movement / total_movement
-```
+
+$x_{cartesian} = x_{start} + \frac{d_{move} \times \sum{x_{movement}}}{\sum{d_{movement}}}$
+
+$y_{cartesian} = y_{start} + \frac{d_{move} \times \sum{y_{movement}}}{\sum{d_{movement}}}$
+
+$z_{cartesian} = z_{start} + \frac{d_{move} \times \sum{z_{movement}}}{\sum{d_{movement}}}$
 
 ### Cartesian Robots
 
@@ -171,31 +169,28 @@ movement on each axis is directly related to the movement in cartesian
 space.
 
 Key formulas:
-```
-stepper_x_position = cartesian_x_position
-stepper_y_position = cartesian_y_position
-stepper_z_position = cartesian_z_position
-```
+
+$x_{stepper} = x_{cartesian}$
+$y_{stepper} = y_{cartesian}$
+$z_{stepper} = z_{cartesian}$
 
 ### CoreXY Robots
 
 Generating steps on a CoreXY machine is only a little more complex
 than basic cartesian robots. The key formulas are:
-```
-stepper_a_position = cartesian_x_position + cartesian_y_position
-stepper_b_position = cartesian_x_position - cartesian_y_position
-stepper_z_position = cartesian_z_position
-```
+
+$a_{stepper} = x_{cartesian} + y_{cartesian}$
+$b_{stepper} = x_{cartesian} - y_{cartesian}$
+$z_{stepper} = z_{cartesian}$
 
 ### Delta Robots
 
 Step generation on a delta robot is based on Pythagoras's theorem:
-```
-stepper_position = (sqrt(arm_length^2
-                         - (cartesian_x_position - tower_x_position)^2
-                         - (cartesian_y_position - tower_y_position)^2)
-                    + cartesian_z_position)
-```
+
+$x_{stepper} = \sqrt{l_{arm}^2
+                         - (x_{cartesian\ position} - x_{tower\ position})^2
+                         - (y_{cartesian\ position} - y_{tower\ position})^2}
+                     + z_{cartesian\ position}$
 
 ### Stepper motor acceleration limits
 
@@ -228,9 +223,8 @@ movement.
 
 Basic extruder movement is simple to calculate. The step time
 generation uses the same formulas that cartesian robots use:
-```
-stepper_position = requested_e_position
-```
+
+$e_{stepper} = e_{requested}$
 
 ### Pressure advance
 
@@ -256,9 +250,8 @@ through the nozzle orifice (as in
 [Poiseuille's law](https://en.wikipedia.org/wiki/Poiseuille_law)). The
 key idea is that the relationship between filament, pressure, and flow
 rate can be modeled using a linear coefficient:
-```
-pa_position = nominal_position + pressure_advance_coefficient * nominal_velocity
-```
+
+$x_{pa} = x_{nominal} + PA \times \vec{v}_{nominal}$
 
 See the [pressure advance](Pressure_Advance.md) document for
 information on how to find this pressure advance coefficient.
@@ -285,9 +278,8 @@ moving prior to the nominal start of the first extrusion move and will
 continue to move after the nominal end of the last extrusion move.
 
 Key formula for "smoothed pressure advance":
-```
-smooth_pa_position(t) =
-    ( definitive_integral(pa_position(x) * (smooth_time/2 - abs(t - x)) * dx,
-                          from=t-smooth_time/2, to=t+smooth_time/2)
-     / (smooth_time/2)^2 )
-```
+
+$x_{smooth\ pa}(t) =
+    \frac{\int_{t - \frac{t_{smooth}}{2}}^{t + \frac{t_{smooth}}{2}}
+    x_{pa}(x) \times (\frac{t_{smooth}}{2} - |t - x|) \times \Delta x)}
+    {(\frac{t_{smooth}}{2})^2}$

--- a/docs/Kinematics.md
+++ b/docs/Kinematics.md
@@ -28,8 +28,9 @@ inverse is not always true).
 
 Klipper implements constant acceleration. The key formula for constant
 acceleration is:
-
-$\vec{v}(time) = \vec{v}_{start} + a \times t$
+```
+velocity(time) = start_velocity + accel*time
+```
 
 ## Trapezoid generator
 
@@ -91,8 +92,9 @@ velocity"), and the junction speeds for other angles are derived from
 that.
 
 Key formula for look-ahead:
-
-$\vec{v}_{end}^2 = \vec{v}_{start}^2 + 2 \times a \times x_{move}$
+```
+end_velocity^2 = start_velocity^2 + 2*accel*move_distance
+```
 
 ### Smoothed look-ahead
 
@@ -146,21 +148,21 @@ these calculated times.
 
 The key formula to determine how far a move should travel under
 constant acceleration is:
-
-$d_{move} = (\vec{v}_{start} + .5 \times a \times t_{move}) \times t_{move}$
-
+```
+move_distance = (start_velocity + .5 * accel * move_time) * move_time
+```
 and the key formula for movement with constant velocity is:
-
-$d_{move} = \vec{v}_{cruise} \times t_{move}$
+```
+move_distance = cruise_velocity * move_time
+```
 
 The key formulas for determining the cartesian coordinate of a move
 given a move distance is:
-
-$x_{cartesian} = x_{start} + \frac{d_{move} \times \sum{x_{movement}}}{\sum{d_{movement}}}$
-
-$y_{cartesian} = y_{start} + \frac{d_{move} \times \sum{y_{movement}}}{\sum{d_{movement}}}$
-
-$z_{cartesian} = z_{start} + \frac{d_{move} \times \sum{z_{movement}}}{\sum{d_{movement}}}$
+```
+cartesian_x_position = start_x + move_distance * total_x_movement / total_movement
+cartesian_y_position = start_y + move_distance * total_y_movement / total_movement
+cartesian_z_position = start_z + move_distance * total_z_movement / total_movement
+```
 
 ### Cartesian Robots
 
@@ -169,28 +171,31 @@ movement on each axis is directly related to the movement in cartesian
 space.
 
 Key formulas:
-
-$x_{stepper} = x_{cartesian}$
-$y_{stepper} = y_{cartesian}$
-$z_{stepper} = z_{cartesian}$
+```
+stepper_x_position = cartesian_x_position
+stepper_y_position = cartesian_y_position
+stepper_z_position = cartesian_z_position
+```
 
 ### CoreXY Robots
 
 Generating steps on a CoreXY machine is only a little more complex
 than basic cartesian robots. The key formulas are:
-
-$a_{stepper} = x_{cartesian} + y_{cartesian}$
-$b_{stepper} = x_{cartesian} - y_{cartesian}$
-$z_{stepper} = z_{cartesian}$
+```
+stepper_a_position = cartesian_x_position + cartesian_y_position
+stepper_b_position = cartesian_x_position - cartesian_y_position
+stepper_z_position = cartesian_z_position
+```
 
 ### Delta Robots
 
 Step generation on a delta robot is based on Pythagoras's theorem:
-
-$x_{stepper} = \sqrt{l_{arm}^2
-                         - (x_{cartesian\ position} - x_{tower\ position})^2
-                         - (y_{cartesian\ position} - y_{tower\ position})^2}
-                     + z_{cartesian\ position}$
+```
+stepper_position = (sqrt(arm_length^2
+                         - (cartesian_x_position - tower_x_position)^2
+                         - (cartesian_y_position - tower_y_position)^2)
+                    + cartesian_z_position)
+```
 
 ### Stepper motor acceleration limits
 
@@ -223,8 +228,9 @@ movement.
 
 Basic extruder movement is simple to calculate. The step time
 generation uses the same formulas that cartesian robots use:
-
-$e_{stepper} = e_{requested}$
+```
+stepper_position = requested_e_position
+```
 
 ### Pressure advance
 
@@ -250,8 +256,9 @@ through the nozzle orifice (as in
 [Poiseuille's law](https://en.wikipedia.org/wiki/Poiseuille_law)). The
 key idea is that the relationship between filament, pressure, and flow
 rate can be modeled using a linear coefficient:
-
-$x_{pa} = x_{nominal} + PA \times \vec{v}_{nominal}$
+```
+pa_position = nominal_position + pressure_advance_coefficient * nominal_velocity
+```
 
 See the [pressure advance](Pressure_Advance.md) document for
 information on how to find this pressure advance coefficient.
@@ -278,8 +285,9 @@ moving prior to the nominal start of the first extrusion move and will
 continue to move after the nominal end of the last extrusion move.
 
 Key formula for "smoothed pressure advance":
-
-$x_{smooth\ pa}(t) =
-    \frac{\int_{t - \frac{t_{smooth}}{2}}^{t + \frac{t_{smooth}}{2}}
-    x_{pa}(x) \times (\frac{t_{smooth}}{2} - |t - x|) \times \Delta x)}
-    {(\frac{t_{smooth}}{2})^2}$
+```
+smooth_pa_position(t) =
+    ( definitive_integral(pa_position(x) * (smooth_time/2 - abs(t - x)) * dx,
+                          from=t-smooth_time/2, to=t+smooth_time/2)
+     / (smooth_time/2)^2 )
+```

--- a/docs/Kinematics.md
+++ b/docs/Kinematics.md
@@ -280,7 +280,7 @@ retracted (the extruder will have a negative velocity).
 The "smoothing" is implemented using a weighted average of the
 extruder position over a small time period (as specified by the
 `pressure_advance_smooth_time` config parameter). This averaging can
-span multiple g-code moves. Note how the extruder motor will start
+span multiple G-Code moves. Note how the extruder motor will start
 moving prior to the nominal start of the first extrusion move and will
 continue to move after the nominal end of the last extrusion move.
 

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -30,13 +30,13 @@ not require any particular setup.
 
 Common startup commands:
 
-* `set_digital_out pin=%u value=%c` : This command immediately
+- `set_digital_out pin=%u value=%c` : This command immediately
   configures the given pin as a digital out GPIO and it sets it to
   either a low level (value=0) or a high level (value=1). This command
   may be useful for configuring the initial value of LEDs and for
   configuring the initial value of stepper driver micro-stepping pins.
 
-* `set_pwm_out pin=%u cycle_ticks=%u value=%hu` : This command will
+- `set_pwm_out pin=%u cycle_ticks=%u value=%hu` : This command will
   immediately configure the given pin to use hardware based
   pulse-width-modulation (PWM) with the given number of
   cycle_ticks. The "cycle_ticks" is the number of MCU clock ticks each
@@ -60,7 +60,7 @@ information). After the data dictionary is obtained the host will
 check if the micro-controller is in a "configured" state and configure
 it if not. Configuration involves the following phases:
 
-* `get_config` : The host starts by checking if the micro-controller
+- `get_config` : The host starts by checking if the micro-controller
   is already configured. The micro-controller responds to this command
   with a "config" response message. The micro-controller software
   always starts in an unconfigured state at power-on. It remains in
@@ -70,7 +70,7 @@ it if not. Configuration involves the following phases:
   the desired settings) then no further action is needed by the host
   and the configuration process ends successfully.
 
-* `allocate_oids count=%c` : This command is issued to inform the
+- `allocate_oids count=%c` : This command is issued to inform the
   micro-controller of the maximum number of object-ids (oid) that the
   host requires. It is only valid to issue this command once. An oid
   is an integer identifier allocated to each stepper, each endstop,
@@ -79,7 +79,7 @@ it if not. Configuration involves the following phases:
   this to the micro-controller so that it may allocate sufficient
   memory to store a mapping from oid to internal object.
 
-* `config_XXX oid=%c ...` : By convention any command starting with
+- `config_XXX oid=%c ...` : By convention any command starting with
   the "config_" prefix creates a new micro-controller object and
   assigns the given oid to it. For example, the config_digital_out
   command will configure the specified pin as a digital output GPIO
@@ -91,7 +91,7 @@ it if not. Configuration involves the following phases:
   configured state (ie, prior to the host sending finalize_config) and
   after the allocate_oids command has been sent.
 
-* `finalize_config crc=%u` : The finalize_config command transitions
+- `finalize_config crc=%u` : The finalize_config command transitions
   the micro-controller from an unconfigured state to a configured
   state. The crc parameter passed to the micro-controller is stored
   and provided back to the host in "config" response messages. By
@@ -106,7 +106,7 @@ it if not. Configuration involves the following phases:
 
 This section lists some commonly used config commands.
 
-* `config_digital_out oid=%c pin=%u value=%c default_value=%c
+- `config_digital_out oid=%c pin=%u value=%c default_value=%c
   max_duration=%u` : This command creates an internal micro-controller
   object for the given GPIO 'pin'. The pin will be configured in
   digital output mode and set to an initial value as specified by
@@ -125,26 +125,26 @@ This section lists some commonly used config commands.
   used with heater pins to ensure the host does not enable the heater
   and then go off-line.
 
-* `config_pwm_out oid=%c pin=%u cycle_ticks=%u value=%hu
+- `config_pwm_out oid=%c pin=%u cycle_ticks=%u value=%hu
   default_value=%hu max_duration=%u` : This command creates an
   internal object for hardware based PWM pins that the host may
   schedule updates for. Its usage is analogous to config_digital_out -
   see the description of the 'set_pwm_out' and 'config_digital_out'
   commands for parameter description.
 
-* `config_analog_in oid=%c pin=%u` : This command is used to configure
+- `config_analog_in oid=%c pin=%u` : This command is used to configure
   a pin in analog input sampling mode. Once configured, the pin can be
   sampled at regular interval using the query_analog_in command (see
   below).
 
-* `config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c` : This
+- `config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c` : This
   command creates an internal stepper object. The 'step_pin' and
   'dir_pin' parameters specify the step and direction pins
   respectively; this command will configure them in digital output
   mode. The 'invert_step' parameter specifies whether a step occurs on
   a rising edge (invert_step=0) or falling edge (invert_step=1).
 
-* `config_endstop oid=%c pin=%c pull_up=%c stepper_count=%c` : This
+- `config_endstop oid=%c pin=%c pull_up=%c stepper_count=%c` : This
   command creates an internal "endstop" object. It is used to specify
   the endstop pins and to enable "homing" operations (see the
   endstop_home command below). The command will configure the
@@ -154,7 +154,7 @@ This section lists some commonly used config commands.
   specifies the maximum number of steppers that this endstop may need
   to halt during a homing operation (see endstop_home below).
 
-* `config_spi oid=%c bus=%u pin=%u mode=%u rate=%u shutdown_msg=%*s` :
+- `config_spi oid=%c bus=%u pin=%u mode=%u rate=%u shutdown_msg=%*s` :
   This command creates an internal SPI object. It is used with
   spi_transfer and spi_send commands (see below). The "bus"
   identifies the SPI bus to use (if the micro-controller has more than
@@ -165,7 +165,7 @@ This section lists some commonly used config commands.
   the given device should the micro-controller go into a shutdown
   state.
 
-* `config_spi_without_cs oid=%c bus=%u mode=%u rate=%u
+- `config_spi_without_cs oid=%c bus=%u mode=%u rate=%u
   shutdown_msg=%*s` : This command is similar to config_spi, but
   without a CS pin definition. It is useful for SPI devices that do
   not have a chip select line.
@@ -175,14 +175,14 @@ This section lists some commonly used config commands.
 This section lists some commonly used run-time commands. It is likely
 only of interest to developers looking to gain insight into Klipper.
 
-* `set_digital_out_pwm_cycle oid=%c cycle_ticks=%u` : This command
+- `set_digital_out_pwm_cycle oid=%c cycle_ticks=%u` : This command
   configures a digital output pin (as created by config_digital_out)
   to use "software PWM". The 'cycle_ticks' is the number of clock
   ticks for the PWM cycle. Because the output switching is implemented
   in the micro-controller software, it is recommended that
   'cycle_ticks' correspond to a time of 10ms or greater.
 
-* `queue_digital_out oid=%c clock=%u on_ticks=%u` : This command will
+- `queue_digital_out oid=%c clock=%u on_ticks=%u` : This command will
   schedule a change to a digital output GPIO pin at the given clock
   time. To use this command a 'config_digital_out' command with the
   same 'oid' parameter must have been issued during micro-controller
@@ -191,11 +191,11 @@ only of interest to developers looking to gain insight into Klipper.
   Otherwise, 'on_ticks' should be either 0 (for low voltage) or 1 (for
   high voltage).
 
-* `queue_pwm_out oid=%c clock=%u value=%hu` : Schedules a change to a
+- `queue_pwm_out oid=%c clock=%u value=%hu` : Schedules a change to a
   hardware PWM output pin. See the 'queue_digital_out' and
   'config_pwm_out' commands for more info.
 
-* `query_analog_in oid=%c clock=%u sample_ticks=%u sample_count=%c
+- `query_analog_in oid=%c clock=%u sample_ticks=%u sample_count=%c
   rest_ticks=%u min_value=%hu max_value=%hu` : This command sets up a
   recurring schedule of analog input samples. To use this command a
   'config_analog_in' command with the same 'oid' parameter must have
@@ -210,7 +210,7 @@ only of interest to developers looking to gain insight into Klipper.
   pins attached to thermistors controlling heaters - it can be used to
   check that a heater is within a temperature range.
 
-* `get_clock` : This command causes the micro-controller to generate a
+- `get_clock` : This command causes the micro-controller to generate a
   "clock" response message. The host sends this command once a second
   to obtain the value of the micro-controller clock and to estimate
   the drift between host and micro-controller clocks. It enables the
@@ -218,7 +218,7 @@ only of interest to developers looking to gain insight into Klipper.
 
 ### Stepper commands
 
-* `queue_step oid=%c interval=%u count=%hu add=%hi` : This command
+- `queue_step oid=%c interval=%u count=%hu add=%hi` : This command
   schedules 'count' number of steps for the given stepper, with
   'interval' number of clock ticks between each step. The first step
   will be 'interval' number of clock ticks since the last scheduled
@@ -232,22 +232,22 @@ only of interest to developers looking to gain insight into Klipper.
   to queue potentially hundreds of thousands of steps - all with
   reliable and predictable schedule times.
 
-* `set_next_step_dir oid=%c dir=%c` : This command specifies the value
+- `set_next_step_dir oid=%c dir=%c` : This command specifies the value
   of the dir_pin that the next queue_step command will use.
 
-* `reset_step_clock oid=%c clock=%u` : Normally, step timing is
+- `reset_step_clock oid=%c clock=%u` : Normally, step timing is
   relative to the last step for a given stepper. This command resets
   the clock so that the next step is relative to the supplied 'clock'
   time. The host usually only sends this command at the start of a
   print.
 
-* `stepper_get_position oid=%c` : This command causes the
+- `stepper_get_position oid=%c` : This command causes the
   micro-controller to generate a "stepper_position" response message
   with the stepper's current position. The position is the total
   number of steps generated with dir=1 minus the total number of steps
   generated with dir=0.
 
-* `endstop_home oid=%c clock=%u sample_ticks=%u sample_count=%c
+- `endstop_home oid=%c clock=%u sample_ticks=%u sample_count=%c
   rest_ticks=%u pin_value=%c` : This command is used during stepper
   "homing" operations. To use this command a 'config_endstop' command
   with the same 'oid' parameter must have been issued during
@@ -278,11 +278,11 @@ scheduling new queue_step commands accordingly.
 
 ### SPI Commands
 
-* `spi_transfer oid=%c data=%*s` : This command causes the
+- `spi_transfer oid=%c data=%*s` : This command causes the
   micro-controller to send 'data' to the spi device specified by 'oid'
   and it generates a "spi_transfer_response" response message with the
   data returned during the transmission.
 
-* `spi_send oid=%c data=%*s` : This command is similar to
+- `spi_send oid=%c data=%*s` : This command is similar to
   "spi_transfer", but it does not generate a "spi_transfer_response"
   message.

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -156,7 +156,7 @@ This section lists some commonly used config commands.
 
 * `config_spi oid=%c bus=%u pin=%u mode=%u rate=%u shutdown_msg=%*s` :
   This command creates an internal SPI object. It is used with
-  spi_transfer and spi_send commands (see below).  The "bus"
+  spi_transfer and spi_send commands (see below). The "bus"
   identifies the SPI bus to use (if the micro-controller has more than
   one SPI bus available). The "pin" specifies the chip select (CS) pin
   for the device. The "mode" is the SPI mode (should be between 0 and

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -12,13 +12,13 @@ the low-level micro-controller commands.
 See the [protocol](Protocol.md) document for more information on the
 format of commands and their transmission. The commands here are
 described using their "printf" style syntax - for those unfamiliar
-with that format, just note that where a '%...' sequence is seen it
+with that format, just note that where a `%...` sequence is seen it
 should be replaced with an actual integer. For example, a description
-with "count=%c" could be replaced with the text "count=10". Note that
+with `count=%c` could be replaced with the text `count=10`. Note that
 parameters that are considered "enumerations" (see the above protocol
 document) take a string value which is automatically converted to an
 integer value for the micro-controller. This is common with parameters
-named "pin" (or that have a suffix of "_pin").
+named "pin" (or that have a suffix of `_pin`).
 
 ## Startup Commands
 

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -49,7 +49,7 @@ Some printers have the ability to manually adjust the location of the
 physical endstop switch. However, it's recommended to perform Z
 endstop positioning in software with Klipper - once the physical
 location of the endstop is in a convenient location, one can make any
-further adjustments by running Z_ENDSTOP_CALIBRATE or by manually
+further adjustments by running `Z_ENDSTOP_CALIBRATE` or by manually
 updating the Z position_endstop in the configuration file.
 
 ## Adjusting bed leveling screws

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -189,10 +189,10 @@ Recv: ok
 
 This means that:
 
-    - front left screw is the reference point you must not change it.
-    - front right screw must be turned clockwise 1 full turn and a quarter turn
-    - rear right screw must be turned counter-clockwise 50 minutes
-    - read left screw must be turned clockwise 2 minutes (not need it's ok)
+- front left screw is the reference point you must not change it.
+- front right screw must be turned clockwise 1 full turn and a quarter turn
+- rear right screw must be turned counter-clockwise 50 minutes
+- read left screw must be turned clockwise 2 minutes (not need it's ok)
 
 Repeat the process several times until you get a good level bed -
 normally when all adjustments are below 6 minutes.

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -18,15 +18,18 @@ to move to a Z position that is at least five millimeters above the
 bed (if it is not already), command the head to move to an XY position
 near the center of the bed, then navigate to the OctoPrint terminal
 tab and run:
-```
+
+```gcode
 Z_ENDSTOP_CALIBRATE
 ```
+
 Then follow the steps described at
 ["the paper test"](Bed_Level.md#the-paper-test) to determine the
 actual distance between the nozzle and bed at the given location. Once
 those steps are complete one can `ACCEPT` the position and save the
 results to the config file with:
-```
+
+```gcode
 SAVE_CONFIG
 ```
 
@@ -61,7 +64,8 @@ screw XY location.
 
 This is done by creating a `[bed_screws]` config section. For example,
 it might look something similar to:
-```
+
+```cfg
 [bed_screws]
 screw1: 100,50
 screw2: 100,150
@@ -75,7 +79,8 @@ bed.
 
 Once the config file is ready, run `RESTART` to load that config, and
 then one can start the tool by running:
-```
+
+```gcode
 BED_SCREWS_ADJUST
 ```
 
@@ -124,7 +129,8 @@ adjustment when the nozzle is at position D.
 To enable this feature, one would determine the additional nozzle
 coordinates and add them to the config file. For example, it might
 look like:
-```
+
+```cfg
 [bed_screws]
 screw1: 100,50
 screw1_fine_adjust: 0,0
@@ -149,7 +155,7 @@ To enable this feature, one would determine the nozzle coordinates
 such that the Z probe is above the screws, and then add them to the
 config file. For example, it might look like:
 
-```
+```cfg
 [screws_tilt_adjust]
 screw1: -5,30
 screw1_name: front left screw
@@ -168,7 +174,8 @@ The screw1 is always the reference point for the others, so the system
 assumes that screw1 is at the correct height. Always run `G28` first
 and then run `SCREWS_TILT_CALCULATE` - it should produce output
 similar to:
-```
+
+```cfg
 Send: G28
 Recv: ok
 Send: SCREWS_TILT_CALCULATE
@@ -179,6 +186,7 @@ Recv: // rear right screw : y=155.0, y=190.0, z=2.71500 : adjust CCW 00:50
 Recv: // read left screw : x=-5.0, y=190.0, z=2.47250 : adjust CW 00:02
 Recv: ok
 ```
+
 This means that:
 
     - front left screw is the reference point you must not change it.

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -518,15 +518,15 @@ The data can be processed later by the following scripts:
 of them accept one or several raw csv files as the input depending on the
 mode. The graph_accelerometer.py script supports several modes of operation:
 
-  * plotting raw accelerometer data (use `-r` parameter), only 1 input is
+- plotting raw accelerometer data (use `-r` parameter), only 1 input is
     supported;
-  * plotting a frequency response (no extra parameters required), if multiple
+- plotting a frequency response (no extra parameters required), if multiple
     inputs are specified, the average frequency response is computed;
-  * comparison of the frequency response between several inputs (use `-c`
+- comparison of the frequency response between several inputs (use `-c`
     parameter); you can additionally specify which accelerometer axis to
     consider via `-a x`, `-a y` or `-a z` parameter (if none specified,
     the sum of vibrations for all axes is used);
-  * plotting the spectrogram (use `-s` parameter), only 1 input is supported;
+- plotting the spectrogram (use `-s` parameter), only 1 input is supported;
     you can additionally specify which accelerometer axis to consider via
     `-a x`, `-a y` or `-a z` parameter (if none specified, the sum of vibrations
     for all axes is used).
@@ -552,16 +552,16 @@ the CSV file if `-c output.csv` parameter is specified.
 Providing several inputs to shaper_calibrate.py script can be useful if running
 some advanced tuning of the input shapers, for example:
 
-  * Running `TEST_RESONANCES AXIS=X OUTPUT=raw_data` (and `Y` axis) for a single
+- Running `TEST_RESONANCES AXIS=X OUTPUT=raw_data` (and `Y` axis) for a single
     axis twice on a bed slinger printer with the accelerometer attached to the
     toolhead the first time, and the accelerometer attached to the bed the
     second time in order to detect axes cross-resonances and attempt to cancel
     them with input shapers.
-  * Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on a bed slinger with
+- Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on a bed slinger with
     a glass bed and a magnetic surfaces (which is lighter) to find the input
     shaper parameters that work well for any print surface configuration.
-  * Combining the resonance data from multiple test points.
-  * Combining the resonance data from 2 axis (e.g. on a bed slinger printer
+- Combining the resonance data from multiple test points.
+- Combining the resonance data from 2 axis (e.g. on a bed slinger printer
     to configure X-axis input_shaper from both X and Y axes resonances to
     cancel vibrations of the *bed* in case the nozzle 'catches' a print when
     moving in X axis direction).

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -66,16 +66,19 @@ the system that may damage the electronics.
 Note that resonance measurements and shaper auto-calibration require additional
 software dependencies not installed by default. First, you will have to run on
 your Raspberry Pi the following command:
-```
+
+```bash
 ~/klippy-env/bin/pip install -v numpy
 ```
+
 to install `numpy` package. Note that, depending on the performance of the
 CPU, it may take *a lot* of time, up to 10-20 minutes. Be patient and wait
 for the completion of the installation. On some occasions, if the board has
 too little RAM, the installation may fail and you will need to enable swap.
 
 Next, run the following commands to install the additional dependencies:
-```
+
+```bash
 sudo apt update
 sudo apt install python-numpy python-matplotlib
 ```
@@ -88,7 +91,8 @@ Make sure the Linux SPI driver is enabled by running `sudo
 raspi-config` and enabling SPI under the "Interfacing options" menu.
 
 Add the following to the printer.cfg file:
-```
+
+```cfg
 [mcu rpi]
 serial: /tmp/klipper_host_mcu
 
@@ -100,6 +104,7 @@ accel_chip: adxl345
 probe_points:
     100,100,20  # an example
 ```
+
 It is advised to start with 1 probe point, in the middle of the print bed,
 slightly above it.
 
@@ -120,7 +125,8 @@ Now you can test a connection.
 
 You should see the current measurements from the accelerometer, including the
 free-fall acceleration, e.g.
-```
+
+```text
 Recv: // adxl345 values (x, y, z): 470.719200, 941.438400, 9728.196800
 ```
 
@@ -138,9 +144,11 @@ noisy imbalanced fans on a 3D printer.
 ### Measuring the resonances
 
 Now you can run some real-life tests. Run the following command:
-```
+
+```gcode
 TEST_RESONANCES AXIS=X
 ```
+
 Note that it will create vibrations on X axis. It will also disable input
 shaping if it was enabled previously, as it is not valid to run the resonance
 testing with the input shaper enabled.
@@ -150,7 +158,8 @@ the vibrations do not become too violent (`M112` command can be used to abort
 the test in case of emergency; hopefully it will not come to this though).
 If the vibrations do get too strong, you can attempt to specify a lower than the
 default value for `accel_per_hz` parameter in `[resonance_tester]` section, e.g.
-```
+
+```cfg
 [resonance_tester]
 accel_chip: adxl345
 accel_per_hz: 50  # default is 75
@@ -158,23 +167,28 @@ probe_points: ...
 ```
 
 If it works for X axis, run for Y axis as well:
-```
+
+```gcode
 TEST_RESONANCES AXIS=Y
 ```
+
 This will generate 2 CSV files (`/tmp/resonances_x_*.csv` and
 `/tmp/resonances_y_*.csv`). These files can be processed with the stand-alone
 script on a Raspberry Pi. To do that, run running the following commands:
-```
+
+```bash
 ~/klipper/scripts/calibrate_shaper.py /tmp/resonances_x_*.csv -o /tmp/shaper_calibrate_x.png
 ~/klipper/scripts/calibrate_shaper.py /tmp/resonances_y_*.csv -o /tmp/shaper_calibrate_y.png
 ```
+
 This script will generate the charts `/tmp/shaper_calibrate_x.png` and
 `/tmp/shaper_calibrate_y.png` with frequency responses. You will also get the
 suggested frequencies for each input shaper, as well as which input shaper is
 recommended for your setup. For example:
 
 ![Resonances](img/calibrate-y.png)
-```
+
+```text
 Fitted shaper 'zv' frequency = 34.4 Hz (vibrations = 4.0%, smoothing ~= 0.132)
 To avoid too much smoothing with 'zv', suggested max_accel <= 4500 mm/sec^2
 Fitted shaper 'mzv' frequency = 34.6 Hz (vibrations = 0.0%, smoothing ~= 0.170)
@@ -190,7 +204,8 @@ Recommended shaper is mzv @ 34.6 Hz
 
 The suggested configuration can be added to `[input_shaper]` section of
 `printer.cfg`, e.g.:
-```
+
+```cfg
 [input_shaper]
 shaper_freq_x: ...
 shaper_type_x: ...
@@ -200,6 +215,7 @@ shaper_type_y: mzv
 [printer]
 max_accel: 3000  # should not exceed the estimated max_accel for X and Y axes
 ```
+
 or you can choose some other configuration yourself based on the generated
 charts: peaks in the power spectral density on the charts correspond to
 the resonance frequencies of the printer.
@@ -220,7 +236,8 @@ However, you can also connect two accelerometers simultaneously, though they
 must be connected to different boards (say, to an RPi and printer MCU board), or
 to two different physical SPI interfaces on the same board (rarely available).
 Then they can be configured in the following manner:
-```
+
+```cfg
 [adxl345 hotend]
 # Assuming `hotend` chip is connected to an RPi
 cs_pin: rpi:None
@@ -253,7 +270,8 @@ the maximum smoothing from the input shaper.
 Let's consider the following results from the automatic tuning:
 
 ![Resonances](img/calibrate-x.png)
-```
+
+```text
 Fitted shaper 'zv' frequency = 57.8 Hz (vibrations = 20.3%, smoothing ~= 0.053)
 To avoid too much smoothing with 'zv', suggested max_accel <= 13000 mm/sec^2
 Fitted shaper 'mzv' frequency = 34.8 Hz (vibrations = 3.6%, smoothing ~= 0.168)
@@ -266,6 +284,7 @@ Fitted shaper '3hump_ei' frequency = 48.0 Hz (vibrations = 0.0%, smoothing ~= 0.
 To avoid too much smoothing with '3hump_ei', suggested max_accel <= 1500 mm/sec^2
 Recommended shaper is 2hump_ei @ 45.2 Hz
 ```
+
 Note that the reported `smoothing` values are some abstract projected values.
 These values can be used to compare different configurations: the higher the
 value, the more smoothing a shaper will create. However, these smoothing scores
@@ -277,13 +296,16 @@ smoothing exactly a chosen configuration creates.
 In the example above the suggested shaper parameters are not bad, but what if
 you want to get less smoothing on the X axis? You can try to limit the maximum
 shaper smoothing using the following command:
-```
+
+```bash
 ~/klipper/scripts/calibrate_shaper.py /tmp/resonances_x_*.csv -o /tmp/shaper_calibrate_x.png --max_smoothing=0.2
 ```
+
 which limits the smoothing to 0.2 score. Now you can get the following result:
 
 ![Resonances](img/calibrate-x-max-smoothing.png)
-```
+
+```text
 Fitted shaper 'zv' frequency = 55.4 Hz (vibrations = 19.7%, smoothing ~= 0.057)
 To avoid too much smoothing with 'zv', suggested max_accel <= 12000 mm/sec^2
 Fitted shaper 'mzv' frequency = 34.6 Hz (vibrations = 3.6%, smoothing ~= 0.170)
@@ -314,12 +336,14 @@ reported by the script and make sure they are not too high.
 
 Note that if you chose a good `max_smoothing` value for both of your axes, you
 can store it in the `printer.cfg` as
-```
+
+```cfg
 [resonance_tester]
 accel_chip: ...
 probe_points: ...
 max_smoothing: 0.25  # an example
 ```
+
 Then, if you [rerun](#input-shaper-re-calibration) the input shaper auto-tuning
 using `SHAPER_CALIBRATE` Klipper command in the future, it will use the stored
 `max_smoothing` value as a reference.
@@ -361,27 +385,35 @@ useful for input shaper calibration, it can be used to study printer
 resonances in-depth and to check, for example, belt tension.
 
 To check the belt tension on CoreXY printers, execute
-```
+
+```gcode
 TEST_RESONANCES AXIS=1,1 OUTPUT=raw_data
 TEST_RESONANCES AXIS=1,-1 OUTPUT=raw_data
 ```
+
 and use `graph_accelerometer.py` to process the generated files, e.g.
-```
+
+```bash
 ~/klipper/scripts/graph_accelerometer.py -c /tmp/raw_data_axis*.csv -o /tmp/resonances.png
 ```
+
 which will generate `/tmp/resonances.png` comparing the resonances.
 
 For Delta printers with the default tower placement
 (tower A ~= 210 degrees, B ~= 330 degrees, and C ~= 90 degrees), execute
-```
+
+```gcode
 TEST_RESONANCES AXIS=0,1 OUTPUT=raw_data
 TEST_RESONANCES AXIS=-0.866025404,-0.5 OUTPUT=raw_data
 TEST_RESONANCES AXIS=0.866025404,-0.5 OUTPUT=raw_data
 ```
+
 and then use the same command
-```
+
+```bash
 ~/klipper/scripts/graph_accelerometer.py -c /tmp/raw_data_axis*.csv -o /tmp/resonances.png
 ```
+
 to generate `/tmp/resonances.png` comparing the resonances.
 
 ## Input Shaper auto-calibration
@@ -389,7 +421,8 @@ to generate `/tmp/resonances.png` comparing the resonances.
 Besides manually choosing the appropriate parameters for the input shaper
 feature, it is also possible to run the auto-tuning for the input shaper
 directly from Klipper. Run the following command via Octoprint terminal:
-```
+
+```gcode
 SHAPER_CALIBRATE
 ```
 
@@ -399,7 +432,7 @@ and the suggested input shapers. You will also get the suggested
 frequencies for each input shaper, as well as which input shaper is
 recommended for your setup, on Octoprint console. For example:
 
-```
+```text
 Calculating the best input shaper parameters for y axis
 Fitted shaper 'zv' frequency = 39.0 Hz (vibrations = 13.2%, smoothing ~= 0.105)
 To avoid too much smoothing with 'zv', suggested max_accel <= 5900 mm/sec^2
@@ -413,17 +446,18 @@ Fitted shaper '3hump_ei' frequency = 59.0 Hz (vibrations = 0.0%, smoothing ~= 0.
 To avoid too much smoothing with '3hump_ei', suggested max_accel <= 2500 mm/sec^2
 Recommended shaper_type_y = mzv, shaper_freq_y = 36.8 Hz
 ```
+
 If you agree with the suggested parameters, you can execute `SAVE_CONFIG`
 now to save them and restart the Klipper. Note that this will not update
 `max_accel` value in `[printer]` section. You should update it manually
 following the considerations in [Selecting max_accel](#selecting-max_accel)
 section.
 
-
 If your printer is a bed slinger printer, you can specify which axis
 to test, so that you can change the accelerometer mounting point between
 the tests (by default the test is performed for both axes):
-```
+
+```gcode
 SHAPER_CALIBRATE AXIS=Y
 ```
 
@@ -440,7 +474,8 @@ the future, especially if some changes to the printer that can affect its
 kinematics are made. One can either re-run the full calibration using
 `SHAPER_CALIBRATE` command, or restrict the auto-calibration to a single axis by
 supplying `AXIS=` parameter, like
-```
+
+```gcode
 SHAPER_CALIBRATE AXIS=X
 ```
 
@@ -465,10 +500,12 @@ print some test prints before using them to confirm they are good.
 It is possible to generate the raw accelerometer data and process it offline
 (e.g. on a host machine), for example to find resonances. In order to do so,
 run the following commands via Octoprint terminal:
-```
+
+```gcode
 SET_INPUT_SHAPER SHAPER_FREQ_X=0 SHAPER_FREQ_Y=0
 TEST_RESONANCES AXIS=X OUTPUT=raw_data
 ```
+
 ignoring any errors for `SET_INPUT_SHAPER` command. For `TEST_RESONANCES`
 command, specify the desired test axis. The raw data will be written into
 `/tmp` directory on the RPi.
@@ -500,9 +537,11 @@ Note that graph_accelerometer.py script supports only the raw_data\*.csv files
 and not resonances\*.csv or calibration_data\*.csv files.
 
 For example,
-```
+
+```bash
 ~/klipper/scripts/graph_accelerometer.py /tmp/raw_data_x_*.csv -o /tmp/resonances_x.png -c -a z
 ```
+
 will plot the comparison of several `/tmp/raw_data_x_*.csv` files for Z axis to
 `/tmp/resonances_x.png` file.
 

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -13,7 +13,6 @@ SPI mode (small number of boards appear to be hard-configured for I2C by
 pulling SDO to GND), and, if it is going to be connected to a 5V printer MCU,
 that it has a voltage regulator and a level shifter.
 
-
 ## Installation instructions
 
 ### Wiring
@@ -34,7 +33,6 @@ and **will not work**. The recommended connection scheme:
 Fritzing wiring diagrams for some of the ADXL345 boards:
 
 ![ADXL345-Rpi](img/adxl345-fritzing.png)
-
 
 Double-check your wiring before powering up the Raspberry Pi to prevent
 damaging it or the accelerometer.

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -21,14 +21,14 @@ You need to connect ADXL345 to your Raspberry Pi via SPI. Note that the I2C
 connection, which is suggested by ADXL345 documentation, has too low throughput
 and **will not work**. The recommended connection scheme:
 
-| ADXL345 pin | RPi pin | RPi pin name |
-|:--:|:--:|:--:|
-| 3V3 (or VCC) | 01 | 3.3v DC power |
-| GND | 06 | Ground |
-| CS | 24 | GPIO08 (SPI0_CE0_N) |
-| SDO | 21 | GPIO09 (SPI0_MISO) |
-| SDA | 19 | GPIO10 (SPI0_MOSI) |
-| SCL | 23 | GPIO11 (SPI0_SCLK) |
+| ADXL345 pin  | RPi pin |    RPi pin name     |
+| :----------: | :-----: | :-----------------: |
+| 3V3 (or VCC) |   01    |    3.3v DC power    |
+|     GND      |   06    |       Ground        |
+|      CS      |   24    | GPIO08 (SPI0_CE0_N) |
+|     SDO      |   21    | GPIO09 (SPI0_MISO)  |
+|     SDA      |   19    | GPIO10 (SPI0_MOSI)  |
+|     SCL      |   23    | GPIO11 (SPI0_SCLK)  |
 
 Fritzing wiring diagrams for some of the ADXL345 boards:
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 Welcome to the Klipper documentation. If new to Klipper, start with
-the [features](Features.md) and [installation](Installation.md)
+the [Features](Features.md) and [Installation](Installation.md)
 documents.
 
 ## Overview information

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -1,4 +1,4 @@
-# Packaging klipper
+# Packaging Klipper
 
 Klipper is somewhat of a packaging anomaly among python programs, as it doesn't
 use setuptools to build and install. Some notes regarding how best to package it
@@ -20,7 +20,7 @@ klippy`.
 ## Versioning
 
 If you are building a package of Klipper from git, it is usual practice not to
-ship a .git directory, so the versioning must be handled without git.  To do
+ship a .git directory, so the versioning must be handled without git. To do
 this, use the script shipped in `scripts/make_version.py` which should be run as
 follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
 

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -27,5 +27,5 @@ follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
 ## Sample packaging script
 
 klipper-git is packaged for Arch Linux, and has a PKGBUILD (package build
-script) available at
-https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klipper-git.
+script) available at [Arch Linux User Repository](https://aur.\
+archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klipper-git).

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -27,5 +27,5 @@ follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
 ## Sample packaging script
 
 klipper-git is packaged for Arch Linux, and has a PKGBUILD (package build
-script) available at [Arch Linux User Repository](https://aur.\
-archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klipper-git).
+script) available at
+https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=klipper-git.

--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -25,19 +25,25 @@ height should be around 75% of the nozzle diameter). Make sure any
 "dynamic acceleration control" is disabled in the slicer.
 
 Prepare for the test by issuing the following G-Code command:
-```
+
+```gcode
 SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=1 ACCEL=500
 ```
+
 This command makes the nozzle travel slower through corners to
 emphasize the effects of extruder pressure. Then for printers with a
 direct drive extruder run the command:
-```
+
+```gcode
 TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START=0 FACTOR=.005
 ```
+
 For long bowden extruders use:
-```
+
+```gcode
 TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START=0 FACTOR=.020
 ```
+
 Then print the object. When fully printed the test print looks like:
 
 ![tuning_tower](img/tuning_tower.jpg)

--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -92,20 +92,20 @@ cornering speeds to their normal values.
 
 ## Important Notes
 
-* The pressure advance value is dependent on the extruder, the nozzle,
+- The pressure advance value is dependent on the extruder, the nozzle,
   and the filament. It is common for filament from different
   manufactures or with different pigments to require significantly
   different pressure advance values. Therefore, one should calibrate
   pressure advance on each printer and with each spool of filament.
 
-* Printing temperature and extrusion rates can impact pressure
+- Printing temperature and extrusion rates can impact pressure
   advance. Be sure to tune the
   [extruder rotation_distance](Rotation_Distance.md#calibrating-rotation_distance-on-extruders)
   and
   [nozzle temperature](http://reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide#Nozzle_Temperature)
   prior to tuning pressure advance.
 
-* The test print is designed to run with a high extruder flow rate,
+- The test print is designed to run with a high extruder flow rate,
   but otherwise "normal" slicer settings. A high flow rate is obtained
   by using a high printing speed (eg, 100mm/s) and a coarse layer
   height (typically around 75% of the nozzle diameter). Other slicer
@@ -114,7 +114,7 @@ cornering speeds to their normal values.
   external perimeter speed to be the same speed as the rest of the
   print, but it is not a requirement.
 
-* It is common for the test print to show different behavior on each
+- It is common for the test print to show different behavior on each
   corner. Often the slicer will arrange to change layers at one corner
   which can result in that corner being significantly different from
   the remaining three corners. If this occurs, then ignore that corner
@@ -125,7 +125,7 @@ cornering speeds to their normal values.
   well for all the remaining corners. If in doubt, prefer a lower
   pressure advance value.
 
-* If a high pressure advance value (eg, over 0.200) is used then one
+- If a high pressure advance value (eg, over 0.200) is used then one
   may find that the extruder skips when returning to the printer's
   normal acceleration. The pressure advance system accounts for
   pressure by pushing in extra filament during acceleration and
@@ -134,7 +134,7 @@ cornering speeds to their normal values.
   enough torque to push the required filament. If this occurs, either
   use a lower acceleration value or disable pressure advance.
 
-* Once pressure advance is tuned in Klipper, it may still be useful to
+- Once pressure advance is tuned in Klipper, it may still be useful to
   configure a small retract value in the slicer (eg, 0.75mm) and to
   utilize the slicer's "wipe on retract option" if available. These
   slicer settings may help counteract ooze caused by filament cohesion
@@ -142,7 +142,7 @@ cornering speeds to their normal values.
   plastic). It is recommended to disable the slicer's "z-lift on
   retract" option.
 
-* The pressure advance system does not change the timing or path of
+- The pressure advance system does not change the timing or path of
   the toolhead. A print with pressure advance enabled will take the
   same amount of time as a print without pressure advance. Pressure
   advance also does not change the total amount of filament extruded

--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -18,7 +18,7 @@ and operational as the tuning test involves printing and inspecting a
 test object. It is a good idea to read this document in full prior to
 running the test.
 
-Use a slicer to generate g-code for the large hollow square found in
+Use a slicer to generate G-Code for the large hollow square found in
 [docs/prints/square_tower.stl](prints/square_tower.stl). Use a high
 speed (eg, 100mm/s), zero infill, and a coarse layer height (the layer
 height should be around 75% of the nozzle diameter). Make sure any

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -79,7 +79,7 @@ results to the config file with:
 SAVE_CONFIG
 ```
 
-Note that if a change is made to the printer's motion system, hotend
+\*\*\* Note that if a change is made to the printer's motion system, hotend
 position, or probe location then it will invalidate the results of
 `PROBE_CALIBRATE`.
 

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -43,8 +43,8 @@ to move the nozzle to an X position of 57 and Y of 30. Once one finds
 the position directly above the mark, use the `GET_POSITION` command
 to report that position. This is the nozzle position.
 
-The x_offset is then the `nozzle_x_position - probe_x_position` and
-y_offset is similarly the `nozzle_y_position - probe_y_position`.
+The x_offset is then the $x_{nozzle} - x_{probe}$ and
+y_offset is similarly the $x_{nozzle} - x_{probe}$.
 Update the printer.cfg file with the given values, remove the
 tape/marks from the bed, and then issue a `RESTART` command so that
 the new values take effect.
@@ -125,11 +125,11 @@ Ideally the tool will report an identical maximum and minimum value.
 (That is, ideally the probe obtains an identical result on all ten
 probes.) However, it's normal for the minimum and maximum values to
 differ by one Z "step distance" or up to 5 microns (.005mm). A "step
-distance" is
-`rotation_distance/(full_steps_per_rotation*microsteps)`. The distance
-between the minimum and the maximum value is called the range. So, in
-the above example, since the printer uses a Z step distance of .0125,
-a range of 0.012500 would be considered normal.
+distance" is$\frac{rotation\_distance}{full\_steps\_per\_rotation
+\times microsteps}$.
+The distance between the minimum and the maximum value is called the
+range. So, in the above example, since the printer uses a Z step
+distance of .0125, a range of 0.012500 would be considered normal.
 
 If the results of the test show a range value that is greater than 25
 microns (.025mm) then the probe does not have sufficient accuracy for

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -81,17 +81,17 @@ SAVE_CONFIG
 
 Note that if a change is made to the printer's motion system, hotend
 position, or probe location then it will invalidate the results of
-PROBE_CALIBRATE.
+`PROBE_CALIBRATE`.
 
 If the probe has an X or Y offset and the bed tilt is changed (eg, by
-adjusting bed screws, running DELTA_CALIBRATE, running Z_TILT_ADJUST,
-running QUAD_GANTRY_LEVEL, or similar) then it will invalidate the
-results of PROBE_CALIBRATE. After making any of the above adjustments
-it will be necessary to run PROBE_CALIBRATE again.
+adjusting bed screws, running `DELTA_CALIBRATE`, running `Z_TILT_ADJUST`,
+running `QUAD_GANTRY_LEVEL,` or similar) then it will invalidate the
+results of `PROBE_CALIBRATE`. After making any of the above adjustments
+it will be necessary to run `PROBE_CALIBRATE` again.
 
-If the results of PROBE_CALIBRATE are invalidated, then any previous
+If the results of `PROBE_CALIBRATE` are invalidated, then any previous
 [bed mesh](Bed_Mesh.md) results that were obtained using the probe are
-also invalidated - it will be necessary to rerun BED_MESH_CALIBRATE
+also invalidated - it will be necessary to rerun `BED_MESH_CALIBRATE`
 after recalibrating the probe.
 
 ## Repeatability check

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -43,8 +43,8 @@ to move the nozzle to an X position of 57 and Y of 30. Once one finds
 the position directly above the mark, use the `GET_POSITION` command
 to report that position. This is the nozzle position.
 
-The x_offset is then the $x_{nozzle} - x_{probe}$ and
-y_offset is similarly the $x_{nozzle} - x_{probe}$.
+The x_offset is then the `nozzle_x_position - probe_x_position` and
+y_offset is similarly the `nozzle_y_position - probe_y_position`.
 Update the printer.cfg file with the given values, remove the
 tape/marks from the bed, and then issue a `RESTART` command so that
 the new values take effect.
@@ -125,11 +125,11 @@ Ideally the tool will report an identical maximum and minimum value.
 (That is, ideally the probe obtains an identical result on all ten
 probes.) However, it's normal for the minimum and maximum values to
 differ by one Z "step distance" or up to 5 microns (.005mm). A "step
-distance" is$\frac{rotation\_distance}{full\_steps\_per\_rotation
-\times microsteps}$.
-The distance between the minimum and the maximum value is called the
-range. So, in the above example, since the printer uses a Z step
-distance of .0125, a range of 0.012500 would be considered normal.
+distance" is
+`rotation_distance/(full_steps_per_rotation*microsteps)`. The distance
+between the minimum and the maximum value is called the range. So, in
+the above example, since the printer uses a Z step distance of .0125,
+a range of 0.012500 would be considered normal.
 
 If the results of the test show a range value that is greater than 25
 microns (.025mm) then the probe does not have sufficient accuracy for

--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -13,26 +13,32 @@ move the head to a position near the center of the bed.
 Place a piece of blue painters tape (or similar) on the bed underneath
 the probe. Navigate to the OctoPrint "Terminal" tab and issue a PROBE
 command:
-```
+
+```gcode
 PROBE
 ```
+
 Place a mark on the tape directly under where the probe is (or use a
 similar method to note the location on the bed).
 
 Issue a `GET_POSITION` command and record the toolhead XY location
 reported by that command. For example if one sees:
-```
+
+```text
 Recv: // toolhead: X:46.500000 Y:27.000000 Z:15.000000 E:0.000000
 ```
+
 then one would record a probe X position of 46.5 and probe Y position
 of 27.
 
 After recording the probe position, issue a series of G1 commands
 until the nozzle is directly above the mark on the bed. For example,
 one might issue:
-```
+
+```gcode
 G1 F300 X57 Y30 Z15
 ```
+
 to move the nozzle to an X position of 57 and Y of 30. Once one finds
 the position directly above the mark, use the `GET_POSITION` command
 to report that position. This is the nozzle position.
@@ -68,7 +74,8 @@ Once the manual probe tool starts, follow the steps described at
 actual distance between the nozzle and bed at the given location. Once
 those steps are complete one can `ACCEPT` the position and save the
 results to the config file with:
-```
+
+```gcode
 SAVE_CONFIG
 ```
 
@@ -97,7 +104,8 @@ bed. Navigate to the OctoPrint terminal tab and run the
 
 This command will run the probe ten times and produce output similar
 to the following:
-```
+
+```text
 Recv: // probe accuracy: at X:0.000 Y:0.000 Z:10.000
 Recv: // and read 10 times with speed of 5 mm/s
 Recv: // probe at -0.003,0.005 is z=2.506948

--- a/docs/Protocol.md
+++ b/docs/Protocol.md
@@ -236,7 +236,7 @@ integers. The following table shows the number of bytes each integer
 takes to encode:
 
 | Integer                   | Encoded size |
-|---------------------------|--------------|
+| ------------------------- | ------------ |
 | -32 .. 95                 | 1            |
 | -4096 .. 12287            | 2            |
 | -524288 .. 1572863        | 3            |

--- a/docs/Protocol.md
+++ b/docs/Protocol.md
@@ -7,7 +7,7 @@ of command and response strings that are compressed, transmitted, and
 then processed at the receiving side. An example series of commands in
 uncompressed human-readable format might look like:
 
-```
+```c
 set_digital_out pin=PA3 value=1
 set_digital_out pin=PA7 value=1
 schedule_digital_out oid=8 clock=4000000 value=0
@@ -43,7 +43,7 @@ results.
 The micro-controller software declares a "command" by using the
 DECL_COMMAND() macro in the C code. For example:
 
-```
+```c
 DECL_COMMAND(command_update_digital_out, "update_digital_out oid=%c value=%c");
 ```
 
@@ -75,7 +75,7 @@ To send information from the micro-controller to the host a "response"
 is generated. These are both declared and transmitted using the
 sendf() C macro. For example:
 
-```
+```c
 sendf("status clock=%u status=%c", sched_read_time(), sched_is_shutdown());
 ```
 
@@ -101,7 +101,7 @@ invoked, and it may invoke sendf() at any time from a task handler.
 To simplify debugging, there is also an output() C function. For
 example:
 
-```
+```c
 output("The value of %u is %s with size %u.", x, buf, buf_len);
 ```
 
@@ -114,7 +114,7 @@ Enumerations allow the host code to use string identifiers for
 parameters that the micro-controller handles as integers. They are
 declared in the micro-controller code - for example:
 
-```
+```c
 DECL_ENUMERATION("spi_bus", "spi", 0);
 
 DECL_ENUMERATION_RANGE("pin", "PC0", 16, 8);
@@ -135,7 +135,7 @@ be transmitted with integers 16, 17, 18, ..., 23.
 
 Constants can also be exported. For example, the following:
 
-```
+```c
 DECL_CONSTANT("SERIAL_BAUD", 250000);
 ```
 
@@ -143,7 +143,7 @@ would export a constant named "SERIAL_BAUD" with a value of 250000
 from the micro-controller to the host. It is also possible to declare
 a constant that is a string - for example:
 
-```
+```c
 DECL_CONSTANT_STR("MCU", "pru");
 ```
 
@@ -159,7 +159,7 @@ All data sent from host to micro-controller and vice-versa are
 contained in "message blocks". A message block has a two byte header
 and a three byte trailer. The format of a message block is:
 
-```
+```text
 <1 byte length><1 byte sequence><n-byte content><2 byte crc><1 byte sync>
 ```
 
@@ -193,7 +193,7 @@ parameters for the given command.
 As an example, the following four commands might be placed in a single
 message block:
 
-```
+```c
 update_digital_out oid=6 value=1
 update_digital_out oid=5 value=0
 get_config
@@ -202,7 +202,7 @@ get_clock
 
 and encoded into the following eight VLQ integers:
 
-```
+```text
 <id_update_digital_out><6><1><id_update_digital_out><5><0><id_get_config><id_get_clock>
 ```
 
@@ -250,7 +250,7 @@ command or response is a dynamic string then the parameter is not
 encoded as a simple VLQ integer. Instead it is encoded by transmitting
 the length as a VLQ encoded integer followed by the contents itself:
 
-```
+```text
 <VLQ encoded length><n-byte contents>
 ```
 

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -89,7 +89,7 @@ To check the pin number and the pin availability tun:
 gpioinfo
 ```
 
-The chosen pin can thus be used within the configuration as `gpiochip<n>/gpio<o>` where **n** is the chip number as seen by the `gpiodetect` command and **o** is the line number seen by the` gpioinfo` command.
+The chosen pin can thus be used within the configuration as `gpiochip<n>/gpio<o>` where **n** is the chip number as seen by the `gpiodetect` command and **o** is the line number seen by the `gpioinfo` command.
 
 ***Warning:*** only gpio marked as `unused` can be used. It is not possible for a *line* to be used by multiple processes simultaneously.
 

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -10,7 +10,7 @@ pre-configured number of exposed pins to manage the main printing
 functions (thermal resistors, extruders, steppers ...).
 Using the RPi where Klipper is installed as a secondary MCU gives the
 possibility to directly use the GPIOs and the buses (i2c, spi) of the RPi
-inside klipper without using Octoprint plugins (if used) or external
+inside Klipper without using Octoprint plugins (if used) or external
 programs giving the ability to control everything within the print GCODE.
 
 **Warning**: If your platform is a _Beaglebone_ and you have correctly followed the installation steps, the linux mcu is already installed and configured for your system.
@@ -40,6 +40,7 @@ for the "Linux process":
 cd ~/klipper/
 make menuconfig
 ```
+
 In the menu, set "Microcontroller Architecture" to "Linux process," then save and exit.
 
 To build and install the new micro-controller code, run:
@@ -67,8 +68,8 @@ following the instructions in
 
 ## Optional: Identify the correct gpiochip
 
-On Rasperry and on many clones the pins exposed on the GPIO belong to the first gpiochip. They can therefore be used on klipper simply by referring them with the name `gpio0..n`.
-However, there are cases in which the exposed pins belong to gpiochips other than the first. For example in the case of some OrangePi models or if a Port Expander is used. In these cases it is useful to use the commands to access the _Linux GPIO character device_ to verify the configuration.
+On Rasperry and on many clones the pins exposed on the GPIO belong to the first gpiochip. They can therefore be used on Klipper simply by referring them with the name `gpio0..n`.
+However, there are cases in which the exposed pins belong to gpiochips other than the first. For example in the case of some OrangePi models or if a Port Expander is used. In these cases it is useful to use the commands to access the *Linux GPIO character device* to verify the configuration.
 
 To install the _Linux GPIO character device - binary_ on a debian based distro like octopi run:
 
@@ -92,7 +93,7 @@ The chosen pin can thus be used within the configuration as `gpiochip<n>/gpio<o>
 
 ***Warning:*** only gpio marked as `unused` can be used. It is not possible for a _line_ to be used by multiple processes simultaneously.
 
-For example on a RPi 3B+ where klipper use the GPIO20 for a switch:
+For example on a RPi 3B+ where Klipper use the GPIO20 for a switch:
 
 ```bash
 $ gpiodetect

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -20,7 +20,8 @@ programs giving the ability to control everything within the print GCODE.
 If you want to use the host as a secondary MCU the klipper_mcu process must run before the klippy process.
 
 After installing Klipper, install the script. run:
-```
+
+```bash
 cd ~/klipper/
 sudo cp "./scripts/klipper-mcu-start.sh" /etc/init.d/klipper_mcu
 sudo update-rc.d klipper_mcu defaults
@@ -34,14 +35,16 @@ Make sure the Linux SPI driver is enabled by running sudo raspi-config and enabl
 
 To compile the Klipper micro-controller code, start by configuring it
 for the "Linux process":
-```
+
+```bash
 cd ~/klipper/
 make menuconfig
 ```
 In the menu, set "Microcontroller Architecture" to "Linux process," then save and exit.
 
 To build and install the new micro-controller code, run:
-```
+
+```bash
 sudo service klipper stop
 make flash
 sudo service klipper start
@@ -50,7 +53,8 @@ sudo service klipper start
 If klippy.log reports a "Permission denied" error when attempting to connect
 to `/tmp/klipper_host_mcu` then you need to add your user to the tty group.
 The following command will add the "pi" user to the tty group:
-```
+
+```bash
 sudo usermod -a -G tty pi
 ```
 
@@ -67,17 +71,20 @@ On Rasperry and on many clones the pins exposed on the GPIO belong to the first 
 However, there are cases in which the exposed pins belong to gpiochips other than the first. For example in the case of some OrangePi models or if a Port Expander is used. In these cases it is useful to use the commands to access the _Linux GPIO character device_ to verify the configuration.
 
 To install the _Linux GPIO character device - binary_ on a debian based distro like octopi run:
-```
+
+```bash
 sudo apt-get install gpiod
 ```
 
 To check available gpiochip run:
-```
+
+```bash
 gpiodetect
 ```
 
 To check the pin number and the pin availability tun:
-```
+
+```bash
 gpioinfo
 ```
 
@@ -86,7 +93,8 @@ The chosen pin can thus be used within the configuration as `gpiochip<n>/gpio<o>
 ***Warning:*** only gpio marked as `unused` can be used. It is not possible for a _line_ to be used by multiple processes simultaneously.
 
 For example on a RPi 3B+ where klipper use the GPIO20 for a switch:
-```
+
+```bash
 $ gpiodetect
 gpiochip0 [pinctrl-bcm2835] (54 lines)
 gpiochip1 [raspberrypi-exp-gpio] (8 lines)
@@ -163,27 +171,33 @@ gpiochip1 - 8 lines:
 Raspberry Pi's have two PWM channels (PWM0 and PWM1) which are exposed on the header or if not, can be routed to existing gpio pins.
 The Linux mcu daemon uses the pwmchip sysfs interface to control hardware pwm devices on Linux hosts.
 The pwm sysfs interface is not exposed by default on a Raspberry and can be activated by adding a line to ```/boot/config.txt```:
-```
+
+```cfg
 # Enable pwmchip sysfs interface
 dtoverlay=pwm,pin=12,func=4
 ```
+
 This example enables only PWM0 and routes it to gpio12. If both PWM channels need to be enabled you can use ```pwm-2chan```.
 
 The overlay does not expose the pwm line on sysfs on boot and needs to be exported by echo'ing the number of the pwm channel to ```/sys/class/pwm/pwmchip0/export```:
-```
+
+```bash
 echo 0 > /sys/class/pwm/pwmchip0/export
 ```
+
 This will create device ```/sys/class/pwm/pwmchip0/pwm0``` in the filesystem.
 The easiest way to do this is by adding this to ```/etc/rc.local``` before the ```exit 0``` line.
 
 With the sysfs in place, you can now use either the pwm channel(s) by adding the following piece of configuration to your ```printer.cfg```:
-```
+
+```gcode
 [output_pin caselight]
 pin: host:pwmchip0/pwm0
 pwm: True
 hardware_pwm: True
 cycle_time: 0.000001
 ```
+
 This will add hardware pwm control to gpio12 on the Pi (because the overlay was configured to route pwm0 to pin=12).
 
 PWM0 can be routed to gpio12 and gpio18, PWM1 can be routed to gpio13 and gpio19:

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -202,9 +202,9 @@ cycle_time: 0.000001
 This will add hardware pwm control to gpio12 on the Pi (because the overlay was configured to route pwm0 to pin=12).
 
 PWM0 can be routed to gpio12 and gpio18, PWM1 can be routed to gpio13 and gpio19:
-|PWM|gpio PIN|Func|
-|---|--------|----|
-|  0|      12|   4|
-|  0|      18|   2|
-|  1|      13|   4|
-|  1|      19|   2|
+| PWM | gpio PIN | Func |
+| --- | -------- | ---- |
+| 0   | 12       | 4    |
+| 0   | 18       | 2    |
+| 1   | 13       | 4    |
+| 1   | 19       | 2    |

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -13,7 +13,7 @@ possibility to directly use the GPIOs and the buses (i2c, spi) of the RPi
 inside Klipper without using Octoprint plugins (if used) or external
 programs giving the ability to control everything within the print GCODE.
 
-**Warning**: If your platform is a _Beaglebone_ and you have correctly followed the installation steps, the linux mcu is already installed and configured for your system.
+**Warning**: If your platform is a *Beaglebone* and you have correctly followed the installation steps, the linux mcu is already installed and configured for your system.
 
 ## Install the rc script
 
@@ -71,7 +71,7 @@ following the instructions in
 On Rasperry and on many clones the pins exposed on the GPIO belong to the first gpiochip. They can therefore be used on Klipper simply by referring them with the name `gpio0..n`.
 However, there are cases in which the exposed pins belong to gpiochips other than the first. For example in the case of some OrangePi models or if a Port Expander is used. In these cases it is useful to use the commands to access the *Linux GPIO character device* to verify the configuration.
 
-To install the _Linux GPIO character device - binary_ on a debian based distro like octopi run:
+To install the *Linux GPIO character device - binary* on a debian based distro like octopi run:
 
 ```bash
 sudo apt-get install gpiod
@@ -91,7 +91,7 @@ gpioinfo
 
 The chosen pin can thus be used within the configuration as `gpiochip<n>/gpio<o>` where **n** is the chip number as seen by the `gpiodetect` command and **o** is the line number seen by the` gpioinfo` command.
 
-***Warning:*** only gpio marked as `unused` can be used. It is not possible for a _line_ to be used by multiple processes simultaneously.
+***Warning:*** only gpio marked as `unused` can be used. It is not possible for a *line* to be used by multiple processes simultaneously.
 
 For example on a RPi 3B+ where Klipper use the GPIO20 for a switch:
 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -7,6 +7,7 @@ History of Klipper releases. Please see
 
 Available on 20201020. Major changes in this release:
 * Support for "Input Shaping" - a mechanism to counteract printer
+
   resonance. It can reduce or eliminate "ringing" in prints.
 * New "Smooth Pressure Advance" system. This implements "Pressure
   Advance" without introducing instantaneous velocity changes. It is
@@ -44,6 +45,7 @@ Available on 20201028. Release containing only bug fixes.
 
 Available on 20191021. Major changes in this release:
 * New G-Code command template support. G-Code in the config file is
+
   now evaluated with the Jinja2 template language.
 * Improvements to Trinamic stepper drivers:
   * New support for TMC2209 and TMC5160 drivers.
@@ -85,6 +87,7 @@ Available on 20191021. Major changes in this release:
 Available on 20181220. Major changes in this release:
 * Klipper now supports "mesh" bed leveling
 * New support for "enhanced" delta calibration (calibrates print x/y
+
   dimensions on delta printers)
 * Support for run-time configuration of Trinamic stepper motor drivers
   (tmc2130, tmc2208, tmc2660)
@@ -119,6 +122,7 @@ Available on 20180331. Major changes in this release:
 * Enhanced heater and thermistor hardware failure checks
 * Support for Z probes
 * Initial support for automatic parameter calibration on deltas (via a
+
   new delta_calibrate command)
 * Initial support for bed tilt compensation (via bed_tilt_calibrate
   command)

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -6,36 +6,36 @@ History of Klipper releases. Please see
 ## Klipper 0.9.0
 
 Available on 20201020. Major changes in this release:
-* Support for "Input Shaping" - a mechanism to counteract printer
 
+- Support for "Input Shaping" - a mechanism to counteract printer
   resonance. It can reduce or eliminate "ringing" in prints.
-* New "Smooth Pressure Advance" system. This implements "Pressure
+- New "Smooth Pressure Advance" system. This implements "Pressure
   Advance" without introducing instantaneous velocity changes. It is
   also now possible to tune pressure advance using a "Tuning Tower"
   method.
-* New "webhooks" API server. This provides a programmable JSON
+- New "webhooks" API server. This provides a programmable JSON
   interface to Klipper.
-* The LCD display and menu are now configurable using the Jinja2
+- The LCD display and menu are now configurable using the Jinja2
   template language.
-* The TMC2208 stepper motor drivers can now be used in "standalone"
+- The TMC2208 stepper motor drivers can now be used in "standalone"
   mode with Klipper.
-* Improved BL-Touch v3 support.
-* Improved USB identification. Klipper now has its own USB
+- Improved BL-Touch v3 support.
+- Improved USB identification. Klipper now has its own USB
   identification code and micro-controllers can now report their
   unique serial numbers during USB identification.
-* New kinematic support for "Rotary Delta" and "CoreXZ" printers.
-* Micro-controller improvements: support for stm32f070, support for
+- New kinematic support for "Rotary Delta" and "CoreXZ" printers.
+- Micro-controller improvements: support for stm32f070, support for
   stm32f207, support for GPIO pins on "Linux MCU", stm32 "HID
   bootloader" support, Chitu bootloader support, MKS Robin bootloader
   support.
-* Improved handling of Python "garbage collection" events.
-* Many additional modules added: adc_scaled, adxl345, bme280,
+- Improved handling of Python "garbage collection" events.
+- Many additional modules added: adc_scaled, adxl345, bme280,
   display_status, extruder_stepper, fan_generic,
   hall_filament_width_sensor, htu21d, homing_heaters, input_shaper,
   lm75, print_stats, resonance_tester, shaper_calibrate, query_adc,
   graph_accelerometer, graph_extruder, graph_motion, graph_shaper,
   graph_temp_sensor, whconsole
-* Several bug fixes and code cleanups.
+- Several bug fixes and code cleanups.
 
 ### Klipper 0.9.1
 
@@ -44,177 +44,177 @@ Available on 20201028. Release containing only bug fixes.
 ## Klipper 0.8.0
 
 Available on 20191021. Major changes in this release:
-* New G-Code command template support. G-Code in the config file is
 
+- New G-Code command template support. G-Code in the config file is
   now evaluated with the Jinja2 template language.
-* Improvements to Trinamic stepper drivers:
-  * New support for TMC2209 and TMC5160 drivers.
-  * Improved DUMP_TMC, SET_TMC_CURRENT, and INIT_TMC G-Code commands.
-  * Improved support for TMC UART handling with an analog mux.
-* Improved homing, probing, and bed leveling support:
-  * New manual_probe, bed_screws, screws_tilt_adjust, skew_correction,
+- Improvements to Trinamic stepper drivers:
+  - New support for TMC2209 and TMC5160 drivers.
+  - Improved DUMP_TMC, SET_TMC_CURRENT, and INIT_TMC G-Code commands.
+  - Improved support for TMC UART handling with an analog mux.
+- Improved homing, probing, and bed leveling support:
+  - New manual_probe, bed_screws, screws_tilt_adjust, skew_correction,
     safe_z_home modules added.
-  * Enhanced multi-sample probing with median, average, and retry
+  - Enhanced multi-sample probing with median, average, and retry
     logic.
-  * Improved documentation for BL-Touch, probe calibration, endstop
+  - Improved documentation for BL-Touch, probe calibration, endstop
     calibration, delta calibration, sensorless homing, and endstop
     phase calibration.
-  * Improved homing support on a large Z axis.
-* Many Klipper micro-controller improvements:
-  * Klipper ported to: SAM3X8C, SAM4S8C, SAMD51, STM32F042, STM32F4
-  * New USB CDC driver implementations on SAM3X, SAM4, STM32F4.
-  * Enhanced support for flashing Klipper over USB.
-  * Software SPI support.
-  * Greatly improved temperature filtering on the LPC176x.
-  * Early output pin settings can be configured in the
+  - Improved homing support on a large Z axis.
+- Many Klipper micro-controller improvements:
+  - Klipper ported to: SAM3X8C, SAM4S8C, SAMD51, STM32F042, STM32F4
+  - New USB CDC driver implementations on SAM3X, SAM4, STM32F4.
+  - Enhanced support for flashing Klipper over USB.
+  - Software SPI support.
+  - Greatly improved temperature filtering on the LPC176x.
+  - Early output pin settings can be configured in the
     micro-controller.
-* New website with the Klipper documentation: http://klipper3d.org/
-  * Klipper now has a logo.
-* Experimental support for polar and "cable winch" kinematics.
-* The config file can now include other config files.
-* Many additional modules added: board_pins, controller_fan,
+- New website with the Klipper documentation: http://klipper3d.org/
+  - Klipper now has a logo.
+- Experimental support for polar and "cable winch" kinematics.
+- The config file can now include other config files.
+- Many additional modules added: board_pins, controller_fan,
   delayed_gcode, dotstar, filament_switch_sensor, firmware_retraction,
   gcode_arcs, gcode_button, heater_generic, manual_stepper, mcp4018,
   mcp4728, neopixel, pause_resume, respond, temperature_sensor
   tsl1401cl_filament_width_sensor, tuning_tower
-* Many additional commands added: RESTORE_GCODE_STATE,
+- Many additional commands added: RESTORE_GCODE_STATE,
   SAVE_GCODE_STATE, SET_GCODE_VARIABLE, SET_HEATER_TEMPERATURE,
   SET_IDLE_TIMEOUT, SET_TEMPERATURE_FAN_TARGET
-* Several bug fixes and code cleanups.
+- Several bug fixes and code cleanups.
 
 ## Klipper 0.7.0
 
 Available on 20181220. Major changes in this release:
-* Klipper now supports "mesh" bed leveling
-* New support for "enhanced" delta calibration (calibrates print x/y
 
+- Klipper now supports "mesh" bed leveling
+- New support for "enhanced" delta calibration (calibrates print x/y
   dimensions on delta printers)
-* Support for run-time configuration of Trinamic stepper motor drivers
+- Support for run-time configuration of Trinamic stepper motor drivers
   (tmc2130, tmc2208, tmc2660)
-* Improved temperature sensor support: MAX6675, MAX31855, MAX31856,
+- Improved temperature sensor support: MAX6675, MAX31855, MAX31856,
   MAX31865, custom thermistors, common pt100 style sensors
-* Several new modules: temperature_fan, sx1509, force_move, mcp4451,
+- Several new modules: temperature_fan, sx1509, force_move, mcp4451,
   z_tilt, quad_gantry_level, endstop_phase, bltouch
-* Several new commands added: SAVE_CONFIG, SET_PRESSURE_ADVANCE,
+- Several new commands added: SAVE_CONFIG, SET_PRESSURE_ADVANCE,
   SET_GCODE_OFFSET, SET_VELOCITY_LIMIT, STEPPER_BUZZ, TURN_OFF_HEATERS,
   M204, custom G-Code macros
-* Expanded LCD display support:
-  * Support for run-time menus
-  * New display icons
-  * Support for "uc1701" and "ssd1306" displays
-* Additional micro-controller support:
-  * Klipper ported to: LPC176x (Smoothieboards), SAM4E8E (Duet2),
+- Expanded LCD display support:
+  - Support for run-time menus
+  - New display icons
+  - Support for "uc1701" and "ssd1306" displays
+- Additional micro-controller support:
+  - Klipper ported to: LPC176x (Smoothieboards), SAM4E8E (Duet2),
     SAMD21 (Arduino Zero), STM32F103 ("Blue pill" devices), atmega32u4
-  * New Generic USB CDC driver implemented on AVR, LPC176x, SAMD21, and
+  - New Generic USB CDC driver implemented on AVR, LPC176x, SAMD21, and
     STM32F103
-  * Performance improvements on ARM processors
-* The kinematics code was rewritten to use an "iterative solver"
-* New automatic test cases for the Klipper host software
-* Many new example config files for common off-the-shelf printers
-* Documentation updates for bootloaders, benchmarking,
+  - Performance improvements on ARM processors
+- The kinematics code was rewritten to use an "iterative solver"
+- New automatic test cases for the Klipper host software
+- Many new example config files for common off-the-shelf printers
+- Documentation updates for bootloaders, benchmarking,
     micro-controller porting, config checks, pin mapping, slicer
     settings, packaging, and more
-* Several bug fixes and code cleanups
+- Several bug fixes and code cleanups
 
 ## Klipper 0.6.0
 
 Available on 20180331. Major changes in this release:
-* Enhanced heater and thermistor hardware failure checks
-* Support for Z probes
-* Initial support for automatic parameter calibration on deltas (via a
 
+- Enhanced heater and thermistor hardware failure checks
+- Support for Z probes
+- Initial support for automatic parameter calibration on deltas (via a
   new delta_calibrate command)
-* Initial support for bed tilt compensation (via bed_tilt_calibrate
+- Initial support for bed tilt compensation (via bed_tilt_calibrate
   command)
-* Initial support for "safe homing" and homing overrides
-* Initial support for displaying status on RepRapDiscount style 2004
+- Initial support for "safe homing" and homing overrides
+- Initial support for displaying status on RepRapDiscount style 2004
   and 12864 displays
-* New multi-extruder improvements:
-  * Support for shared heaters
-  * Initial support for dual carriages
-* Support for configuring multiple steppers per axis (eg, dual Z)
-* Support for custom digital and PWM output pins (with a new SET_PIN command)
-* Initial support for a "virtual sdcard" that allows printing directly
+- New multi-extruder improvements:
+  - Support for shared heaters
+  - Initial support for dual carriages
+- Support for configuring multiple steppers per axis (eg, dual Z)
+- Support for custom digital and PWM output pins (with a new SET_PIN command)
+- Initial support for a "virtual sdcard" that allows printing directly
   from Klipper (helps on machines too slow to run OctoPrint well)
-* Support for setting different arm lengths on each tower of a delta
-* Support for G-Code M220/M221 commands (speed factor override /
+- Support for setting different arm lengths on each tower of a delta
+- Support for G-Code M220/M221 commands (speed factor override /
   extrude factor override)
-* Several documentation updates:
-  * Many new example config files for common off-the-shelf printers
-  * New multiple MCU config example
-  * New bltouch sensor config example
-  * New FAQ, config check, and G-Code documents
-* Initial support for continuous integration testing on all GitHub commits
-* Several bug fixes and code cleanups
+- Several documentation updates:
+  - Many new example config files for common off-the-shelf printers
+  - New multiple MCU config example
+  - New bltouch sensor config example
+  - New FAQ, config check, and G-Code documents
+- Initial support for continuous integration testing on all GitHub commits
+- Several bug fixes and code cleanups
 
 ## Klipper 0.5.0
 
 Available on 20171025. Major changes in this release:
 
-* Support for printers with multiple extruders.
-* Initial support for running on the Beaglebone PRU. Initial support
+- Support for printers with multiple extruders.
+- Initial support for running on the Beaglebone PRU. Initial support
   for the Replicape board.
-* Initial support for running the micro-controller code in a real-time
+- Initial support for running the micro-controller code in a real-time
   Linux process.
-* Support for multiple micro-controllers. (For example, one could
+- Support for multiple micro-controllers. (For example, one could
   control an extruder with one micro-controller and the rest of the
   printer with another.) Software clock synchronization is implemented
   to coordinate actions between micro-controllers.
-* Stepper performance improvements (20Mhz AVRs up to 189K steps per
+- Stepper performance improvements (20Mhz AVRs up to 189K steps per
   second).
-* Support for controlling servos and support for defining nozzle
+- Support for controlling servos and support for defining nozzle
   cooling fans.
-* Several bug fixes and code cleanups
+- Several bug fixes and code cleanups
 
 ## Klipper 0.4.0
 
 Available on 20170503. Major changes in this release:
 
-* Improved installation on Raspberry Pi machines. Most of the install
+- Improved installation on Raspberry Pi machines. Most of the install
   is now scripted.
-* Support for corexy kinematics
-* Documentation updates: New Kinematics document, new Pressure Advance
+- Support for corexy kinematics
+- Documentation updates: New Kinematics document, new Pressure Advance
   tuning guide, new example config files, and more
-* Stepper performance improvements (20Mhz AVRs over 175K steps per
+- Stepper performance improvements (20Mhz AVRs over 175K steps per
   second, Arduino Due over 460K)
-* Support for automatic micro-controller resets. Support for resets
+- Support for automatic micro-controller resets. Support for resets
   via toggling USB power on Raspberry Pi.
-* The pressure advance algorithm now works with look-ahead to reduce
+- The pressure advance algorithm now works with look-ahead to reduce
   pressure changes during cornering.
-* Support for limiting the top speed of short zigzag moves
-* Support for AD595 sensors
-* Several bug fixes and code cleanups
+- Support for limiting the top speed of short zigzag moves
+- Support for AD595 sensors
+- Several bug fixes and code cleanups
 
 ## Klipper 0.3.0
 
 Available on 20161223. Major changes in this release:
 
-* Improved documentation
-* Support for robots with delta kinematics
-* Support for Arduino Due micro-controller (ARM cortex-M3)
-* Support for USB based AVR micro-controllers
-* Support for "pressure advance" algorithm - it reduces ooze during
+- Improved documentation
+- Support for robots with delta kinematics
+- Support for Arduino Due micro-controller (ARM cortex-M3)
+- Support for USB based AVR micro-controllers
+- Support for "pressure advance" algorithm - it reduces ooze during
   prints.
-* New "stepper phased based endstop" feature - enables higher
+- New "stepper phased based endstop" feature - enables higher
   precision on endstop homing.
-* Support for "extended G-Code" commands such as "help", "restart",
+- Support for "extended G-Code" commands such as "help", "restart",
   and "status".
-* Support for reloading the Klipper config and restarting the host
+- Support for reloading the Klipper config and restarting the host
   software by issuing a "restart" command from the terminal.
-* Stepper performance improvements (20Mhz AVRs up to 158K steps per
+- Stepper performance improvements (20Mhz AVRs up to 158K steps per
   second).
-* Improved error reporting. Most errors now shown via the terminal
+- Improved error reporting. Most errors now shown via the terminal
   along with help on how to resolve.
-* Several bug fixes and code cleanups
+- Several bug fixes and code cleanups
 
 ## Klipper 0.2.0
 
 Initial release of Klipper. Available on 20160525. Major features
 available in the initial release include:
 
-* Basic support for cartesian printers (steppers, extruder, heated
+- Basic support for cartesian printers (steppers, extruder, heated
   bed, cooling fan).
-* Support for common G-Code commands. Support for interfacing with
+- Support for common G-Code commands. Support for interfacing with
   OctoPrint.
-* Acceleration and lookahead handling
-* Support for AVR micro-controllers via standard serial ports
+- Acceleration and lookahead handling
+- Support for AVR micro-controllers via standard serial ports

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -94,7 +94,7 @@ Available on 20181220. Major changes in this release:
   z_tilt, quad_gantry_level, endstop_phase, bltouch
 * Several new commands added: SAVE_CONFIG, SET_PRESSURE_ADVANCE,
   SET_GCODE_OFFSET, SET_VELOCITY_LIMIT, STEPPER_BUZZ, TURN_OFF_HEATERS,
-  M204, custom g-code macros
+  M204, custom G-Code macros
 * Expanded LCD display support:
   * Support for run-time menus
   * New display icons
@@ -129,7 +129,7 @@ Available on 20180331. Major changes in this release:
   * Support for shared heaters
   * Initial support for dual carriages
 * Support for configuring multiple steppers per axis (eg, dual Z)
-* Support for custom digital and pwm output pins (with a new SET_PIN command)
+* Support for custom digital and PWM output pins (with a new SET_PIN command)
 * Initial support for a "virtual sdcard" that allows printing directly
   from Klipper (helps on machines too slow to run OctoPrint well)
 * Support for setting different arm lengths on each tower of a delta
@@ -140,7 +140,7 @@ Available on 20180331. Major changes in this release:
   * New multiple MCU config example
   * New bltouch sensor config example
   * New FAQ, config check, and G-Code documents
-* Initial support for continuous integration testing on all github commits
+* Initial support for continuous integration testing on all GitHub commits
 * Several bug fixes and code cleanups
 
 ## Klipper 0.5.0
@@ -193,7 +193,7 @@ Available on 20161223. Major changes in this release:
   prints.
 * New "stepper phased based endstop" feature - enables higher
   precision on endstop homing.
-* Support for "extended g-code" commands such as "help", "restart",
+* Support for "extended G-Code" commands such as "help", "restart",
   and "status".
 * Support for reloading the Klipper config and restarting the host
   software by issuing a "restart" command from the terminal.
@@ -210,7 +210,7 @@ available in the initial release include:
 
 * Basic support for cartesian printers (steppers, extruder, heated
   bed, cooling fan).
-* Support for common g-code commands. Support for interfacing with
+* Support for common G-Code commands. Support for interfacing with
   OctoPrint.
 * Acceleration and lookahead handling
 * Support for AVR micro-controllers via standard serial ports

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -74,9 +74,7 @@ First, measure the **ringing frequency**.
    skipping the first oscillation or two. To measure the distance between
    oscillations more easily, mark the oscillations first, then measure the
    distance between the marks with a ruler or calipers:
-
     |![Mark ringing](img/ringing-mark.jpg)|![Measure ringing](img/ringing-measure.jpg)|
-
 10. Count how many oscillations *N* the measured distance *D* corresponds to.
     If you are unsure how to count the oscillations, refer to the picture
     above, which shows *N* = 6 oscillations.
@@ -290,9 +288,9 @@ to 7000 already, complete the following steps for each of the axes X and Y:
 6. Print the test model.
 7. Reset the original frequency value:
    `SET_INPUT_SHAPER SHAPER_FREQ_X=...`.
-7. Find the band which shows ringing the least and count its number from the
+8. Find the band which shows ringing the least and count its number from the
    bottom starting at 1.
-8. Calculate the new shaper_freq_x value via old
+9. Calculate the new shaper_freq_x value via old
    shaper_freq_x * (39 + 5 * #band-number) / 66.
 
 Repeat these steps for the Y axis in the same manner, replacing references to X

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -130,7 +130,8 @@ frequencies to see if they have changed.
 
 After the ringing frequencies for X and Y axes are measured, you can add the
 following section to your `printer.cfg`:
-```
+
+```cfg
 [input_shaper]
 shaper_freq_x: ...  # frequency for the X mark of the test model
 shaper_freq_y: ...  # frequency for the Y mark of the test model
@@ -178,7 +179,8 @@ results than MZV, use EI shaper, otherwise prefer MZV. Note that EI shaper will
 cause more smoothing in printed parts (see the next section for further
 details). Add `shaper_type: mzv` (or ei) parameter to [input_shaper] section,
 e.g.:
-```
+
+```cfg
 [input_shaper]
 shaper_freq_x: ...
 shaper_freq_y: ...
@@ -385,7 +387,8 @@ providing the shaper_freq_x=... and shaper_freq_y=... as determined previously.
 If EI shaper shows very comparable good results as 2HUMP_EI shaper, stick with
 EI shaper and the frequency determined earlier, otherwise use 2HUMP_EI shaper
 with the corresponding frequency. Add the results to `printer.cfg` as, e.g.
-```
+
+```cfg
 [input_shaper]
 shaper_freq_x: 50
 shaper_freq_y: 50
@@ -434,7 +437,8 @@ of the carriages, and calculate the ringing frequencies for X and Y axes for
 each of the carriages independently. Then put the values for carriage 0 into
 [input_shaper] section, and change the values on the fly when changing
 carriages, e.g. as a part of some macro:
-```
+
+```gcode
 SET_DUAL_CARRIAGE CARRIAGE=1
 SET_INPUT_SHAPER SHAPER_FREQ_X=... SHAPER_FREQ_Y=...
 ```

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -13,7 +13,6 @@ insufficiently rigid printer frame, non-tight or too springy belts, alignment
 issues of mechanical parts, heavy moving mass, etc. Those should be checked
 and fixed first, if possible.
 
-
 [Input shaping](https://en.wikipedia.org/wiki/Input_shaping) is an open-loop
 control technique which creates a commanding signal that cancels its
 own vibrations. Input shaping requires some tuning and measurements before it
@@ -25,7 +24,6 @@ of the stealthChop mode of Trinamic stepper drivers.
 
 Basic tuning requires measuring the ringing frequencies of the printer and
 adding a few parameters to `printer.cfg` file.
-
 
 Slice the ringing test model, which can be found in
 [docs/prints/ringing_tower.stl](prints/ringing_tower.stl), in the slicer:
@@ -247,7 +245,6 @@ Choose the minimum out of the two acceleration values (from ringing and
 smoothing), and put it as max_accel into printer.cfg (you can delete
 max_accel_or_decel or revert it to the old value).
 
-
 As a note, it may happen - especially at low ringing frequencies - that EI
 shaper will cause too much smoothing even at lower accelerations. In this case,
 MZV may be a better choice, because it may allow higher acceleration values.
@@ -336,7 +333,6 @@ accelerometer and measure the resonances with it (refer to the
 [docs](Measuring_Resonances.md) describing the required hardware and the setup
 process) - but this option requires some crimping and soldering.
 
-
 For tuning, add empty `[input_shaper]` section to your `printer.cfg`. Then,
 assuming that you have sliced the ringing model with suggested parameters and
 increased `max_accel` and `max_accel_to_decel` parameters in the `printer.cfg`
@@ -397,7 +393,6 @@ shaper_type: 2hump_ei
 
 Continue the tuning with [Selecting max_accel](#selecting-max_accel) section.
 
-
 ## Troubleshooting and FAQ
 
 ### I cannot get reliable measurements of resonance frequencies
@@ -419,7 +414,6 @@ Check the considerations in [Selecting max_accel](#selecting-max_accel) section.
 If the resonance frequency is low, one should not set too high max_accel or
 increase square_corner_velocity parameters. It might also be better to choose
 MZV or even ZV input shapers over EI (or 2HUMP_EI and 3HUMP_EI shapers).
-
 
 ### After successfully printing for some time without ringing, it appears to come back
 
@@ -450,7 +444,6 @@ And similarly when switching back to carriage 0.
 No, `input_shaper` feature has pretty much no impact on the print times by
 itself. However, the value of `max_accel` certainly does (tuning of this
 parameter described in [this section](#selecting-max_accel)).
-
 
 ## Technical details
 

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -28,16 +28,16 @@ adding a few parameters to `printer.cfg` file.
 Slice the ringing test model, which can be found in
 [docs/prints/ringing_tower.stl](prints/ringing_tower.stl), in the slicer:
 
- * Suggested layer height is 0.2 or 0.25 mm.
- * Infill and top layers can be set to 0.
- * Use 1-2 perimeters, or even better the smooth vase mode with 1-2 mm base.
- * Use sufficiently high speed, around 80-100 mm/sec, for **external** perimeters.
- * Make sure that the minimum layer time is **at most** 3 seconds.
- * Make sure any "dynamic acceleration control" is disabled in the slicer.
- * Do not turn the model. The model has X and Y marks at the back of the model.
-   Note the unusual location of the marks vs. the axes of the printer - it is
-   not a mistake. The marks can be used later in the tuning process as a
-   reference, because they show which axis the measurements correspond to.
+- Suggested layer height is 0.2 or 0.25 mm.
+- Infill and top layers can be set to 0.
+- Use 1-2 perimeters, or even better the smooth vase mode with 1-2 mm base.
+- Use sufficiently high speed, around 80-100 mm/sec, for **external** perimeters.
+- Make sure that the minimum layer time is **at most** 3 seconds.
+- Make sure any "dynamic acceleration control" is disabled in the slicer.
+- Do not turn the model. The model has X and Y marks at the back of the model.
+  Note the unusual location of the marks vs. the axes of the printer - it is
+  not a mistake. The marks can be used later in the tuning process as a
+  reference, because they show which axis the measurements correspond to.
 
 ### Ringing frequency
 
@@ -114,12 +114,12 @@ Note that the ringing frequencies can change if the changes are made to the
 printer that affect the moving mass or change the stiffness of the system,
 for example:
 
-  * Some tools are installed, removed or replaced on the toolhead that change
+- Some tools are installed, removed or replaced on the toolhead that change
     its mass, e.g. a new (heavier or lighter) stepper motor for direct extruder
     or a new hotend is installed, heavy fan with a duct is added, etc.
-  * Belts are tightened.
-  * Some addons to increase frame rigidity are installed.
-  * Different bed is installed on a bed-slinger printer, or glass added, etc.
+- Belts are tightened.
+- Some addons to increase frame rigidity are installed.
+- Different bed is installed on a bed-slinger printer, or glass added, etc.
 
 If such changes are made, it is a good idea to at least measure the ringing
 frequencies to see if they have changed.
@@ -187,12 +187,12 @@ shaper_type: mzv
 
 A few notes on shaper selection:
 
-  * EI shaper may be more suited for bed slinger printers (if the resonance
+- EI shaper may be more suited for bed slinger printers (if the resonance
     frequency and resulting smoothing allows): as more filament is deposited
     on the moving bed, the mass of the bed increases and the resonance frequency
     will decrease. Since EI shaper is more robust to resonance frequency
     changes, it may work better when printing large parts.
-  * Due to the nature of delta kinematics, resonance frequencies can differ a
+- Due to the nature of delta kinematics, resonance frequencies can differ a
     lot in different parts of the build volume. Therefore, EI shaper can be a
     better fit for delta printers rather than MZV or ZV, and should be
     considered for the use. If the resonance frequency is sufficiently large
@@ -260,7 +260,6 @@ Another consideration is that if a resonance frequency is too low (below 20-25
 Hz), it might be a good idea to increase the printer stiffness or reduce the
 moving mass. Otherwise, acceleration and printing speed may be limited due too
 much smoothing now instead of ringing.
-
 
 ### Fine-tuning resonance frequencies
 
@@ -369,9 +368,9 @@ with 50 Hz.
 Now check if EI shaper would be good enough in your case. Choose EI shaper
 frequency based on the frequency of 2HUMP_EI shaper you chose:
 
-  * For 2HUMP_EI 60 Hz shaper, use EI shaper with shaper_freq = 50 Hz.
-  * For 2HUMP_EI 50 Hz shaper, use EI shaper with shaper_freq = 40 Hz.
-  * For 2HUMP_EI 40 Hz shaper, use EI shaper with shaper_freq = 33 Hz.
+- For 2HUMP_EI 60 Hz shaper, use EI shaper with shaper_freq = 50 Hz.
+- For 2HUMP_EI 50 Hz shaper, use EI shaper with shaper_freq = 40 Hz.
+- For 2HUMP_EI 40 Hz shaper, use EI shaper with shaper_freq = 33 Hz.
 
 Now print the test model one more time, running
 
@@ -478,18 +477,18 @@ so the values for 10% vibration tolerance are provided only for the reference.
 
 **How to use this table:**
 
-  * Shaper duration affects the smoothing in parts - the larger it is, the more
+- Shaper duration affects the smoothing in parts - the larger it is, the more
     smooth the parts are. This dependency is not linear, but can give a sense of
     which shapers 'smooth' more for the same frequency. The ordering by
     smoothing is like this: ZV < MZV < ZVD ≈ EI < 2HUMP_EI < 3HUMP_EI. Also,
     it is rarely practical to set shaper_freq = resonance freq for shapers
     2HUMP_EI and 3HUMP_EI (they should be used to reduce vibrations for several
     frequencies).
-  * One can estimate a range of frequencies in which the shaper reduces
+- One can estimate a range of frequencies in which the shaper reduces
     vibrations. For example, MZV with shaper_freq = 35 Hz reduces vibrations
     to 5% for frequencies [33.6, 36.4] Hz. 3HUMP_EI with shaper_freq = 50 Hz
     reduces vibrations to 5% in range [27.5, 75] Hz.
-  * One can use this table to check which shaper they should be using if they
+- One can use this table to check which shaper they should be using if they
     need to reduce vibrations at several frequencies. For example, if one has
     resonances at 35 Hz and 60 Hz on the same axis: a) EI shaper needs to have
     shaper_freq = 35 / (1 - 0.2) = 43.75 Hz, and it will reduce resonances
@@ -500,7 +499,7 @@ so the values for 10% vibration tolerance are provided only for the reference.
     for a given shaper (perhaps with some safety margin, so in this example
     shaper_freq ≈ 50-52 Hz would work best), and try to use a shaper with as
     small shaper duration as possible.
-  * If one needs to reduce vibrations at several very different frequencies
+- If one needs to reduce vibrations at several very different frequencies
     (say, 30 Hz and 100 Hz), they may see that the table above does not provide
     enough information. In this case one may have more luck with
     [scripts/graph_shaper.py](../scripts/graph_shaper.py)

--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -13,13 +13,15 @@ The designers of your 3d printer originally calculated `steps_per_mm`
 from a rotation distance. If you know the steps_per_mm then it is
 possible to use this general formula to obtain that original rotation
 distance:
-```
+
+```text
 rotation_distance = <full_steps_per_rotation> * <microsteps> / <steps_per_mm>
 ```
 
 Or, if you have an older Klipper configuration and know the
 `step_distance` parameter you can use this formula:
-```
+
+```text
 rotation_distance = <full_steps_per_rotation> * <microsteps> * <step_distance>
 ```
 
@@ -96,7 +98,8 @@ First determine the type of belt. Most printers use a 2mm belt pitch
 (that is, each tooth on the belt is 2mm apart). Then count the number
 of teeth on the stepper motor pulley. The rotation_distance is then
 calculated as:
-```
+
+```text
 rotation_distance = <belt_pitch> * <number_of_teeth_on_pulley>
 ```
 
@@ -107,7 +110,8 @@ teeth, then the rotation distance is 40.
 
 It is easy to calculate the rotation_distance for common lead screws
 using the following formula:
-```
+
+```text
 rotation_distance = <screw_pitch> * <number_of_separate_threads>
 ```
 

--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -128,7 +128,11 @@ has a rotation distance of 1.25.
 
 It's possible to obtain an initial rotation distance for extruders by
 measuring the diameter of the "hobbed bolt" that pushes the filament
-and using the following formula: `rotation_distance = <diameter> * 3.14`
+and using the following formula:
+
+```text
+rotation_distance = <diameter> * 3.14
+```
 
 If the extruder uses gears then it will also be necessary to
 [determine and set the gear_ratio](#using-a-gear_ratio) for the

--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -55,6 +55,7 @@ be obtained from
 or by [inspecting the hardware](#extruder).
 
 Then use the following procedure to "measure and trim":
+
 1. Make sure the extruder has filament in it, the hotend is heated to
    an appropriate temperature, and the printer is ready to extrude.
 2. Use a marker to place a mark on the filament around 70mm from the

--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -116,6 +116,7 @@ BOARD_DEFS = {
 ```
 
 The following fields may be specified:
+
 - `mcu`: The mcu type. This can be retrevied after configuring the build
   via `make menuconfig` by running `cat .config | grep CONFIG_MCU`. This
   field is required.
@@ -130,6 +131,7 @@ The following fields may be specified:
 
 If software SPI is required the `spi_bus` field should be set to `swspi`
 and the following additional field should be specified:
+
 - `spi_pins`:  This should be 3 comma separated pins that are connected to
   the SD Card in the format of `miso,mosi,sclk`.
 

--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -15,7 +15,8 @@ The procedure for updating MCU firmware using the SD Card is similar to that
 of other methods.  Instead of using `make flash` it is necessary to run a
 helper script, `flash-sdcard.sh`.  Updating a BigTreeTech SKR 1.3 might look
 like the following:
-```
+
+```bash
 sudo service klipper stop
 cd ~/klipper
 git pull
@@ -32,9 +33,11 @@ If a user needs to flash multiple boards, `flash-sdcard.sh` (or
 restarting the Klipper service.
 
 Supported boards can be listed with the following command:
-```
+
+```bash
 ./scripts/flash-sdcard.sh -l
 ```
+
 If you do not see your board listed it may be necessary to add a new
 board definition as [described below](#board-definitions).
 
@@ -44,7 +47,8 @@ The above commands assume that your MCU connects at the default baud rate
 of 250000 and the firmware is located at `~/klipper/out/klipper.bin`.  The
 `flash-sdcard.sh` script provides options for changing these defaults.
 All options can be viewed by the help screen:
-```
+
+```bash
 ./scripts/flash-sdcard.sh -h
 SD Card upload utility for Klipper
 
@@ -64,13 +68,15 @@ optional arguments:
 
 If your board is flashed with firmware that connects at a custom baud
 rate it is possible to upgrade by specifying the `-b` option:
-```
+
+```bash
 ./scripts/flash-sdcard.sh -b 115200 /dev/ttyAMA0 btt-skr-v1.3
 ```
 
 If you wish to flash a build of Klipper located somewhere other than
 the default location it can be done by specifying the `-f` option:
-```
+
+```bash
 ./scripts/flash-sdcard.sh -f ~/downloads/klipper.bin /dev/ttyAMA0 btt-skr-v1.3
 ```
 
@@ -97,6 +103,7 @@ Most common boards should be available, however it is possible to add a new
 board definition if necessary.  Board definitions are located in
 `~/klipper/scripts/spi_flash/board_defs.py`.  The definitions are stored
 in dictionary, for example:
+
 ```python
 BOARD_DEFS = {
     'generic-lpc1768': {
@@ -135,6 +142,7 @@ existing board definition meets the criteria necessary for the new board.
 If this is the case, a `BOARD_ALIAS` may be specified.  For example, the
 following alias may be added to specify `my-new-board` as an alias for
 `generic-lpc1768`:
+
 ```python
 BOARD_ALIASES = {
     ...<previous aliases>,

--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -1,9 +1,9 @@
 # SDCard updates
 
 Many of today's popular controller boards ship with a bootloader capable of
-updating firmware via SD Card.  While this is convenient in many
+updating firmware via SD Card. While this is convenient in many
 circumstances, these bootloaders typically provide no other way to update
-firmware.  This can be a nuisance if your board is mounted in a location
+firmware. This can be a nuisance if your board is mounted in a location
 that is difficult to access or if you need to update firmware often.
 After Klipper has been initially flashed to a controller it is possible to
 transfer new firmware to the SD Card and initiate the flashing procedure
@@ -12,8 +12,8 @@ via ssh.
 ## Typical Upgrade Procedure
 
 The procedure for updating MCU firmware using the SD Card is similar to that
-of other methods.  Instead of using `make flash` it is necessary to run a
-helper script, `flash-sdcard.sh`.  Updating a BigTreeTech SKR 1.3 might look
+of other methods. Instead of using `make flash` it is necessary to run a
+helper script, `flash-sdcard.sh`. Updating a BigTreeTech SKR 1.3 might look
 like the following:
 
 ```bash
@@ -44,7 +44,7 @@ board definition as [described below](#board-definitions).
 ## Advanced Usage
 
 The above commands assume that your MCU connects at the default baud rate
-of 250000 and the firmware is located at `~/klipper/out/klipper.bin`.  The
+of 250000 and the firmware is located at `~/klipper/out/klipper.bin`. The
 `flash-sdcard.sh` script provides options for changing these defaults.
 All options can be viewed by the help screen:
 
@@ -87,7 +87,7 @@ This procedure is automated during the upload process.
 ## Caveats
 
 - As mentioned in the introduction, this method only works for upgrading
-  firmware.  The initial flashing procedure must be done manually per the
+  firmware. The initial flashing procedure must be done manually per the
   instructions that apply to your controller board.
 - While it is possible to flash a build that changes the Serial Baud or
   connection interface (ie: from USB to UART), verification will always
@@ -100,8 +100,8 @@ This procedure is automated during the upload process.
 ## Board Definitions
 
 Most common boards should be available, however it is possible to add a new
-board definition if necessary.  Board definitions are located in
-`~/klipper/scripts/spi_flash/board_defs.py`.  The definitions are stored
+board definition if necessary. Board definitions are located in
+`~/klipper/scripts/spi_flash/board_defs.py`. The definitions are stored
 in dictionary, for example:
 
 ```python
@@ -116,17 +116,17 @@ BOARD_DEFS = {
 ```
 
 The following fields may be specified:
-- `mcu`: The mcu type.  This can be retrevied after configuring the build
-  via `make menuconfig` by running `cat .config | grep CONFIG_MCU`.  This
+- `mcu`: The mcu type. This can be retrevied after configuring the build
+  via `make menuconfig` by running `cat .config | grep CONFIG_MCU`. This
   field is required.
-- `spi_bus`:  The SPI bus connected to the SD Card.  This should be retreived
-  from the board's schematic.  This field is required.
-- `cs_pin`: The Chip Select Pin connected to the SD Card.  This should be
-  retreived from the board schematic.  This field is required.
+- `spi_bus`:  The SPI bus connected to the SD Card. This should be retreived
+  from the board's schematic. This field is required.
+- `cs_pin`: The Chip Select Pin connected to the SD Card. This should be
+  retreived from the board schematic. This field is required.
 - `firmware_path`: The path on the SD Card where firmware should be
-  transferred.  The default is `firmware.bin`.
+  transferred. The default is `firmware.bin`.
 - `current_firmware_path`  The path on the SD Card where the renamed firmware
-  file is located after a successful flash.  The default is `firmware.cur`.
+  file is located after a successful flash. The default is `firmware.cur`.
 
 If software SPI is required the `spi_bus` field should be set to `swspi`
 and the following additional field should be specified:
@@ -139,7 +139,7 @@ provides an example.
 
 Prior to creating a new board definition one should check to see if an
 existing board definition meets the criteria necessary for the new board.
-If this is the case, a `BOARD_ALIAS` may be specified.  For example, the
+If this is the case, a `BOARD_ALIAS` may be specified. For example, the
 following alias may be added to specify `my-new-board` as an alias for
 `generic-lpc1768`:
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -376,7 +376,7 @@ object is available if z_tilt is defined):
 The following information is available for each `[neopixel led_name]` and
 `[dotstar led_name]` defined in printer.cfg:
 - `color_data`:  An array of objects, with each object containing the RGBW
-  values for a led in the chain.  Note that not all configurations will contain
-  a white value.  Each value is represented as a float from 0 to 1.  For
+  values for a led in the chain. Note that not all configurations will contain
+  a white value. Each value is represented as a float from 0 to 1. For
   example, the blue value of the second neopixel in a chain could be accessed
   at `printer["neopixel <config_name>"].color_data[1].B`.

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -326,7 +326,7 @@ The following information is available in the `toolhead` object
   "homed" state. This is a string containing one or more of "x", "y",
   "z".
 - `axis_minimum`, `axis_maximum`: The axis travel limits (mm) after
-  homing.  It is possible to access the x, y, z components of this
+  homing. It is possible to access the x, y, z components of this
   limit value (eg, `axis_minimum.x`, `axis_maximum.z`).
 - `max_velocity`, `max_accel`, `max_accel_to_decel`,
   `square_corner_velocity`: The current printing limits that are in

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -14,6 +14,7 @@ Klipper software.
 
 The following information is available in the
 [bed_mesh](Config_Reference.md#bed_mesh) object:
+
 - `profile_name`, `mesh_min`, `mesh_max`, `probed_matrix`,
   `mesh_matrix`: Information on the currently active bed_mesh.
 
@@ -21,6 +22,7 @@ The following information is available in the
 
 The following information is available in the `configfile` object
 (this object is always available):
+
 - `settings.<section>.<option>`: Returns the given config file setting
   (or default value) during the last software start or restart. (Any
   settings changed at run-time will not be reflected here.)
@@ -34,6 +36,7 @@ The following information is available in the `configfile` object
 The following information is available in the `display_status` object
 (this object is automatically available if a
 [display](Config_Reference.md#display) config section is defined):
+
 - `progress`: The progress value of the last `M73` G-Code command (or
   `virtual_sdcard.progress` if no recent `M73` received).
 - `message`: The message contained in the last `M117` G-Code command.
@@ -42,6 +45,7 @@ The following information is available in the `display_status` object
 
 The following information is available in the
 [endstop_phase](Config_Reference.md#endstop_phase) object:
+
 - `last_home.<stepper name>.phase`: The phase of the stepper motor at
   the end of the last home attempt.
 - `last_home.<stepper name>.phases`: The total number of phases
@@ -59,6 +63,7 @@ The following information is available in
 [heater_fan some_name](Config_Reference.md#heater_fan) and
 [controller_fan some_name](Config_Reference.md#controller_fan)
 objects:
+
 - `speed`: The fan speed as a float between 0.0 and 1.0.
 - `rpm`: The measured fan speed in rotations per minute if the fan has
   a tachometer_pin defined.
@@ -68,6 +73,7 @@ objects:
 The following information is available in
 [filament_switch_sensor some_name](Config_Reference.md#filament_switch_sensor)
 objects:
+
 - `enabled`: Returns True if the switch sensor is currently enabled.
 - `filament_detected`: Returns True if the sensor is in a triggered
   state.
@@ -77,6 +83,7 @@ objects:
 The following information is available in
 [filament_motion_sensor some_name](Config_Reference.md#filament_motion_sensor)
 objects:
+
 - `enabled`: Returns True if the motion sensor is currently enabled.
 - `filament_detected`: Returns True if the sensor is in a triggered
   state.
@@ -85,6 +92,7 @@ objects:
 
 The following information is available in the
 [firmware_retraction](Config_Reference.md#firmware_retraction) object:
+
 - `retract_length`, `retract_speed`, `unretract_extra_length`,
   `unretract_speed`: The current settings for the firmware_retraction
   module. These settings may differ from the config file if a
@@ -94,6 +102,7 @@ The following information is available in the
 
 The following information is available in
 [gcode_macro some_name](Config_Reference.md#gcode_macro) objects:
+
 - `<variable>`: The current value of a
   [gcode_macro variable](Command_Templates.md#variables).
 
@@ -101,6 +110,7 @@ The following information is available in
 
 The following information is available in the `gcode_move` object
 (this object is always available):
+
 - `gcode_position`: The current position of the toolhead relative to
   the current G-Code origin. That is, positions that one might
   directly send to a `G1` command. It is possible to access the x, y,
@@ -131,6 +141,7 @@ The following information is available in the `gcode_move` object
 The following information is available in the
 [hall_filament_width_sensor](Config_Reference.md#hall_filament_width_sensor)
 object:
+
 - `is_active`: Returns True if the sensor is currently active.
 - `Diameter`, `Raw`: The last read values from the sensor.
 
@@ -140,6 +151,7 @@ The following information is available for heater objects such as
 [extruder](Config_Reference.md#extruder),
 [heater_bed](Config_Reference.md#heater_bed), and
 [heater_generic](Config_Reference.md#heater_generic):
+
 - `temperature`: The last reported temperature (in Celsius as a float)
   for the given heater.
 - `target`: The current target temperature (in Celsius as a float) for
@@ -153,6 +165,7 @@ The following information is available for heater objects such as
 
 The following information is available in the `heaters` object (this
 object is available if any heater is defined):
+
 - `available_heaters`: Returns a list of all currently available
   heaters by their full config section names, e.g. `["extruder",
   "heater_bed", "heater_generic my_custom_heater"]`.
@@ -166,6 +179,7 @@ object is available if any heater is defined):
 The following information is available in the
 [idle_timeout](Config_Reference.md#idle_timeout) object (this object
 is always available):
+
 - `state`: The current state of the printer as tracked by the
   idle_timeout module. It is one of the following strings: "Idle",
   "Printing", "Ready".
@@ -178,6 +192,7 @@ is always available):
 The following information is available in
 [mcu](Config_Reference.md#mcu) and
 [mcu some_name](Config_Reference.md#mcu-my_extra_mcu) objects:
+
 - `mcu_version`: The Klipper code version reported by the
   micro-controller.
 - `mcu_build_versions`: Information on the build tools used to
@@ -194,6 +209,7 @@ The following information is available in
 The following information is available in the `motion_report` object
 (this object is automatically available if any stepper config section
 is defined):
+
 - `live_position`: The requested toolhead position interpolated to the
   current time.
 - `live_velocity`: The requested toolhead velocity (in mm/s) at the
@@ -205,12 +221,14 @@ is defined):
 
 The following information is available in
 [output_pin some_name](Config_Reference.md#output_pin) objects:
+
 - `value`: The "value" of the pin, as set by a `SET_PIN` command.
 
 ## palette2
 
 The following information is available in the
 [palette2](Config_Reference.md#palette2) object:
+
 - `ping`: Amount of the last reported Palette 2 ping in percent.
 - `remaining_load_length`: When starting a Palette 2 print, this will
   be the amount of filament to load into the extruder.
@@ -220,6 +238,7 @@ The following information is available in the
 
 The following information is available in the
 [pause_resume](Config_Reference.md#pause_resume) object:
+
 - `is_paused`: Returns true if a PAUSE command has been executed
   without a corresponding RESUME.
 
@@ -229,6 +248,7 @@ The following information is available in the `print_stats` object
 (this object is automatically available if a
 [virtual_sdcard](Config_Reference.md#virtual_sdcard) config section is
 defined):
+
 - `filename`, `total_duration`, `print_duration`, `filament_used`,
   `state`, `message`: Estimated information about the current print
   when a virtual_sdcard print is active.
@@ -239,6 +259,7 @@ The following information is available in the
 [probe](Config_Reference.md#probe) object (this object is also
 available if a [bltouch](Config_Reference.md#bltouch) config section
 is defined):
+
 - `last_query`: Returns True if the probe was reported as "triggered"
   during the last QUERY_PROBE command. Note, if this is used in a
   macro, due to the order of template expansion, the QUERY_PROBE
@@ -252,6 +273,7 @@ is defined):
 
 The following information is available in the `quad_gantry_level` object
 (this object is available if quad_gantry_level is defined):
+
 - `applied`: True if the gantry leveling process has been run and completed
   successfully.
 
@@ -259,6 +281,7 @@ The following information is available in the `quad_gantry_level` object
 
 The following information is available in the `query_endstops` object
 (this object is available if any endstop is defined):
+
 - `last_query["<endstop>"]`: Returns True if the given endstop was
   reported as "triggered" during the last QUERY_ENDSTOP command. Note,
   if this is used in a macro, due to the order of template expansion,
@@ -269,6 +292,7 @@ The following information is available in the `query_endstops` object
 
 The following information is available in
 [servo some_name](Config_Reference.md#servo) objects:
+
 - `printer["servo <config_name>"].value`: The last setting of the PWM
   pin (a value between 0.0 and 1.0) associated with the servo.
 
@@ -276,6 +300,7 @@ The following information is available in
 
 The following information is available in the `system_stats` object
 (this object is always available):
+
 - `sysload`, `cputime`, `memavail`: Information on the host operating
   system and process load.
 
@@ -289,6 +314,7 @@ The following information is available in
 and
 [temperature_host config_section_name](Config_Reference.md#host-temperature-sensor)
 objects:
+
 - `temperature`: The last read temperature from the sensor.
 - `humidity`, `pressure`, `gas`: The last read values from the sensor
   (only on bme280, htu21d, and lm75 sensors).
@@ -298,6 +324,7 @@ objects:
 The following information is available in
 [temperature_fan some_name](Config_Reference.md#temperature_fan)
 objects:
+
 - `temperature`: The last read temperature from the sensor.
 - `target`: The target temperature for the fan.
 
@@ -306,6 +333,7 @@ objects:
 The following information is available in
 [temperature_sensor some_name](Config_Reference.md#temperature_sensor)
 objects:
+
 - `temperature`: The last read temperature from the sensor.
 - `measured_min_temp`, `measured_max_temp`: The lowest and highest
   temperature seen by the sensor since the Klipper host software was
@@ -315,6 +343,7 @@ objects:
 
 The following information is available in the `toolhead` object
 (this object is always available):
+
 - `position`: The last commanded position of the toolhead relative to
   the coordinate system specified in the config file. It is possible
   to access the x, y, z, and e components of this position (eg,
@@ -341,6 +370,7 @@ The following information is available in the `toolhead` object
 The following information is available in
 [dual_carriage](Config_Reference.md#dual_carriage)
 on a hybrid_corexy or hybrid_corexz robot
+
 - `mode`: The current mode. Possible values are: "FULL_CONTROL"
 - `active_carriage`: The current active carriage.
 Possible values are: "CARRIAGE_0", "CARRIAGE_1"
@@ -349,6 +379,7 @@ Possible values are: "CARRIAGE_0", "CARRIAGE_1"
 
 The following information is available in the
 [virtual_sdcard](Config_Reference.md#virtual_sdcard) object:
+
 - `is_active`: Returns True if a print from file is currently active.
 - `progress`: An estimate of the current print progress (based of file
   size and file position).
@@ -360,6 +391,7 @@ The following information is available in the
 
 The following information is available in the `webhooks` object (this
 object is always available):
+
 - `state`: Returns a string indicating the current Klipper
   state. Possible values are: "ready", "startup", "shutdown", "error".
 - `state_message`: A human readable string giving additional context
@@ -369,12 +401,15 @@ object is always available):
 
 The following information is available in the `z_tilt` object (this
 object is available if z_tilt is defined):
+
 - `applied`: True if the z-tilt leveling process has been run and completed
   successfully.
 
 ## neopixel / dotstar
+
 The following information is available for each `[neopixel led_name]` and
 `[dotstar led_name]` defined in printer.cfg:
+
 - `color_data`:  An array of objects, with each object containing the RGBW
   values for a led in the chain. Note that not all configurations will contain
   a white value. Each value is represented as a float from 0 to 1. For

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -101,7 +101,8 @@ stall at very slow speeds.
 A good starting point for the homing speed is for the stepper motor to
 make a full rotation every two seconds. For many axes this will be the
 `rotation_distance` divided by two. For example:
-```
+
+```gcode
 [stepper_x]
 rotation_distance: 40
 homing_speed: 20
@@ -125,7 +126,8 @@ will confuse the tuning process.)
 It is necessary to configure the sensorless homing pins and to
 configure initial "stallguard" settings. A tmc2209 example
 configuration for an X axis might look like:
-```
+
+```gcode
 [tmc2209 stepper_x]
 diag_pin: ^PA1      # Set to MCU pin connected to TMC DIAG pin
 driver_SGTHRS: 255  # 255 is most sensitive value, 0 is least sensitive
@@ -138,7 +140,8 @@ homing_retract_dist: 0
 ```
 
 An example tmc2130 or tmc5160 config might look like:
-```
+
+```gcode
 [tmc2130 stepper_x]
 diag1_pin: ^!PA1 # Pin connected to TMC DIAG1 pin (or use diag0_pin / DIAG0 pin)
 driver_SGT: -64  # -64 is most sensitive value, 63 is least sensitive
@@ -151,7 +154,8 @@ homing_retract_dist: 0
 ```
 
 An example tmc2660 config might look like:
-```
+
+```gcode
 [tmc2660 stepper_x]
 driver_SGT: -64     # -64 is most sensitive value, 63 is least sensitive
 ...
@@ -171,11 +175,14 @@ for all the available options.
 
 Place the carriage near the center of the rail. Use the SET_TMC_FIELD
 command to set the highest sensitivity. For tmc2209:
-```
+
+```gcode
 SET_TMC_FIELD STEPPER=stepper_x FIELD=SGTHRS VALUE=255
 ```
+
 For tmc2130, tmc5160, and tmc2660:
-```
+
+```gcode
 SET_TMC_FIELD STEPPER=stepper_x FIELD=sgt VALUE=-64
 ```
 
@@ -275,7 +282,8 @@ is not recommended during sensorless homing).
 
 An example macro might look something like:
 <!-- {% raw %} -->
-```
+
+```gcode
 [gcode_macro SENSORLESS_HOME_X]
 gcode:
     {% set HOME_CUR = 0.700 %}

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -81,6 +81,7 @@ A few prerequisites are needed to use sensorless homing:
 ### Tuning
 
 The procedure described here has six major steps:
+
 1. Choose a homing speed.
 2. Configure the `printer.cfg` file to enable sensorless homing.
 3. Find the stallguard setting with highest sensitivity that
@@ -321,6 +322,7 @@ to detect stalls when homing the Y carriage.
 Use the tuning guide described above to find the appropriate "stall
 sensitivity" for each carriage, but be aware of the following
 restrictions:
+
 1. When using sensorless homing on CoreXY, make sure there is no
    `hold_current` in effect for either stepper during homing.
 2. While tuning, make sure both the X and Y carriages are near the

--- a/docs/TSL1401CL_Filament_Width_Sensor.md
+++ b/docs/TSL1401CL_Filament_Width_Sensor.md
@@ -6,23 +6,26 @@ This document describes Filament Width Sensor host module. Hardware used for dev
 Sensor generates analog output based on calculated filament width. Output voltage always equals to detected filament width (Ex. 1.65v, 1.70v, 3.0v). Host module monitors voltage changes and adjusts extrusion multiplier.
 
 ## Configuration
-    [tsl1401cl_filament_width_sensor]
-    pin: analog5
-    # Analog input pin for sensor output on Ramps board
 
-    default_nominal_filament_diameter: 1.75
-    # This parameter is in millimeters (mm)
+```gcode
+[tsl1401cl_filament_width_sensor]
+pin: analog5
+# Analog input pin for sensor output on Ramps board
 
-    max_difference: 0.2
-    #  Maximum allowed filament diameter difference in millimeters (mm)
-    #  If difference between nominal filament diameter and sensor output is more
-    #  than +- max_difference, extrusion multiplier set back to %100
+default_nominal_filament_diameter: 1.75
+# This parameter is in millimeters (mm)
 
-    measurement_delay 100
-    #  The distance from sensor to the melting chamber/hot-end in millimeters (mm).
-    #  The filament between the sensor and the hot-end will be treated as the default_nominal_filament_diameter.
-    #  Host module works with FIFO logic. It keeps each sensor value and position in
-    #  an array and POP them back in correct position.
+max_difference: 0.2
+#  Maximum allowed filament diameter difference in millimeters (mm)
+#  If difference between nominal filament diameter and sensor output is more
+#  than +- max_difference, extrusion multiplier set back to %100
+
+measurement_delay 100
+#  The distance from sensor to the melting chamber/hot-end in millimeters (mm).
+#  The filament between the sensor and the hot-end will be treated as the default_nominal_filament_diameter.
+#  Host module works with FIFO logic. It keeps each sensor value and position in
+#  an array and POP them back in correct position.
+```
 
 Sensor readings done with 10 mm intervals by default. If necessary you are free to change this setting by editing ***MEASUREMENT_INTERVAL_MM*** parameter in **filament_width_sensor.py** file.
 

--- a/docs/TSL1401CL_Filament_Width_Sensor.md
+++ b/docs/TSL1401CL_Filament_Width_Sensor.md
@@ -3,6 +3,7 @@
 This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on TSL1401CL linear sensor array but it can work with any sensor array that has analog output. You can find designs at [thingiverse.com](https://www.thingiverse.com/search?q=filament%20width%20sensor)
 
 ## How does it work?
+
 Sensor generates analog output based on calculated filament width. Output voltage always equals to detected filament width (Ex. 1.65v, 1.70v, 3.0v). Host module monitors voltage changes and adjusts extrusion multiplier.
 
 ## Configuration
@@ -30,6 +31,7 @@ measurement_delay 100
 Sensor readings done with 10 mm intervals by default. If necessary you are free to change this setting by editing ***MEASUREMENT_INTERVAL_MM*** parameter in **filament_width_sensor.py** file.
 
 ## Commands
+
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 **RESET_FILAMENT_WIDTH_SENSOR** – Clear all sensor readings. Can be used after filament change.
 **DISABLE_FILAMENT_WIDTH_SENSOR** – Turn off the filament width sensor and stop using it to do flow control

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -3,8 +3,8 @@
 This document describes how to setup a PWM-controlled laser or spindle
 using `output_pin` and some macros.
 
-
 ## How does it work?
+
 With re-purposing the printhead's fan PWM output, you can control
 lasers or spindles.
 This is useful if you use switchable print heads, for example
@@ -12,7 +12,6 @@ the E3D toolchanger or a DIY solution.
 Usually, cam-tools such as LaserWeb can be configured to use `M3-M5`
 commands, which stand for _spindle speed CW_ (`M3 S[0-255]`),
 _spindle speed CCW_ (`M4 S[0-255]`) and _spindle stop_ (`M5`).
-
 
 **Warning:** When driving a laser, keep all security precautions
 that you can think of! Diode lasers are usually inverted.

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -10,14 +10,14 @@ lasers or spindles.
 This is useful if you use switchable print heads, for example
 the E3D toolchanger or a DIY solution.
 Usually, cam-tools such as LaserWeb can be configured to use `M3-M5`
-commands, which stand for _spindle speed CW_ (`M3 S[0-255]`),
-_spindle speed CCW_ (`M4 S[0-255]`) and _spindle stop_ (`M5`).
+commands, which stand for *spindle speed CW* (`M3 S[0-255]`),
+*spindle speed CCW* (`M4 S[0-255]`) and *spindle stop* (`M5`).
 
 **Warning:** When driving a laser, keep all security precautions
 that you can think of! Diode lasers are usually inverted.
 This means, that when the MCU restarts, the laser will be
-_fully on_ for the time it takes the MCU to start up again.
-For good measure, it is recommended to _always_ wear appropriate
+*fully on* for the time it takes the MCU to start up again.
+For good measure, it is recommended to *always* wear appropriate
 laser-goggles of the right wavelength if the laser is powered;
 and to disconnect the laser when it is not needed.
 Also, you should configure a safety timeout,

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -5,7 +5,7 @@ using `output_pin` and some macros.
 
 
 ## How does it work?
-With re-purposing the printhead's fan pwm output, you can control
+With re-purposing the printhead's fan PWM output, you can control
 lasers or spindles.
 This is useful if you use switchable print heads, for example
 the E3D toolchanger or a DIY solution.

--- a/docs/_klipper3d/README
+++ b/docs/_klipper3d/README
@@ -1,5 +1,5 @@
 This directory defines the https://www.klipper3d.org/ website. The
-site is hosted using "github pages". The
+site is hosted using "GitHub pages". The
 .github/workflows/klipper3d-deploy.yaml tool uses mkdocs (
 https://www.mkdocs.org/ ) to automatically convert the markdown files
 in the docs/ directory to html. In addition to the files in this

--- a/docs/_klipper3d/mkdocs_hooks.py
+++ b/docs/_klipper3d/mkdocs_hooks.py
@@ -2,12 +2,12 @@
 import re
 import logging
 
-# This script translates some github specific markdown formatting to
-# improve rendering with mkdocs.  The goal is for pages to render
-# similarly on both github and the web site.  It has three main tasks:
+# This script translates some GitHub specific markdown formatting to
+# improve rendering with mkdocs. The goal is for pages to render
+# similarly on both GitHub and the web site. It has three main tasks:
 # 1. Convert links outside of the docs directory (any reference
 #    starting with "../") to an absolute link to the raw file on
-#    github.
+#    GitHub.
 # 2. Convert a trailing backslash on a text line to a "<br>".
 # 3. Remove leading spaces from top-level lists so that those lists
 #    are rendered correctly.

--- a/docs/beaglebone.md
+++ b/docs/beaglebone.md
@@ -11,7 +11,7 @@ image. One may run the image from either a micro-SD card or from
 builtin eMMC. If using the eMMC, install it to eMMC now by following
 the instructions from the above link.
 
-Then ssh into the beaglebone machine (ssh debian@beaglebone --
+Then ssh into the Beaglebone machine (ssh debian@beaglebone --
 password is "temppwd") and install Klipper by running the following
 commands:
 

--- a/docs/beaglebone.md
+++ b/docs/beaglebone.md
@@ -14,7 +14,8 @@ the instructions from the above link.
 Then ssh into the beaglebone machine (ssh debian@beaglebone --
 password is "temppwd") and install Klipper by running the following
 commands:
-```
+
+```bash
 git clone https://github.com/KevinOConnor/klipper
 ./klipper/scripts/install-beaglebone.sh
 ```
@@ -22,7 +23,8 @@ git clone https://github.com/KevinOConnor/klipper
 ## Install Octoprint
 
 One may then install Octoprint:
-```
+
+```bash
 git clone https://github.com/foosel/OctoPrint.git
 cd OctoPrint/
 virtualenv venv
@@ -30,7 +32,8 @@ virtualenv venv
 ```
 
 And setup OctoPrint to start at bootup:
-```
+
+```bash
 sudo cp ~/OctoPrint/scripts/octoprint.init /etc/init.d/octoprint
 sudo chmod +x /etc/init.d/octoprint
 sudo cp ~/OctoPrint/scripts/octoprint.default /etc/default/octoprint
@@ -42,12 +45,14 @@ configuration file. One must change the OCTOPRINT_USER user to
 "debian", change NICELEVEL to 0, uncomment the BASEDIR, CONFIGFILE,
 and DAEMON settings and change the references from "/home/pi/" to
 "/home/debian/":
-```
+
+```bash
 sudo nano /etc/default/octoprint
 ```
 
 Then start the Octoprint service:
-```
+
+```bash
 sudo systemctl start octoprint
 ```
 
@@ -58,13 +63,15 @@ Make sure the octoprint web server is accessible - it should be at:
 
 To compile the Klipper micro-controller code, start by configuring it
 for the "Beaglebone PRU":
-```
+
+```bash
 cd ~/klipper/
 make menuconfig
 ```
 
 To build and install the new micro-controller code, run:
-```
+
+```bash
 sudo service klipper stop
 make flash
 sudo service klipper start
@@ -73,12 +80,14 @@ sudo service klipper start
 It is also necessary to compile and install the micro-controller code
 for a Linux host process. Run "make menuconfig" a second time and
 configure it for a "Linux process":
-```
+
+```bash
 make menuconfig
 ```
 
 Then install this micro-controller code as well:
-```
+
+```bash
 sudo service klipper stop
 make flash
 sudo service klipper start

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hide:
 title: Welcome
 ---
 
-![](img/klipper-logo.png){ .center-image }
+![Klipper Logo](img/klipper-logo.png){ .center-image }
 
 Klipper is a 3d-Printer firmware. It combines the power of a general
 purpose computer with one or more micro-controllers. See the
@@ -14,4 +14,4 @@ should use Klipper.
 To begin using Klipper start by [installing](Installation.md) it.
 
 Klipper is Free Software. Read the [documentation](Overview.md) or
-view [the Klipper code on github](https://github.com/KevinOConnor/klipper).
+view [the Klipper code on GitHub](https://github.com/KevinOConnor/klipper).

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -7,6 +7,7 @@ first use mechanical means to get your printer as square as possible prior
 to applying software based correction.
 
 ## Print a Calibration Object
+
 The first step in correcting skew is to print a
 [calibration object](https://www.thingiverse.com/thing:2563185/files)
 along the plane you want to correct. There is also a
@@ -19,6 +20,7 @@ do this by either removing the [skew_correction] module from printer.cfg
 or by issuing a `SET_SKEW CLEAR=1` gcode.
 
 ## Take your measurements
+
 The [skew_correcton] module requires 3 measurements for each plane you want
 to correct; the length from Corner A to Corner C, the length from Corner B
 to Corner D, and the length from corner A to corner D. When measuring length
@@ -27,6 +29,7 @@ AD do not include the flats on the corners that some test objects provide.
 ![skew_lengths](img/skew_lengths.png)
 
 ## Configure your skew
+
 Make sure [skew_correction] is in printer.cfg. You may now use the `SET_SKEW`
 gcode to configure skew_correcton. For example, if your measured lengths
 along XY are as follows:
@@ -78,6 +81,7 @@ After removing a profile you will be prompted to issue a `SAVE_CONFIG` to
 make this change persist.
 
 ## Verifying your correction
+
 After skew_correction has been configured you may reprint the calibration
 part with correction enabled. Use the following gcode to check your
 skew on each plane. The results should be lower than those reported via

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -1,7 +1,7 @@
 # Skew correction
 
 Software based skew correction can help resolve dimensional inaccuracies
-resulting from a printer assembly that is not perfectly square.  Note
+resulting from a printer assembly that is not perfectly square. Note
 that if your printer is significantly skewed it is strongly recommended to
 first use mechanical means to get your printer as square as possible prior
 to applying software based correction.
@@ -9,26 +9,26 @@ to applying software based correction.
 ## Print a Calibration Object
 The first step in correcting skew is to print a
 [calibration object](https://www.thingiverse.com/thing:2563185/files)
-along the plane you want to correct.  There is also a
+along the plane you want to correct. There is also a
 [calibration object](https://www.thingiverse.com/thing:2972743)
-that includes all planes in one model.  You want the object oriented
+that includes all planes in one model. You want the object oriented
 so that corner A is toward the origin of the plane.
 
-Make sure that no skew correction is applied during this print.  You may
+Make sure that no skew correction is applied during this print. You may
 do this by either removing the [skew_correction] module from printer.cfg
 or by issuing a `SET_SKEW CLEAR=1` gcode.
 
 ## Take your measurements
 The [skew_correcton] module requires 3 measurements for each plane you want
 to correct; the length from Corner A to Corner C, the length from Corner B
-to Corner D, and the length from corner A to corner D.  When measuring length
+to Corner D, and the length from corner A to corner D. When measuring length
 AD do not include the flats on the corners that some test objects provide.
 
 ![skew_lengths](img/skew_lengths.png)
 
 ## Configure your skew
-Make sure [skew_correction] is in printer.cfg.  You may now use the `SET_SKEW`
-gcode to configure skew_correcton.  For example, if your measured lengths
+Make sure [skew_correction] is in printer.cfg. You may now use the `SET_SKEW`
+gcode to configure skew_correcton. For example, if your measured lengths
 along XY are as follows:
 
 ```bash
@@ -50,7 +50,7 @@ SET_SKEW XY=140.4,142.8,99.8 XZ=141.6,141.4,99.8 YZ=142.4,140.5,99.5
 ```
 
 The [skew_correction] module also supports profile management in a manner
-similar to [bed_mesh].  After setting skew using the `SET_SKEW` gcode,
+similar to [bed_mesh]. After setting skew using the `SET_SKEW` gcode,
 you may use the `SKEW_PROFILE` gcode to save it:
 
 ```gcode
@@ -58,8 +58,8 @@ SKEW_PROFILE SAVE=my_skew_profile
 ```
 
 After this command you will be prompted to issue a `SAVE_CONFIG` gcode to
-save the profile to persistent storage.  If no profile is named
-`my_skew_profile` then a new profile will be created.  If the named profile
+save the profile to persistent storage. If no profile is named
+`my_skew_profile` then a new profile will be created. If the named profile
 exists it will be overwritten.
 
 Once you have a saved profile, you may load it:
@@ -79,8 +79,8 @@ make this change persist.
 
 ## Verifying your correction
 After skew_correction has been configured you may reprint the calibration
-part with correction enabled.  Use the following gcode to check your
-skew on each plane.  The results should be lower than those reported via
+part with correction enabled. Use the following gcode to check your
+skew on each plane. The results should be lower than those reported via
 `GET_CURRENT_SKEW`.
 
 ```gcode
@@ -91,11 +91,11 @@ CALC_MEASURED_SKEW AC=<ac_length> BD=<bd_length> AD=<ad_length>
 
 Due to the nature of skew correction it is recommended to configure skew
 in your start gcode, after homing and any kind of movement that travels
-near the edge of the print area such as a purge or nozzle wipe.   You may
-use use the `SET_SKEW` or `SKEW_PROFILE` gcodes to accomplish this.  It is
+near the edge of the print area such as a purge or nozzle wipe.  You may
+use use the `SET_SKEW` or `SKEW_PROFILE` gcodes to accomplish this. It is
 also recommended to issue a `SET_SKEW CLEAR=1` in your end gcode.
 
 Keep in mind that it is possible for [skew_correction] to generate a correction
-that moves the tool beyond the printer's boundries on the X and/or Y axes.  It
+that moves the tool beyond the printer's boundries on the X and/or Y axes. It
 is recommended to arrange parts away from the edges when using
 [skew_correction].

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -30,7 +30,8 @@ AD do not include the flats on the corners that some test objects provide.
 Make sure [skew_correction] is in printer.cfg.  You may now use the `SET_SKEW`
 gcode to configure skew_correcton.  For example, if your measured lengths
 along XY are as follows:
-```
+
+```bash
 Length AC = 140.4
 Length BD = 142.8
 Length AD = 99.8
@@ -38,12 +39,13 @@ Length AD = 99.8
 
 `SET_SKEW` can be used to configure skew correction for the XY plane.
 
-```
+```gcode
 SET_SKEW XY=140.4,142.8,99.8
 ```
+
 You may also add measurements for XZ and YZ to the gcode:
 
-```
+```gcode
 SET_SKEW XY=140.4,142.8,99.8 XZ=141.6,141.4,99.8 YZ=142.4,140.5,99.5
 ```
 
@@ -51,23 +53,27 @@ The [skew_correction] module also supports profile management in a manner
 similar to [bed_mesh].  After setting skew using the `SET_SKEW` gcode,
 you may use the `SKEW_PROFILE` gcode to save it:
 
-```
+```gcode
 SKEW_PROFILE SAVE=my_skew_profile
 ```
+
 After this command you will be prompted to issue a `SAVE_CONFIG` gcode to
 save the profile to persistent storage.  If no profile is named
 `my_skew_profile` then a new profile will be created.  If the named profile
 exists it will be overwritten.
 
 Once you have a saved profile, you may load it:
-```
+
+```gcode
 SKEW_PROFILE LOAD=my_skew_profile
 ```
 
 It is also possible to remove an old or out of date profile:
-```
+
+```gcode
 SKEW_PROFILE REMOVE=my_skew_profile
 ```
+
 After removing a profile you will be prompted to issue a `SAVE_CONFIG` to
 make this change persist.
 
@@ -77,7 +83,7 @@ part with correction enabled.  Use the following gcode to check your
 skew on each plane.  The results should be lower than those reported via
 `GET_CURRENT_SKEW`.
 
-```
+```gcode
 CALC_MEASURED_SKEW AC=<ac_length> BD=<bd_length> AD=<ad_length>
 ```
 


### PR DESCRIPTION
Affect Rendering

- Added empty line above/below the fenced code blocks
- Added language specifiers to improve code block rendering
- Correct things like gcode to G-Code
- remove the double space after the period (do not show up in render).
- Added some empty lines I missed earlier
- 
Signed-off-by: Yifei Ding <yifeiding@protonmail.com>

# Please review the rendered text on Github!