### PR TITLE
gcode: Allow rename_existing also for register_mux_command

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -126,7 +126,8 @@ class GCodeDispatch:
     def register_mux_command(self, cmd, key, value, func, desc=None):
         prev = self.mux_commands.get(cmd)
         if prev is None:
-            self.register_command(cmd, self._cmd_mux, desc=desc)
+            handler = lambda gcmd: self._cmd_mux(cmd, gcmd)
+            self.register_command(cmd, handler, desc=desc)
             self.mux_commands[cmd] = prev = (key, {})
         prev_key, prev_values = prev
         if prev_key != key:
@@ -274,8 +275,8 @@ class GCodeDispatch:
             # Don't warn about requests to turn off fan when fan not present
             return
         gcmd.respond_info('Unknown command:"%s"' % (cmd,))
-    def _cmd_mux(self, gcmd):
-        key, values = self.mux_commands[gcmd.get_command()]
+    def _cmd_mux(self, command, gcmd):
+        key, values = self.mux_commands[command]
         if None in values:
             key_param = gcmd.get(key, None)
         else:


### PR DESCRIPTION
﻿This PR allows now to use rename_existing at GCodes internally registered as register_mux_command
The changes where done by the discord user dalegaard.

At the tide integrated UIs like fluidd/mainsail you need to use the same GCode name as the base klipper. This was not possible for some of the GCodes. The user only sees an internal error with no explanation what the problem was. After the merge that problem would be gone.

I personally testet it with:
- SET_FILAMENT_SENSOR SENSOR
- SET_PIN
- SET_HEATER_TEMPERATURE
- ACTIVATE_EXTRUDER

Test Case looks like: 
```
[gcode_macro SET_PIN]
rename_existing: SET_PIN_BASE
gcode:
  ##### get params and prepare to send them to the base macro #####
  {% set get_params = [] %}
  {% for key in params %}
    {% set get_params = get_params.append(key + "=" + params[key])  %}
  {% endfor %}
  ##### end of definitions #####
  {action_respond_info(get_params|join(" "))}
  SET_PIN_BASE {get_params|join(" ")}
```
I also verified that rename_existing still works for GCodes registered as register_command. Used GCodes
- BED_MESH_CALIBRATE
- QUAD_GANTRY_LEVEL
- PAUSE
- RESUME

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com