### PR TITLE
idle_timeout: exit the timer if the printer is shutdown

### DIFF
--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -71,6 +71,8 @@ class IdleTimeout:
         # Idle timeout has elapsed
         return self.transition_idle_state(eventtime)
     def timeout_handler(self, eventtime):
+        if self.printer.is_shutdown():
+            return self.reactor.NEVER
         if self.state == "Ready":
             return self.check_idle_timeout(eventtime)
         # Check if need to transition to "ready" state


### PR DESCRIPTION
This resolves an issue where the idle_timeout attempts to transition from "Ready" to "Idle" when the printer is shutdown.  Currently this will result in a failed attempt to run the idle gcode, which will repeat every second until Klippy is restarted.

The following steps can be taken to reproduce the issue:
1) Set the idle timeout to a low value: `SET_IDLE_TIMEOUT TIMEOUT=2`
2) Run a command to put the printer in the `Printing` state: `G4 P1000`
3) Emergency Stop

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>