### PR TITLE
Add option to PROBE command to report probe position instead of toolhead position.

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -362,9 +362,12 @@ the [probe calibrate guide](Probe_Calibrate.md)):
 - `PROBE [PROBE_SPEED=<mm/s>] [LIFT_SPEED=<mm/s>] [SAMPLES=<count>]
   [SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_TOLERANCE=<mm>]
   [SAMPLES_TOLERANCE_RETRIES=<count>]
-  [SAMPLES_RESULT=median|average]`: Move the nozzle downwards until
-  the probe triggers. If any of the optional parameters are provided
-  they override their equivalent setting in the
+  [SAMPLES_RESULT=median|average]
+  [REPORT_PROBE_POSITION=0|1]`: Move the nozzle downwards until
+  the probe triggers. `REPORT_PROBE_POSITION=1` will cause the command
+  to report the probe position instead of toolhead position at trigger
+  (according to probe offsets). If any of other the optional parameters
+  are provided they override their equivalent setting in the
   [probe config section](Config_Reference.md#probe).
 - `QUERY_PROBE`: Report the current status of the probe ("triggered"
   or "open").


### PR DESCRIPTION
PROBE command response implies that it is reporting the probe location:
`// probe at 0.908,-0.316 is z=0.002357
// Result is z=0.002357`
 but it is in fact reporting the toolhead location.

It may be a bug, but at this point I assume the current behavior of PROBE should stay stable as someone may depend on it.

So I created a new boolean optional parameter to PROBE for REPORT_PROBE_POSITION which takes into account the probe offset as configured.

Signed-off-by: Fabio Santos <fabiosan@live.com>