### PR TITLE
Update generic-printrboard.cfg to mention different Y endstop pin on RevF hardware

### DIFF
--- a/config/generic-printrboard.cfg
+++ b/config/generic-printrboard.cfg
@@ -29,6 +29,8 @@ enable_pin: !PE6
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PB0
+# Printrboard RevF uses a different Y endstop pin. 
+#endstop_pin: ^PB4
 position_endstop: 0
 position_max: 200
 homing_speed: 50


### PR DESCRIPTION
Just a simple comment which may help others with a RevF or F4 board - the Y endstop pin is different from RevD boards.

Since there's already comments for other RevF changes I figured this might be appropriate to include as well.