### PR TITLE
Fix: inverted rotation for screw_tilt_adjust

### DIFF
--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -93,9 +93,9 @@ class ScrewsTiltAdjust:
                 else:
                     adjust = diff / threads_factor.get(self.thread, 0.5)
                 if is_clockwise_thread:
-                    sign = "CW" if adjust >= 0 else "CCW"
-                else:
                     sign = "CCW" if adjust >= 0 else "CW"
+                else:
+                    sign = "CW" if adjust >= 0 else "CCW"
                 adjust = abs(adjust)
                 full_turns = math.trunc(adjust)
                 decimal_part = adjust - full_turns


### PR DESCRIPTION
- I just reversed the instruction for the adjust sens (was writing to tighten the screws to up the bed)
- Example of the issue with the original code with thread CW-M4 where CW = tighten the screw and CCW = loosen the screw:
```
// front left screw (base) : x=7.0, y=9.0, z=2.33000
// front right screw : x=177.0, y=9.0, z=2.31250 : adjust CW 00:01
// rear right screw : x=177.0, y=179.0, z=2.29500 : adjust CW 00:03
// rear left screw : x=7.0, y=179.0, z=2.34500 : adjust CCW 00:01
```

 - Biorn Walliser (biorn@me.com)