### PR TITLE
Create printer-tronxy-xy2-v6-2021.cfg

### DIFF
--- a/config/printer-tronxy-xy2-v6-2021.cfg
+++ b/config/printer-tronxy-xy2-v6-2021.cfg
@@ -1,0 +1,132 @@
+# This is a Klipper configuration for TronXY XY2, with CXY-V6
+# motherboard.
+
+#            === FLASHING WITH STOCK BOOTLOADER ===
+# You should make firmware for STM32F103 with bootloader offset
+# at 0x8008800 (Chitu v6 Bootloader) and serial (on USART1 PA10/PA9)
+# communication.
+
+# Use "./scripts/update_chitu.py ./out/klipper.bin ./out/update.cbd"
+# after make to generate update.cbd.  Put `update.cbd` onto SD card,
+# and reboot the printer.  It will be automatically installed, and you
+# will be able to update it this way.
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[stepper_x]
+step_pin: PE5
+dir_pin: PE6
+enable_pin: !PC13
+microsteps: 16
+rotation_distance: 20
+endstop_pin: !PG10
+position_endstop: -1
+position_min: -1
+position_max: 255
+homing_speed: 50
+homing_retract_dist: 10
+second_homing_speed: 10.0
+
+[stepper_y]
+step_pin: PE2
+dir_pin: PE3
+enable_pin: !PE4
+microsteps: 16
+rotation_distance: 20
+endstop_pin: !PA12
+position_endstop: 0
+position_max: 255
+homing_retract_dist: 10
+homing_speed: 50.0
+second_homing_speed: 10.0
+
+[stepper_z]
+step_pin: PB9
+dir_pin: !PE0
+enable_pin: !PE1
+microsteps: 16
+rotation_distance: 4
+endstop_pin: probe:z_virtual_endstop
+position_max: 260
+position_min: -2
+
+[extruder]
+step_pin: PB4
+dir_pin: !PB5
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 3.908
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PG12
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PA1
+control: pid
+pid_Kp=18.331
+pid_Ki=0.548
+pid_Kd=153.291
+min_temp: 0
+max_temp: 250
+max_extrude_only_distance: 300
+
+[heater_bed]
+heater_pin: PG11
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+control: pid
+min_temp: 0
+max_temp: 130
+pid_Kp=59.995
+pid_Ki=1.047
+pid_Kd=859.435
+
+[heater_fan hotend_fan]
+pin: PG14
+fan_speed: 0.5
+
+[fan]
+pin: PG13
+max_power: 1.0
+
+[controller_fan drivers_fan]
+pin: PD6
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: True
+runout_gcode:
+  M25
+switch_pin: !PA15
+
+[output_pin beeper]
+pin: PB0
+
+[safe_z_home]
+home_xy_position: 167,127
+speed: 50
+z_hop: 10
+z_hop_speed: 5
+
+[bed_mesh]
+speed: 60
+probe_count: 5,5
+mesh_pps: 2,2
+horizontal_move_z: 5
+algorithm: lagrange
+mesh_min : 20,20
+mesh_max : 215,220
+
+[probe]
+x_offset: -40
+y_offset: 5
+pin: !PG9
+speed: 30
+z_offset: 1.000


### PR DESCRIPTION
module: config

Adding a new base printer profile for the Tronxy XY2 with a Chitu V6 motherboard.


Signed-off-by: Tom Lawson tom@tomlawson.io