### PR TITLE
stm32f4: resolve bootloader issues

### DIFF
--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -260,6 +260,12 @@ armcm_main(void)
     SystemInit();
     SCB->VTOR = (uint32_t)VectorTable;
 
+    // Reset peripheral clocks (for some bootloaders that don't)
+    RCC->AHB1ENR = 0x38000;
+    RCC->AHB2ENR = 0;
+    RCC->APB1ENR = 0;
+    RCC->APB2ENR = 0;
+
     clock_setup();
 
     sched_main();

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -24,10 +24,17 @@ enable_pclock(uint32_t periph_base)
         uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
         RCC->APB1ENR |= (1<<pos);
         RCC->APB1ENR;
+        RCC->APB1RSTR |= (1<<pos);
+        RCC->APB1RSTR &= ~(1<<pos);
     } else if (periph_base < AHB1PERIPH_BASE) {
         uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
         RCC->APB2ENR |= (1<<pos);
         RCC->APB2ENR;
+        // Skip ADC peripheral reset as they share a bit
+        if (pos < 8 || pos > 10) {
+            RCC->APB2RSTR |= (1<<pos);
+            RCC->APB2RSTR &= ~(1<<pos);
+        }
     } else if (periph_base < AHB2PERIPH_BASE) {
         uint32_t pos = (periph_base - AHB1PERIPH_BASE) / 0x400;
         RCC->AHB1ENR |= (1<<pos);


### PR DESCRIPTION
This PR resets the peripheral clocks on init and performs a factory reset on the peripheral registers as they are enabled in `enable_pclock()`.  The implementation mimicks how it is handled with the STM32F1, with the FLITF and SRAM clocks enabled.

As bit 8 of APB2RSTR resets all 3 ADCs I thought it wise to avoid it.  My assumption is that it would cause an unwanted reset if multiple ADCs are enabled.

This should resolve #4838 and #4856.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>