### PR TITLE
docs:  List/Table/Title Indentation Correction

### DIFF
--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -5,6 +5,7 @@ This document describes Filament Width Sensor host module. Hardware used for dev
 [Hall based filament width sensor assembly video](https://www.youtube.com/watch?v=TDO9tME8vp4)
 
 ## How does it work?
+
 Sensor generates two analog output based on calculated filament width. Sum of output voltage always equals to detected filament width . Host module monitors voltage changes and adjusts extrusion multiplier. I use aux2 connector on ramps-like board analog11 and analog12 pins. You can use different pins and differenr boards
 
 ## Configuration
@@ -71,6 +72,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 
 
 ## Commands
+
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 
 **RESET_FILAMENT_WIDTH_SENSOR** вЂ“ Clear all sensor readings. Can be used after filament change.
@@ -107,6 +109,7 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
     index: 1
 
 ## Calibration procedure
+
 Insert first  calibration rod (1.5 mm size) get first  raw sensor value
 
 To get raw sensor value you can use menu item or  **QUERY_RAW_FILAMENT_WIDTH** command in terminal
@@ -116,9 +119,11 @@ Insert second calibration rod (2.0 mm size) get second raw sensor value
 Save raw values in config
 
 ## How to enable sensor
+
 After power on by default sensor disabled.
 Enable sensor in start g-code by command **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config
 
 ## Logging
+
 After power on by default diameter Logging disabled.
 Data to log added on every measurement interval (10 mm by default)

--- a/docs/HallFilamentWidthSensor.md
+++ b/docs/HallFilamentWidthSensor.md
@@ -1,6 +1,6 @@
 # Hall filament width sensor
 
-This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on Two Hall liniar sensors (ss49e for example). Sensors in the body are located opposite sides.  Principle of operation : two hall sensors work in differential mode, temperature drift same for sensor. Special temperature compensation not needed. You can find designs at [thingiverse.com](https://www.thingiverse.com/thing:4138933)
+This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on Two Hall liniar sensors (ss49e for example). Sensors in the body are located opposite sides. Principle of operation : two hall sensors work in differential mode, temperature drift same for sensor. Special temperature compensation not needed. You can find designs at [Thingiverse](https://www.thingiverse.com/thing:4138933)
 
 [Hall based filament width sensor assembly video](https://www.youtube.com/watch?v=TDO9tME8vp4)
 
@@ -10,74 +10,75 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 
 ## Configuration
 
-    [hall_filament_width_sensor]
+```
+[hall_filament_width_sensor]
 
-    adc1: analog11
-    adc2: analog12
-    # adc1 and adc2 channels select own pins Analog input pins on 3d printer board
-    # Sensor power supply can be 3.3v or 5v
+adc1: analog11
+adc2: analog12
+# adc1 and adc2 channels select own pins Analog input pins on 3d printer board
+# Sensor power supply can be 3.3v or 5v
 
-    Cal_dia1: 1.50 # Reference diameter point 1 (mm)
-    Cal_dia2: 2.00 # Reference diameter point 2 (mm)
+Cal_dia1: 1.50 # Reference diameter point 1 (mm)
+Cal_dia2: 2.00 # Reference diameter point 2 (mm)
 
-    # The measurement principle provides for two-point calibration
-    # In calibration process you must use rods of known diameter
-    # I use drill rods as the base diameter.
-    # nominal filament diameter must be between Cal_dia1 and Cal_dia2
-    # Your size may differ from the indicated ones, for example 2.05
+# The measurement principle provides for two-point calibration
+# In calibration process you must use rods of known diameter
+# I use drill rods as the base diameter.
+# nominal filament diameter must be between Cal_dia1 and Cal_dia2
+# Your size may differ from the indicated ones, for example 2.05
 
-    Raw_dia1:10630 # Raw sensor value for reference point 1
-    Raw_dia2:8300  # Raw sensor value for reference point 2
+Raw_dia1:10630 # Raw sensor value for reference point 1
+Raw_dia2:8300  # Raw sensor value for reference point 2
 
-    # Raw value of sensor in units
-    # can be readed by command QUERY_RAW_FILAMENT_WIDTH
+# Raw value of sensor in units
+# can be readed by command QUERY_RAW_FILAMENT_WIDTH
 
-    default_nominal_filament_diameter: 1.75 # This parameter is in millimeters (mm)
+default_nominal_filament_diameter: 1.75 # This parameter is in millimeters (mm)
 
-    max_difference: 0.15
-    # Maximum allowed filament diameter difference in millimeters (mm)
-    # If difference between nominal filament diameter and sensor output is more
-    # than +- max_difference, extrusion multiplier set back to %100
+max_difference: 0.15
+# Maximum allowed filament diameter difference in millimeters (mm)
+# If difference between nominal filament diameter and sensor output is more
+# than +- max_difference, extrusion multiplier set back to %100
 
-    measurement_delay: 70
-    # The distance from sensor to the melting chamber/hot-end in millimeters (mm).
-    # The filament between the sensor and the hot-end will be treated as the default_nominal_filament_diameter.
-    # Host module works with FIFO logic. It keeps each sensor value and position in
-    # an array and POP them back in correct position.
+measurement_delay: 70
+# The distance from sensor to the melting chamber/hot-end in millimeters (mm).
+# The filament between the sensor and the hot-end will be treated as the default_nominal_filament_diameter.
+# Host module works with FIFO logic. It keeps each sensor value and position in
+# an array and POP them back in correct position.
 
-    #enable:False
-    # Sensor enabled or disabled after power on. Disabled by default
+#enable:False
+# Sensor enabled or disabled after power on. Disabled by default
 
-    # measurement_interval:10
-    # Sensor readings done with 10 mm intervals by default. If necessary you are free to change this setting
+# measurement_interval:10
+# Sensor readings done with 10 mm intervals by default. If necessary you are free to change this setting
 
-    #logging: False
-    #  Out diameter to terminal and klipper.log
-    #  can be turn on|of by command
+#logging: False
+#  Out diameter to terminal and klipper.log
+#  can be turn on|of by command
 
-    #Virtual filament_switch_sensor suppurt. Create sensor named hall_filament_width_sensor.
-    #
-    #min_diameter:1.0
-    #Minimal diameter for trigger virtual filament_switch_sensor.
-    #use_current_dia_while_delay: False
-    #   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
-    #
-    #Values from filament_switch_sensor. See the "filament_switch_sensor" section for information on these parameters.
-    #
-    #pause_on_runout: True
-    #runout_gcode:
-    #insert_gcode:
-    #event_delay: 3.0
-    #pause_delay: 0.5
+#Virtual filament_switch_sensor suppurt. Create sensor named hall_filament_width_sensor.
+#
+#min_diameter:1.0
+#Minimal diameter for trigger virtual filament_switch_sensor.
+#use_current_dia_while_delay: False
+#   Use the current diameter instead of the nominal diamenter while the measurement delay has not run through.
+#
+#Values from filament_switch_sensor. See the "filament_switch_sensor" section for information on these parameters.
+#
+#pause_on_runout: True
+#runout_gcode:
+#insert_gcode:
+#event_delay: 3.0
+#pause_delay: 0.5
+```
 
-
-## Commands
+## G-Code Commands
 
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 
-**RESET_FILAMENT_WIDTH_SENSOR** вЂ“ Clear all sensor readings. Can be used after filament change.
+**RESET_FILAMENT_WIDTH_SENSOR** - Clear all sensor readings. Can be used after filament change.
 
-**DISABLE_FILAMENT_WIDTH_SENSOR** вЂ“ Turn off the filament width sensor and stop using it to do flow control
+**DISABLE_FILAMENT_WIDTH_SENSOR** - Turn off the filament width sensor and stop using it to do flow control
 
 **ENABLE_FILAMENT_WIDTH_SENSOR** - Turn on the filament width sensor and start using it to do flow control
 
@@ -96,34 +97,41 @@ Sensor generates two analog output based on calculated filament width. Sum of ou
 **hall_filament_width_sensor.is_active** Sensor on or off
 
 ## Template for menu variables
-    [menu __main __filament __width_current]
-    type: command
-    enable: {'hall_filament_width_sensor' in printer}
-    name: Dia: {'%.2F' % printer.hall_filament_width_sensor.Diameter}
-    index: 0
 
-    [menu __main __filament __raw_width_current]
-    type: command
-    enable: {'hall_filament_width_sensor' in printer}
-    name: Raw: {'%4.0F' % printer.hall_filament_width_sensor.Raw}
-    index: 1
+```
+[menu __main __filament __width_current]
+type: command
+enable: {'hall_filament_width_sensor' in printer}
+name: Dia: {'%.2F' % printer.hall_filament_width_sensor.Diameter}
+index: 0
+
+[menu __main __filament __raw_width_current]
+type: command
+enable: {'hall_filament_width_sensor' in printer}
+name: Raw: {'%4.0F' % printer.hall_filament_width_sensor.Raw}
+index: 1
+```
 
 ## Calibration procedure
 
-Insert first  calibration rod (1.5 mm size) get first  raw sensor value
+To get raw sensor value you can use menu item or **QUERY_RAW_FILAMENT_WIDTH** command in terminal
 
-To get raw sensor value you can use menu item or  **QUERY_RAW_FILAMENT_WIDTH** command in terminal
+1. Insert first calibration rod (1.5 mm size) get first raw sensor value
 
-Insert second calibration rod (2.0 mm size) get second raw sensor value
+2. Insert second calibration rod (2.0 mm size) get second raw sensor value
 
-Save raw values in config
+3. Save raw sensor values in config parameter `Raw_dia1` and `Raw_dia2`
 
 ## How to enable sensor
 
-After power on by default sensor disabled.
-Enable sensor in start g-code by command **ENABLE_FILAMENT_WIDTH_SENSOR** or change enable parameter in config
+By default, the sensor is disabled at power-on.
+
+To enable the sensor, issue **ENABLE_FILAMENT_WIDTH_SENSOR** command or set the `enable` parameter to `true.`
 
 ## Logging
 
-After power on by default diameter Logging disabled.
-Data to log added on every measurement interval (10 mm by default)
+By default, diameter logging is disabled at power-on.
+
+Issue **ENABLE_FILAMENT_WIDTH_LOG** command to start logging and issue **DISABLE_FILAMENT_WIDTH_LOG** command to stop logging. To enable logging at power-on, set the `logging` parameter to `true`.
+
+Filament diameter is logged on every measurement interval (10 mm by default).

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -181,10 +181,10 @@ Recv: ok
 ```
 This means that:
 
-    - front left screw is the reference point you must not change it.
-    - front right screw must be turned clockwise 1 full turn and a quarter turn
-    - rear right screw must be turned counter-clockwise 50 minutes
-    - read left screw must be turned clockwise 2 minutes (not need it's ok)
+- front left screw is the reference point you must not change it.
+- front right screw must be turned clockwise 1 full turn and a quarter turn
+- rear right screw must be turned counter-clockwise 50 minutes
+- read left screw must be turned clockwise 2 minutes (not need it's ok)
 
 Repeat the process several times until you get a good level bed -
 normally when all adjustments are below 6 minutes.

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -483,18 +483,18 @@ The data can be processed later by the following scripts:
 of them accept one or several raw csv files as the input depending on the
 mode. The graph_accelerometer.py script supports several modes of operation:
 
-  * plotting raw accelerometer data (use `-r` parameter), only 1 input is
-    supported;
-  * plotting a frequency response (no extra parameters required), if multiple
-    inputs are specified, the average frequency response is computed;
-  * comparison of the frequency response between several inputs (use `-c`
-    parameter); you can additionally specify which accelerometer axis to
+* plotting raw accelerometer data (use `-r` parameter), only 1 input is
+  supported;
+* plotting a frequency response (no extra parameters required), if multiple
+  inputs are specified, the average frequency response is computed;
+* comparison of the frequency response between several inputs (use `-c`
+  parameter); you can additionally specify which accelerometer axis to
     consider via `-a x`, `-a y` or `-a z` parameter (if none specified,
     the sum of vibrations for all axes is used);
-  * plotting the spectrogram (use `-s` parameter), only 1 input is supported;
-    you can additionally specify which accelerometer axis to consider via
-    `-a x`, `-a y` or `-a z` parameter (if none specified, the sum of vibrations
-    for all axes is used).
+* plotting the spectrogram (use `-s` parameter), only 1 input is supported;
+  you can additionally specify which accelerometer axis to consider via
+  `-a x`, `-a y` or `-a z` parameter (if none specified, the sum of vibrations
+  for all axes is used).
 
 Note that graph_accelerometer.py script supports only the raw_data\*.csv files
 and not resonances\*.csv or calibration_data\*.csv files.
@@ -515,16 +515,16 @@ the CSV file if `-c output.csv` parameter is specified.
 Providing several inputs to shaper_calibrate.py script can be useful if running
 some advanced tuning of the input shapers, for example:
 
-  * Running `TEST_RESONANCES AXIS=X OUTPUT=raw_data` (and `Y` axis) for a single
-    axis twice on a bed slinger printer with the accelerometer attached to the
-    toolhead the first time, and the accelerometer attached to the bed the
-    second time in order to detect axes cross-resonances and attempt to cancel
-    them with input shapers.
-  * Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on a bed slinger with
-    a glass bed and a magnetic surfaces (which is lighter) to find the input
-    shaper parameters that work well for any print surface configuration.
-  * Combining the resonance data from multiple test points.
-  * Combining the resonance data from 2 axis (e.g. on a bed slinger printer
-    to configure X-axis input_shaper from both X and Y axes resonances to
-    cancel vibrations of the *bed* in case the nozzle 'catches' a print when
-    moving in X axis direction).
+* Running `TEST_RESONANCES AXIS=X OUTPUT=raw_data` (and `Y` axis) for a single
+  axis twice on a bed slinger printer with the accelerometer attached to the
+  toolhead the first time, and the accelerometer attached to the bed the
+  second time in order to detect axes cross-resonances and attempt to cancel
+  them with input shapers.
+* Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on a bed slinger with
+  a glass bed and a magnetic surfaces (which is lighter) to find the input
+  shaper parameters that work well for any print surface configuration.
+* Combining the resonance data from multiple test points.
+* Combining the resonance data from 2 axis (e.g. on a bed slinger printer
+  to configure X-axis input_shaper from both X and Y axes resonances to
+  cancel vibrations of the *bed* in case the nozzle 'catches' a print when
+  moving in X axis direction).

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -30,16 +30,16 @@ adding a few parameters to `printer.cfg` file.
 Slice the ringing test model, which can be found in
 [docs/prints/ringing_tower.stl](prints/ringing_tower.stl), in the slicer:
 
- * Suggested layer height is 0.2 or 0.25 mm.
- * Infill and top layers can be set to 0.
- * Use 1-2 perimeters, or even better the smooth vase mode with 1-2 mm base.
- * Use sufficiently high speed, around 80-100 mm/sec, for **external** perimeters.
- * Make sure that the minimum layer time is **at most** 3 seconds.
- * Make sure any "dynamic acceleration control" is disabled in the slicer.
- * Do not turn the model. The model has X and Y marks at the back of the model.
-   Note the unusual location of the marks vs. the axes of the printer - it is
-   not a mistake. The marks can be used later in the tuning process as a
-   reference, because they show which axis the measurements correspond to.
+* Suggested layer height is 0.2 or 0.25 mm.
+* Infill and top layers can be set to 0.
+* Use 1-2 perimeters, or even better the smooth vase mode with 1-2 mm base.
+* Use sufficiently high speed, around 80-100 mm/sec, for **external** perimeters.
+* Make sure that the minimum layer time is **at most** 3 seconds.
+* Make sure any "dynamic acceleration control" is disabled in the slicer.
+* Do not turn the model. The model has X and Y marks at the back of the model.
+ Note the unusual location of the marks vs. the axes of the printer - it is
+ not a mistake. The marks can be used later in the tuning process as a
+ reference, because they show which axis the measurements correspond to.
 
 ### Ringing frequency
 
@@ -116,12 +116,12 @@ Note that the ringing frequencies can change if the changes are made to the
 printer that affect the moving mass or change the stiffness of the system,
 for example:
 
-  * Some tools are installed, removed or replaced on the toolhead that change
-    its mass, e.g. a new (heavier or lighter) stepper motor for direct extruder
-    or a new hotend is installed, heavy fan with a duct is added, etc.
-  * Belts are tightened.
-  * Some addons to increase frame rigidity are installed.
-  * Different bed is installed on a bed-slinger printer, or glass added, etc.
+* Some tools are installed, removed or replaced on the toolhead that change
+ its mass, e.g. a new (heavier or lighter) stepper motor for direct extruder
+ or a new hotend is installed, heavy fan with a duct is added, etc.
+* Belts are tightened.
+* Some addons to increase frame rigidity are installed.
+* Different bed is installed on a bed-slinger printer, or glass added, etc.
 
 If such changes are made, it is a good idea to at least measure the ringing
 frequencies to see if they have changed.
@@ -187,19 +187,19 @@ shaper_type: mzv
 
 A few notes on shaper selection:
 
-  * EI shaper may be more suited for bed slinger printers (if the resonance
-    frequency and resulting smoothing allows): as more filament is deposited
-    on the moving bed, the mass of the bed increases and the resonance frequency
-    will decrease. Since EI shaper is more robust to resonance frequency
-    changes, it may work better when printing large parts.
-  * Due to the nature of delta kinematics, resonance frequencies can differ a
-    lot in different parts of the build volume. Therefore, EI shaper can be a
-    better fit for delta printers rather than MZV or ZV, and should be
-    considered for the use. If the resonance frequency is sufficiently large
-    (more than 50-60 Hz), then one can even attempt to test 2HUMP_EI shaper
-    (by running the suggested test above with
-    `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI`), but check the considerations in
-    the [section below](#selecting-max_accel) before enabling it.
+* EI shaper may be more suited for bed slinger printers (if the resonance
+ frequency and resulting smoothing allows): as more filament is deposited
+ on the moving bed, the mass of the bed increases and the resonance frequency
+ will decrease. Since EI shaper is more robust to resonance frequency
+ changes, it may work better when printing large parts.
+* Due to the nature of delta kinematics, resonance frequencies can differ a
+ lot in different parts of the build volume. Therefore, EI shaper can be a
+ better fit for delta printers rather than MZV or ZV, and should be
+ considered for the use. If the resonance frequency is sufficiently large
+ (more than 50-60 Hz), then one can even attempt to test 2HUMP_EI shaper
+ (by running the suggested test above with
+ `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI`), but check the considerations in
+ the [section below](#selecting-max_accel) before enabling it.
 
 ### Selecting max_accel
 
@@ -292,9 +292,9 @@ to 7000 already, complete the following steps for each of the axes X and Y:
 6. Print the test model.
 7. Reset the original frequency value:
    `SET_INPUT_SHAPER SHAPER_FREQ_X=...`.
-7. Find the band which shows ringing the least and count its number from the
+8. Find the band which shows ringing the least and count its number from the
    bottom starting at 1.
-8. Calculate the new shaper_freq_x value via old
+9. Calculate the new shaper_freq_x value via old
    shaper_freq_x * (39 + 5 * #band-number) / 66.
 
 Repeat these steps for the Y axis in the same manner, replacing references to X
@@ -371,9 +371,9 @@ with 50 Hz.
 Now check if EI shaper would be good enough in your case. Choose EI shaper
 frequency based on the frequency of 2HUMP_EI shaper you chose:
 
-  * For 2HUMP_EI 60 Hz shaper, use EI shaper with shaper_freq = 50 Hz.
-  * For 2HUMP_EI 50 Hz shaper, use EI shaper with shaper_freq = 40 Hz.
-  * For 2HUMP_EI 40 Hz shaper, use EI shaper with shaper_freq = 33 Hz.
+* For 2HUMP_EI 60 Hz shaper, use EI shaper with shaper_freq = 50 Hz.
+* For 2HUMP_EI 50 Hz shaper, use EI shaper with shaper_freq = 40 Hz.
+* For 2HUMP_EI 40 Hz shaper, use EI shaper with shaper_freq = 33 Hz.
 
 Now print the test model one more time, running
 
@@ -481,30 +481,30 @@ so the values for 10% vibration tolerance are provided only for the reference.
 
 **How to use this table:**
 
-  * Shaper duration affects the smoothing in parts - the larger it is, the more
-    smooth the parts are. This dependency is not linear, but can give a sense of
-    which shapers 'smooth' more for the same frequency. The ordering by
-    smoothing is like this: ZV < MZV < ZVD ≈ EI < 2HUMP_EI < 3HUMP_EI. Also,
-    it is rarely practical to set shaper_freq = resonance freq for shapers
-    2HUMP_EI and 3HUMP_EI (they should be used to reduce vibrations for several
-    frequencies).
-  * One can estimate a range of frequencies in which the shaper reduces
-    vibrations. For example, MZV with shaper_freq = 35 Hz reduces vibrations
-    to 5% for frequencies [33.6, 36.4] Hz. 3HUMP_EI with shaper_freq = 50 Hz
-    reduces vibrations to 5% in range [27.5, 75] Hz.
-  * One can use this table to check which shaper they should be using if they
-    need to reduce vibrations at several frequencies. For example, if one has
-    resonances at 35 Hz and 60 Hz on the same axis: a) EI shaper needs to have
-    shaper_freq = 35 / (1 - 0.2) = 43.75 Hz, and it will reduce resonances
-    until 43.75 * (1 + 0.2) = 52.5 Hz, so it is not sufficient; b) 2HUMP_EI
-    shaper needs to have shaper_freq = 35 / (1 - 0.35) = 53.85 Hz and will
-    reduce vibrations until 53.85 * (1 + 0.35) = 72.7 Hz - so this is an
-    acceptable configuration. Always try to use as high shaper_freq as possible
-    for a given shaper (perhaps with some safety margin, so in this example
-    shaper_freq ≈ 50-52 Hz would work best), and try to use a shaper with as
-    small shaper duration as possible.
-  * If one needs to reduce vibrations at several very different frequencies
-    (say, 30 Hz and 100 Hz), they may see that the table above does not provide
-    enough information. In this case one may have more luck with
-    [scripts/graph_shaper.py](../scripts/graph_shaper.py)
-    script, which is more flexible.
+* Shaper duration affects the smoothing in parts - the larger it is, the more
+ smooth the parts are. This dependency is not linear, but can give a sense of
+ which shapers 'smooth' more for the same frequency. The ordering by
+ smoothing is like this: ZV < MZV < ZVD ≈ EI < 2HUMP_EI < 3HUMP_EI. Also,
+ it is rarely practical to set shaper_freq = resonance freq for shapers
+ 2HUMP_EI and 3HUMP_EI (they should be used to reduce vibrations for several
+ frequencies).
+* One can estimate a range of frequencies in which the shaper reduces
+ vibrations. For example, MZV with shaper_freq = 35 Hz reduces vibrations
+ to 5% for frequencies [33.6, 36.4] Hz. 3HUMP_EI with shaper_freq = 50 Hz
+ reduces vibrations to 5% in range [27.5, 75] Hz.
+* One can use this table to check which shaper they should be using if they
+ need to reduce vibrations at several frequencies. For example, if one has
+ resonances at 35 Hz and 60 Hz on the same axis: a) EI shaper needs to have
+ shaper_freq = 35 / (1 - 0.2) = 43.75 Hz, and it will reduce resonances
+ until 43.75 * (1 + 0.2) = 52.5 Hz, so it is not sufficient; b) 2HUMP_EI
+ shaper needs to have shaper_freq = 35 / (1 - 0.35) = 53.85 Hz and will
+ reduce vibrations until 53.85 * (1 + 0.35) = 72.7 Hz - so this is an
+ acceptable configuration. Always try to use as high shaper_freq as possible
+ for a given shaper (perhaps with some safety margin, so in this example
+ shaper_freq ≈ 50-52 Hz would work best), and try to use a shaper with as
+ small shaper duration as possible.
+* If one needs to reduce vibrations at several very different frequencies
+ (say, 30 Hz and 100 Hz), they may see that the table above does not provide
+ enough information. In this case one may have more luck with
+ [scripts/graph_shaper.py](../scripts/graph_shaper.py)
+ script, which is more flexible.

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -447,7 +447,6 @@ No, `input_shaper` feature has pretty much no impact on the print times by
 itself. However, the value of `max_accel` certainly does (tuning of this
 parameter described in [this section](#selecting-max_accel)).
 
-
 ## Technical details
 
 ### Input shapers

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -396,6 +396,7 @@ object is available if z_tilt is defined):
   successfully.
 
 ## neopixel / dotstar
+
 The following information is available for each `[neopixel led_name]` and
 `[dotstar led_name]` defined in printer.cfg:
 - `color_data`:  An array of objects, with each object containing the RGBW

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -167,7 +167,7 @@ homing. See the
 [config reference](Config_Reference.md#tmc-stepper-driver-configuration)
 for all the available options.
 
-### Find highest sensitivity that successfully homes
+#### Find highest sensitivity that successfully homes
 
 Place the carriage near the center of the rail. Use the SET_TMC_FIELD
 command to set the highest sensitivity. For tmc2209:
@@ -427,14 +427,16 @@ state.
 
 Some common errors and tips for diagnosing them:
 
-**TMC reports error: ... ot=1(OvertempError!)"**: This indicates the
-motor driver disabled itself because it became too hot. Typical
+#### TMC reports error: ... ot=1(OvertempError!)"
+
+This indicates the motor driver disabled itself because it became too hot. Typical
 solutions are to decrease the stepper motor current, increase cooling
 on the stepper motor driver, and/or increase cooling on the stepper
 motor.
 
-**TMC reports error: ... ShortToGND** OR **LowSideShort**: This
-indicates the driver has disabled itself because it detected very high
+#### TMC reports error: ... ShortToGND** OR **LowSideShort
+
+This indicates the driver has disabled itself because it detected very high
 current passing through the driver. This may indicate a loose or
 shorted wire to the stepper motor or within the stepper motor itself.
 
@@ -445,13 +447,15 @@ current through the motor and trigger its own over-current detection.)
 To test this, disable stealthchop mode and check if the errors
 continue to occur.
 
-**TMC reports error: ... reset=1(Reset)** OR **CS_ACTUAL=0(Reset?)**
-OR **SE=0(Reset?)**: This indicates that the driver has reset itself
+#### TMC reports error: ... reset=1(Reset)** OR **CS_ACTUAL=0(Reset?)**OR **SE=0(Reset?)
+
+This indicates that the driver has reset itself
 mid-print. This may be due to voltage or wiring issues.
 
-**TMC reports error: ... uv_cp=1(Undervoltage!)**: This indicates the
-driver has detected a low-voltage event and has disabled itself. This
-may be due to wiring or power supply issues.
+#### TMC reports error: ... uv_cp=1(Undervoltage!)
+
+This indicates the driver has detected a low-voltage event and has
+disabled itself. This may be due to wiring or power supply issues.
 
 It's also possible that a **TMC reports error** shutdown occurs due to
 SPI errors that prevent communication with the driver (on tmc2130,

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -11,14 +11,14 @@ this document are not available.
 In addition to this document, be sure to review the
 [TMC driver config reference](Config_Reference.md#tmc-stepper-driver-configuration).
 
-## Enabling "Stealthchop" mode
+## Enabling "StealthChop" Mode
 
-By default, Klipper places the TMC drivers in "spreadcycle" mode. If
-the driver supports "stealthchop" then it can be enabled by adding
+By default, Klipper places the TMC drivers in "spreadCycle" mode. If
+the driver supports "stealthChop" then it can be enabled by adding
 `stealthchop_threshold: 999999` to the TMC config section.
 
-It is recommended to always use "spreadcycle" mode (by not specifying
-`stealthchop_threshold`) or to always use "stealthchop" mode (by
+It is recommended to always use "spreadCycle" mode (by not specifying
+`stealthchop_threshold`) or to always use "stealthChop" mode (by
 setting `stealthchop_threshold` to 999999). Unfortunately, the drivers
 often produce poor and confusing results if the mode changes while the
 motor is at a non-zero velocity.
@@ -68,7 +68,7 @@ also find more details on limitations of this setup.
 
 A few prerequisites are needed to use sensorless homing:
 
-1. A StallGuard capable TMC stepper driver (tmc2130, tmc2209, tmc2660,
+1. A stallGuard capable TMC stepper driver (tmc2130, tmc2209, tmc2660,
    or tmc5160).
 2. SPI / UART interface of the TMC driver wired to micro-controller
    (stand-alone mode does not work).
@@ -81,6 +81,7 @@ A few prerequisites are needed to use sensorless homing:
 ### Tuning
 
 The procedure described here has six major steps:
+
 1. Choose a homing speed.
 2. Configure the `printer.cfg` file to enable sensorless homing.
 3. Find the stallguard setting with highest sensitivity that
@@ -363,14 +364,14 @@ high-level value of 0.
 
 ## Common Questions
 
-### Can I use stealthchop mode on an extruder with pressure advance?
+### Can I use stealthChop mode on an extruder with pressure advance?
 
-Many people successfully use "stealthchop" mode with Klipper's
+Many people successfully use "stealthChop" mode with Klipper's
 pressure advance. Klipper implements
 [smooth pressure advance](Kinematics.md#pressure-advance) which does
 not introduce any instantaneous velocity changes.
 
-However, "stealthchop" mode may produce lower motor torque and/or
+However, "stealthChop" mode may produce lower motor torque and/or
 produce higher motor heat. It may or may not be an adequate mode for
 your particular printer.
 
@@ -425,38 +426,6 @@ ignored movement commands. If Klipper detects that an active driver
 has disabled itself, it will transition the printer into a "shutdown"
 state.
 
-Some common errors and tips for diagnosing them:
-
-#### TMC reports error: ... ot=1(OvertempError!)"
-
-This indicates the motor driver disabled itself because it became too hot. Typical
-solutions are to decrease the stepper motor current, increase cooling
-on the stepper motor driver, and/or increase cooling on the stepper
-motor.
-
-#### TMC reports error: ... ShortToGND** OR **LowSideShort
-
-This indicates the driver has disabled itself because it detected very high
-current passing through the driver. This may indicate a loose or
-shorted wire to the stepper motor or within the stepper motor itself.
-
-This error may also occur if using stealthchop mode and the TMC driver
-is not able to accurately predict the mechanical load of the motor.
-(If the driver makes a poor prediction then it may send too much
-current through the motor and trigger its own over-current detection.)
-To test this, disable stealthchop mode and check if the errors
-continue to occur.
-
-#### TMC reports error: ... reset=1(Reset)** OR **CS_ACTUAL=0(Reset?)**OR **SE=0(Reset?)
-
-This indicates that the driver has reset itself
-mid-print. This may be due to voltage or wiring issues.
-
-#### TMC reports error: ... uv_cp=1(Undervoltage!)
-
-This indicates the driver has detected a low-voltage event and has
-disabled itself. This may be due to wiring or power supply issues.
-
 It's also possible that a **TMC reports error** shutdown occurs due to
 SPI errors that prevent communication with the driver (on tmc2130,
 tmc5160, or tmc2660). If this occurs, it's common for the reported
@@ -466,7 +435,39 @@ READRSP@RDSEL2: 00000000 ...`. Such a failure may be due to an SPI
 wiring problem or may be due to a self-reset or failure of the TMC
 driver.
 
-### How do I tune spreadcycle/coolstep/etc. mode on my drivers?
+Some common errors and tips for diagnosing them:
+
+#### TMC reports error: `... ot=1(OvertempError!)`"
+
+This indicates the motor driver disabled itself because it became too hot. Typical
+solutions are to decrease the stepper motor current, increase cooling
+on the stepper motor driver, and/or increase cooling on the stepper
+motor.
+
+#### TMC reports error: `... ShortToGND` OR `LowSideShort`
+
+This indicates the driver has disabled itself because it detected very high
+current passing through the driver. This may indicate a loose or
+shorted wire to the stepper motor or within the stepper motor itself.
+
+This error may also occur if using stealthChop mode and the TMC driver
+is not able to accurately predict the mechanical load of the motor.
+(If the driver makes a poor prediction then it may send too much
+current through the motor and trigger its own over-current detection.)
+To test this, disable stealthChop mode and check if the errors
+continue to occur.
+
+#### TMC reports error: `... reset=1(Reset)` OR `CS_ACTUAL=0(Reset?)**OR **SE=0(Reset?)`
+
+This indicates that the driver has reset itself
+mid-print. This may be due to voltage or wiring issues.
+
+#### TMC reports error: `... uv_cp=1(Undervoltage!)`
+
+This indicates the driver has detected a low-voltage event and has
+disabled itself. This may be due to wiring or power supply issues.
+
+### How do I tune spreadCycle/coolStep/etc. mode on my drivers?
 
 The [Trinamic website](https://www.trinamic.com/) has guides on
 configuring the drivers. These guides are often technical, low-level,

--- a/docs/TSL1401CL_Filament_Width_Sensor.md
+++ b/docs/TSL1401CL_Filament_Width_Sensor.md
@@ -3,9 +3,11 @@
 This document describes Filament Width Sensor host module. Hardware used for developing this host module is based on TSL1401CL linear sensor array but it can work with any sensor array that has analog output. You can find designs at [thingiverse.com](https://www.thingiverse.com/search?q=filament%20width%20sensor)
 
 ## How does it work?
+
 Sensor generates analog output based on calculated filament width. Output voltage always equals to detected filament width (Ex. 1.65v, 1.70v, 3.0v). Host module monitors voltage changes and adjusts extrusion multiplier.
 
 ## Configuration
+
     [tsl1401cl_filament_width_sensor]
     pin: analog5
     # Analog input pin for sensor output on Ramps board
@@ -27,6 +29,7 @@ Sensor generates analog output based on calculated filament width. Output voltag
 Sensor readings done with 10 mm intervals by default. If necessary you are free to change this setting by editing ***MEASUREMENT_INTERVAL_MM*** parameter in **filament_width_sensor.py** file.
 
 ## Commands
+
 **QUERY_FILAMENT_WIDTH** - Return the current measured filament width as result
 **RESET_FILAMENT_WIDTH_SENSOR** – Clear all sensor readings. Can be used after filament change.
 **DISABLE_FILAMENT_WIDTH_SENSOR** – Turn off the filament width sensor and stop using it to do flow control

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -3,8 +3,8 @@
 This document describes how to setup a PWM-controlled laser or spindle
 using `output_pin` and some macros.
 
-
 ## How does it work?
+
 With re-purposing the printhead's fan pwm output, you can control
 lasers or spindles.
 This is useful if you use switchable print heads, for example

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -16,23 +16,24 @@ that includes all planes in one model.  You want the object oriented
 so that corner A is toward the origin of the plane.
 
 Make sure that no skew correction is applied during this print.  You may
-do this by either removing the [skew_correction] module from printer.cfg
+do this by either removing the `[skew_correction]` module from printer.cfg
 or by issuing a `SET_SKEW CLEAR=1` gcode.
 
 ## Take your measurements
 
-The [skew_correcton] module requires 3 measurements for each plane you want
+The `[skew_correcton]` module requires 3 measurements for each plane you want
 to correct; the length from Corner A to Corner C, the length from Corner B
-to Corner D, and the length from corner A to corner D.  When measuring length
+to Corner D, and the length from Corner A to Corner D.  When measuring length
 AD do not include the flats on the corners that some test objects provide.
 
 ![skew_lengths](img/skew_lengths.png)
 
 ## Configure your skew
-Make sure [skew_correction] is in printer.cfg.  You may now use the `SET_SKEW`
 
+Make sure `[skew_correction]` is in printer.cfg.  You may now use the `SET_SKEW`
 gcode to configure skew_correcton.  For example, if your measured lengths
 along XY are as follows:
+
 ```
 Length AC = 140.4
 Length BD = 142.8
@@ -50,8 +51,8 @@ You may also add measurements for XZ and YZ to the gcode:
 SET_SKEW XY=140.4,142.8,99.8 XZ=141.6,141.4,99.8 YZ=142.4,140.5,99.5
 ```
 
-The [skew_correction] module also supports profile management in a manner
-similar to [bed_mesh].  After setting skew using the `SET_SKEW` gcode,
+The `[skew_correction]` module also supports profile management in a manner
+similar to `[bed_mesh]`.  After setting skew using the `SET_SKEW` gcode,
 you may use the `SKEW_PROFILE` gcode to save it:
 
 ```
@@ -93,7 +94,7 @@ near the edge of the print area such as a purge or nozzle wipe.   You may
 use use the `SET_SKEW` or `SKEW_PROFILE` gcodes to accomplish this.  It is
 also recommended to issue a `SET_SKEW CLEAR=1` in your end gcode.
 
-Keep in mind that it is possible for [skew_correction] to generate a correction
-that moves the tool beyond the printer's boundries on the X and/or Y axes.  It
+Keep in mind that it is possible for `[skew_correction]` to generate a correction
+that moves the tool beyond the printer's boundaries on the X and/or Y axes.  It
 is recommended to arrange parts away from the edges when using
-[skew_correction].
+`[skew_correction]`.

--- a/docs/skew_correction.md
+++ b/docs/skew_correction.md
@@ -7,6 +7,7 @@ first use mechanical means to get your printer as square as possible prior
 to applying software based correction.
 
 ## Print a Calibration Object
+
 The first step in correcting skew is to print a
 [calibration object](https://www.thingiverse.com/thing:2563185/files)
 along the plane you want to correct.  There is also a
@@ -19,6 +20,7 @@ do this by either removing the [skew_correction] module from printer.cfg
 or by issuing a `SET_SKEW CLEAR=1` gcode.
 
 ## Take your measurements
+
 The [skew_correcton] module requires 3 measurements for each plane you want
 to correct; the length from Corner A to Corner C, the length from Corner B
 to Corner D, and the length from corner A to corner D.  When measuring length
@@ -28,6 +30,7 @@ AD do not include the flats on the corners that some test objects provide.
 
 ## Configure your skew
 Make sure [skew_correction] is in printer.cfg.  You may now use the `SET_SKEW`
+
 gcode to configure skew_correcton.  For example, if your measured lengths
 along XY are as follows:
 ```
@@ -72,6 +75,7 @@ After removing a profile you will be prompted to issue a `SAVE_CONFIG` to
 make this change persist.
 
 ## Verifying your correction
+
 After skew_correction has been configured you may reprint the calibration
 part with correction enabled.  Use the following gcode to check your
 skew on each plane.  The results should be lower than those reported via


### PR DESCRIPTION
- Aligned some tables
- Added blank line to before and after some lists to match most lists
- Changed some bold text to titles
- Added blank line before and after some titles
- Removed some extra blank lines
- use fenced code block instead of the indented code block to match other docs
- Corrected some indentation errors on the title and lists

Signed-off-by: Yifei Ding <yifeiding@protonmail.com>