### PR TITLE
scripts: Leverage Docker Multistage Builds

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,44 +1,117 @@
-# This is an example Dockerfile showing how it's possible to install Klipper in Docker.
-# IMPORTANT: The docker build must be run from the root of the repo, either copy the
-# Dockerfile to the root, or run docker build with "-f", for example:
-#       docker build . -f scripts/Dockerfile -t klipper
-# Note that the host still needs to run Linux to connect the printers serial port to
-# the container.
-# When running, the serial port of your printer should be connected, including an
-# argument such as:
-#       --device /dev/ttyUSB0:/dev/ttyUSB0
-# It's also required that your control program (eg: OctoPrint) be included in the same
-# container as Docker does not allow sharing of the virtual serial port outside the
-# container.
-# The config should be in a file named "printer.cfg" in a directory mounted at:
-#       /home/klippy/.config/
-# For more Dockerfile examples with Klipper (and Octoprint) see:
-# https://github.com/sillyfrog/OctoPrint-Klipper-mjpg-Dockerfile
-FROM ubuntu:18.04
+# This is an example Dockerfile showing how it's possible to run Klipper in Docker.
 
-RUN apt-get update && \
-    apt-get install -y sudo
+# Building the Image
+#
+# Run 'docker build -f scripts/Dockerfile --target run -t klipper' from the root of this 
+# Repository. This builds a runtime Image that contains klippy with its Dependencies. 
+#
+# Run 'docker build -f scripts/Dockerfile --target mcu -t klipper' from the root of this
+# Repository to Build an Image that contains everything you need to build and flash your MCU.
 
-# Create user
-RUN useradd -ms /bin/bash klippy && adduser klippy dialout
-USER klippy
+# Building and flashing MCU code
+#
+# If you already have a build config, copy it to 'build.config' in your current directory or
+# create an empty File named 'build.config'. Repace the serial port at '--device' with your MCUs
+# Device.
+# Running the following command will execute
+# * make menuconfig
+# * make
+# * make flash
+#
+# docker run \
+#   --rm \
+#   --volume $(pwd)/build.config:/opt/klipper/.config \
+#   --volume $(pwd)/out:/opt/klipper/out \
+#   --interactive \
+#   --tty \
+#   --device /dev/ttyUSB0:/dev/ttyUSB0
+#   klipper:mcu \
+#     bash -c "cd /opt/klipper; make menuconfig && make && make flash"
 
-#This fixes issues with the volume command setting wrong permissions
-RUN mkdir /home/klippy/.config
-VOLUME /home/klippy/.config
+# When intending to use this Image with moonraker, the serial Port of your Printer should
+# be attached to the Container via the '--device' directive. 
+# Adding the 'run' Volume to moonraker grants it access to the klippy-provided socket
+# which is located in /opt/run/klipper.sock and needed for communication between both processes.
+# Example:
+#
+# docker run klipper \
+#   --device /dev/ttyUSB0:/dev/ttyUSB0 \
+#   -v $(pwd)/config:/opt/cfg \
+#   -v $(pwd)/gcode:/opt/gcode \
+#   -v $(pwd)/run:/opt/run
+#
+# docker run klipper:mcu \
+#   --device /dev/ttyUSB0:/dev/ttyUSB0 \
+#   -v $(pwd)/config:/opt/cfg \
+#   -v $(pwd)/gcode:/opt/gcode \
+#   -v $(pwd)/run:/opt/run \
 
-### Klipper setup ###
-WORKDIR /home/klippy
+# If you intend on using OctoPrint as your Webinterface, you may want to start
+# this Container in privileged mode and ommit the '--device' directive.
+# Running this Container in privileged mode bears security implications, as privileged
+# Mode grants processes within the Container root access to devices of the Host machine.
+# When Running OctoPrint also in privileged mode, it is possible for Octoprint to access
+# the tty Interface created by klippy in /opt/run/klipper.tty as long as it also has 
+# the 'run' Volume mounted.
+# Example:
+#
+# docker run klipper \
+#   --privileged \
+#   -v $(pwd)/config:/opt/cfg \
+#   -v $(pwd)/gcode:/opt/gcode \
+#   -v $(pwd)/run:/opt/run \
+#   -v /dev:/dev
+#
+# docker run octoprint/octoprint:slim \
+#   --privileged \
+#   -v $(pwd)/octoprint:/octoprint \
+#   -v $(pwd)/run:/opt/run \
+#   -v /dev:/dev
 
