### PR TITLE
extras: Smart Effector support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1743,6 +1743,58 @@ control_pin:
 #   See the "probe" section for information on these parameters.
 ```
 
+### [smart_effector]
+Smart Effector. One may define this section instead of `[probe]` to enable
+the SmartEffector-specific features. This also enables
+[runtime commands](G-Codes.md#smart-effector) to adjust the parameters of
+the Smart Effector at run time.
+
+```
+[smart_effector]
+pin:
+#   Pin connected to the Smart Effector Z Probe output pin (pin 5). Note that
+#   pullup resistor on the board is generally not required. However, if the
+#   output pin is connected to the board pin with a pullup resistor, that
+#   resistor must be high value (e.g. 10K Ohm or more). Some boards have a low
+#   value pullup resistor on the Z probe input, which will likely result in an
+#   always-triggered probe state. In this case, connect the Smart Effector to
+#   a different pin on the board. This parameter is required.
+# control_pin:
+#   Pin connected to the Smart Effector control input pin (pin 7). If provided,
+#   Smart Effector sensitivity programming commands become available.
+# probe_accel:
+#   If set, limits the acceleration of the probing moves (in mm/sec^2).
+#   A sudden large acceleration at the beginning of the probing move may
+#   cause spurious probe triggering, especially if the hotend is heavy.
+#   To prevent that, it may be necessary to reduce the acceleration of
+#   the probing moves via this parameter.
+# recovery_time: 0.4
+#   A delay between the travel moves and the probing moves in seconds. A fast
+#   travel move prior to probing may result in a spurious probe triggering.
+#   This may cause 'Probe triggered prior to movement' errors if no delay
+#   is set. Value 0 disables the recovery delay.
+#   Default value is 0.4.
+#x_offset:
+#y_offset:
+#   Should be left unset (or set to 0).
+z_offset:
+#   Trigger height of the probe. Start with -0.1 (mm), and adjust later using
+#   `PROBE_CALIBRATE` command. This parameter must be provided.
+#speed:
+#   Speed (in mm/s) of the Z axis when probing. It is recommended to start
+#   with the probing speed of 20 mm/s and adjust it as necessary to improve
+#   the accuracy and repeatability of the probe triggering.
+#samples:
+#sample_retract_dist:
+#samples_result:
+#samples_tolerance:
+#samples_tolerance_retries:
+#activate_gcode:
+#deactivate_gcode:
+#deactivate_on_each_sample:
+#   See the "probe" section for more information on the parameters above.
+```
+
 ## Additional stepper motors and extruders
 
 ### [stepper_z1]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1053,6 +1053,34 @@ profile matching the supplied name from persistent memory. Note that
 after SAVE or REMOVE operations have been run the SAVE_CONFIG gcode
 must be run to make the changes to persistent memory permanent.
 
+### [smart_effector]
+
+Several commands are available when a
+[smart_effector config section](Config_Reference.md#smart-effector) is enabled.
+Be sure to check the official documentation for the Smart Effector on the
+[Duet3D Wiki](https://duet3d.dozuki.com/Wiki/Smart_effector_and_carriage_adapters_for_delta_printer)
+before changing the Smart Effector parameters. Also check the
+[probe calibration guide](Probe_Calibrate.md).
+
+#### SET_SMART_EFFECTOR
+`SET_SMART_EFFECTOR [SENSITIVITY=<sensitivity>] [ACCEL=<accel>]
+[RECOVERY_TIME=<time>]`: Set the Smart Effector parameters. When `SENSITIVITY`
+is specified, the respective value is written to the SmartEffector EEPROM
+(requires `control_pin` to be provided). Acceptable <sensitivity> values are
+0..255, the default is 50. Lower values require less nozzle contact force to
+trigger (but there is a higher risk of false triggering due to vibrations
+during probing), and higher values reduce false triggering (but require larger
+contact force to trigger). Since the sensitivity is written to EEPROM, it is
+preserved after the shutdown, and so it does not need to be configured on
+every printer startup. `ACCEL` and `RECOVERY_TIME` allow to override the
+corresponding parameters at run-time, see the
+[config section](Config_Reference.md#smart-effector) of Smart Effector for
+more info on those parameters.
+
+#### RESET_SMART_EFFECTOR
+`RESET_SMART_EFFECTOR`: Resets Smart Effector sensitivity to its factory
+settings. Requires `control_pin` to be provided in the config section.
+
 ### [stepper_enable]
 
 The stepper_enable module is automatically loaded.

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -1,0 +1,154 @@
+# SmartEffector support
+#
+# Copyright (C) 2021  Dmitry Butyugin <dmbutyugin@google.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+from . import probe
+
+# SmartEffector communication protocol implemented here originates from
+# https://github.com/Duet3D/SmartEffectorFirmware
+BITS_PER_SECOND = 1000.
+
+class ControlPinHelper:
+    def __init__(self, pin_params):
+        self._mcu = pin_params['chip']
+        self._pin = pin_params['pin']
+        self._start_value = self._invert = pin_params['invert']
+        self._oid = None
+        self._set_cmd = None
+        self._mcu.register_config_callback(self._build_config)
+    def _build_config(self):
+        self._mcu.request_move_queue_slot()
+        self._oid = self._mcu.create_oid()
+        self._mcu.add_config_cmd(
+            "config_digital_out oid=%d pin=%s value=%d default_value=%d"
+            " max_duration=%d" % (self._oid, self._pin, self._start_value,
+                                  self._start_value, 0))
+        cmd_queue = self._mcu.alloc_command_queue()
+        self._set_cmd = self._mcu.lookup_command(
+            "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue)
+    def write_bits(self, start_time, bit_stream):
+        bit_step = 1. / BITS_PER_SECOND
+        last_value = self._start_value
+        bit_time = start_time
+        for b in bit_stream:
+            value = (not not b) ^ self._invert
+            if value != last_value:
+                clock = self._mcu.print_time_to_clock(bit_time)
+                self._set_cmd.send([self._oid, clock, value])
+                last_value = value
+            bit_time += bit_step
+        # After the last bit, the signal on the control pin must go back
+        # to its start value.
+        if value != self._start_value:
+            clock = self._mcu.print_time_to_clock(bit_time)
+            self._set_cmd.send([self._oid, clock, self._start_value])
+            bit_time += bit_step
+        return bit_time
+
+class SmartEffectorEndstopWrapper:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.probe_accel = config.getfloat('probe_accel', 0., minval=0.)
+        self.recovery_time = config.getfloat('recovery_time', 0.4, minval=0.)
+        self.probe_wrapper = probe.ProbeEndstopWrapper(config)
+        # Wrappers
+        self.get_mcu = self.probe_wrapper.get_mcu
+        self.add_stepper = self.probe_wrapper.add_stepper
+        self.get_steppers = self.probe_wrapper.get_steppers
+        self.home_start = self.probe_wrapper.home_start
+        self.home_wait = self.probe_wrapper.home_wait
+        self.query_endstop = self.probe_wrapper.query_endstop
+        self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
+        self.multi_probe_end = self.probe_wrapper.multi_probe_end
+        # SmartEffector control
+        control_pin = config.get('control_pin', None)
+        if control_pin:
+            ppins = self.printer.lookup_object('pins')
+            pin_params = ppins.lookup_pin(control_pin, can_invert=True)
+            self.control_pin = ControlPinHelper(pin_params)
+            self.gcode.register_command("RESET_SMART_EFFECTOR",
+                                        self.cmd_RESET_SMART_EFFECTOR,
+                                        desc=self.cmd_RESET_SMART_EFFECTOR_help)
+        else:
+            self.control_pin = None
+        self.gcode.register_command("SET_SMART_EFFECTOR",
+                                    self.cmd_SET_SMART_EFFECTOR,
+                                    desc=self.cmd_SET_SMART_EFFECTOR_help)
+    def probe_prepare(self, hmove):
+        toolhead = self.printer.lookup_object('toolhead')
+        self.probe_wrapper.probe_prepare(hmove)
+        if self.probe_accel:
+            systime = self.printer.get_reactor().monotonic()
+            toolhead_info = toolhead.get_status(systime)
+            self.old_max_accel = toolhead_info['max_accel']
+            self.gcode.run_script_from_command(
+                    "M204 S%.3f" % (self.probe_accel,))
+        if self.recovery_time:
+            toolhead.dwell(self.recovery_time)
+    def probe_finish(self, hmove):
+        if self.probe_accel:
+            self.gcode.run_script_from_command(
+                    "M204 S%.3f" % (self.old_max_accel,))
+        self.probe_wrapper.probe_finish(hmove)
+    def _send_command(self, buf):
+        # Each byte is sent to the SmartEffector as
+        # [0 0 1 0 b7 b6 b5 b4 !b4 b3 b2 b1 b0 !b0]
+        bit_stream = []
+        for b in buf:
+            b = b & 0xFF
+            bit_stream.extend([0, 0, 1, 0])
+            bit_stream.extend([b & 0x80, b & 0x40, b & 0x20, b & 0x10])
+            bit_stream.append((~b) & 0x10)
+            bit_stream.extend([b & 0x08, b & 0x04, b & 0x02, b & 0x01])
+            bit_stream.append((~b) & 0x01)
+        # Wait for previous actions to finish
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.wait_moves()
+        start_time = toolhead.get_last_move_time()
+        # Write generated bits to the control pin
+        end_time = self.control_pin.write_bits(start_time, bit_stream)
+        # Dwell to make sure no subseqent actions are queued together
+        # with the SmartEffector programming
+        toolhead.dwell(end_time - start_time)
+        toolhead.wait_moves()
+    cmd_SET_SMART_EFFECTOR_help = 'Set SmartEffector parameters'
+    def cmd_SET_SMART_EFFECTOR(self, gcmd):
+        sensitivity = gcmd.get_int('SENSITIVITY', None, minval=0, maxval=255)
+        respond_info = []
+        if sensitivity is not None:
+            if self.control_pin is not None:
+                buf = [105, sensitivity, 255 - sensitivity]
+                self._send_command(buf)
+                respond_info.append("sensitivity: %d" % (sensitivity,))
+            else:
+                raise gcmd.error("control_pin must be set in [smart_effector] "
+                                 "for sensitivity programming")
+        self.probe_accel = gcmd.get_float('ACCEL', self.probe_accel, minval=0.)
+        self.recovery_time = gcmd.get_float('RECOVERY_TIME', self.recovery_time,
+                                            minval=0.)
+        if self.probe_accel:
+            respond_info.append(
+                    "probing accelartion: %.3f" % (self.probe_accel,))
+        else:
+            respond_info.append("probing acceleration control disabled")
+        if self.recovery_time:
+            respond_info.append(
+                    "probe recovery time: %.3f" % (self.recovery_time,))
+        else:
+            respond_info.append("probe recovery time disabled")
+        gcmd.respond_info("SmartEffector:\n" + "\n".join(respond_info))
+    cmd_RESET_SMART_EFFECTOR_help = 'Reset SmartEffector settings (sensitivity)'
+    def cmd_RESET_SMART_EFFECTOR(self, gcmd):
+        buf = [131, 131]
+        self._send_command(buf)
+        gcmd.respond_info('SmartEffector sensitivity was reset')
+
+def load_config(config):
+    smart_effector = SmartEffectorEndstopWrapper(config)
+    config.get_printer().add_object('probe',
+                                    probe.PrinterProbe(config, smart_effector))
+    return smart_effector


### PR DESCRIPTION
This PR adds support of programmable sensitivity for Smart Effector, if the effector control pin is wired to a GPIO pin,
as well as a few other features useful in combination with the custom sensitivity: probing acceleration and recovery time.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>