### PR TITLE
scripts: Try to read klippy/.version when building mcu firmware

### DIFF
--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -469,8 +469,12 @@ def git_version():
 def build_version(extra, cleanbuild):
     version = git_version()
     if not version:
-        cleanbuild = False
-        version = "?"
+        try:
+            with open(os.path.join('klippy', '.version')) as h:
+                version = h.read().rstrip()
+        except IOError:
+            cleanbuild = False
+            version = "?"
     elif 'dirty' in version:
         cleanbuild = False
     if not cleanbuild:


### PR DESCRIPTION
I'm installing Klipper as a system package on Arch Linux ARM (using the unofficial [package definition](https://aur.archlinux.org/packages/klipper-git/) found in the AUR) instead of a git checkout in the user directory. When building the MCU portion of klipper, it receives a version similar to `?-20210922_185922-build.hostname.local` consisting of a question mark followed by a timestamp and the hostname of the machine that built klipper. Unfortunately, this string is not that great to use when debugging/troubleshooting as it doesn't relate to the version of klipper it was built from.

This pull request utilizes the existing mechanism of klippy to receive version information even in an out-of-git environment (`klippy/.version` generated using `scripts/make_version.py`) and extends that to be used when building the MCU firmware.

Old version string: `?-20210922_185922-build.hostname.local`
New version string: `v0.9.1-795-gd841a789-ARCHLINUX`