### PR TITLE
z_endstop_set_calibration: Calibrate endstop based on current position

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -402,6 +402,15 @@ see the [BL-Touch guide](BLTouch.md)):
 - `BLTOUCH_STORE MODE=<output_mode>`: This stores an output mode in the
   EEPROM of a BLTouch V3.1 Available output_modes are: `5V`, `OD`
 
+
+### Z Endstop Calibration by Current Position
+
+The following commands are available when the z_endstop_set_calibration config
+section (which has no further options) is enabled:
+- `Z_ENDSTOP_SET_CALIBRATION Z=<value>`: This command will change the
+  `position_endstop` value for the Z stepper such that the current Z position
+  will equal the given Z coordinate. Requires a `SAVE_CONFIG` to take effect.
+
 ### Delta Calibration
 
 The following commands are available when the

--- a/klippy/extras/z_endstop_set_calibration.py
+++ b/klippy/extras/z_endstop_set_calibration.py
@@ -1,0 +1,39 @@
+# Allow self-calibration of Z endstop using a Z probe.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+
+class ZEndstopSetCalibration:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command('Z_ENDSTOP_SET_CALIBRATION',
+                               self.cmd_Z_ENDSTOP_SET_CALIBRATION,
+                               desc=self.cmd_Z_ENDSTOP_SET_CALIBRATION_help)
+
+        zconfig = config.getsection('stepper_z')
+        self.z_position_endstop = zconfig.getfloat('position_endstop', None,
+                                                   note_valid=False)
+        if self.z_position_endstop is None:
+            raise gcode.error("Cannot find position_endstop in [stepper_z]")
+
+
+    cmd_Z_ENDSTOP_SET_CALIBRATION_help = "Self-calibrate Z endstop after "     \
+          "running PROBE command."
+
+
+    def cmd_Z_ENDSTOP_SET_CALIBRATION(self, gcmd):
+        new_z = gcmd.get_float("Z")
+        tool = self.printer.lookup_object('toolhead')
+        pos = tool.get_position()
+        z_pos = self.z_position_endstop - pos[2] + new_z
+        gcmd.respond_info(
+            "stepper_z: position_endstop: %.3f\n"
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "with the above and restart the printer." % (z_pos,))
+        configfile = self.printer.lookup_object('configfile')
+        configfile.set('stepper_z', 'position_endstop', "%.3f" % z_pos)
+
+
+def load_config(config):
+    return ZEndstopSetCalibration(config)


### PR DESCRIPTION
Add new module which allows to calibrate the z-axis endstop position
based on the current position. This can be used with load cell-based
or accelerometer-based probes, as discussed in #3496.