### PR TITLE
Module: Toolhead, implements independent X-Y axis acceleration

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -93,6 +93,12 @@ max_velocity:
 max_accel:
 #   Maximum acceleration (in mm/s^2) of the toolhead (relative to the
 #   print). This parameter must be specified.
+max_accel_x:
+#   Maximum acceleration (in mm/s^2) of the toolhead in the direction
+#   of the X axis (relative to the print).  The default is max_accel.
+max_accel_y:
+#   Maximum acceleration (in mm/s^2) of the toolhead in the direction
+#   of the Y axis (relative to the print).  The default is max_accel.
 #max_accel_to_decel:
 #   A pseudo acceleration (in mm/s^2) controlling how fast the
 #   toolhead may go from acceleration to deceleration. It is used to

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -228,8 +228,10 @@ class ToolHead:
         # Velocity and acceleration control
         self.max_velocity = config.getfloat('max_velocity', above=0.)
         self.max_accel = config.getfloat('max_accel', above=0.)
-        self.max_accel_x = config.getfloat('max_accel_x', self.max_accel, above=0.)
-        self.max_accel_y = config.getfloat('max_accel_y', self.max_accel, above=0.)
+        self.max_accel_x = config.getfloat(
+            'max_accel_x', self.max_accel, above=0.)
+        self.max_accel_y = config.getfloat(
+            'max_accel_y', self.max_accel, above=0.)
 
         self.requested_accel_to_decel = config.getfloat(
             'max_accel_to_decel', self.max_accel * 0.5, above=0.)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -232,7 +232,6 @@ class ToolHead:
             'max_accel_x', self.max_accel, above=0.)
         self.max_accel_y = config.getfloat(
             'max_accel_y', self.max_accel, above=0.)
-
         self.requested_accel_to_decel = config.getfloat(
             'max_accel_to_decel', self.max_accel * 0.5, above=0.)
         self.max_accel_to_decel = self.requested_accel_to_decel


### PR DESCRIPTION
Adds the ability to allow for independent x-y axis acceleration.  This allows for bedslingers or printers with different resonance characteristics on the X and Y axis to further improve print quality/speed.

Signed-off-by: Jason Hamilton <jasonscotthamilton@gmail.com>