### PR TITLE
Round reported temperatures to 2 decimal places

### DIFF
--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -464,7 +464,7 @@ class BME280:
 
     def get_status(self, eventtime):
         data = {
-            'temperature': self.temp,
+            'temperature': round(self.temp, 2),
             'pressure': self.pressure
         }
         if self.chip_type in ('BME280', 'BME680'):

--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -69,7 +69,7 @@ class DS18B20:
 
     def get_status(self, eventtime):
         return {
-            'temperature': self.temp,
+            'temperature': round(self.temp, 2),
         }
 
 def load_config(config):

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -133,7 +133,7 @@ class Heater:
             target_temp = self.target_temp
             smoothed_temp = self.smoothed_temp
             last_pwm_value = self.last_pwm_value
-        return {'temperature': smoothed_temp, 'target': target_temp,
+        return {'temperature': round(smoothed_temp, 2), 'target': target_temp,
                 'power': last_pwm_value}
     cmd_SET_HEATER_TEMPERATURE_help = "Sets a heater temperature"
     def cmd_SET_HEATER_TEMPERATURE(self, gcmd):

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -236,7 +236,7 @@ class HTU21D:
 
     def get_status(self, eventtime):
         return {
-            'temperature': self.temp,
+            'temperature': round(self.temp, 2),
             'humidity': self.humidity,
         }
 

--- a/klippy/extras/lm75.py
+++ b/klippy/extras/lm75.py
@@ -98,7 +98,7 @@ class LM75:
 
     def get_status(self, eventtime):
         return {
-            'temperature': self.temp,
+            'temperature': round(self.temp, 2),
         }
 
 

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -75,7 +75,7 @@ class Temperature_HOST:
 
     def get_status(self, eventtime):
         return {
-            'temperature': self.temp,
+            'temperature': round(self.temp, 2),
         }
 
 

--- a/klippy/extras/temperature_sensor.py
+++ b/klippy/extras/temperature_sensor.py
@@ -33,9 +33,9 @@ class PrinterSensorGeneric:
         return False, '%s: temp=%.1f' % (self.name, self.last_temp)
     def get_status(self, eventtime):
         return {
-            'temperature': self.last_temp,
-            'measured_min_temp': self.measured_min,
-            'measured_max_temp': self.measured_max
+            'temperature': round(self.last_temp, 2),
+            'measured_min_temp': round(self.measured_min, 2),
+            'measured_max_temp': round(self.measured_max, 2)
         }
 
 def load_config_prefix(config):


### PR DESCRIPTION
This PR rounds temperatures reported by `get_status()` for the various sensors, as the additional precision is unnecessary.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>