### PR TITLE
Allow release info changes when installing on Octoprint

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -21,7 +21,7 @@ install_packages()
 
     # Update system package info
     report_status "Running apt-get update..."
-    sudo apt-get update
+    sudo apt-get update --allow-releaseinfo-change
 
     # Install desired packages
     report_status "Installing packages..."


### PR DESCRIPTION
Follow on from issue #4623, to make installation a little more seamless from a fresh octopi image.