### PR TITLE
Update generic-mellow-super-infinty-hv.cfg to use hardware SPI

### DIFF
--- a/config/generic-mellow-super-infinty-hv.cfg
+++ b/config/generic-mellow-super-infinty-hv.cfg
@@ -53,7 +53,7 @@ microsteps: 16
 rotation_distance: 33.500
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-heater_pin: PC7 # Heat0
+heater_pin: PB0 # Heat0
 sensor_pin: PF4 # ADC_0
 sensor_type: EPCOS 100K B57560G104F
 control: pid

--- a/config/generic-mellow-super-infinty-hv.cfg
+++ b/config/generic-mellow-super-infinty-hv.cfg
@@ -248,9 +248,7 @@ max_z_accel: 100
 
 #[tmc5160 stepper_x]
 #cs_pin: PC4
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PG12
 #run_current: 0.800
 #hold_current: 0.500
@@ -258,9 +256,7 @@ max_z_accel: 100
 
 #[tmc5160 stepper_y]
 #cs_pin: PF12
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PG11
 #run_current: 0.800
 #hold_current: 0.500
@@ -268,9 +264,7 @@ max_z_accel: 100
 
 #[tmc5160 stepper_z]
 #cs_pin: PF15
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PG10
 #run_current: 0.650
 #hold_current: 0.450
@@ -278,9 +272,7 @@ max_z_accel: 100
 
 #[tmc5160 extruder]
 #cs_pin: PE7
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PG9
 #run_current: 0.800
 #hold_current: 0.500
@@ -288,9 +280,7 @@ max_z_accel: 100
 
 #[tmc5160 extruder1]
 #cs_pin: PE10
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PD7
 #run_current: 0.800
 #hold_current: 0.500
@@ -298,9 +288,7 @@ max_z_accel: 100
 
 #[tmc5160 extruder2]
 #cs_pin: PF1
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PD6
 #run_current: 0.800
 #hold_current: 0.500
@@ -308,9 +296,7 @@ max_z_accel: 100
 
 #[tmc5160 extruder3]
 #cs_pin: PG2
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PA8
 #run_current: 0.800
 #hold_current: 0.500
@@ -318,9 +304,7 @@ max_z_accel: 100
 
 #[tmc5160 extruder4]
 #cs_pin: PG5
-#spi_software_miso_pin: PB5
-#spi_software_mosi_pin: PB4
-#spi_software_sclk_pin: PB3
+#spi_bus: spi3
 ##diag1_pin: PF3
 #run_current: 0.800
 #hold_current: 0.500


### PR DESCRIPTION
TMC2130/5160 can make use of `spi3`, which is operated on the software SPI pins in the current configuration. The supplied defaults for software SPI do not currently work.

Signed-Off-By: Wijnand Modderman-Lenstra <maze@maze.io>