### PR TITLE
manual_probe: Add X and Y ENDSTOP_CALIBRATE helpers

### DIFF
--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -164,11 +164,12 @@ class ManualProbeHelper:
 
     def move_axis(self, axis_pos):
         curpos = self.toolhead.get_position()
+        non_move = [None, None, None]
         try:
             axis_bob_pos = axis_pos + AXIS_BOB_MINIMUM
             if curpos[self.axis] < axis_bob_pos:
-                self.toolhead.manual_move([None, None, axis_bob_pos], self.speed)
-            self.toolhead.manual_move([None, None, axis_pos], self.speed)
+                self.toolhead.manual_move(non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], self.speed)
+            self.toolhead.manual_move(non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], self.speed)
         except self.printer.command_error as e:
             self.finalize(False)
             raise

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -1,4 +1,4 @@
-# Helper script for manual z height probing
+# Helper script for manual axis height probing
 #
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
@@ -13,10 +13,36 @@ class ManualProbe:
         self.gcode_move = self.printer.load_object(config, "gcode_move")
         self.gcode.register_command('MANUAL_PROBE', self.cmd_MANUAL_PROBE,
                                     desc=self.cmd_MANUAL_PROBE_help)
+                                    
+        xconfig = config.getsection('stepper_x')
+        yconfig = config.getsection('stepper_y')
         zconfig = config.getsection('stepper_z')
-        self.z_position_endstop = zconfig.getfloat('position_endstop', None,
-                                                   note_valid=False)
-        if self.z_position_endstop is not None:
+
+        self.endstop_positions = [
+            xconfig.getfloat('position_endstop', None, note_valid=False),
+            yconfig.getfloat('position_endstop', None, note_valid=False),
+            zconfig.getfloat('position_endstop', None, note_valid=False)
+        ]
+
+        if self.endstop_positions[0] is not None:
+            self.gcode.register_command(
+                'X_ENDSTOP_CALIBRATE', self.cmd_X_ENDSTOP_CALIBRATE,
+                desc=self.cmd_X_ENDSTOP_CALIBRATE_help)
+            self.gcode.register_command(
+                'X_OFFSET_APPLY_ENDSTOP',
+                self.cmd_X_OFFSET_APPLY_ENDSTOP,
+                desc=self.cmd_X_OFFSET_APPLY_ENDSTOP_help)
+                                    
+        if self.endstop_positions[1] is not None:
+            self.gcode.register_command(
+                'Y_ENDSTOP_CALIBRATE', self.cmd_Y_ENDSTOP_CALIBRATE,
+                desc=self.cmd_Y_ENDSTOP_CALIBRATE_help)
+            self.gcode.register_command(
+                'Y_OFFSET_APPLY_ENDSTOP',
+                self.cmd_Y_OFFSET_APPLY_ENDSTOP,
+                desc=self.cmd_Y_OFFSET_APPLY_ENDSTOP_help)
+                                    
+        if self.endstop_positions[2] is not None:
             self.gcode.register_command(
                 'Z_ENDSTOP_CALIBRATE', self.cmd_Z_ENDSTOP_CALIBRATE,
                 desc=self.cmd_Z_ENDSTOP_CALIBRATE_help)
@@ -24,39 +50,64 @@ class ManualProbe:
                 'Z_OFFSET_APPLY_ENDSTOP',
                 self.cmd_Z_OFFSET_APPLY_ENDSTOP,
                 desc=self.cmd_Z_OFFSET_APPLY_ENDSTOP_help)
-    def manual_probe_finalize(self, kin_pos):
+
+    def manual_probe_finalize(self, kin_pos, axis, axis_label):
         if kin_pos is not None:
-            self.gcode.respond_info("Z position is %.3f" % (kin_pos[2],))
+            self.gcode.respond_info("%s position is %.3f" % (axis_label, kin_pos[axis],))
+
     cmd_MANUAL_PROBE_help = "Start manual probe helper script"
     def cmd_MANUAL_PROBE(self, gcmd):
