### PR TITLE
Apt update missing an arg for OctoPI

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -21,7 +21,7 @@ install_packages()
 
     # Update system package info
     report_status "Running apt-get update..."
-    sudo apt-get update
+    sudo apt-get update --allow-releaseinfo-change
 
     # Install desired packages
     report_status "Installing packages..."


### PR DESCRIPTION
 --allow-releaseinfo-change needed for the current version of OctoPi...
 
 `
 pi@octopi:~ $ ./klipper/scripts/install-octopi.sh


###### Running apt-get update...

Get:1 http://archive.raspberrypi.org/debian buster InRelease [32.6 kB]
Get:2 http://raspbian.raspberrypi.org/raspbian buster InRelease [15.0 kB]
Get:3 http://archive.raspberrypi.org/debian buster/main armhf Packages [393 kB]
Reading package lists... Done    
E: Repository 'http://raspbian.raspberrypi.org/raspbian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
`