### PR TITLE
When doing z_hop moves, abort on zmax endstop trigger

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -280,8 +280,9 @@ class PrinterConfig:
             for option in fileconfig.options(section_name):
                 option = option.lower()
                 if (section, option) not in access_tracking:
-                    raise error("Option '%s' is not valid in section '%s'"
-                                % (option, section))
+                    if option != 'endstop_max_pin':
+                        raise error("Option '%s' is not valid in section '%s'"
+                                    % (option, section))
         # Setup self.status_settings
         self.status_settings = {}
         for (section, option), value in config.access_tracking.items():

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -45,6 +45,8 @@ class CartKinematics:
             self.printer.lookup_object('gcode').register_command(
                 'SET_DUAL_CARRIAGE', self.cmd_SET_DUAL_CARRIAGE,
                 desc=self.cmd_SET_DUAL_CARRIAGE_help)
+    def get_rails(self):
+        return self.rails
     def get_steppers(self):
         rails = self.rails
         if self.dual_carriage_axis is not None:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -408,6 +408,8 @@ class ToolHead:
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")
     def move(self, newpos, speed):
+        logging.info("DEBUG: TEST")
+        logging.info("DEBUG: cp:{} np:{}".format(self.commanded_pos, newpos))
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
             return


### PR DESCRIPTION
_Note_ this patch does **not** work! I just wanted to ask a question with some digging already done. I can open up and issue instead, but the diffs might help the convo...

On a Makergear M2 I use a bltouch and thus I relocated the (now unused) Z Min endstop
to the bottom of my printer. I now use the old Zmin microswitch as a Z Max.
If I dont do this the homing sequence does the following (in both Marlin and Klipper):

- Turn on printer
- bed is resting at (or near zmax)
- homing procedure starts
- Z is moved + some for z_hop (grinds stepper)
- X is homed
- Y is homed
- Z is moved + some again for z_hop(?) (stepper grinds)
- XY goes to 100,100
- bltouch probe is deployed
- Z is mobved -
- Z is homed to zero

So... I need to fix this so that when the bed Z is already at Z Max the homing
does not try and move + some. Or I need the z_hop routines to watch for the
Z Max trigger (or all homing moves to watch for Z Max).

I am looking at the code and Im not so sure this is correct, but could we,
conditionally register the Z Max endstop with the stepper then if such a config
item exists in the SafeZHoming class replace calls to manual_move with
`homing_move()`??

Im not entirely sure... but it looks like `homing_move()` is a bit like
`manual_move()` but it does an async check for endstops. Thus if those calls
for z_hops (which are my problem) use `homing_move()` I think it would
resolve my issue.

I got lost in the code a bit, its my first time looking.
Is there a better way to implement this?