### PR TITLE
Added "allow-releaseinfo-change" configuration to docs/Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -31,6 +31,7 @@ is "raspberry") and run the following commands:
 
 ```
 git clone https://github.com/Klipper3d/klipper
+sudo apt update --allow-releaseinfo-change
 ./klipper/scripts/install-octopi.sh
 ```
 


### PR DESCRIPTION
When installing Klipper using this installation guide and running the command "./klipper/scripts/install-octopi.sh" I was getting the following error message and the script failed to complete. Using "sudo apt update --allow-releaseinfo-change" first resolved this issue.

###### Running apt-get update...
Hit:1 http://archive.raspberrypi.org/debian buster InRelease
Get:2 http://raspbian.raspberrypi.org/raspbian buster InRelease [15.0 kB]
Reading package lists... Done
E: Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.