### PR TITLE
Use Unix signals in linux mcu code to notify when a timer is pending

### DIFF
--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -7,7 +7,7 @@ src-y += linux/pca9685.c linux/spidev.c linux/analog.c linux/hard_pwm.c
 src-y += linux/i2c.c linux/gpio.c generic/crc16_ccitt.c generic/alloc.c
 src-y += linux/sensor_ds18b20.c
 
-CFLAGS_klipper.elf += -lutil -lpthread
+CFLAGS_klipper.elf += -lutil -lrt -lpthread
 
 flash: $(OUT)klipper.elf
 	@echo "  Flashing"

--- a/src/linux/internal.h
+++ b/src/linux/internal.h
@@ -2,6 +2,7 @@
 #define __LINUX_INTERNAL_H
 // Local definitions for micro-controllers running on linux
 
+#include <signal.h> // sigset_t
 #include <stdint.h> // uint32_t
 #include "autoconf.h" // CONFIG_CLOCK_FREQ
 
@@ -9,7 +10,6 @@
 #define GPIO(PORT, NUM) ((PORT) * MAX_GPIO_LINES + (NUM))
 #define GPIO2PORT(PIN) ((PIN) / MAX_GPIO_LINES)
 #define GPIO2PIN(PIN) ((PIN) % MAX_GPIO_LINES)
-
 
 #define NSECS 1000000000
 #define NSECS_PER_TICK (NSECS / CONFIG_CLOCK_FREQ)
@@ -19,10 +19,12 @@ void report_errno(char *where, int rc);
 int set_non_blocking(int fd);
 int set_close_on_exec(int fd);
 int console_setup(char *name);
-void console_sleep(struct timespec ts);
+void console_sleep(sigset_t *sigset);
 
 // timer.c
 int timer_check_periodic(uint32_t *ts);
+void timer_disable_signals(void);
+void timer_enable_signals(void);
 
 // watchdog.c
 int watchdog_setup(void);

--- a/src/linux/sensor_ds18b20.c
+++ b/src/linux/sensor_ds18b20.c
@@ -163,7 +163,9 @@ command_config_ds18b20(uint32_t *args)
         goto fail4;
 
     pthread_t reader_tid; // Not used
+    timer_disable_signals();
     ret = pthread_create(&reader_tid, NULL, reader_start_routine, d);
+    timer_enable_signals();
     if (ret)
         goto fail5;
 


### PR DESCRIPTION
Use Unix signals in software timer implementation.  This makes the code a little more efficient.

This was part of work I did earlier in the year as part of the discussion on #4201 and #3387 .  It should be generally useful though, so I think it's worth merging.

@tntclaus - fyi.

-Kevin