### PR TITLE
Fysetc Spider SD Card Upload Fix

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -50,9 +50,16 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4"
     },
-    'fysetc-spider': {
+    'fysetc-s6': {
         'mcu': "stm32f446xx",
         'spi_bus': "spi1",
+        "cs_pin": "PA4",
+        "current_firmware_path": "OLD.BIN"
+    },
+    'fysetc-spider': {
+        'mcu': "stm32f446xx",
+        'spi_bus': "swspi",
+        "spi_pins": "PA6,PA7,PA5",
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
     }
@@ -87,8 +94,8 @@ BOARD_ALIASES = {
     'btt-gtr-v1': BOARD_DEFS['btt-gtr'],
     'mks-robin-e3d': BOARD_DEFS['mks-robin-e3'],
     'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
-    'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
-    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider']
+    'fysetc-s6-v1.2': BOARD_DEFS['fysetc-s6'],
+    'fysetc-s6-v2': BOARD_DEFS['fysetc-s6']
 }
 
 def list_boards():


### PR DESCRIPTION
flash_sdcard / board_defs: Fix to allow Fysetc Spider to use flash_sdcard.sh correctly

Fix for issue #4838 - corrects the board defs for the Fysetc Spider.  Issue on Fysetc github has testimonials for fix working on both v1.0 and v1.1 of board.  As the S6 has not been tested, I have kept the original board definitions for the S6 split out as a separate entry.

Signed-off-by: Oli Wright (github@falo.co.uk)