### PR TITLE
extras: Added probe offsets values in get_status return

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -196,7 +196,11 @@ class PrinterProbe:
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     def get_status(self, eventtime):
         return {'last_query': self.last_state,
-                'last_z_result': self.last_z_result}
+                'last_z_result': self.last_z_result,
+                'offsets': {
+                    'x': self.x_offset,
+                    'y': self.y_offset,
+                    'z': self.z_offset}}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):
         speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)


### PR DESCRIPTION
module: extras/probe.py

Added probe offset values of x, y and z axes in the return of the get_status method so that made possible to get these values in macros, e.g.:

```
[gcode_macro PRINT_PROBE_OFFSETS]
gcode:
  {% set offsets = printer.probe.offsets %}
  {action_respond_info('Probe offsets X:%.3f Y:%.3f Z:%.3f'|format(offsets.x, offsets.y, offsets.z))}

[gcode_macro CENTER_PROBE]
description: Move toolhead probe to center of the bed.
gcode:
  G28
  G90

  {% set offsets = printer.probe.offsets %}
  {% set center_x = printer.toolhead.axis_maximum.x / 2 - offsets.x %}
  {% set center_y = printer.toolhead.axis_maximum.y / 2 - offsets.y %}
  
  {% if printer.toolhead.position.z < 1 %}
    G1 Z1 F6000
  {% endif %}

  G1 X{center_x} Y{center_y} Z10 F6000

  G91
```

Signed-off-by: Roberto Besser <rmbesser@gmail.com>