### PR TITLE
Support custom step pulse duration at run-time and optimize for tmc drivers

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20211104: The "step pulse duration" option in "make menuconfig" has
+been removed. A new `step_pulse_duration` setting in the
+[stepper config section](Config_Reference.md#stepper) should be set
+for all steppers that need a custom pulse duration.
+
 20211102: Several deprecated features have been removed.  The stepper
 `step_distance` option has been removed (deprecated on 20201222).  The
 `rpi_temperature` sensor alias has been removed (deprecated on

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -153,6 +153,11 @@ microsteps:
 #   gear_ratio is specified then rotation_distance specifies the
 #   distance the axis travels for one full rotation of the final gear.
 #   The default is to not use a gear ratio.
+#step_pulse_duration:
+#   The minimum time between the step pulse signal edge and the
+#   following "unstep" signal edge. This is also used to set the
+#   minimum time between a step pulse and a direction change signal.
+#   The default is 0.000002 (which is 2us).
 endstop_pin:
 #   Endstop switch detection pin. If this endstop pin is on a
 #   different mcu than the stepper motor then it enables "multi-mcu

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -137,12 +137,17 @@ This section lists some commonly used config commands.
   sampled at regular interval using the query_analog_in command (see
   below).
 
-* `config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c` : This
-  command creates an internal stepper object. The 'step_pin' and
-  'dir_pin' parameters specify the step and direction pins
-  respectively; this command will configure them in digital output
-  mode. The 'invert_step' parameter specifies whether a step occurs on
-  a rising edge (invert_step=0) or falling edge (invert_step=1).
+* `config_stepper oid=%c step_pin=%c dir_pin=%c invert_step=%c
+  step_pulse_ticks=%u` : This command creates an internal stepper
+  object. The 'step_pin' and 'dir_pin' parameters specify the step and
+  direction pins respectively; this command will configure them in
+  digital output mode. The 'invert_step' parameter specifies whether a
+  step occurs on a rising edge (invert_step=0) or falling edge
+  (invert_step=1). The 'step_pulse_ticks' parameter specifies the
+  minimum duration of the step pulse. If the mcu exports the constant
+  'STEPPER_BOTH_EDGE=1' then setting step_pulse_ticks=0 and
+  invert_step=-1 will setup for stepping on both the rising and
+  falling edges of the step pin.
 
 * `config_endstop oid=%c pin=%c pull_up=%c stepper_count=%c` : This
   command creates an internal "endstop" object. It is used to specify

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -98,7 +98,6 @@ SignedFields = ["sgt"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
 FieldFormatters.update({
-    "dedge": (lambda v: "1(Both Edges Active!)" if v else ""),
     "chm": (lambda v: "1(constant toff)" if v else "0(spreadCycle)"),
     "vsense": (lambda v: "1(165mV)" if v else "0(305mV)"),
     "sdoff": (lambda v: "1(Step/Dir disabled!)" if v else ""),

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -32,6 +32,7 @@ class MCU_stepper:
                 "Stepper dir pin must be on same mcu as step pin")
         self._dir_pin = dir_pin_params['pin']
         self._invert_dir = dir_pin_params['invert']
+        self._step_both_edge = self._req_step_both_edge = False
         self._mcu_position_offset = 0.
         self._reset_cmd_tag = self._get_position_cmd = None
         self._active_callbacks = []
@@ -54,6 +55,12 @@ class MCU_stepper:
     def units_in_radians(self):
         # Returns true if distances are in radians instead of millimeters
         return self._units_in_radians
+    def get_pulse_duration(self):
+        return self._step_pulse_duration, self._step_both_edge
+    def setup_default_pulse_duration(self, pulse_duration, step_both_edge):
+        if self._step_pulse_duration is None:
+            self._step_pulse_duration = pulse_duration
+        self._req_step_both_edge = step_both_edge
     def setup_itersolve(self, alloc_func, *params):
         ffi_main, ffi_lib = chelper.get_ffi()
         sk = ffi_main.gc(getattr(ffi_lib, alloc_func)(*params), ffi_lib.free)
@@ -61,11 +68,18 @@ class MCU_stepper:
     def _build_config(self):
         if self._step_pulse_duration is None:
             self._step_pulse_duration = .000002
+        invert_step = self._invert_step
+        sbe = int(self._mcu.get_constants().get('STEPPER_BOTH_EDGE', '0'))
+        if self._req_step_both_edge and sbe:
+            # Enable stepper optimized step on both edges
+            self._step_both_edge = True
+            self._step_pulse_duration = 0.
+            invert_step = -1
         step_pulse_ticks = self._mcu.seconds_to_clock(self._step_pulse_duration)
         self._mcu.add_config_cmd(
             "config_stepper oid=%d step_pin=%s dir_pin=%s invert_step=%d"
             " step_pulse_ticks=%u" % (self._oid, self._step_pin, self._dir_pin,
-                                      self._invert_step, step_pulse_ticks))
+                                      invert_step, step_pulse_ticks))
         self._mcu.add_config_cmd("reset_step_clock oid=%d clock=0"
                                  % (self._oid,), on_restart=True)
         step_cmd_tag = self._mcu.lookup_command_tag(

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -17,9 +17,10 @@ class error(Exception):
 # Interface to low-level mcu and chelper code
 class MCU_stepper:
     def __init__(self, name, step_pin_params, dir_pin_params, step_dist,
-                 units_in_radians=False):
+                 step_pulse_duration=None, units_in_radians=False):
         self._name = name
         self._step_dist = step_dist
+        self._step_pulse_duration = step_pulse_duration
         self._units_in_radians = units_in_radians
         self._mcu = step_pin_params['chip']
         self._oid = oid = self._mcu.create_oid()
@@ -58,9 +59,13 @@ class MCU_stepper:
         sk = ffi_main.gc(getattr(ffi_lib, alloc_func)(*params), ffi_lib.free)
         self.set_stepper_kinematics(sk)
     def _build_config(self):
+        if self._step_pulse_duration is None:
+            self._step_pulse_duration = .000002
+        step_pulse_ticks = self._mcu.seconds_to_clock(self._step_pulse_duration)
         self._mcu.add_config_cmd(
             "config_stepper oid=%d step_pin=%s dir_pin=%s invert_step=%d"
-            % (self._oid, self._step_pin, self._dir_pin, self._invert_step))
+            " step_pulse_ticks=%u" % (self._oid, self._step_pin, self._dir_pin,
+                                      self._invert_step, step_pulse_ticks))
         self._mcu.add_config_cmd("reset_step_clock oid=%d clock=0"
                                  % (self._oid,), on_restart=True)
         step_cmd_tag = self._mcu.lookup_command_tag(
@@ -73,9 +78,9 @@ class MCU_stepper:
             "stepper_get_position oid=%c",
             "stepper_position oid=%c pos=%i", oid=self._oid)
         max_error = self._mcu.get_max_stepper_error()
+        max_error_ticks = self._mcu.seconds_to_clock(max_error)
         ffi_main, ffi_lib = chelper.get_ffi()
-        ffi_lib.stepcompress_fill(self._stepqueue,
-                                  self._mcu.seconds_to_clock(max_error),
+        ffi_lib.stepcompress_fill(self._stepqueue, max_error_ticks,
                                   self._invert_dir, step_cmd_tag, dir_cmd_tag)
     def get_oid(self):
         return self._oid
@@ -201,8 +206,10 @@ def PrinterStepper(config, units_in_radians=False):
     dir_pin = config.get('dir_pin')
     dir_pin_params = ppins.lookup_pin(dir_pin, can_invert=True)
     step_dist = parse_step_distance(config, units_in_radians, True)
+    step_pulse_duration = config.getfloat('step_pulse_duration', None,
+                                          minval=0., maxval=.001)
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params, step_dist,
-                              units_in_radians)
+                              step_pulse_duration, units_in_radians)
     # Register with helper modules
     for mname in ['stepper_enable', 'force_move', 'motion_report']:
         m = printer.load_object(config, mname)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -73,31 +73,6 @@ config USB_SERIAL_NUMBER
     string "USB serial number" if !USB_SERIAL_NUMBER_CHIPID
 endmenu
 