-COPY . klipper/
-USER root
-RUN echo 'klippy ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/klippy && \
-    chown klippy:klippy -R klipper
-# This is to allow the install script to run without error
-RUN ln -s /bin/true /bin/systemctl
-USER klippy
-RUN ./klipper/scripts/install-ubuntu-18.04.sh
-# Clean up install script workaround
-RUN sudo rm -f /bin/systemctl
+# See https://github.com/mkuf/prind for further examples
 
-CMD ["/home/klippy/klippy-env/bin/python", "/home/klippy/klipper/klippy/klippy.py", "/home/klippy/.config/printer.cfg"]
+# Get Code and Build venv
+FROM python:2 as build
+
+WORKDIR /opt
+COPY . klipper
+
+RUN virtualenv -p python2 venv \
+ && venv/bin/pip install -r klipper/scripts/klippy-requirements.txt \
+ && venv/bin/python -m compileall klipper/klippy \
+ && venv/bin/python klipper/klippy/chelper/__init__.py
+
+# Runtime Image
+FROM python:2-slim as run
+
+WORKDIR /opt
+COPY --from=build /opt/klipper ./klipper
+COPY --from=build /opt/venv ./venv
+
+RUN mkdir run cfg gcode
+RUN groupadd klipper --gid 1000 \
+ && useradd klipper --uid 1000 --gid klipper \
+ && usermod klipper --append --groups dialout \
+ && chown -R klipper:klipper /opt/*
+
+USER klipper
+VOLUME ["/opt/run", "/opt/cfg", "/opt/gcode"]
+ENTRYPOINT ["/opt/venv/bin/python", "klipper/klippy/klippy.py"]
+CMD ["-I", "run/klipper.tty", "-a", "run/klipper.sock", "cfg/printer.cfg"]
+
+# For building MCU Code
+FROM ubuntu:18.04 as mcu
+
+WORKDIR /opt
+COPY --from=build /opt/klipper ./klipper
+COPY --from=build /opt/venv ./venv
+
+RUN apt update \
+ && apt install -y \
+      virtualenv python-dev libffi-dev build-essential \
+      libncurses-dev \
+      libusb-dev \
+      avrdude gcc-avr binutils-avr avr-libc \
+      stm32flash libnewlib-arm-none-eabi \
+      gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 \
+ && apt clean

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -40,7 +40,7 @@
 #   -v $(pwd)/gcode:/opt/gcode \
 #   -v $(pwd)/run:/opt/run
 #
-# docker run klipper:mcu \
+# docker run moonraker \
 #   --device /dev/ttyUSB0:/dev/ttyUSB0 \
 #   -v $(pwd)/config:/opt/cfg \
 #   -v $(pwd)/gcode:/opt/gcode \


### PR DESCRIPTION
Hi There, 

for a recent Project of mine called [prind](https://github.com/mkuf/prind), I build [Klipper Docker Images](https://hub.docker.com/r/mkuf/klipper) on a daily basis.  

These Images are decoupled from the actual Source and use git to fetch the code.  
Based on this work and my findings I reworked the existing Dockerfile to decrease image size and decouple the MCU buildprocess from the runtime Image.

See the following Comparison, where `master` refers to a Image built with the current Dockerfile.
`multistage-run` refers to the new runtime Image that executes klippy and `multistage-mcu` is used for building MCU code.

```
klipper         master            dbb0540ac413   46 minutes ago   1.79GB
klipper         multistage-run    87822351db88    2 minutes ago    443MB
klipper         multistage-mcu    8342679c52f9   23 seconds ago   1.65GB
```

While updating the Image itself I also added some documentation on common usecases.

If you deem this an Improvement this would certainly pave the way for an official klipper Docker Image that is universally applicable.

-Markus



