### PR TITLE
Update BLTouch.md to prevent position_endstop error

### DIFF
--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -23,7 +23,7 @@ control_pin: P1.26
 
 If the BL-Touch will be used to home the Z axis then set `endstop_pin:
 probe:z_virtual_endstop` and remove `position_endstop` in the `[stepper_z]` config section,
-then add a `[safe_z_home]` config section to raise the z axis, home the xy axes, 
+then add a `[safe_z_home]` config section to raise the z axis, home the xy axes,
 move to the center of the bed, and home the z axis. For example:
 
 ```

--- a/docs/BLTouch.md
+++ b/docs/BLTouch.md
@@ -22,8 +22,8 @@ control_pin: P1.26
 ```
 
 If the BL-Touch will be used to home the Z axis then set `endstop_pin:
-probe:z_virtual_endstop` in the `[stepper_z]` config section and add a
-`[safe_z_home]` config section to raise the z axis, home the xy axes,
+probe:z_virtual_endstop` and remove `position_endstop` in the `[stepper_z]` config section,
+then add a `[safe_z_home]` config section to raise the z axis, home the xy axes, 
 move to the center of the bed, and home the z axis. For example:
 
 ```


### PR DESCRIPTION
module: BLTOUCH DOCUMENTATION

Klipper with Fluid complains about `position_endstop` line when `endstop_pin: probe:z_virtual_endstop` is used.

Signed-off-by: Ilia Rebane <Agilatosay@gmail.com>