-# Step timing customization
-config CUSTOM_STEP_DELAY
-    bool "Specify a custom step pulse duration"
-    depends on LOW_LEVEL_OPTIONS
-config STEP_DELAY
-    int
-    default 2
-config STEP_DELAY
-    int "Step pulse duration (in microseconds)"
-    depends on CUSTOM_STEP_DELAY
-    help
-        Specify the duration of the stepper step pulse time. This
-        setting applies to all stepper drivers controlled by the
-        micro-controller. If this value is set to zero (or less) then
-        the code will "step" and "unstep" in the same C function.
-
-        A setting of zero (or less) on 8-bit AVR micro-controllers
-        results in a minimum step pulse time a little over 2us.
-
-        A setting of zero on ARM micro-controllers typically results
-        in a minimum step pulse time of 20 cpu cycles.
-
-        The default for AVR is -1, for all other micro-controllers it
-        is 2us.
-
 config INITIAL_PINS
     string "GPIO pins to set at micro-controller startup"
     depends on LOW_LEVEL_OPTIONS

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -108,6 +108,9 @@ config HAVE_STRICT_TIMING
 config HAVE_CHIPID
     bool
     default n
+config HAVE_STEPPER_BOTH_EDGE
+    bool
+    default n
 
 config INLINE_STEPPER_HACK
     # Enables gcc to inline stepper_event() into the main timer irq handler

