### PR TITLE
rp2040: implement fix for RP2040-E5 errata

### DIFF
--- a/src/rp2040/usbserial.c
+++ b/src/rp2040/usbserial.c
@@ -10,8 +10,11 @@
 #include "board/usb_cdc.h" // usb_notify_ep0
 #include "board/usb_cdc_ep.h" // USB_CDC_EP_BULK_IN
 #include "board/usbstd.h" // USB_ENDPOINT_XFER_INT
+#include "board/misc.h" // timer_read_time
 #include "hardware/structs/resets.h" // RESETS_RESET_USBCTRL_BITS
 #include "hardware/structs/usb.h" // usb_hw
+#include "hardware/structs/iobank0.h" // iobank0_hw
+#include "hardware/structs/padsbank0.h" // padsbank0_hw
 #include "internal.h" // enable_pclock
 #include "sched.h" // DECL_INIT
 
@@ -157,6 +160,131 @@ usb_request_bootloader(void)
     reset_to_usb_boot(0, 0);
 }
 
+/****************************************************************
+ * Errata RP2040-E5 fix
+ *
+ * By the RP2040-E5 errata the USB controller will never go into
+ * the connected state if it sees continuous traffic on the port.
+ * We fix this by using the GPIO15 debug function to force the
+ * USB DP signal high, while the pad itself is left disconnected.
+ *
+ * We don't need to do anything with the DM signal, it will be
+ * pulled to zero already.
+ *
+ * When the USB controller is reset, we trigger the following
+ * sequence:
+ * - Wait for the reset to finish, i.e. check line_state != SE0.
+ *   This can take some time, so we set a timer to do this check
+ *   periodically.
+ * - Using GPIO15, force a J state on the line
+ * - Wait 1ms
+ * - Re-enable GPIO15
+ *
+ * Since we need to use GPIO15 there's some concern about racing
+ * with `initial_pins`. We avoid this by scheduling the actual
+ * GPIO manipulation to happen via the timer system. This means
+ * that all the init functions, including `initial_pins` will
+ * already have been run at this point.
+ *
+ * When GPIO15 is hijacked it is set into "bus keep" mode, which
+ * will weakly pull the pin to whatever the state of the pin
+ * currently is. This means that there should be no glitch on the
+ * output.
+ ****************************************************************/
+
+struct enumeration_fix_state {
+    struct timer     timer;
+    uint32_t         prev_pad_ctrl;
+    uint32_t         prev_gpio_ctrl;
+};
+static struct enumeration_fix_state efs;
+
+static const uint32_t dp = 15;
+
+static uint_fast8_t
+enumeration_fix_finish(struct timer *t)
+{
+    if (!(usb_hw->sie_status & USB_SIE_STATUS_CONNECTED_BITS)) {
+        // Still not connected, let's wait another 100us then
+        t->waketime = timer_read_time() + timer_from_us(100);
+        return SF_RESCHEDULE;
+    }
+
+    // Switch back to USB phy
+    usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS | USB_USB_MUXING_SOFTCON_BITS;
+    // Unset PHY pullup overrides
+    hw_clear_alias(usb_hw)->phy_direct_override =
+        USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
+
+    // Restore GPIO control states
+    iobank0_hw->io[dp].ctrl = efs.prev_gpio_ctrl;
+    padsbank0_hw->io[dp] = efs.prev_pad_ctrl;
+
+    return SF_DONE;
+}
+
+static uint_fast8_t
+enumeration_fix_force_j(struct timer *t)
+{
+    // Grab current pad and gpio control states
+    efs.prev_pad_ctrl = padsbank0_hw->io[dp];
+    efs.prev_gpio_ctrl = iobank0_hw->io[dp].ctrl;
+
+    // Enable bus keep
+    hw_write_masked(&padsbank0_hw->io[dp],
+                    PADS_BANK0_GPIO15_PUE_BITS | PADS_BANK0_GPIO15_PDE_BITS,
+                    PADS_BANK0_GPIO15_PUE_BITS | PADS_BANK0_GPIO15_PDE_BITS);
+    // Disable pad output
+    hw_write_masked(&iobank0_hw->io[dp].ctrl,
+                    0x2 << IO_BANK0_GPIO15_CTRL_OEOVER_LSB,
+                    IO_BANK0_GPIO15_CTRL_OEOVER_BITS);
+    // Enable USB debug muxing function
+    hw_write_masked(&iobank0_hw->io[dp].ctrl,
+                    8 << IO_BANK0_GPIO15_CTRL_FUNCSEL_LSB,
+                    IO_BANK0_GPIO15_CTRL_FUNCSEL_BITS);
+    // Set input override
+    hw_write_masked(&iobank0_hw->io[dp].ctrl,
+                    0x3 << IO_BANK0_GPIO15_CTRL_INOVER_LSB,
+                    IO_BANK0_GPIO15_CTRL_INOVER_BITS);
+    // PHY pullups need to stay on
+    hw_set_alias(usb_hw)->phy_direct = USB_USBPHY_DIRECT_DP_PULLUP_EN_BITS;
+    hw_set_alias(usb_hw)->phy_direct_override =
+        USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
+    // Switch from USB PHY to GPIO PHY, now with J forced
+    usb_hw->muxing = (USB_USB_MUXING_TO_DIGITAL_PAD_BITS
+                      | USB_USB_MUXING_SOFTCON_BITS);
+
+    // Wake up again in 1ms and put things back to normal
+    t->func = enumeration_fix_finish;
+    t->waketime = timer_read_time() + timer_from_us(1000);
+    return SF_RESCHEDULE;
+}
+
+static uint_fast8_t
+enumeration_fix_check(struct timer *t)
+{
+    // We might actually have connected meanwhile, if so we are done
+    if (usb_hw->sie_status & USB_SIE_STATUS_CONNECTED_BITS) {
+        return SF_DONE;
+    }
+
+    uint8_t line_state = ((usb_hw->sie_status & USB_SIE_STATUS_LINE_STATE_BITS)
+                          >> USB_SIE_STATUS_LINE_STATE_LSB);
+    // If we are still in SE0, try again later
+    if (line_state == 0) {
+        t->waketime = timer_read_time() + timer_from_us(1000);
+        return SF_RESCHEDULE;
+    }
+    return enumeration_fix_force_j(t);
+}
+
+static void
+enumeration_fix_begin(void)
+{
+    efs.timer.func = enumeration_fix_check;
+    efs.timer.waketime = timer_read_time() + timer_from_us(1000);
+    sched_add_timer(&efs.timer);
+}
 
 /****************************************************************
  * Setup and interrupts
@@ -184,6 +312,12 @@ USB_Handler(void)
                 set_address = 0;
             }
         }
+    }
+    if (ints & USB_INTS_BUS_RESET_BITS) {
+        hw_clear_alias(usb_hw)->sie_status = USB_SIE_STATUS_BUS_RESET_BITS;
+        set_address = 0;
+        usb_hw->dev_addr_ctrl = set_address;
+        enumeration_fix_begin();
     }
 }
 
@@ -224,7 +358,9 @@ usbserial_init(void)
 
     // Enable irqs
     usb_hw->sie_ctrl = USB_SIE_CTRL_EP0_INT_1BUF_BITS;
-    usb_hw->inte = USB_INTE_BUFF_STATUS_BITS | USB_INTE_SETUP_REQ_BITS;
+    usb_hw->inte = (USB_INTE_BUFF_STATUS_BITS
+                    | USB_INTE_SETUP_REQ_BITS
+                    | USB_INTE_BUS_RESET_BITS);
     armcm_enable_irq(USB_Handler, USBCTRL_IRQ_IRQn, 1);
 
     // Enable USB pullup


### PR DESCRIPTION
The rp2040 USB controller needs a forced J state after reset in order to go in to connected mode. This patch implements that.

The rp2040 datasheet better explains the issue, but in a nutshell the USB controller requires 800us of J-state(D+ high, D- low) to transition from RESET to CONNECTED. On a busy USB bus, e.g. on a single-TT hub with other 12Mbps USB devices, this might never happen. Using some internal debug logic we can force this to happen(as seen from the USB controller).

Both I and @Coffee0297 have had issues with this on setups with multiple Picos connected to the same Raspberry Pi or hub. In our testing this patch solves the issue.

The pico SDK implements this same fix in `rp2040_usb_device_enumeration.c`. The method used in this patch is a re-implementation of that fix to be compatible with the Klipper codebase.