-        ManualProbeHelper(self.printer, gcmd, self.manual_probe_finalize)
-    def z_endstop_finalize(self, kin_pos):
+        ManualProbeHelper(self.printer, gcmd, 2, self.manual_probe_finalize)
+
+    def endstop_finalize(self, kin_pos, axis, axis_label):
         if kin_pos is None:
             return
-        z_pos = self.z_position_endstop - kin_pos[2]
+        pos = self.endstop_positions[axis] - kin_pos[axis]
         self.gcode.respond_info(
-            "stepper_z: position_endstop: %.3f\n"
+            "stepper_%s: position_endstop: %.3f\n"
             "The SAVE_CONFIG command will update the printer config file\n"
-            "with the above and restart the printer." % (z_pos,))
+            "with the above and restart the printer." % (axis_label, pos,))
         configfile = self.printer.lookup_object('configfile')
-        configfile.set('stepper_z', 'position_endstop', "%.3f" % (z_pos,))
-    cmd_Z_ENDSTOP_CALIBRATE_help = "Calibrate a Z endstop"
-    def cmd_Z_ENDSTOP_CALIBRATE(self, gcmd):
-        ManualProbeHelper(self.printer, gcmd, self.z_endstop_finalize)
-    def cmd_Z_OFFSET_APPLY_ENDSTOP(self,gcmd):
-        offset = self.gcode_move.get_status()['homing_origin'].z
+        configfile.set('stepper_'+axis_label, 'position_endstop', "%.3f" % (pos,))
+
+    def offset_apply_endstop(self, gcmd, axis, axis_label):
+        offset = self.gcode_move.get_status()['homing_origin'][axis]
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
-            self.gcode.respond_info("Nothing to do: Z Offset is 0")
+            self.gcode.respond_info("Nothing to do: %s Offset is 0" % (axis_label))
         else:
             new_calibrate = self.z_position_endstop - offset
             self.gcode.respond_info(
-                "stepper_z: position_endstop: %.3f\n"
+                "stepper_%s: position_endstop: %.3f\n"
                 "The SAVE_CONFIG command will update the printer config file\n"
-                "with the above and restart the printer." % (new_calibrate))
-            configfile.set('stepper_z', 'position_endstop',
+                "with the above and restart the printer." % (axis_label, new_calibrate))
+            configfile.set('stepper_'+axis_label, 'position_endstop',
                 "%.3f" % (new_calibrate,))
+
+
+    cmd_X_ENDSTOP_CALIBRATE_help = "Calibrate an x endstop"
+    def cmd_X_ENDSTOP_CALIBRATE(self, gcmd):
+        ManualProbeHelper(self.printer, gcmd, 0, self.endstop_finalize)
+
+    cmd_X_OFFSET_APPLY_ENDSTOP_help = "Adjust the x endstop_position"
+    def cmd_X_OFFSET_APPLY_ENDSTOP(self,gcmd):
+        self.offset_apply_endstop(gcmd, 0, 'x')
+
+    cmd_Y_ENDSTOP_CALIBRATE_help = "Calibrate a y endstop"
+    def cmd_Y_ENDSTOP_CALIBRATE(self, gcmd):
+        ManualProbeHelper(self.printer, gcmd, 1, self.endstop_finalize)
+
+    cmd_Y_OFFSET_APPLY_ENDSTOP_help = "Adjust the y endstop_position"
+    def cmd_Y_OFFSET_APPLY_ENDSTOP(self,gcmd):
+        self.offset_apply_endstop(gcmd, 1, 'y')
+
+    cmd_Z_ENDSTOP_CALIBRATE_help = "Calibrate a z endstop"
+    def cmd_Z_ENDSTOP_CALIBRATE(self, gcmd):
+        ManualProbeHelper(self.printer, gcmd, 2, self.endstop_finalize)
+
     cmd_Z_OFFSET_APPLY_ENDSTOP_help = "Adjust the z endstop_position"
+    def cmd_Z_OFFSET_APPLY_ENDSTOP(self,gcmd):
+        self.offset_apply_endstop(gcmd, 2, 'z')
 
 # Verify that a manual probe isn't already in progress
 def verify_no_manual_probe(printer):