--- a/src/atsam/Kconfig
+++ b/src/atsam/Kconfig
@@ -13,6 +13,7 @@ config ATSAM_SELECT
     select HAVE_GPIO_BITBANGING
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
+    select HAVE_STEPPER_BOTH_EDGE
 
 config BOARD_DIRECTORY
     string

--- a/src/atsamd/Kconfig
+++ b/src/atsamd/Kconfig
@@ -13,6 +13,7 @@ config ATSAMD_SELECT
     select HAVE_GPIO_BITBANGING
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
+    select HAVE_STEPPER_BOTH_EDGE
 
 config HAVE_SERCOM
     depends on HAVE_GPIO_I2C || HAVE_GPIO_SPI

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -13,9 +13,6 @@ config AVR_SELECT
     select HAVE_GPIO_BITBANGING if !MACH_atmega168
     select HAVE_STRICT_TIMING
 
-config STEP_DELAY
-    default -1
-
 config BOARD_DIRECTORY
     string
     default "avr"

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -13,6 +13,7 @@ config LPC_SELECT
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
     select HAVE_GPIO_HARD_PWM
+    select HAVE_STEPPER_BOTH_EDGE
 
 config BOARD_DIRECTORY
     string

--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -12,6 +12,7 @@ config RP2040_SELECT
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
     select HAVE_GPIO_HARD_PWM
+    select HAVE_STEPPER_BOTH_EDGE
 
 config BOARD_DIRECTORY
     string

--- a/src/stepper.c
+++ b/src/stepper.c
@@ -14,9 +14,18 @@
 #include "stepper.h" // stepper_event
 #include "trsync.h" // trsync_add_signal
 
-#if CONFIG_INLINE_STEPPER_HACK && CONFIG_MACH_AVR
+#if CONFIG_INLINE_STEPPER_HACK && CONFIG_HAVE_STEPPER_BOTH_EDGE
+ #define HAVE_SINGLE_SCHEDULE 1
+ #define HAVE_EDGE_OPTIMIZATION 1
+ #define HAVE_AVR_OPTIMIZATION 0
+ DECL_CONSTANT("STEPPER_BOTH_EDGE", 1);
+#elif CONFIG_INLINE_STEPPER_HACK && CONFIG_MACH_AVR
+ #define HAVE_SINGLE_SCHEDULE 1
+ #define HAVE_EDGE_OPTIMIZATION 0
  #define HAVE_AVR_OPTIMIZATION 1
 #else
+ #define HAVE_SINGLE_SCHEDULE 0
+ #define HAVE_EDGE_OPTIMIZATION 0
  #define HAVE_AVR_OPTIMIZATION 0
 #endif
 
@@ -66,9 +75,10 @@ stepper_load_next(struct stepper *s, uint32_t min_next_time)
     struct stepper_move *m = container_of(mn, struct stepper_move, node);
     s->add = m->add;
     s->interval = m->interval + m->add;
