### PR TITLE
Add get_status() method to screws_tilt_adjust

### DIFF
--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -12,7 +12,9 @@ class ScrewsTiltAdjust:
         self.config = config
         self.printer = config.get_printer()
         self.screws = []
+        self.results = []
         self.max_diff = None
+        self.max_diff_error = False
         # Read config
         for i in range(99):
             prefix = "screw%d" % (i + 1,)
@@ -57,7 +59,13 @@ class ScrewsTiltAdjust:
         self.direction = direction
         self.probe_helper.start_probe(gcmd)
 
+    def get_status(self, eventtime):
+        return {'error': self.max_diff_error,
+            'results': self.results}
+
     def probe_finalize(self, offsets, positions):
+        self.results = []
+        self.max_diff_error = False
         # Factors used for CW-M3, CCW-M3, CW-M4, CCW-M4, CW-M5 and CCW-M5
         threads_factor = {0: 0.5, 1: 0.5, 2: 0.7, 3: 0.7, 4: 0.8, 5: 0.8}
         is_clockwise_thread = (self.thread & 1) == 0
@@ -84,6 +92,8 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
+                self.results.append({'name':name + ' (base)', 'x':coord[0], 'y':coord[1],
+                    'z':z})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -104,7 +114,10 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
+                self.results.append({'name':name, 'x':coord[0], 'y':coord[1],
+                    'z':z, 'sign':sign, 'adjust':"%02d:%02d" % (full_turns, minutes)})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
+            self.max_diff_error = True
             raise self.gcode.error(
                 "bed level exceeds configured limits ({}mm)! " \
                 "Adjust screws and restart print.".format(self.max_diff))

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -92,8 +92,8 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
-                self.results.append({'name':name + ' (base)', 'x':coord[0], 'y':coord[1],
-                    'z':z})
+                self.results.append({'name':name + ' (base)', 'x':coord[0],
+                    'y':coord[1], 'z':z})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -114,8 +114,9 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
-                self.results.append({'name':name, 'x':coord[0], 'y':coord[1],
-                    'z':z, 'sign':sign, 'adjust':"%02d:%02d" % (full_turns, minutes)})
+                self.results.append({'name':name, 'x':coord[0], 'y':coord[c1],
+                    'z':z, 'sign':sign,
+                    'adjust':"%02d:%02d" % (full_turns, minutes)})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
             self.max_diff_error = True
             raise self.gcode.error(

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -114,7 +114,7 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
-                self.results.append({'name':name, 'x':coord[0], 'y':coord[c1],
+                self.results.append({'name':name, 'x':coord[0], 'y':coord[1],
                     'z':z, 'sign':sign,
                     'adjust':"%02d:%02d" % (full_turns, minutes)})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):


### PR DESCRIPTION
This adds a get_status() method to the screws_tilt_adjust.py module so that gcode macros and menu elements can read the results from the `screws_tilt_calculate` command. This creates a new `printer.screws_tilt_adjust` object with two properties:

`error`: False by default, but True if the `screws_tilt_calculate` command triggered the "bed level exceeds configured limits" error.
`results`: Until the `screws_tilt_calculate` command is run, this is an empty python list. But once `screws_tilt_calculate` has completed successfully, this is a list containing a python dictionary for each configured bed screw. Each of those dictionaries contains the following keys:

- **name**: Value is the name of the screw from the config file
- **x**: Value is the configured X coordinate of the screw
- **y**: Value is the configured Y coordinate of the screw
- **z**: Value is the measured Z probe height above the screw
- **sign**:* Value is either "CW" for clockwise or "CCW" for counter-clockwise 
- **adjust**:* Value is the amount the screw must be adjusted, expressed in the same "time" format as is output in the console. (e.g. `01:15` for one full turn plus a quarter turn)

*_The dictionary for the "base" screw does not have the **sign** or **adjust** keys because the calculation assumes the base screw will not be adjusted._

I have successfully used this new get_status() method together with a handful of macros, custom menus, display groups, and even a couple of custom glyphs to enable Z-probe bed tramming directly from the printer LCD, with a rudimentary GUI and everything.