@@ -65,15 +116,15 @@ def verify_no_manual_probe(printer):
         gcode.register_command('ACCEPT', 'dummy')
     except printer.config_error as e:
         raise gcode.error(
-            "Already in a manual Z probe. Use ABORT to abort it.")
+            "Already in a manual probe. Use ABORT to abort it.")
     gcode.register_command('ACCEPT', None)
 
-Z_BOB_MINIMUM = 0.500
+AXIS_BOB_MINIMUM = 0.500
 BISECT_MAX = 0.200
 
-# Helper script to determine a Z height
+# Helper script to determine an axis height
 class ManualProbeHelper:
-    def __init__(self, printer, gcmd, finalize_callback):
+    def __init__(self, printer, gcmd, axis, finalize_callback):
         self.printer = printer
         self.finalize_callback = finalize_callback
         self.gcode = self.printer.lookup_object('gcode')
@@ -81,6 +132,8 @@ class ManualProbeHelper:
         self.speed = gcmd.get_float("SPEED", 5.)
         self.past_positions = []
         self.last_toolhead_pos = self.last_kinematics_pos = None
+        self.axis = axis
+        self.axis_label = ['X', 'Y', 'Z'][self.axis]
         # Register commands
         verify_no_manual_probe(printer)
         self.gcode.register_command('ACCEPT', self.cmd_ACCEPT,
@@ -88,13 +141,14 @@ class ManualProbeHelper:
         self.gcode.register_command('NEXT', self.cmd_ACCEPT)
         self.gcode.register_command('ABORT', self.cmd_ABORT,
                                     desc=self.cmd_ABORT_help)
-        self.gcode.register_command('TESTZ', self.cmd_TESTZ,
-                                    desc=self.cmd_TESTZ_help)
+        self.gcode.register_command('TEST'+self.axis_label, self.cmd_TEST_AXIS,
+                                    desc=self.cmd_TEST_AXIS_help)
         self.gcode.respond_info(
             "Starting manual Z probe. Use TESTZ to adjust position.\n"
             "Finish with ACCEPT or ABORT command.")
         self.start_position = self.toolhead.get_position()
-        self.report_z_status()
+        self.report_axis_status()
+
     def get_kinematics_pos(self):
         toolhead_pos = self.toolhead.get_position()
         if toolhead_pos == self.last_toolhead_pos:
@@ -107,28 +161,30 @@ class ManualProbeHelper:
         self.last_toolhead_pos = toolhead_pos
         self.last_kinematics_pos = kin_pos
         return kin_pos
-    def move_z(self, z_pos):
+
+    def move_axis(self, axis_pos):
         curpos = self.toolhead.get_position()
         try:
-            z_bob_pos = z_pos + Z_BOB_MINIMUM
-            if curpos[2] < z_bob_pos:
-                self.toolhead.manual_move([None, None, z_bob_pos], self.speed)
-            self.toolhead.manual_move([None, None, z_pos], self.speed)
+            axis_bob_pos = axis_pos + AXIS_BOB_MINIMUM
+            if curpos[self.axis] < axis_bob_pos:
+                self.toolhead.manual_move([None, None, axis_bob_pos], self.speed)
+            self.toolhead.manual_move([None, None, axis_pos], self.speed)
         except self.printer.command_error as e:
             self.finalize(False)
             raise
-    def report_z_status(self, warn_no_change=False, prev_pos=None):
+
+    def report_axis_status(self, warn_no_change=False, prev_pos=None):
         # Get position
         kin_pos = self.get_kinematics_pos()
-        z_pos = kin_pos[2]
-        if warn_no_change and z_pos == prev_pos:
+        axis_pos = kin_pos[self.axis]
+        if warn_no_change and axis_pos == prev_pos:
             self.gcode.respond_info(
                 "WARNING: No change in position (reached stepper resolution)")
         # Find recent positions that were tested
         pp = self.past_positions
-        next_pos = bisect.bisect_left(pp, z_pos)
+        next_pos = bisect.bisect_left(pp, axis_pos)
         prev_pos = next_pos - 1
-        if next_pos < len(pp) and pp[next_pos] == z_pos:
+        if next_pos < len(pp) and pp[next_pos] == axis_pos:
             next_pos += 1
         prev_str = next_str = "??????"
         if prev_pos >= 0:
@@ -136,61 +192,65 @@ class ManualProbeHelper:
         if next_pos < len(pp):
             next_str = "%.3f" % (pp[next_pos],)
         # Find recent positions
-        self.gcode.respond_info("Z position: %s --> %.3f <-- %s"
-                                % (prev_str, z_pos, next_str))
-    cmd_ACCEPT_help = "Accept the current Z position"
+        self.gcode.respond_info("%s position: %s --> %.3f <-- %s"
+                                % (self.axis_label, prev_str, axis_pos, next_str))
+
+    cmd_ACCEPT_help = "Accept the current position"
     def cmd_ACCEPT(self, gcmd):
         pos = self.toolhead.get_position()
         start_pos = self.start_position
-        if pos[:2] != start_pos[:2] or pos[2] >= start_pos[2]:
+        if pos[:self.axis]+pos[self.axis+1:] != start_pos[:self.axis]+start_pos[self.axis+1:] or pos[self.axis] >= start_pos[self.axis]:
             gcmd.respond_info(
-                "Manual probe failed! Use TESTZ commands to position the\n"
+                f"Manual probe failed! Use TEST{self.axis_label} commands to position the\n"
                 "nozzle prior to running ACCEPT.")
             self.finalize(False)
             return
         self.finalize(True)
-    cmd_ABORT_help = "Abort manual Z probing tool"
+
+    cmd_ABORT_help = "Abort manual probing tool"
     def cmd_ABORT(self, gcmd):
         self.finalize(False)
-    cmd_TESTZ_help = "Move to new Z height"
-    def cmd_TESTZ(self, gcmd):
+
+    cmd_TEST_AXIS_help = "Move to new location"
+    def cmd_TEST_AXIS(self, gcmd):
         # Store current position for later reference
         kin_pos = self.get_kinematics_pos()
-        z_pos = kin_pos[2]
+        axis_pos = kin_pos[self.axis]
         pp = self.past_positions
-        insert_pos = bisect.bisect_left(pp, z_pos)
-        if insert_pos >= len(pp) or pp[insert_pos] != z_pos:
-            pp.insert(insert_pos, z_pos)
+        insert_pos = bisect.bisect_left(pp, axis_pos)
+        if insert_pos >= len(pp) or pp[insert_pos] != axis_pos:
+            pp.insert(insert_pos, axis_pos)
         # Determine next position to move to
-        req = gcmd.get("Z")
+        req = gcmd.get(self.axis_label)
         if req in ('+', '++'):
-            check_z = 9999999999999.9
+            check_axis = 9999999999999.9
             if insert_pos < len(self.past_positions) - 1:
-                check_z = self.past_positions[insert_pos + 1]
+                check_axis = self.past_positions[insert_pos + 1]
             if req == '+':
-                check_z = (check_z + z_pos) / 2.
-            next_z_pos = min(check_z, z_pos + BISECT_MAX)
+                check_axis = (check_axis + axis_pos) / 2.
+            next_z_pos = min(check_axis, axis_pos + BISECT_MAX)
         elif req in ('-', '--'):
-            check_z = -9999999999999.9
+            check_axis = -9999999999999.9
             if insert_pos > 0:
-                check_z = self.past_positions[insert_pos - 1]
+                check_axis = self.past_positions[insert_pos - 1]
             if req == '-':
-                check_z = (check_z + z_pos) / 2.
-            next_z_pos = max(check_z, z_pos - BISECT_MAX)
+                check_axis = (check_axis + axis_pos) / 2.
+            next_axis_pos = max(check_axis, axis_pos - BISECT_MAX)
         else:
-            next_z_pos = z_pos + gcmd.get_float("Z")
+            next_axis_pos = axis_pos + gcmd.get_float(self.axis_label)
         # Move to given position and report it
-        self.move_z(next_z_pos)
-        self.report_z_status(next_z_pos != z_pos, z_pos)
+        self.move_axis(next_axis_pos)
+        self.report_axis_status(next_axis_pos != axis_pos, axis_pos)
+
     def finalize(self, success):
         self.gcode.register_command('ACCEPT', None)
         self.gcode.register_command('NEXT', None)
         self.gcode.register_command('ABORT', None)
-        self.gcode.register_command('TESTZ', None)
+        self.gcode.register_command('TEST'+self.axis_label, None)
         kin_pos = None
         if success:
             kin_pos = self.get_kinematics_pos()
-        self.finalize_callback(kin_pos)
+        self.finalize_callback(kin_pos, self.axis, self.axis_label)
 
 def load_config(config):
     return ManualProbe(config)

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -13,7 +13,7 @@ class ManualProbe:
         self.gcode_move = self.printer.load_object(config, "gcode_move")
         self.gcode.register_command('MANUAL_PROBE', self.cmd_MANUAL_PROBE,
                                     desc=self.cmd_MANUAL_PROBE_help)
-                                    
+
         xconfig = config.getsection('stepper_x')
         yconfig = config.getsection('stepper_y')
         zconfig = config.getsection('stepper_z')
@@ -32,7 +32,7 @@ class ManualProbe:
                 'X_OFFSET_APPLY_ENDSTOP',
                 self.cmd_X_OFFSET_APPLY_ENDSTOP,
                 desc=self.cmd_X_OFFSET_APPLY_ENDSTOP_help)