-    if (HAVE_AVR_OPTIMIZATION && s->flags & SF_SINGLE_SCHED) {
+    if (HAVE_SINGLE_SCHEDULE && s->flags & SF_SINGLE_SCHED) {
         s->time.waketime += m->interval;
-        s->flags = m->add ? s->flags | SF_HAVE_ADD : s->flags & ~SF_HAVE_ADD;
+        if (HAVE_AVR_OPTIMIZATION)
+            s->flags = m->add ? s->flags|SF_HAVE_ADD : s->flags & ~SF_HAVE_ADD;
         s->count = m->count;
     } else {
         // On faster mcus, it is necessary to schedule unstep events
@@ -95,6 +105,22 @@ stepper_load_next(struct stepper *s, uint32_t min_next_time)
 
     move_free(m);
     return SF_RESCHEDULE;
+}
+
+// Optimized step function to step on each step pin edge
+uint_fast8_t
+stepper_event_edge(struct timer *t)
+{
+    struct stepper *s = container_of(t, struct stepper, time);
+    gpio_out_toggle_noirq(s->step_pin);
+    uint32_t count = s->count - 1;
+    if (likely(count)) {
+        s->count = count;
+        s->time.waketime += s->interval;
+        s->interval += s->add;
+        return SF_RESCHEDULE;
+    }
+    return stepper_load_next(s, 0);
 }
 
 #define AVR_STEP_INSNS 40 // minimum instructions between step gpio pulses
@@ -150,6 +176,8 @@ reschedule_min:
 uint_fast8_t
 stepper_event(struct timer *t)
 {
+    if (HAVE_EDGE_OPTIMIZATION)
+        return stepper_event_edge(t);
     if (HAVE_AVR_OPTIMIZATION)
         return stepper_event_avr(t);
     return stepper_event_full(t);
@@ -159,13 +187,19 @@ void
 command_config_stepper(uint32_t *args)
 {
     struct stepper *s = oid_alloc(args[0], command_config_stepper, sizeof(*s));
-    s->flags = args[3] ? SF_INVERT_STEP : 0;
+    int_fast8_t invert_step = args[3];
+    s->flags = invert_step > 0 ? SF_INVERT_STEP : 0;
     s->step_pin = gpio_out_setup(args[1], s->flags & SF_INVERT_STEP);
     s->dir_pin = gpio_out_setup(args[2], 0);
     s->position = -POSITION_BIAS;
     s->step_pulse_ticks = args[4];
     move_queue_setup(&s->mq, sizeof(struct stepper_move));
-    if (HAVE_AVR_OPTIMIZATION) {
+    if (HAVE_EDGE_OPTIMIZATION) {
+        if (!s->step_pulse_ticks && invert_step < 0)
+            s->flags |= SF_SINGLE_SCHED;
+        else
+            s->time.func = stepper_event_full;
+    } else if (HAVE_AVR_OPTIMIZATION) {
         if (s->step_pulse_ticks <= AVR_STEP_INSNS)
             s->flags |= SF_SINGLE_SCHED;
         else
@@ -252,7 +286,7 @@ stepper_get_position(struct stepper *s)
 {
     uint32_t position = s->position;
     // If stepper is mid-move, subtract out steps not yet taken
-    if (HAVE_AVR_OPTIMIZATION && s->flags & SF_SINGLE_SCHED)
+    if (HAVE_SINGLE_SCHEDULE && s->flags & SF_SINGLE_SCHED)
         position -= s->count;
     else
         position -= s->count / 2;
@@ -286,7 +320,8 @@ stepper_stop(struct trsync_signal *tss, uint8_t reason)
     s->count = 0;
     s->flags = (s->flags & (SF_INVERT_STEP|SF_SINGLE_SCHED)) | SF_NEED_RESET;
     gpio_out_write(s->dir_pin, 0);
-    gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
+    if (!(HAVE_EDGE_OPTIMIZATION && s->flags & SF_SINGLE_SCHED))
+        gpio_out_write(s->step_pin, s->flags & SF_INVERT_STEP);
     while (!move_queue_empty(&s->mq)) {
         struct move_node *mn = move_queue_pop(&s->mq);
         struct stepper_move *m = container_of(mn, struct stepper_move, node);

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -13,6 +13,7 @@ config STM32_SELECT
     select HAVE_GPIO_BITBANGING if !MACH_STM32F031
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
+    select HAVE_STEPPER_BOTH_EDGE
 
 config BOARD_DIRECTORY
     string


### PR DESCRIPTION
The current mcu build defaults to a 2us step pulse duration.  Changing this duration requires recompiling of the micro-controller code today and any change applies to all steppers on the given mcu.  This PR changes the code so that the pulse duration is no longer a compile-time setting and is instead configured for each stepper in a new `step_pulse_duration` option in the printer.cfg file.

Along with this change, TMC drivers configured via UART or SPI mode will automatically enable new optimizations for generating step pulses.  In particular, the `DEDGE=1` driver setting is enabled so that steps are taken on both rising and falling edges of the step gpio pin.  These optimizations make it possible for the default mcu build to obtain dramatically higher step rates on 32-bit micro-controllers.  (Many of these chips will now be able to reach over a million steps per second.)

-Kevin