### PR TITLE
virtual_sdcard: round reported progress to 2 decimal places

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -81,7 +81,7 @@ class VirtualSD:
     def get_status(self, eventtime):
         return {
             'file_path': self.file_path(),
-            'progress': self.progress(),
+            'progress': round(self.progress(), 2),
             'is_active': self.is_active(),
             'file_position': self.file_position,
             'file_size': self.file_size,


### PR DESCRIPTION
This PR rounds progress reported by get_status() for virtual_sdcard (which in turn is used by display_status), as the additional precision is unnecessary.

This follows up on #4795

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>