### PR TITLE
Add support for BTT octopus to flash-sdcard.sh

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -55,6 +55,12 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
+    },
+    'btt-octopus': {
+        'mcu': "stm32f446xx",
+        'spi_bus': "swspi",
+        "spi_pins": "PC8,PD2,PC12",
+        "cs_pin": "PC11",
     }
 }
 
@@ -88,7 +94,10 @@ BOARD_ALIASES = {
     'mks-robin-e3d': BOARD_DEFS['mks-robin-e3'],
     'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
-    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider']
+    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider'],
+    'btt-octopus-v1': BOARD_DEFS['btt-octopus'],
+    'btt-octopus-v1.1': BOARD_DEFS['btt-octopus'],
+    
 }
 
 def list_boards():


### PR DESCRIPTION
Using swspi updates work for BTT octpus. Tested and works.

```
$ ./scripts/flash-sdcard.sh /dev/ttyAMA0  btt-octopus-v1
Flashing /home/pi/klipper/out/klipper.bin to /dev/ttyAMA0
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
Initializing SD Card and Mounting file system...

SD Card Information:
Version: 2.0
SDHC/SDXC: True
Write Protected: False
Sectors: 7774208
manufacturer_id: 39
oem_id: PH
product_name: SD4GB
product_revision: 5.80
serial_number: DABB21FB
manufacturing_date: 7/2017
capacity: 3.7 GiB
fs_type: FAT32
volume_label: boot
volume_serial: 1575249500
Uploading Klipper Firmware to SD Card...Done
Validating Upload...Done
Firmware Upload Complete: firmware.bin, Size: 20104, Checksum (SHA1): D7E8740FDB68C459B75EF651274AA2AFDA0C751E
Attempting MCU Reset...Done
Waiting for device to reconnect...Done
Connecting to MCU...Connected
Verifying Flash...Version matched...Done
Found and deleted firmware.bin after reset
Firmware Flash Successful
Current Firmware: v0.10.0-1-gb806d71e-dirty-20211105_051612-raspberrypi
Attempting MCU Reset...Done
SD Card Flash Complete
```