### PR TITLE
config: Added cfg for Prusa i3 MK2/S

### DIFF
--- a/config/printer-prusa-i3-mk2s-2017.cfg
+++ b/config/printer-prusa-i3-mk2s-2017.cfg
@@ -1,12 +1,9 @@
-# Adapted for Prusa i3 MK2/S by Andrew Howard <ahoward@divisionind.com>. Derived from generic-mini-rambo.cfg.
+# Adapted for Prusa i3 MK2/S from generic-mini-rambo.cfg.
 # Firmware should be compiled for the AVR atmega2560.
 
 # See docs/Config_Reference.md for a description of parameters.
 # Note: Adjust [probe]->z_offset, run mesh bed leveling, and do
 #       skew correction as a MINIMUM before printing for the best experience.
-
-# remove if not running mainsail
-[include mainsail.cfg]
 
 [stepper_x]
 step_pin: PC0
@@ -79,7 +76,7 @@ step_pin: PC3
 dir_pin: !PL6
 enable_pin: !PA4
 microsteps: 16
-rotation_distance: 18.5572135
+rotation_distance: 18.56
 nozzle_diameter: 0.4
 filament_diameter: 1.75
 heater_pin: PE5
@@ -92,7 +89,6 @@ pid_Kd: 107.171
 min_temp: 10
 max_temp: 305
 max_extrude_cross_section: 1.0
-pressure_advance: 0.0769
 
 [heater_bed]
 heater_pin: PG5
@@ -176,4 +172,5 @@ click_pin: ^!PH6
 [output_pin beeper]
 pin: PH2
 
+# required for mk2 because of how it is assembled
 [skew_correction]

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -2,8 +2,8 @@
 # Firmware should be compiled for the AVR atmega2560.
 
 # See docs/Config_Reference.md for a description of parameters.
-# Note: Adjust [probe]->z_offset, run mesh bed leveling, calibrate pressure advance, 
-#       and do skew correction before printing for the best results.
+# Note: Adjust [probe]->z_offset, run mesh bed leveling, and do
+#       skew correction as a MINIMUM before printing for the best experience.
 
 # remove if not running mainsail
 [include mainsail.cfg]
@@ -59,10 +59,6 @@ speed: 100.0
 #z_hop: 5.0
 #z_hop_speed: 20.0
 
-# mesh bed leveling was inconsistent on the stock i3
-# however, using a BuildTak flex plate fixed the issue
-# its possible that the pinda probe is slightly misaligned with the test points in this cfg, which 
-# could cause the inductive sensor to reach threshold at different heights
 [bed_mesh]
 speed: 120
 horizontal_move_z: 5

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -2,7 +2,7 @@
 # Firmware should be compiled for the AVR atmega2560.
 
 # See docs/Config_Reference.md for a description of parameters.
-# Note: Adjust [probe]->z_offset, run mesh bed leveling, re-calibrate pressure advance, 
+# Note: Adjust [probe]->z_offset, run mesh bed leveling, calibrate pressure advance, 
 #       and do skew correction before printing for the best results.
 
 # remove if not running mainsail
@@ -96,7 +96,6 @@ pid_Kd: 107.171
 min_temp: 10
 max_temp: 305
 max_extrude_cross_section: 1.0
-pressure_advance: 0.105 # usually 0.1-0.14 works well ~100mm/s
 
 [heater_bed]
 heater_pin: PG5

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -96,6 +96,7 @@ pid_Kd: 107.171
 min_temp: 10
 max_temp: 305
 max_extrude_cross_section: 1.0
+pressure_advance: 0.0769
 
 [heater_bed]
 heater_pin: PG5

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -125,6 +125,7 @@ max_velocity: 500
 max_accel: 9000
 max_z_velocity: 12
 max_z_accel: 120
+square_corner_velocity: 1 #5
 
 # motor currents
 [output_pin stepper_xy_current]

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -56,8 +56,8 @@ samples_tolerance_retries: 1
 [safe_z_home]
 home_xy_position: 15,-1
 speed: 100.0
-z_hop: 5.0
-z_hop_speed: 20.0
+#z_hop: 5.0
+#z_hop_speed: 20.0
 
 # mesh bed leveling was inconsistent on the stock i3
 # however, using a BuildTak flex plate fixed the issue

