### PR TITLE
docs: Note "NTC 100k beta 3950" as not preferred

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -696,9 +696,9 @@ heater_pin:
 #   periods) to the heater. The default is 1.0.
 sensor_type:
 #   Type of sensor - common thermistors are "EPCOS 100K B57560G104F",
-#   "ATC Semitec 104GT-2", "NTC 100K beta 3950", "Honeywell 100K
-#   135-104LAG-J01", "NTC 100K MGB18-104F39050L32", "SliceEngineering
-#   450", and "TDK NTCG104LH104JT1". See the "Temperature sensors"
+#   "ATC Semitec 104GT-2", "Honeywell 100 K135-104LAG-J01",
+#   "NTC 100K MGB18-104F39050L32", "SliceEngineering 450",
+#   and "TDK NTCG104LH104JT1". See the "Temperature sensors"
 #   section for other sensors. This parameter must be provided.
 sensor_pin:
 #   Analog input pin connected to the sensor. This parameter must be
@@ -2053,9 +2053,9 @@ sections that use one of these sensors.
 ```
 sensor_type:
 #   One of "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2",
-#   "NTC 100K beta 3950", "Honeywell 100K 135-104LAG-J01",
-#   "NTC 100K MGB18-104F39050L32", "SliceEngineering 450", or
-#   "TDK NTCG104LH104JT1"
+#   "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
+#   "SliceEngineering 450", "TDK NTCG104LH104JT1", or "NTC 100K beta
+#   3950"(not preferred).
 sensor_pin:
 #   Analog input pin connected to the thermistor. This parameter must
 #   be provided.


### PR DESCRIPTION
docs: Note "NTC 100k beta 3950" as not preferred

As pointed out in issue #4054, the "NTC 100k beta 3950" sensor
type is not as accurate as "EPCOS 100K B57560G104F" for most
NTC 100k B3950 thermistors. The generic name and inclusion
next to other sensor types with more specific names, implies
that it would be a good default option.

To guide users away from this option, this PR removes it from
the [extruder] section, and lists it at the end of the options in
the "Common thermistors" section with "not preferred" in
parenthesis next to it.

Signed-off-by: Andrew Stowell <crashmaxx@gmail.com>