### PR TITLE
Deprecate "NTC 100K beta 3950" thermistor

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -73,7 +73,7 @@ max_temp: 250
 
 [heater_bed]
 heater_pin: PD7
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PA1
 control: watermark
 min_temp: 0

--- a/config/generic-duet3-mini.cfg
+++ b/config/generic-duet3-mini.cfg
@@ -123,7 +123,7 @@ sense_resistor: 0.056
 
 [heater_bed]
 heater_pin: PB17 #out1
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: vref_scaled:PC0
 control: pid
 pullup_resistor: 2200

--- a/config/generic-mks-rumba32-v1.0.cfg
+++ b/config/generic-mks-rumba32-v1.0.cfg
@@ -72,7 +72,7 @@ max_temp: 250
 
 [heater_bed]
 heater_pin: PA1
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PC0
 control: watermark
 min_temp: 0

--- a/config/generic-rumba.cfg
+++ b/config/generic-rumba.cfg
@@ -74,7 +74,7 @@ max_temp: 250
 
 [heater_bed]
 heater_pin: PH6
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PK3
 control: watermark
 min_temp: 0

--- a/config/kit-voron2-250mm.cfg
+++ b/config/kit-voron2-250mm.cfg
@@ -141,7 +141,7 @@ max_extrude_only_distance: 780.0
 heater_pin: PB4
 #   D10 on mcu_xye
 max_power: 1.0
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PK5
 #   T0 on mcu_xye
 smooth_time: 3.0

--- a/config/printer-mtw-create-2015.cfg
+++ b/config/printer-mtw-create-2015.cfg
@@ -79,7 +79,7 @@ max_temp: 275
 
 [heater_bed]
 heater_pin: PE5
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PF2
 control: watermark
 min_temp: 0

--- a/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
@@ -127,7 +127,7 @@ rotation_distance: 29.888
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PD5
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PA7
 control: pid
 pid_Kp: 18.214030
@@ -138,7 +138,7 @@ max_temp: 230
 
 [heater_bed]
 heater_pin: PD4
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PA6
 control: pid
 pid_Kp: 71.321

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,13 @@ All dates in this document are approximate.
 
 ## Changes
 