-                                    
+
         if self.endstop_positions[1] is not None:
             self.gcode.register_command(
                 'Y_ENDSTOP_CALIBRATE', self.cmd_Y_ENDSTOP_CALIBRATE,
@@ -41,7 +41,7 @@ class ManualProbe:
                 'Y_OFFSET_APPLY_ENDSTOP',
                 self.cmd_Y_OFFSET_APPLY_ENDSTOP,
                 desc=self.cmd_Y_OFFSET_APPLY_ENDSTOP_help)
-                                    
+
         if self.endstop_positions[2] is not None:
             self.gcode.register_command(
                 'Z_ENDSTOP_CALIBRATE', self.cmd_Z_ENDSTOP_CALIBRATE,
@@ -53,7 +53,8 @@ class ManualProbe:
 
     def manual_probe_finalize(self, kin_pos, axis, axis_label):
         if kin_pos is not None:
-            self.gcode.respond_info("%s position is %.3f" % (axis_label, kin_pos[axis],))
+            self.gcode.respond_info("%s position is %.3f" 
+                % (axis_label, kin_pos[axis],))
 
     cmd_MANUAL_PROBE_help = "Start manual probe helper script"
     def cmd_MANUAL_PROBE(self, gcmd):
@@ -68,19 +69,22 @@ class ManualProbe:
             "The SAVE_CONFIG command will update the printer config file\n"
             "with the above and restart the printer." % (axis_label, pos,))
         configfile = self.printer.lookup_object('configfile')
