### PR TITLE
Updating Creality Ender-3 Y home coordinate to reflect real Y endstop

### DIFF
--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -29,7 +29,8 @@ enable_pin: !PD6
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PC3
-position_endstop: 0
+position_endstop: -10
+position_min: -10
 position_max: 235
 homing_speed: 50
 

--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -34,7 +34,8 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PA6
-position_endstop: 0
+position_endstop: -10
+position_min: -10
 position_max: 235
 homing_speed: 50
 


### PR DESCRIPTION
See Issue [4780](https://github.com/Klipper3d/klipper/issues/4780)

The Y endstop swtich hangs the hotend over (past) the print bed. A negative value in "position_endstop" will set the hotend on the edge of the print bed. You will need to add "position_min" with the same negative value to prevent a boundary error.

Setting the position_endstop to a negative value to reflect the real world Y endstop. Adding position_min to avoid boundary barfing.

