### PR TITLE
Update generic MKS Robin Nano V1

### DIFF
--- a/config/generic-mks-robin-nano-v1.cfg
+++ b/config/generic-mks-robin-nano-v1.cfg
@@ -1,13 +1,15 @@
 # This file contains common pin mappings for MKS Robin Nano (v1.2.004)
 # boards. To use this config, the firmware should be compiled for the
 # STM32F103. When running "make menuconfig", enable "extra low-level
-# configuration setup", select the 28KiB bootloader, and serial (on
-# USART3 PB11/PB10) communication.
+# configuration setup", select the 28KiB bootloader, disable "USB for
+# communication", and select USART3 for the "Serial Port" (PB11/PB10)
+# or USART1 for Wifi pins (PA9/PA10).
+# GPIO pins to set at startup: (!PC6, !PD13) to disable screen at firmware startup.
 
 # Note that the "make flash" command does not work with MKS Robin
 # boards. After running "make", run the following command:
-#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano.bin
-# Copy the file out/Robin_nano.bin to an SD card and then restart the
+#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano43.bin
+# Copy the file out/Robin_nano43.bin to an SD card and then restart the
 # printer with that SD card.
 
 # See docs/Config_Reference.md for a description of parameters.


### PR DESCRIPTION
I updated the header to clarify wich usart to select when using UART or USB. Also the script after make was renamed to give the output bin a name that make possible to flash firmware when LCD is not attached.