### PR TITLE
Pass `commandline` as an additional macro param

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -178,6 +178,7 @@ class GCodeMacro:
         kwparams = dict(self.variables)
         kwparams.update(self.template.create_template_context())
         kwparams['params'] = gcmd.get_command_parameters()
+        kwparams['commandline'] = gcmd.get_commandline()
         self.in_script = True
         try:
             self.template.run_gcode_from_command(kwparams)

--- a/test/klippy/macros.cfg
+++ b/test/klippy/macros.cfg
@@ -109,6 +109,14 @@ gcode:
     M112
   {% endif %}
 
+[gcode_macro T1]
+description: Test commandline is passed to macro
+gcode:
+  { action_respond_info("T1") }
+  {% if commandline != "T1 testing 1 2 3" %}
+    M112
+  {% endif %}
+
 [gcode_macro TEST_in]
 gcode:
   {% if "abc" in printer or "toolhead" not in printer %}
@@ -128,5 +136,6 @@ gcode:
   TEST_expression
   TEST_variable
   TEST_param T=123
+  T1 testing 1 2 3
   TEST_unicode
   TEST_in


### PR DESCRIPTION
Although `params` is useful in most cases, M117, for instance, does not use the input as a list of parameters, but as a string.
For these cases, it is useful to have the full command line available.

An example macro would be:

```
[gcode_macro M117]
rename_existing: M117.1
gcode:
  {% set macro_name = "M117" %}
  {% macro log(message, level='info') %}
  RESPOND PREFIX="{ "\"[%s%s%s]\"" % (macro_name,":" if level else "", level) }" MSG="{message}"
  {% endmacro %}
  {% set message = "".join(commandline[5:]) %}
  {log(message, "")}
```

In this case, the input to M117 is sent both to the display as usual, but also to the console.

Although the obvious solution would be to use `{" ".join(params.keys()}`, this doesn't actually work as expected - the dict is reordered, and numbers seem just to be ignored. ie: `M117 hello world 123` is sent to the template as `M HELLO`