### PR TITLE
Remove deprecated features

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -91,11 +91,10 @@ of these benchmarks are not reported in the Features.md document.
 
 The following configuration sequence is used on AVR chips:
 ```
-PINS arduino
 allocate_oids count=3
-config_stepper oid=0 step_pin=ar29 dir_pin=ar28 invert_step=0
-config_stepper oid=1 step_pin=ar27 dir_pin=ar26 invert_step=0
-config_stepper oid=2 step_pin=ar23 dir_pin=ar22 invert_step=0
+config_stepper oid=0 step_pin=PA5 dir_pin=PA4 invert_step=0
+config_stepper oid=1 step_pin=PA3 dir_pin=PA2 invert_step=0
+config_stepper oid=2 step_pin=PC7 dir_pin=PC6 invert_step=0
 finalize_config crc=0
 ```
 
@@ -182,11 +181,10 @@ The test was last run on commit `59a60d68` with gcc version
 
 The following configuration sequence is used on the PRU:
 ```
-PINS beaglebone
 allocate_oids count=3
-config_stepper oid=0 step_pin=P8_13 dir_pin=P8_12 invert_step=0
-config_stepper oid=1 step_pin=P8_15 dir_pin=P8_14 invert_step=0
-config_stepper oid=2 step_pin=P8_19 dir_pin=P8_18 invert_step=0
+config_stepper oid=0 step_pin=gpio0_23 dir_pin=gpio1_12 invert_step=0
+config_stepper oid=1 step_pin=gpio1_15 dir_pin=gpio0_26 invert_step=0
+config_stepper oid=2 step_pin=gpio0_22 dir_pin=gpio2_1 invert_step=0
 finalize_config crc=0
 ```
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,17 @@ All dates in this document are approximate.
 
 ## Changes
 
