### PR TITLE
removed forced spaces in respond

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1407,6 +1407,7 @@ Enable the "M118" and "RESPOND" extended
 #   Sets the default prefix of the "M118" and "RESPOND" output to one
 #   of the following:
 #       echo: "echo: " (This is the default)
+#       echo_no_space: "echo:"
 #       command: "// "
 #       error: "!! "
 #default_prefix: echo:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -593,6 +593,8 @@ The following commands are availabe when the
   configured default prefix (or `echo: ` if no prefix is configured).
 - `RESPOND TYPE=echo MSG="<message>"`: echo the message prepended with
   `echo: `.
+- `RESPOND TYPE=echo_no_space MSG="<message>"`: echo the message prepended with
+  `echo:` without a space between prefix and message, helpful for compatibility with some octoprint plugins that expect very specific formatting.
 - `RESPOND TYPE=command MSG="<message>"`: echo the message prepended
   with `// `.  Octopint can be configured to respond to these messages
   (e.g.  `RESPOND TYPE=command MSG=action:pause`).

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -5,9 +5,9 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 respond_types = {
-    'echo': 'echo: ',
-    'command': '// ',
-    'error' : '!! ',
+    'echo': 'echo:',
+    'command': '//',
+    'error' : '!!',
 }
 
 class HostResponder:
@@ -48,7 +48,11 @@ class HostResponder:
                     " of 'echo', 'command', or 'error'" % (respond_type,))
         prefix = gcmd.get('PREFIX', prefix)
         msg = gcmd.get('MSG', '')
-        gcmd.respond_raw("%s%s" % (prefix, msg))
+        no_space = gcmd.get('NO_SPACE', False)        
+        if(no_space):
+            gcmd.respond_raw("%s%s" % (prefix, msg))
+        else:
+            gcmd.respond_raw("%s %s" % (prefix, msg))
 
 def load_config(config):
     return HostResponder(config)

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -10,6 +10,10 @@ respond_types = {
     'error' : '!!',
 }
 
+respond_types_no_space = {
+    'echo_no_space': 'echo:',
+}
+
 class HostResponder:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -36,19 +40,22 @@ class HostResponder:
         gcmd.respond_raw("%s %s" % (self.default_prefix, msg))
     cmd_RESPOND_help = ("Echo the message prepended with a prefix")
     def cmd_RESPOND(self, gcmd):
+        no_space = False
         respond_type = gcmd.get('TYPE', None)
         prefix = self.default_prefix
         if(respond_type != None):
             respond_type = respond_type.lower()
             if(respond_type in respond_types):
                 prefix = respond_types[respond_type]
+            elif(respond_type in respond_types_no_space):
+                prefix = respond_types_no_space[respond_type]
+                no_space = True
             else:
                 raise gcmd.error(
                     "RESPOND TYPE '%s' is invalid. Must be one"
                     " of 'echo', 'command', or 'error'" % (respond_type,))
         prefix = gcmd.get('PREFIX', prefix)
         msg = gcmd.get('MSG', '')
-        no_space = gcmd.get('NO_SPACE', False)
         if(no_space):
             gcmd.respond_raw("%s%s" % (prefix, msg))
         else:

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -5,9 +5,9 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 respond_types = {
-    'echo': 'echo:',
-    'command': '//',
-    'error' : '!!',
+    'echo': 'echo: ',
+    'command': '// ',
+    'error' : '!! ',
 }
 
 class HostResponder:
@@ -48,7 +48,7 @@ class HostResponder:
                     " of 'echo', 'command', or 'error'" % (respond_type,))
         prefix = gcmd.get('PREFIX', prefix)
         msg = gcmd.get('MSG', '')
-        gcmd.respond_raw("%s %s" % (prefix, msg))
+        gcmd.respond_raw("%s%s" % (prefix, msg))
 
 def load_config(config):
     return HostResponder(config)

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -48,7 +48,7 @@ class HostResponder:
                     " of 'echo', 'command', or 'error'" % (respond_type,))
         prefix = gcmd.get('PREFIX', prefix)
         msg = gcmd.get('MSG', '')
-        no_space = gcmd.get('NO_SPACE', False)        
+        no_space = gcmd.get('NO_SPACE', False)
         if(no_space):
             gcmd.respond_raw("%s%s" % (prefix, msg))
         else:


### PR DESCRIPTION
Different take on #4664

I moved the spaces into the default prefixes so it is possible to send responses without a forced space. This is required for some octoprint plugins.

Side-effect:  For people that used custom prefixes before it will slightly change the output of their responses (no space between prefix and msg)

Signed-off-by: Adrian Joachim adi.joachim12@gmail.com