-        configfile.set('stepper_'+axis_label, 'position_endstop', "%.3f" % (pos,))
+        configfile.set('stepper_'+axis_label, 'position_endstop', 
+            "%.3f" % (pos,))
 
     def offset_apply_endstop(self, gcmd, axis, axis_label):
         offset = self.gcode_move.get_status()['homing_origin'][axis]
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
-            self.gcode.respond_info("Nothing to do: %s Offset is 0" % (axis_label))
+            self.gcode.respond_info("Nothing to do: %s Offset is 0" 
+                % (axis_label))
         else:
             new_calibrate = self.z_position_endstop - offset
             self.gcode.respond_info(
                 "stepper_%s: position_endstop: %.3f\n"
                 "The SAVE_CONFIG command will update the printer config file\n"
-                "with the above and restart the printer." % (axis_label, new_calibrate))
+                "with the above and restart the printer." 
+                % (axis_label, new_calibrate))
             configfile.set('stepper_'+axis_label, 'position_endstop',
                 "%.3f" % (new_calibrate,))
 
@@ -144,8 +148,9 @@ class ManualProbeHelper:
         self.gcode.register_command('TEST'+self.axis_label, self.cmd_TEST_AXIS,
                                     desc=self.cmd_TEST_AXIS_help)
         self.gcode.respond_info(
-            "Starting manual "+self.axis_label+" probe. Use TEST"+self.axis_label+" to adjust position.\n"
-            "Finish with ACCEPT or ABORT command.")
+            "Starting manual %s probe. Use TEST%s to adjust position.\n"
+            "Finish with ACCEPT or ABORT command." 
+            % (self.axis_label, self.axis_label))
         self.start_position = self.toolhead.get_position()
         self.report_axis_status()
 
