### PR TITLE
Added raw response functionality

### DIFF
--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -38,17 +38,21 @@ class HostResponder:
     def cmd_RESPOND(self, gcmd):
         respond_type = gcmd.get('TYPE', None)
         prefix = self.default_prefix
-        if(respond_type != None):
-            respond_type = respond_type.lower()
-            if(respond_type in respond_types):
-                prefix = respond_types[respond_type]
-            else:
-                raise gcmd.error(
-                    "RESPOND TYPE '%s' is invalid. Must be one"
-                    " of 'echo', 'command', or 'error'" % (respond_type,))
-        prefix = gcmd.get('PREFIX', prefix)
-        msg = gcmd.get('MSG', '')
-        gcmd.respond_raw("%s %s" % (prefix, msg))
+        raw = gcmd.get('RAW', None)
+        if raw:
+          gcmd.respond_raw(raw)
+        else:
+            if(respond_type != None):
+                respond_type = respond_type.lower()
+                if(respond_type in respond_types):
+                    prefix = respond_types[respond_type]
+                else:
+                    raise gcmd.error(
+                        "RESPOND TYPE '%s' is invalid. Must be one"
+                        " of 'echo', 'command', or 'error'" % (respond_type,))
+            prefix = gcmd.get('PREFIX', prefix)
+            msg = gcmd.get('MSG', '')
+            gcmd.respond_raw("%s %s" % (prefix, msg))
 
 def load_config(config):
     return HostResponder(config)


### PR DESCRIPTION
module: RESPOND, allow sending raw messages without prefix

Some octoprint plugins require quite specific messages, for example the telegram plugin requiring no space between "echo:" and the message or the bed visualizer plugin requiring no space between "echo:" and the message. 

This allows sending completely raw messages back to the host.

Signed-off-by: Adrian Joachim <adi.joachim12@gmail.com>