### PR TITLE
Change install scripts to use python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
 CPP=cpp
-PYTHON=python2
+PYTHON=python3
 
 # Source files
 src-y =

--- a/klippy/console.py
+++ b/klippy/console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Script to implement a test console with firmware over serial port
 #
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Main code for host side printer firmware
 #
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Script to handle build time requests embedded in C code.
 #
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -34,7 +34,7 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
 
     # Install/update dependencies
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt


### PR DESCRIPTION
With the merge of PR #3278 the goal is for Klipper to be able to run on Python3 or Python2.  This PR demonstrates how to convert the default installation scripts to use Python3.

This PR doesn't convert all of the available tools and scripts in the Klipper repository.  More work and testing would be required before switching them.

I do not have a timeframe for making this change.  At this time, this PR is mainly for demonstration purposes.

-Kevin