### PR TITLE
Fix diag pins for BTT Octopus

### DIFF
--- a/config/generic-bigtreetech-octopus.cfg
+++ b/config/generic-bigtreetech-octopus.cfg
@@ -208,7 +208,7 @@ max_z_accel: 100
 #[tmc2130 stepper_x]
 #cs_pin: PC4
 #spi_bus: spi1
-##diag1_pin: PB10
+##diag1_pin: PG6
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 999999
@@ -216,7 +216,7 @@ max_z_accel: 100
 #[tmc2130 stepper_y]
 #cs_pin: PD11
 #spi_bus: spi1
-##diag1_pin: PE12
+##diag1_pin: PG9
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 999999
@@ -224,7 +224,7 @@ max_z_accel: 100
 #[tmc2130 stepper_z]
 #cs_pin: PC6
 #spi_bus: spi1
-##diag1_pin: PG8
+##diag1_pin: PG10
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 999999
@@ -232,7 +232,7 @@ max_z_accel: 100
 #[tmc2130 stepper_]
 #cs_pin: PC7
 #spi_bus: spi1
-##diag1_pin: PE15
+##diag1_pin: PG11
 #run_current: 0.800
 #hold_current: 0.500
 #stealthchop_threshold: 999999


### PR DESCRIPTION
PB10 is definitely the Heater pin.
with reference from https://github.com/bigtreetech/BIGTREETECH-OCTOPUS-V1.0/blob/master/Hardware/BIGTREETECH%20Octopus.pdf the Diag 0 1 2 pins have been added

Signed-off-by: Arne Schwarck <arneschwarck@gmail.com>