### PR TITLE
duplicate pin number

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -154,7 +154,7 @@ max_z_accel: 100
 #run_current: 0.650
 #hold_current: 0.450
 #stealthchop_threshold: 999999
-#diag1_pin: P1.27
+#diag1_pin: P1.27 <--endstop_pin
 
 #[tmc2130 extruder]
 #cs_pin: P1.4


### PR DESCRIPTION
how come endstop_pin and diag1_pin share the same pin 1.27 ?