--- a/config/printer-prusa-i3-mk2s.cfg
+++ b/config/printer-prusa-i3-mk2s.cfg
@@ -1,0 +1,182 @@
+# Adapted for Prusa i3 MK2/S by Andrew Howard <ahoward@divisionind.com>. Derived from generic-mini-rambo.cfg.
+# Firmware should be compiled for the AVR atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+# Note: Adjust [probe]->z_offset, run mesh bed leveling, re-calibrate pressure advance, 
+#       and do skew correction before printing for the best results.
+
+# remove if not running mainsail
+[include mainsail.cfg]
+
+[stepper_x]
+step_pin: PC0
+dir_pin: PL1
+enable_pin: !PA7
+microsteps: 16
+rotation_distance: 32
+endstop_pin: ^PB6
+position_endstop: 0
+position_max: 250
+homing_speed: 50.0
+
+[stepper_y]
+step_pin: PC1
+dir_pin: PL0
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 32
+endstop_pin: ^PB5
+position_endstop: -2.2
+position_min: -3.0
+position_max: 210
+homing_speed: 50.0
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+enable_pin: !PA5
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 210
+position_min: -1.0
+
+[probe]
+pin: PB4
+x_offset: 23
+y_offset: 9
+z_offset: 0
+speed: 5.0
+samples: 3
+samples_result: average
+samples_tolerance: 0.1
+samples_tolerance_retries: 1
+
+# required on prusa to make the pinda probe line up with the inductive point on the bed
+[safe_z_home]
+home_xy_position: 15,-1
+speed: 100.0
+z_hop: 5.0
+z_hop_speed: 20.0
+
+# mesh bed leveling was inconsistent on the stock i3
+# however, using a BuildTak flex plate fixed the issue
+# its possible that the pinda probe is slightly misaligned with the test points in this cfg, which 
+# could cause the inductive sensor to reach threshold at different heights
+[bed_mesh]
+speed: 120
+horizontal_move_z: 5
+mesh_min: 38, 8
+mesh_max: 240,202
+probe_count: 3
+# interpolation:
+mesh_pps: 2,2
+algorithm: bicubic
+bicubic_tension: 0.2
+
+# handy for z-axis leveling
+[force_move]
+enable_force_move: True
+
+[extruder]
+step_pin: PC3
+dir_pin: !PL6
+enable_pin: !PA4
+microsteps: 16
+rotation_distance: 18.5572135
+nozzle_diameter: 0.4
+filament_diameter: 1.75
+heater_pin: PE5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF0
+control: pid
+pid_Kp: 26.692
+pid_Ki: 1.696
+pid_Kd: 107.171
+min_temp: 10
+max_temp: 305
+max_extrude_cross_section: 1.0
+pressure_advance: 0.105 # usually 0.1-0.14 works well ~100mm/s
+
+[heater_bed]
+heater_pin: PG5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PF2
+control: pid
+pid_Kp: 126.13
+pid_Ki: 4.30
+pid_Kd: 924.76
+min_temp: 10
+max_temp: 125
+
+[fan]
+pin: PH3
+
+[heater_fan extruder_fan]
+pin: PH5
+
+[mcu]
+serial: /dev/ttyACM0
+
+# printer stuff
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 9000
+max_z_velocity: 12
+max_z_accel: 120
+
+# motor currents
+[output_pin stepper_xy_current]
+pin: PL3
+pwm: True
+scale: 2000
+static_value: 540
+hardware_pwm: True
+cycle_time: 0.000032258
+
+[output_pin stepper_z_current]
+pin: PL4
+pwm: True
+scale: 2000
+static_value: 830
+hardware_pwm: True
+cycle_time: 0.000032258
+
+[output_pin stepper_e_current]
+pin: PL5
+pwm: True
+scale: 2000
+static_value: 500
+hardware_pwm: True
+cycle_time: 0.000032258
+
+[static_digital_output stepper_config]
+pins:
+    PG1, PG0,
+    PK7, PG2,
+    PK6, PK5,
+    PK3, PK4
+
+# turns on yellow led to let us know everything is working right
+[static_digital_output yellow_led]
+pins: !PB7
+
+# see: https://reprap.org/mediawiki/images/7/7f/MiniRambo1.3a-connections-p1-p2-p3-digital-pins-labeled.png
+[display]
+lcd_type: hd44780
+menu_reverse_navigation: True
+rs_pin: PD5 #EXP1_4
+e_pin: PD3 #EXP1_3
+d4_pin: PD2 #EXP1_5
+d5_pin: PG4 #EXP1_6
+d6_pin: PH7 #EXP1_7
+d7_pin: PG3 #EXP1_8
+encoder_pins: ^PJ2, ^PJ1
+click_pin: ^!PH6
+#kill_pin: ^!EXP2_8
+
+[output_pin beeper]
+pin: PH2
+
+[skew_correction]

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -44,6 +44,7 @@ CONFIG ../../config/printer-makergear-m2-2012.cfg
 CONFIG ../../config/printer-makergear-m2-2016.cfg
 CONFIG ../../config/printer-micromake-d1-2016.cfg
 CONFIG ../../config/printer-mtw-create-2015.cfg
+CONFIG ../../config/printer-prusa-i3-mk2s-2017.cfg
 CONFIG ../../config/printer-robo3d-r2-2017.cfg
 CONFIG ../../config/printer-seemecnc-rostock-max-v2-2015.cfg
 CONFIG ../../config/printer-sovol-sv01-2020.cfg


### PR DESCRIPTION
Parameters based off of those used in the original Prusa-firmware, and were adjusted for
the best results on a Prusa i3 MK2S running stock hardware.

Signed-off-by: Andrew Howard <ahoward@divisionind.com>