### PR TITLE
rp2040: add barrier in usb_read_ep0_setup

### DIFF
--- a/src/rp2040/usbserial.c
+++ b/src/rp2040/usbserial.c
@@ -96,6 +96,7 @@ usb_read_ep0_setup(void *data, uint_fast8_t max_len)
                                      | USB_BUF_CTRL_AVAIL | DPBUF_SIZE);
     usb_hw->sie_status = USB_SIE_STATUS_SETUP_REC_BITS;
     memcpy(data, (void*)usb_dpram->setup_packet, max_len);
+    barrier();
     if (usb_hw->intr & USB_INTR_SETUP_REQ_BITS) {
         // Raced with next setup packet
         usb_notify_ep0();


### PR DESCRIPTION
Well this was a fun one.

Some versions of gcc, in some cases, decide that it is OK to move the read to `INTR` to right after clearing the `SETUP_REC` bit of `SIE_STATUS`, instead of after the `memcpy`.

The rp2040 datasheet doesn't appear to say anything about how quickly the `SETUP_REC` bit will be cleared in `INTR`, but regardless the compiler should not be re-ordering the read like this.

We force the correct order using a memory barrier.

Fixes #4817.

Some extra background:
GCC is very fond of inlining `usb_read_ep0_setup` and the call chain into `run_tasks`, and it was emitting the following(simplified):
```asm
LDR     R0, =0x50110000  ; usb_hw address
MOVS    R3, #131072      ; USB_SIE_STATUS_SETUP_REC_BITS
STR     R3, [R0,#0x50]   ; usb_hw->sie_status
LDR     R0, [R0,#0x8C]   ; load usb_hw->intr
; ... do the memcpy
MOVS    R5, #65536       ; USB_INTR_SETUP_REQ_BITS
TST     R0, R5           ; intr & USB_INTR_SETUP_REQ_BITS
```
I observed that the `LDR` instruction would be reading back the wrong value, with the bit still set, even though the bit as cleared in `SIE_STATUS`.
Interestingly, when marking `usb_read_ep0_setup` as `noline`, the emitted order was now correct.