+20211110: The "NTC 100K beta 3950" temperature sensor is deprecated.
+This sensor will be removed in the near future.  Most users will find
+the "Generic 3950" temperature sensor more accurate.  To continue to
+use the older (typically less accurate) definition, define a custom
+[thermistor](Config_Reference.md#thermistor) with `temperature1: 25`,
+`resistance1: 100000`, and `beta: 3950`.
+
 20211104: The "step pulse duration" option in "make menuconfig" has
 been removed. A new `step_pulse_duration` setting in the
 [stepper config section](Config_Reference.md#stepper) should be set

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -701,7 +701,7 @@ heater_pin:
 #   periods) to the heater. The default is 1.0.
 sensor_type:
 #   Type of sensor - common thermistors are "EPCOS 100K B57560G104F",
-#   "ATC Semitec 104GT-2", "NTC 100K beta 3950", "Honeywell 100K
+#   "ATC Semitec 104GT-2", "Generic 3950", "Honeywell 100K
 #   135-104LAG-J01", "NTC 100K MGB18-104F39050L32", "SliceEngineering
 #   450", and "TDK NTCG104LH104JT1". See the "Temperature sensors"
 #   section for other sensors. This parameter must be provided.
@@ -2058,7 +2058,7 @@ sections that use one of these sensors.
 ```
 sensor_type:
 #   One of "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2",
-#   "NTC 100K beta 3950", "Honeywell 100K 135-104LAG-J01",
+#   "Generic 3950", "Honeywell 100K 135-104LAG-J01",
 #   "NTC 100K MGB18-104F39050L32", "SliceEngineering 450", or
 #   "TDK NTCG104LH104JT1"
 sensor_pin:

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, threading
+import os, logging, threading
 
 
 ######################################################################
@@ -230,7 +230,7 @@ class PrinterHeaters:
         self.gcode_id_to_sensor = {}
         self.available_heaters = []
         self.available_sensors = []
-        self.has_started = False
+        self.has_started = self.have_load_sensors = False
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.printer.register_event_handler("gcode:request_restart",
                                             self.turn_off_all_heaters)
@@ -241,6 +241,18 @@ class PrinterHeaters:
         gcode.register_command("M105", self.cmd_M105, when_not_ready=True)
         gcode.register_command("TEMPERATURE_WAIT", self.cmd_TEMPERATURE_WAIT,
                                desc=self.cmd_TEMPERATURE_WAIT_help)
+    def load_config(self, config):
+        self.have_load_sensors = True
+        # Load default temperature sensors
+        pconfig = self.printer.lookup_object('configfile')
+        dir_name = os.path.dirname(__file__)
+        filename = os.path.join(dir_name, 'temperature_sensors.cfg')
+        try:
+            dconfig = pconfig.read_config(filename)
+        except Exception:
+            raise config.config_error("Cannot load config '%s'" % (filename,))
+        for c in dconfig.get_prefix_sections(''):
+            self.printer.load_object(dconfig, c.get_name())
     def add_sensor_factory(self, sensor_type, sensor_factory):
         self.sensor_factories[sensor_type] = sensor_factory
     def setup_heater(self, config, gcode_id=None):
@@ -262,12 +274,8 @@ class PrinterHeaters:
                 "Unknown heater '%s'" % (heater_name,))
         return self.heaters[heater_name]
     def setup_sensor(self, config):
-        modules = ["thermistor", "adc_temperature", "spi_temperature",
-                   "bme280", "htu21d", "lm75", "temperature_host",
-                   "temperature_mcu", "ds18b20"]
-
-        for module_name in modules:
-            self.printer.load_object(config, module_name)
+        if not self.have_load_sensors:
+            self.load_config(config)
         sensor_type = config.get('sensor_type')
         if sensor_type not in self.sensor_factories:
             raise self.printer.config_error(

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -280,6 +280,8 @@ class PrinterHeaters:
         if sensor_type not in self.sensor_factories:
             raise self.printer.config_error(
                 "Unknown temperature sensor '%s'" % (sensor_type,))
+        if sensor_type == 'NTC 100K beta 3950':
+            config.deprecate('sensor_type', 'NTC 100K beta 3950')
         return self.sensor_factories[sensor_type](config)
     def register_sensor(self, config, psensor, gcode_id=None):
         self.available_sensors.append(config.get_name())

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -1,0 +1,31 @@
+# This file loads the default temperature sensors.
+
+# Load "PT1000", "PT100 INA826", "AD595", "AD597", "AD8494", "AD8495",
+# "AD8496", and "AD8497" sensors
+[adc_temperature]
+
+# Load "BME280" sensor
+[bme280]
+
+# Load "DS18B20" sensor
+[ds18b20]
+
+# Load "SI7013", "SI7020", "SI7021", "SHT21", and "HTU21D" sensors
+[htu21d]
+
+# Load "LM75" sensor
+[lm75]
+
+# Load "MAX6675", "MAX31855", "MAX31856", and "MAX31865" sensors
+[spi_temperature]
+
+# Load "temperature_host" sensor
+[temperature_host]
+
+# Load "temperature_mcu" sensor
+[temperature_mcu]
+
+# Load "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2", "NTC 100K beta 3950",
+# "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
+# "SliceEngineering 450", and "TDK NTCG104LH104JT1" sensors
+[thermistor]

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -54,6 +54,15 @@ resistance2: 1641.9
 temperature3: 250
 resistance3: 226.15
 
+# Definition from (20211101): https://www.keenovo.com/NTC-Thermistor-R-T-Table.pdf
+[thermistor Generic 3950]
+temperature1: 25
+resistance1: 100000
+temperature2: 150
+resistance2: 1770
+temperature3: 250
+resistance3: 230
+
 # Definition from (20211101): https://www.sliceengineering.com/products/thermistor-high-temperature and https://docs.google.com/spreadsheets/d/1904x5JK-Sup-cX5DqHiiZWaFVTK6_PQBFxgi_6yXEJw/edit#gid=0
 [thermistor SliceEngineering 450]
 temperature1: 25

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -1,5 +1,10 @@
 # This file loads the default temperature sensors.
 
+
+########################################
+# Module loading
+########################################
+
 # Load "PT1000", "PT100 INA826", "AD595", "AD597", "AD8494", "AD8495",
 # "AD8496", and "AD8497" sensors
 [adc_temperature]
@@ -25,7 +30,62 @@
 # Load "temperature_mcu" sensor
 [temperature_mcu]
 
-# Load "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2", "NTC 100K beta 3950",
-# "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
-# "SliceEngineering 450", and "TDK NTCG104LH104JT1" sensors
-[thermistor]
+
+########################################
+# Default thermistors
+########################################
+
+# Definition from (20211101): https://download.lulzbot.com/retail_parts/Completed_Parts/100k_Semitech_GT2_Thermistor_KT-EL0059/GT-2-glass-thermistors.pdf
+[thermistor ATC Semitec 104GT-2]
+temperature1: 20
+resistance1: 126800
+temperature2: 150
+resistance2: 1360
+temperature3: 300
+resistance3: 80.65
+
+# Definition from (20211101): https://www.tdk-electronics.tdk.com/inf/50/db/ntc_09/Glass_enc_Sensors__B57560__G560__G1560.pdf
+# (B57560G104 is same definition as B57560G1104)
+[thermistor EPCOS 100K B57560G104F]
+temperature1: 25
+resistance1: 100000
+temperature2: 150
+resistance2: 1641.9
+temperature3: 250
+resistance3: 226.15
+
+# Definition from (20211101): https://www.sliceengineering.com/products/thermistor-high-temperature and https://docs.google.com/spreadsheets/d/1904x5JK-Sup-cX5DqHiiZWaFVTK6_PQBFxgi_6yXEJw/edit#gid=0
+[thermistor SliceEngineering 450]
+temperature1: 25
+resistance1: 500000
+temperature2: 200
+resistance2: 3734
+temperature3: 400
+resistance3: 240
+
+# Definition from (20211101): https://product.tdk.com/system/files/dam/doc/product/sensor/ntc/chip-ntc-thermistor/rt_sheets/ntcg104lh104jt1.csv
+[thermistor TDK NTCG104LH104JT1]
+temperature1: 25
+resistance1: 100000
+temperature2: 50
+resistance2: 31230
+temperature3: 125
+resistance3: 2066
+
+# Definition from (20211101): https://sensing.honeywell.com/135-104lag-j01-thermistors
+[thermistor Honeywell 100K 135-104LAG-J01]
+temperature1: 25
+resistance1: 100000
+beta: 3974
+
+# Definition inherent from name
+[thermistor NTC 100K beta 3950]
+temperature1: 25
+resistance1: 100000
+beta: 3950
+
+# Definition from description of Marlin "thermistor 75"
+[thermistor NTC 100K MGB18-104F39050L32]
+temperature1: 25
+resistance1: 100000
+beta: 4100

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -87,7 +87,7 @@ temperature1: 25
 resistance1: 100000
 beta: 3974
 
-# Definition inherent from name
+# Definition inherent from name. This sensor is deprecated!
 [thermistor NTC 100K beta 3950]
 temperature1: 25
 resistance1: 100000

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -101,32 +101,6 @@ class CustomThermistor:
     def create(self, config):
         return PrinterThermistor(config, self.params)
 
-# Default sensors
-Sensors = {
-    "EPCOS 100K B57560G104F": {
-        't1': 25., 'r1': 100000., 't2': 150., 'r2': 1641.9,
-        't3': 250., 'r3': 226.15 },
-    "ATC Semitec 104GT-2": {
-        't1': 20., 'r1': 126800., 't2': 150., 'r2': 1360.,
-        't3': 300., 'r3': 80.65 },
-    "SliceEngineering 450": {
-        't1': 25., 'r1': 500000., 't2': 200., 'r2': 3734.,
-        't3': 400., 'r3': 240. },
-    "TDK NTCG104LH104JT1": {
-        't1': 25., 'r1': 100000., 't2': 50., 'r2': 31230.,
-        't3': 125., 'r3': 2066. },
-    "NTC 100K beta 3950": { 't1': 25., 'r1': 100000., 'beta': 3950. },
-    "Honeywell 100K 135-104LAG-J01": { 't1': 25., 'r1': 100000., 'beta': 3974.},
-    "NTC 100K MGB18-104F39050L32": { 't1': 25., 'r1': 100000., 'beta': 4100. },
-}
-
-def load_config(config):
-    # Register default thermistor types
-    pheaters = config.get_printer().load_object(config, "heaters")
-    for sensor_type, params in Sensors.items():
-        func = (lambda config, params=params: PrinterThermistor(config, params))
-        pheaters.add_sensor_factory(sensor_type, func)
-
 def load_config_prefix(config):
     thermistor = CustomThermistor(config)
     pheaters = config.get_printer().load_object(config, "heaters")


### PR DESCRIPTION
This PR moves the default thermistor definitions from thermistor.py to a new temperature_sensor.cfg file, introduces a new "Generic 3950" thermistor, and deprecates the "NTC 100K beta 3950" definition.

As discussed in #4054 , it seems most real-world "beta 3950" sensors don't actually follow a true "beta 3950" temperature curve, and instead follow a curve defined in the new "Generic 3950" table.  Deprecating the "NTC 100K beta 3950" definition seems like the best way to raise awareness and move printers over to a more accurate configuration.

-Kevin

Edit: Change name of new thermistor to "Generic 3950".