### PR TITLE
Workflow change - shutting down github issue tracker

### DIFF
--- a/docs/Contact.md
+++ b/docs/Contact.md
@@ -2,7 +2,7 @@
 
 This document provides contact information for Klipper.
 
-1. [Community Forum](#community-forum)
+1. [GitHub Discussions](#github-discussions)
 2. [Discord Chat](#discord-chat)
 3. [I have a question about Klipper](#i-have-a-question-about-klipper)
 4. [I have a feature request](#i-have-a-feature-request)
@@ -10,11 +10,11 @@ This document provides contact information for Klipper.
 6. [I have diagnosed a defect in the Klipper software](#i-have-diagnosed-a-defect-in-the-klipper-software)
 7. [I am making changes that I'd like to include in Klipper](#i-am-making-changes-that-id-like-to-include-in-klipper)
 
-## Community Forum
+## GitHub Discussions
 
 There is a
-[Klipper Community Discourse server](https://community.klipper3d.org)
-for discussions on Klipper.
+[Klipper Discussion area on GitHub](https://github.com/Klipper3d/klipper/discussions)
+for Klipper topics.
 
 ## Discord Chat
 
@@ -32,11 +32,11 @@ Many questions we receive are already answered in the
 documentation and follow the directions provided there.
 
 It is also possible to search for similar questions in the
-[Klipper Community Forum](#community-forum).
+[Klipper Discussion Forum](#github-discussions).
 
 If you are interested in sharing your knowledge and experience with
 other Klipper users then you can join the
-[Klipper Community Forum](#community-forum) or
+[Klipper Discussion Forum](#github-discussions) or
 [Klipper Discord Chat](#discord-chat). Both are communities where
 Klipper users can discuss Klipper with other users.
 
@@ -46,18 +46,14 @@ experiencing general printing problems, then you will likely get a
 better response by asking in a general 3d-printing forum or a forum
 dedicated to your printer hardware.
 
-Do not open a Klipper github issue to ask a question.
-
 ## I have a feature request
 
 All new features require someone interested and able to implement that
 feature. If you are interested in helping to implement or test a new
 feature, you can search for ongoing developments in the
-[Klipper Community Forum](#community-forum). There is also
+[Klipper Discussion Forum](#github-discussions). There is also
 [Klipper Discord Chat](#discord-chat) for discussions between
 collaborators.
-
-Do not open a Klipper github issue to request a feature.
 
 ## Help! It doesn't work!
 
@@ -80,15 +76,13 @@ searching in a general 3d-printing forum or in a forum dedicated to
 your printer hardware.
 
 It is also possible to search for similar issues in the
-[Klipper Community Forum](#community-forum).
+[Klipper Discussion Forum](#github-discussions).
 
 If you are interested in sharing your knowledge and experience with
 other Klipper users then you can join the
-[Klipper Community Forum](#community-forum) or
+[Klipper Discussion Forum](#github-discussions) or
 [Klipper Discord Chat](#discord-chat). Both are communities where
 Klipper users can discuss Klipper with other users.
-
-Do not open a Klipper github issue to request help.
 
 ## I have diagnosed a defect in the Klipper software
 
@@ -97,26 +91,18 @@ diagnose errors in the software.
 
 There is important information that will be needed in order to fix a
 bug. Please follow these steps:
-1. Be sure the bug is in the Klipper software. If you are thinking
-   "there is a problem, I can't figure out why, and therefore it is a
-   Klipper bug", then **do not** open a github issue. In that case,
-   someone interested and able will need to first research and
-   diagnose the root cause of the problem. If you would like to share
-   the results of your research or check if other users are
-   experiencing similar issues then you can search the
-   [Klipper Community Forum](#community-forum).
-2. Make sure you are running unmodified code from
+1. Make sure you are running unmodified code from
    [https://github.com/Klipper3d/klipper](https://github.com/Klipper3d/klipper).
    If the code has been modified or is obtained from another source,
    then you will need to reproduce the problem on the unmodified code
    from
    [https://github.com/Klipper3d/klipper](https://github.com/Klipper3d/klipper)
    prior to reporting an issue.
-3. If possible, run an `M112` command in the OctoPrint terminal window
+2. If possible, run an `M112` command in the OctoPrint terminal window
    immediately after the undesirable event occurs. This causes Klipper
    to go into a "shutdown state" and it will cause additional
    debugging information to be written to the log file.
-4. Obtain the Klipper log file from the event. The log file has been
+3. Obtain the Klipper log file from the event. The log file has been
    engineered to answer common questions the Klipper developers have
    about the software and its environment (software version, hardware
    type, configuration, event timing, and hundreds of other
@@ -138,12 +124,11 @@ bug. Please follow these steps:
       necessary information.
    5. If the log file is very large (eg, greater than 2MB) then one
       may need to compress the log with zip or gzip.
-5. Open a new github issue at
-   [https://github.com/Klipper3d/klipper/issues](https://github.com/Klipper3d/klipper/issues)
-   and provide a clear description of the problem. The Klipper
-   developers need to understand what steps were taken, what the
-   desired outcome was, and what outcome actually occurred. The
-   Klipper log file **must be attached** to that ticket:
+4. Open a new topic on [GitHub discussions](#github-discussions) and
+   provide a clear description of the problem. The Klipper developers
+   need to understand what steps were taken, what the desired outcome
+   was, and what outcome actually occurred. Be sure to **attach** the
+   Klipper log file to your message.
 
    ![attach-issue](img/attach-issue.png)
 
@@ -158,8 +143,8 @@ for important information.
 There are several
 [documents for developers](Overview.md#developer-documentation). If
 you have questions on the code then you can also ask in the
-[Klipper Community Forum](#community-forum) or on the
-[Klipper Community Discord](#discord-chat). If you would like to
-provide an update on your current progress then you can open a Github
-issue with the location of your code, an overview of the changes, and
-a description of its current status.
+[Klipper Discussion Forum](#github-discussions) or on the
+[Klipper Discord](#discord-chat). If you would like to provide an
+update on your current progress then you can open a topic on Github
+Discussions with the location of your code, an overview of the
+changes, and a description of its current status.


### PR DESCRIPTION
I'm planning to disable the Klipper "GitHub issue tracker".  I'm also looking at enabling the "GitHub Discussions" feature.  Going forward, I'm hoping there will be volunteers to help review PRs and identify confirmed software defects.

I'm finding that the GitHub issue tracker is becoming more of a burden than a help.  It seems many people have different views of what the issue tracker should be used for - some view it as a tool to track software defects, some as a todo list, some as a ticket tracker for requests, some as an area for general discussions, and many more views.  Unfortunately, this makes it difficult to manage - I feel it becomes a poor tool for tracking once the number of open tickets increases beyond a few dozen.  However, trying to limit what topics are "valid" on the issue tracker is not working well - it seems too many people have alternative views on what it should be used for - I fear attempts to manage it are consuming time and causing unnecessary conflict.  I also fear that not managing the issue tracker (no enforced guidelines ; no proactive closing of tickets) will give a poor image of the project - those people that view the github issue tracker as a tool for tracking defects may make a conclusion about the health of the project by the number of open "issues".

I'm hoping that using the more neutral "Discussions" feature of GitHub will work better.  In mechanics, the Discussions feature seems to be similar to the issue tracker, but it hopefully wont have this problem of differing expectations.  It'll be an area for discussions - not just discussions on "issues".

I'm also looking for long term contributors to Klipper to help volunteer with doing reviews.  Both reviews of GitHub Discussions and to help review GitHub Pull Requests.  By "long term contributor" I'm referring to people that have had regular activity helping users on Discourse, Discord, or contributing PRs to Klipper over at least six months.  It's not necessary to be a developer to be a "contributor" - many of the topics we need help with are reviews of bug reports, reviews of documentation changes, reviews of config files, reviews of PRs for copyrights/sign-offs, etc.  If interested, let me know.

The change to the Contact.md document in this PR removes the link to the Klipper Discourse server.  I don't have any plans to shutdown the Klipper Discourse.  However, there is quite a bit of overlap between the functionality of "GitHub Discussions" and "Discourse" - the proposal here is to see how well "GitHub Discussions" works as the primary "forum" for Klipper.  We may ultimately run both servers indefinitely, or choose just one of them.

Finally, I know this may seem as "yet another change" to the preferred Klipper forum (github issue tracker, mailing list, Discourse, GitHub Discussions, etc.).  It's certainly a concern of mine as well.  I can just say that I'm trying my best and hope we can come up with a solution that works well for the community.

-Kevin