### PR TITLE
Add min_power option for fans

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2302,6 +2302,14 @@ Print cooling fan.
 [fan]
 pin:
 #   Output pin controlling the fan. This parameter must be provided.
+#min_power: 0.0
+#   The minimum power (expressed as a value from 0.0 to 1.0) that makes
+#   the fan spin. If this value is more than 0.0 then fan speed requests
+#   will be scaled between min_power and max_power (for example, if
+#   min_power is .1 and max_power is 1 a fan speed of 10% is requested then the fan
+#   power will be set to 19%)
+#   This setting may be used to prevent fan stalls at low speeds.
+#   The default is 0.0.
 #max_power: 1.0
 #   The maximum power (expressed as a value from 0.0 to 1.0) that the
 #   pin may be set to. The value 1.0 allows the pin to be set fully
@@ -2309,8 +2317,8 @@ pin:
 #   pin to be enabled for no more than half the time. This setting may
 #   be used to limit the total power output (over extended periods) to
 #   the fan. If this value is less than 1.0 then fan speed requests
-#   will be scaled between zero and max_power (for example, if
-#   max_power is .9 and a fan speed of 80% is requested then the fan
+#   will be scaled between min_power and max_power (for example, if
+#   max_power is .9 and min_power is 0 a fan speed of 80% is requested then the fan
 #   power will be set to 72%). The default is 1.0.
 #shutdown_speed: 0
 #   The desired fan speed (expressed as a value from 0.0 to 1.0) if
@@ -2369,6 +2377,7 @@ a shutdown_speed equal to max_power.
 ```
 [heater_fan my_nozzle_fan]
 #pin:
+#min_power:
 #max_power:
 #shutdown_speed:
 #cycle_time:
@@ -2405,6 +2414,7 @@ watched component.
 ```
 [controller_fan my_controller_fan]
 #pin:
+#min_power:
 #max_power:
 #shutdown_speed:
 #cycle_time:
@@ -2450,6 +2460,7 @@ additional information.
 ```
 [temperature_fan my_temp_fan]
 #pin:
+#min_power:
 #max_power:
 #shutdown_speed:
 #cycle_time:
@@ -2497,6 +2508,7 @@ with the SET_FAN_SPEED
 ```
 [fan_generic extruder_partfan]
 #pin:
+#min_power:
 #max_power:
 #shutdown_speed:
 #cycle_time:

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -13,6 +13,7 @@ class Fan:
         self.last_fan_value = 0.
         self.last_fan_time = 0.
         # Read config
+        self.min_power = config.getfloat('min_power', 0., below=1., minval=0.)
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1,
                                                minval=0.)
@@ -42,7 +43,11 @@ class Fan:
     def set_speed(self, print_time, value):
         if value < self.off_below:
             value = 0.
-        value = max(0., min(self.max_power, value * self.max_power))
+        if value > 0:
+            value = min(self.max_power, max(self.min_power,
+            (self.max_power-self.min_power) * value + self.min_power))
+        # Ensure value is between 0 and 1
+        value = max(0., min(1., value))
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)


### PR DESCRIPTION
An alternative to off_below, min_power raises the fan speeds of commands below min_power up to min_power.
This ensures the fan will always run when commanded to.

Example: My fan starts spinning slowly at 15%. Anything below it and it does not spin.
Using off_below I have to use different filament settings for each of my printers (one starts at 7%, another at 15% and a third around 25%).
With min_power i can adjust each printer fan to start spin at 1% and ramp up to max_power.

Thereby I can use the same filament profile for all printers, as 15% fan is approximately the same across the lineup.
I know there is scaling that differs between them - one fan at 40% blows like another at 60%. - But I can live without that feature for now ;-) 
As long as the fan spins, when we tell it to without having to worry about minimum power needed when working in the slicer.


## Scaling:
This pull request is all about the min_power option that will help me and others I have spoken with about this option.

But I would like to touch upon the scaling option mentioned above, which I of course would love to see in the future - or merged into this branch before merging it into Klipper.
The power scaling should work as such:

### Example:
#### Machine 1: (5015 blower fan)
- min_power = 0.2
- max_power = 1.0
- **power_scaling = 1.0**

#### Machine 2: (4020 blower fan)
- min_power = 0.2
- max_power = 1.0
- **power_scaling = 1.5**

>Without power_scaling:
  
When machine 1 runs with 50% fan, it will move more air than my 4020 fan at 50%.

>With the power_scaling:

machine 1 - 50% will be translated to 50% * power_scaling = 50%
maching 2 - 50% will be translated to 50% * power_scaling = 75%

It will be easier to have machines match the same output with the scaling functionality.




