### PR TITLE
Add MAX_SLOPE capability to TEMPERATURE_WAIT

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -161,6 +161,9 @@ The following standard commands are supported:
 - `TEMPERATURE_WAIT SENSOR=<config_name> [MINIMUM=<target>] [MAXIMUM=<target>]`:
   Wait until the given temperature sensor is at or above the supplied
   MINIMUM and/or at or below the supplied MAXIMUM.
+    - `MAX_SLOPE=<target>` Wait until the given temperature sensor's rate of
+    temperature change is at or below the supplied `MAX_SLOPE` in degrees per
+    minute.
 - `SET_VELOCITY_LIMIT [VELOCITY=<value>] [ACCEL=<value>]
   [ACCEL_TO_DECEL=<value>] [SQUARE_CORNER_VELOCITY=<value>]`: Modify
   the printer's velocity limits.


### PR DESCRIPTION
TEMPERATURE_WAIT updated to support an optional MAX_SLOPE argument that allows a wait for the rate of change of temp to drop below that value.

To support this, both Heaters and PrinterSensorGeneric need a common way to provide the temperature slope to TEMPERATURE_WAIT. The code to do this was already in various places in Heaters.py. A new TemperatureSensorAdapter consolidates this functionality. This is used in both Heater and PrinterSensorGeneric so they now all have a known temperature slope which TEMPERATURE_WAIT can access via the adapter. This removes corresponding functionality from Heater and the control algorithms

Signed-off-by: Gareth Farrington <gareth@waves.ky>

This is an update for https://github.com/Klipper3d/klipper/pull/4273. I'm sorry I didn't have time to make the requested updates until now. Hopefully this version is closer to what you had in mind. It includes all of the changes you requested and tries to stay away from any unnecessary edits or changes to how Heaters or temperature sensors work now.