@@ -168,8 +173,12 @@ class ManualProbeHelper:
         try:
             axis_bob_pos = axis_pos + AXIS_BOB_MINIMUM
             if curpos[self.axis] < axis_bob_pos:
-                self.toolhead.manual_move(non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], self.speed)
-            self.toolhead.manual_move(non_move[:self.axis]+[axis_pos]+non_move[self.axis+1:], self.speed)
+                self.toolhead.manual_move(
+                    non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], 
+                    self.speed)
+            self.toolhead.manual_move(
+                non_move[:self.axis]+[axis_pos]+non_move[self.axis+1:], 
+                self.speed)
         except self.printer.command_error as e:
             self.finalize(False)
             raise
@@ -194,16 +203,18 @@ class ManualProbeHelper:
             next_str = "%.3f" % (pp[next_pos],)
         # Find recent positions
         self.gcode.respond_info("%s position: %s --> %.3f <-- %s"
-                                % (self.axis_label, prev_str, axis_pos, next_str))
+            % (self.axis_label, prev_str, axis_pos, next_str))
 
     cmd_ACCEPT_help = "Accept the current position"
     def cmd_ACCEPT(self, gcmd):
         pos = self.toolhead.get_position()
         start_pos = self.start_position
-        if pos[:self.axis]+pos[self.axis+1:] != start_pos[:self.axis]+start_pos[self.axis+1:] or pos[self.axis] >= start_pos[self.axis]:
+        if pos[:self.axis]+pos[self.axis+1:] != \
+                start_pos[:self.axis]+start_pos[self.axis+1:]
+            or pos[self.axis] >= start_pos[self.axis]:
             gcmd.respond_info(
-                "Manual probe failed! Use TEST"+self.axis_label+" commands to position the\n"
-                "nozzle prior to running ACCEPT.")
+                "Manual probe failed! Use TEST%s commands to position the\n"
+                "nozzle prior to running ACCEPT." % (self.axis_label))
             self.finalize(False)
             return
         self.finalize(True)

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -53,7 +53,7 @@ class ManualProbe:
 
     def manual_probe_finalize(self, kin_pos, axis, axis_label):
         if kin_pos is not None:
-            self.gcode.respond_info("%s position is %.3f" 
+            self.gcode.respond_info("%s position is %.3f"
                 % (axis_label, kin_pos[axis],))
 
     cmd_MANUAL_PROBE_help = "Start manual probe helper script"
@@ -69,21 +69,21 @@ class ManualProbe:
             "The SAVE_CONFIG command will update the printer config file\n"
             "with the above and restart the printer." % (axis_label, pos,))
         configfile = self.printer.lookup_object('configfile')
