### PR TITLE
SKR E3 Turbo builtin board thermistor

### DIFF
--- a/config/generic-bigtreetech-skr-e3-turbo.cfg
+++ b/config/generic-bigtreetech-skr-e3-turbo.cfg
@@ -112,6 +112,10 @@ pin: P2.1
 [heater_fan nozzle_cooling_fan]
 pin: P2.2
 
+[temperature_sensor board]
+sensor_pin: P1.30
+sensor_type: EPCOS 100K B57560G104F
+
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_lpc1769_00000000000000000000000000000000-if00
 


### PR DESCRIPTION
Minor update to `generic-bigtreetech-skr-e3-turbo.cfg`  to add the builtin 100K NTC

![image](https://user-images.githubusercontent.com/239811/139527400-eb76c1d7-6355-4383-8513-1807ce9356ec.png)
