### PR TITLE
Add link to OctoPi-Klipper pre-installed image

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,12 @@ micro-controllers,
 [ARM based micro-controllers](Features.md#step-benchmarks), and
 [Beaglebone PRU](beaglebone.md) based printers.
 
-## Prepping an OS image
+## Use pre-installed ready to use image
+You can download a pre-installed image with OctoPi and Klipper with the correct default settings.
+
+[OctoPi-Klipper can be downloaded here](https://github.com/guysoft/OctoPi-Klipper).
+
+## Prepping an existing OS image
 
 Start by installing [OctoPi](https://github.com/guysoft/OctoPi) on the
 Raspberry Pi computer. Use OctoPi v0.17.0 or later - see the


### PR DESCRIPTION
Add a link to the new pre-installed image, and then change the section that uses OctoPi to explain how t per-existing image can be edited.
I keep seeing people in the discord getting stuck installing OctoPi, then Klipper, this is a much better solution.