-        configfile.set('stepper_'+axis_label, 'position_endstop', 
+        configfile.set('stepper_'+axis_label, 'position_endstop',
             "%.3f" % (pos,))
 
     def offset_apply_endstop(self, gcmd, axis, axis_label):
         offset = self.gcode_move.get_status()['homing_origin'][axis]
         configfile = self.printer.lookup_object('configfile')
         if offset == 0:
-            self.gcode.respond_info("Nothing to do: %s Offset is 0" 
+            self.gcode.respond_info("Nothing to do: %s Offset is 0"
                 % (axis_label))
         else:
             new_calibrate = self.z_position_endstop - offset
             self.gcode.respond_info(
                 "stepper_%s: position_endstop: %.3f\n"
                 "The SAVE_CONFIG command will update the printer config file\n"
-                "with the above and restart the printer." 
+                "with the above and restart the printer."
                 % (axis_label, new_calibrate))
             configfile.set('stepper_'+axis_label, 'position_endstop',
                 "%.3f" % (new_calibrate,))
@@ -149,7 +149,7 @@ class ManualProbeHelper:
                                     desc=self.cmd_TEST_AXIS_help)
         self.gcode.respond_info(
             "Starting manual %s probe. Use TEST%s to adjust position.\n"
-            "Finish with ACCEPT or ABORT command." 
+            "Finish with ACCEPT or ABORT command."
             % (self.axis_label, self.axis_label))
         self.start_position = self.toolhead.get_position()
         self.report_axis_status()
@@ -174,10 +174,10 @@ class ManualProbeHelper:
             axis_bob_pos = axis_pos + AXIS_BOB_MINIMUM
             if curpos[self.axis] < axis_bob_pos:
                 self.toolhead.manual_move(
-                    non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], 
+                    non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:],
                     self.speed)
             self.toolhead.manual_move(
-                non_move[:self.axis]+[axis_pos]+non_move[self.axis+1:], 
+                non_move[:self.axis]+[axis_pos]+non_move[self.axis+1:],
                 self.speed)
         except self.printer.command_error as e:
             self.finalize(False)

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -144,7 +144,7 @@ class ManualProbeHelper:
         self.gcode.register_command('TEST'+self.axis_label, self.cmd_TEST_AXIS,
                                     desc=self.cmd_TEST_AXIS_help)
         self.gcode.respond_info(
-            "Starting manual Z probe. Use TESTZ to adjust position.\n"
+            "Starting manual "+self.axis_label+" probe. Use TEST"+self.axis_label+" to adjust position.\n"
             "Finish with ACCEPT or ABORT command.")
         self.start_position = self.toolhead.get_position()
         self.report_axis_status()
@@ -228,7 +228,7 @@ class ManualProbeHelper:
                 check_axis = self.past_positions[insert_pos + 1]
             if req == '+':
                 check_axis = (check_axis + axis_pos) / 2.
-            next_z_pos = min(check_axis, axis_pos + BISECT_MAX)
+            next_axis_pos = min(check_axis, axis_pos + BISECT_MAX)
         elif req in ('-', '--'):
             check_axis = -9999999999999.9
             if insert_pos > 0:

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -210,7 +210,7 @@ class ManualProbeHelper:
         pos = self.toolhead.get_position()
         start_pos = self.start_position
         if pos[:self.axis]+pos[self.axis+1:] != \
-                start_pos[:self.axis]+start_pos[self.axis+1:]
+                start_pos[:self.axis]+start_pos[self.axis+1:] \
             or pos[self.axis] >= start_pos[self.axis]:
             gcmd.respond_info(
                 "Manual probe failed! Use TEST%s commands to position the\n"

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -169,7 +169,7 @@ class ManualProbeHelper:
             axis_bob_pos = axis_pos + AXIS_BOB_MINIMUM
             if curpos[self.axis] < axis_bob_pos:
                 self.toolhead.manual_move(non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], self.speed)
-            self.toolhead.manual_move(non_move[:self.axis]+[axis_bob_pos]+non_move[self.axis+1:], self.speed)
+            self.toolhead.manual_move(non_move[:self.axis]+[axis_pos]+non_move[self.axis+1:], self.speed)
         except self.printer.command_error as e:
             self.finalize(False)
             raise

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -201,7 +201,7 @@ class ManualProbeHelper:
         start_pos = self.start_position
         if pos[:self.axis]+pos[self.axis+1:] != start_pos[:self.axis]+start_pos[self.axis+1:] or pos[self.axis] >= start_pos[self.axis]:
             gcmd.respond_info(
-                f"Manual probe failed! Use TEST{self.axis_label} commands to position the\n"
+                "Manual probe failed! Use TEST"+self.axis_label+" commands to position the\n"
                 "nozzle prior to running ACCEPT.")
             self.finalize(False)
             return


### PR DESCRIPTION
While the Z_ENDSTOP_CALIBRATE functionality is super useful for most printers, it doesn't assist at all in leveling infinite-z machines like the Creality CR-30, where the Y-axis determines closeness to the bed. 

To that end, I've modified the ManualProbeHelper in manual_probe.py to allow for an axis argument, and added X and Y ENDSTOP_CALIBRATE and OFFSET_APPLY gcode commands, allowing all three axes to be calibrated in this way. 