+20211102: Several deprecated features have been removed.  The stepper
+`step_distance` option has been removed (deprecated on 20201222).  The
+`rpi_temperature` sensor alias has been removed (deprecated on
+20210219).  The mcu `pin_map` option has been removed (deprecated on
+20210325).  The gcode_macro `default_parameter_<name>` and macro
+access to command parameters other than via the `params`
+pseudo-variable has been removed (deprecated on 20210503).  The heater
+`pid_integral_max` option has been removed (deprecated on 20210612).
+
+20210929: Klipper v0.10.0 released.
+
 20210903: The default [`smooth_time`](Config_Reference.md#extruder)
 for heaters has changed to 1 second (from 2 seconds).  For most
 printers this will result in more stable temperature control.

--- a/klippy/console.py
+++ b/klippy/console.py
@@ -47,7 +47,7 @@ class KeyboardReader:
         reactor.register_fd(self.fd, self.process_kbd)
         reactor.register_callback(self.connect)
         self.local_commands = {
-            "PINS": self.command_PINS, "SET": self.command_SET,
+            "SET": self.command_SET,
             "DELAY": self.command_DELAY, "FLOOD": self.command_FLOOD,
             "SUPPRESS": self.command_SUPPRESS, "STATS": self.command_STATS,
             "LIST": self.command_LIST, "HELP": self.command_HELP,
@@ -91,9 +91,6 @@ class KeyboardReader:
     def update_evals(self, eventtime):
         self.eval_globals['freq'] = self.mcu_freq
         self.eval_globals['clock'] = self.clocksync.get_clock(eventtime)
-    def command_PINS(self, parts):
-        mcu_type = self.ser.get_msgparser().get_constant('MCU')
-        self.pins.add_pin_mapping(mcu_type, parts[1])
     def command_SET(self, parts):
         val = parts[2]
         try:

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -180,12 +180,9 @@ class ControlPID:
         self.Ki = config.getfloat('pid_Ki') / PID_PARAM_BASE
         self.Kd = config.getfloat('pid_Kd') / PID_PARAM_BASE
         self.min_deriv_time = heater.get_smooth_time()
-        config.deprecate('pid_integral_max')
-        imax = config.getfloat('pid_integral_max', self.heater_max_power,
-                               minval=0.)
         self.temp_integ_max = 0.
         if self.Ki:
-            self.temp_integ_max = imax / self.Ki
+            self.temp_integ_max = self.heater_max_power / self.Ki
         self.prev_temp = AMBIENT_TEMP
         self.prev_temp_time = 0.
         self.prev_temp_deriv = 0.

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -18,12 +18,7 @@ class Temperature_HOST:
 
         self.temp = self.min_temp = self.max_temp = 0.0
 
-        if config.get("sensor_type", "", note_valid=False).startswith('rpi'):
-            # Temporary backwards compatibility
-            config.deprecate("sensor_type", "rpi_temperature")
-            self.printer.add_object("rpi_temperature " + self.name, self)
-        else:
-            self.printer.add_object("temperature_host " + self.name, self)
+        self.printer.add_object("temperature_host " + self.name, self)
         if self.printer.get_start_args().get('debugoutput') is not None:
             return
         self.sample_timer = self.reactor.register_timer(
@@ -83,4 +78,3 @@ def load_config(config):
     # Register sensor
     pheaters = config.get_printer().load_object(config, "heaters")
     pheaters.add_sensor_factory("temperature_host", Temperature_HOST)
-    pheaters.add_sensor_factory("rpi_temperature", Temperature_HOST) # XXX

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -560,8 +560,6 @@ class MCU:
         self._config_cmds = []
         self._restart_cmds = []
         self._init_cmds = []
-        config.deprecate('pin_map')
-        self._pin_map = config.get('pin_map', None)
         self._mcu_freq = 0.
         # Move command queuing
         ffi_main, self._ffi_lib = chelper.get_ffi()
@@ -651,8 +649,6 @@ class MCU:
         mcu_type = self._serial.get_msgparser().get_constant('MCU')
         ppins = self._printer.lookup_object('pins')
         pin_resolver = ppins.get_pin_resolver(self._name)
-        if self._pin_map is not None:
-            pin_resolver.add_pin_mapping(mcu_type, self._pin_map)
         for cmdlist in (self._config_cmds, self._restart_cmds, self._init_cmds):
             for i, cmd in enumerate(cmdlist):
                 cmdlist[i] = pin_resolver.update_command(cmd)

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -1,147 +1,12 @@
-# Pin name to pin number definitions
+# Pin name handling
 #
-# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import re
 
 class error(Exception):
     pass
-
-
-######################################################################
-# Arduino mappings
-######################################################################
-
-Arduino_standard = [
-    "PD0", "PD1", "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PB0", "PB1",
-    "PB2", "PB3", "PB4", "PB5", "PC0", "PC1", "PC2", "PC3", "PC4", "PC5",
-]
-Arduino_analog_standard = [
-    "PC0", "PC1", "PC2", "PC3", "PC4", "PC5", "PE2", "PE3",
-]
-
-Arduino_mega = [
-    "PE0", "PE1", "PE4", "PE5", "PG5", "PE3", "PH3", "PH4", "PH5", "PH6",
-    "PB4", "PB5", "PB6", "PB7", "PJ1", "PJ0", "PH1", "PH0", "PD3", "PD2",
-    "PD1", "PD0", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7",
-    "PC7", "PC6", "PC5", "PC4", "PC3", "PC2", "PC1", "PC0", "PD7", "PG2",
-    "PG1", "PG0", "PL7", "PL6", "PL5", "PL4", "PL3", "PL2", "PL1", "PL0",
-    "PB3", "PB2", "PB1", "PB0", "PF0", "PF1", "PF2", "PF3", "PF4", "PF5",
-    "PF6", "PF7", "PK0", "PK1", "PK2", "PK3", "PK4", "PK5", "PK6", "PK7",
-]
-Arduino_analog_mega = [
-    "PF0", "PF1", "PF2", "PF3", "PF4", "PF5",
-    "PF6", "PF7", "PK0", "PK1", "PK2", "PK3", "PK4", "PK5", "PK6", "PK7",
-]
-
-Sanguino = [
-    "PB0", "PB1", "PB2", "PB3", "PB4", "PB5", "PB6", "PB7", "PD0", "PD1",
-    "PD2", "PD3", "PD4", "PD5", "PD6", "PD7", "PC0", "PC1", "PC2", "PC3",
-    "PC4", "PC5", "PC6", "PC7", "PA0", "PA1", "PA2", "PA3", "PA4", "PA5",
-    "PA6", "PA7"
-]
-Sanguino_analog = [
-    "PA0", "PA1", "PA2", "PA3", "PA4", "PA5", "PA6", "PA7"
-]
-
-Arduino_Due = [
-    "PA8", "PA9", "PB25", "PC28", "PA29", "PC25", "PC24", "PC23", "PC22","PC21",
-    "PA28", "PD7", "PD8", "PB27", "PD4", "PD5", "PA13", "PA12", "PA11", "PA10",
-    "PB12", "PB13", "PB26", "PA14", "PA15", "PD0", "PD1", "PD2", "PD3", "PD6",
-    "PD9", "PA7", "PD10", "PC1", "PC2", "PC3", "PC4", "PC5", "PC6", "PC7",
-    "PC8", "PC9", "PA19", "PA20", "PC19", "PC18", "PC17", "PC16", "PC15","PC14",
-    "PC13", "PC12", "PB21", "PB14", "PA16", "PA24", "PA23", "PA22", "PA6","PA4",
-    "PA3", "PA2", "PB17", "PB18", "PB19", "PB20", "PB15", "PB16", "PA1", "PA0",
-    "PA17", "PA18", "PC30", "PA21", "PA25", "PA26", "PA27", "PA28", "PB23"
-]
-Arduino_Due_analog = [
-    "PA16", "PA24", "PA23", "PA22", "PA6", "PA4", "PA3", "PA2", "PB17", "PB18",
-    "PB19", "PB20"
-]
-
-Adafruit_GrandCentral = [
-    "PB25", "PB24", "PC18", "PC19", "PC20",
-    "PC21", "PD20", "PD21", "PB18", "PB2",
-    "PB22", "PB23", "PB0", "PB1", "PB16",
-    "PB17", "PC22", "PC23", "PB12", "PB13",
-    "PB20", "PB21", "PD12", "PA15", "PC17",
-    "PC16", "PA12", "PA13", "PA14", "PB19",
-    "PA23", "PA22", "PA21", "PA20", "PA19",
-    "PA18", "PA17", "PA16", "PB15", "PB14",
-    "PC13", "PC12", "PC15", "PC14", "PC11",
-    "PC10", "PC6", "PC7", "PC4", "PC5",
-    "PD11", "PD8", "PD9", "PD10", "PA2",
-    "PA5", "PB3", "PC0", "PC1", "PC2",
-    "PC3", "PB4", "PB5", "PB6", "PB7",
-    "PB8", "PB9", "PA4", "PA6", "PA7"
-]
-Adafruit_GrandCentral_analog = [
-    "PA2", "PA5", "PB3", "PC0", "PC1", "PC2", "PC3", "PB4", "PB5", "PB6", "PB7",
-    "PB8", "PB9", "PA4", "PA6", "PA7"
-]
-
-
-Arduino_from_mcu = {
-    "atmega168": (Arduino_standard, Arduino_analog_standard),
-    "atmega328": (Arduino_standard, Arduino_analog_standard),
-    "atmega328p": (Arduino_standard, Arduino_analog_standard),
-    "atmega644p": (Sanguino, Sanguino_analog),
-    "atmega1280": (Arduino_mega, Arduino_analog_mega),
-    "atmega2560": (Arduino_mega, Arduino_analog_mega),
-    "sam3x8e": (Arduino_Due, Arduino_Due_analog),
-    "samd51p20a": (Adafruit_GrandCentral, Adafruit_GrandCentral_analog),
-}
-
-def get_aliases_arduino(mcu):
-    if mcu not in Arduino_from_mcu:
-        raise error("Arduino aliases not supported on mcu '%s'" % (mcu,))
-    dpins, apins = Arduino_from_mcu[mcu]
-    aliases = {}
-    for i in range(len(dpins)):
-        aliases['ar' + str(i)] = dpins[i]
-    for i in range(len(apins)):
-        aliases['analog%d' % (i,)] = apins[i]
-    return aliases
-
-
-######################################################################
-# Beaglebone mappings
-######################################################################
-
-beagleboneblack_mappings = {
-    'P8_3': 'gpio1_6', 'P8_4': 'gpio1_7', 'P8_5': 'gpio1_2',
-    'P8_6': 'gpio1_3', 'P8_7': 'gpio2_2', 'P8_8': 'gpio2_3',
-    'P8_9': 'gpio2_5', 'P8_10': 'gpio2_4', 'P8_11': 'gpio1_13',
-    'P8_12': 'gpio1_12', 'P8_13': 'gpio0_23', 'P8_14': 'gpio0_26',
-    'P8_15': 'gpio1_15', 'P8_16': 'gpio1_14', 'P8_17': 'gpio0_27',
-    'P8_18': 'gpio2_1', 'P8_19': 'gpio0_22', 'P8_20': 'gpio1_31',
-    'P8_21': 'gpio1_30', 'P8_22': 'gpio1_5', 'P8_23': 'gpio1_4',
-    'P8_24': 'gpio1_1', 'P8_25': 'gpio1_0', 'P8_26': 'gpio1_29',
-    'P8_27': 'gpio2_22', 'P8_28': 'gpio2_24', 'P8_29': 'gpio2_23',
-    'P8_30': 'gpio2_25', 'P8_31': 'gpio0_10', 'P8_32': 'gpio0_11',
-    'P8_33': 'gpio0_9', 'P8_34': 'gpio2_17', 'P8_35': 'gpio0_8',
-    'P8_36': 'gpio2_16', 'P8_37': 'gpio2_14', 'P8_38': 'gpio2_15',
-    'P8_39': 'gpio2_12', 'P8_40': 'gpio2_13', 'P8_41': 'gpio2_10',
-    'P8_42': 'gpio2_11', 'P8_43': 'gpio2_8', 'P8_44': 'gpio2_9',
-    'P8_45': 'gpio2_6', 'P8_46': 'gpio2_7', 'P9_11': 'gpio0_30',
-    'P9_12': 'gpio1_28', 'P9_13': 'gpio0_31', 'P9_14': 'gpio1_18',
-    'P9_15': 'gpio1_16', 'P9_16': 'gpio1_19', 'P9_17': 'gpio0_5',
-    'P9_18': 'gpio0_4', 'P9_19': 'gpio0_13', 'P9_20': 'gpio0_12',
-    'P9_21': 'gpio0_3', 'P9_22': 'gpio0_2', 'P9_23': 'gpio1_17',
-    'P9_24': 'gpio0_15', 'P9_25': 'gpio3_21', 'P9_26': 'gpio0_14',
-    'P9_27': 'gpio3_19', 'P9_28': 'gpio3_17', 'P9_29': 'gpio3_15',
-    'P9_30': 'gpio3_16', 'P9_31': 'gpio3_14', 'P9_41': 'gpio0_20',
-    'P9_42': 'gpio3_20', 'P9_43': 'gpio0_7', 'P9_44': 'gpio3_18',
-
-    'P9_33': 'AIN4', 'P9_35': 'AIN6', 'P9_36': 'AIN5', 'P9_37': 'AIN2',
-    'P9_38': 'AIN3', 'P9_39': 'AIN0', 'P9_40': 'AIN1',
-}
-
-def get_aliases_beaglebone(mcu):
-    if mcu != 'pru':
-        raise error("Beaglebone aliases not supported on mcu '%s'" % (mcu,))
-    return beagleboneblack_mappings
 
 
 ######################################################################
@@ -171,15 +36,6 @@ class PinResolver:
         for existing_alias, existing_pin in self.aliases.items():
             if existing_pin == alias:
                 self.aliases[existing_alias] = pin
-    def add_pin_mapping(self, mcu_type, mapping_name):
-        if mapping_name == 'arduino':
-            pin_mapping = get_aliases_arduino(mcu_type)
-        elif mapping_name == 'beaglebone':
-            pin_mapping = get_aliases_beaglebone(mcu_type)
-        else:
-            raise error("Unknown pin alias mapping '%s'" % (mapping_name,))
-        for alias, pin in pin_mapping.items():
-            self.alias_pin(alias, pin)
     def update_command(self, cmd):
         def pin_fixup(m):
             name = m.group('name')

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -229,13 +229,6 @@ def parse_step_distance(config, units_in_radians=None, note_valid=False):
         rotation_dist = 2. * math.pi
         config.get('gear_ratio', note_valid=note_valid)
     else:
-        rd = config.get('rotation_distance', None, note_valid=False)
-        config.deprecate('step_distance')
-        sd = config.get('step_distance', None, note_valid=False)
-        if rd is None and sd is not None:
-            # Older config format with step_distance
-            return config.getfloat('step_distance', above=0.,
-                                   note_valid=note_valid)
         rotation_dist = config.getfloat('rotation_distance', above=0.,
                                         note_valid=note_valid)
     # Newer config format with rotation_distance


### PR DESCRIPTION
There have been several options deprecated in late 2020 and in early 2021.  This change removes support for those options - anyone that has not yet converted their configs will receive an error after this change is applied.  I plan to commit this early next week (~20211102).

Several deprecated features have been removed.  The stepper
`step_distance` option has been removed (deprecated on 20201222).  The `rpi_temperature` sensor alias has been removed (deprecated on
20210219).  The mcu `pin_map` option has been removed (deprecated on 20210325).  The gcode_macro `default_parameter_<name>` and macro access to command parameters other than via the `params` pseudo-variable has been removed (deprecated on 20210503).  The heater `pid_integral_max` option has been removed (deprecated on 20210612).

-Kevin