### PR TITLE
gcode_macro: Add "rawparams" pseudo-variable

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -129,6 +129,20 @@ gcode:
   M140 S{bed_temp}
 ```
 
+### The "rawparams" variable
+
+The full unparsed parameters for the running macro can be access via the `rawparams` pseudo-variable.
+
+This is quite useful if you want to change the behavior of certain commands like the `M117`. For example:
+
+```
+[gcode_macro M117]
+rename_existing: M117.1
+gcode:
+  M117.1 { rawparams }
+  M118 { rawparams }
+```
+
 ### The "printer" Variable
 
 It is possible to inspect (and alter) the current state of the printer

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -35,19 +35,8 @@ class DisplayStatus:
         curtime = self.printer.get_reactor().monotonic()
         self.expire_progress = curtime + M73_TIMEOUT
     def cmd_M117(self, gcmd):
-        msg = gcmd.get_commandline()
-        umsg = msg.upper()
-        if not umsg.startswith('M117'):
-            # Parse out additional info if M117 recd during a print
-            start = umsg.find('M117')
-            end = msg.rfind('*')
-            if end >= 0:
-                msg = msg[:end]
-            msg = msg[start:]
-        if len(msg) > 5:
-            self.message = msg[5:]
-        else:
-            self.message = None
+        msg = gcmd.get_raw_command_parameters() or None
+        self.message = msg
 
 def load_config(config):
     return DisplayStatus(config)

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -180,6 +180,7 @@ class GCodeMacro:
         kwparams = dict(self.variables)
         kwparams.update(self.template.create_template_context())
         kwparams['params'] = gcmd.get_command_parameters()
+        kwparams['rawparams'] = gcmd.get_raw_command_parameters()
         self.in_script = True
         try:
             self.template.run_gcode_from_command(kwparams)

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -22,17 +22,7 @@ class HostResponder:
         gcode.register_command('RESPOND', self.cmd_RESPOND, True,
                                desc=self.cmd_RESPOND_help)
     def cmd_M118(self, gcmd):
-        msg = gcmd.get_commandline()
-        umsg = msg.upper()
-        if not umsg.startswith('M118'):
-            # Parse out additional info if M118 recd during a print
-            start = umsg.find('M118')
-            end = msg.rfind('*')
-            msg = msg[start:end]
-        if len(msg) > 5:
-            msg = msg[5:]
-        else:
-            msg = ''
+        msg = gcmd.get_raw_command_parameters()
         gcmd.respond_raw("%s %s" % (self.default_prefix, msg))
     cmd_RESPOND_help = ("Echo the message prepended with a prefix")
     def cmd_RESPOND(self, gcmd):

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -26,6 +26,22 @@ class GCodeCommand:
         return self._commandline
     def get_command_parameters(self):
         return self._params
+    def get_raw_command_parameters(self):
+        rawparams = self._commandline
+        command = self._command
+        urawparams = rawparams.upper()
+        if not urawparams.startswith(command):
+            start = urawparams.find(command)
+            end = rawparams.rfind('*')
+            if end >= 0:
+                rawparams = rawparams[:end]
+            rawparams = rawparams[start:]
+        commandlen = len(command) + 1
+        if len(rawparams) > commandlen:
+            rawparams = rawparams[commandlen:]
+        else:
+            rawparams = ''
+        return rawparams
     def ack(self, msg=None):
         if not self._need_ack:
             return False


### PR DESCRIPTION
This adds a new `rawparams` pseudo-variable to the `gcode_macro` template context.

The main usage for this is to allow easier override of an existing G-Code like `M117`, where we don't have any parameters (so `params` is useless) but instead take the whole message after the gcode.

Here's an example of it:

```yaml
[gcode_macro M117]
rename_existing: M117.1
gcode:
  M117.1 { rawparams }
  M118 { rawparams }
```

In the above example, any message sent via `M117` would also be mirrored with `M118`.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>