### PR TITLE
Add support for PCF8574 based I2C adapters for HD44780 LCDs

### DIFF
--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -6,7 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, os, ast
-from . import hd44780, hd44780_spi, st7920, uc1701, menu
+from . import hd44780, hd44780_spi, hd44780_i2c, st7920, uc1701, menu
 
 # Normal time between each screen redraw
 REDRAW_TIME = 0.500
@@ -17,7 +17,8 @@ LCD_chips = {
     'st7920': st7920.ST7920, 'emulated_st7920': st7920.EmulatedST7920,
     'hd44780': hd44780.HD44780, 'uc1701': uc1701.UC1701,
     'ssd1306': uc1701.SSD1306, 'sh1106': uc1701.SH1106,
-    'hd44780_spi': hd44780_spi.hd44780_spi
+    'hd44780_spi': hd44780_spi.hd44780_spi,
+    'hd44780_i2c': hd44780_i2c.hd44780_i2c
 }
 
 # Storage of [display_template my_template] config sections

--- a/klippy/extras/display/hd44780_i2c.py
+++ b/klippy/extras/display/hd44780_i2c.py
@@ -53,8 +53,9 @@ class hd44780_i2c:
             (self.glyph_framebuffer, bytearray('~'*64), 0x40) ]
 
         gcode = self.printer.lookup_object('gcode')
-        gcode.register_command("HD_IIC_LCD_BACKLIGHT", self.cmd_HD_IIC_LCD_BACKLIGHT,
-                                   desc=self.cmd_HD_IIC_LCD_BACKLIGHT_help)
+        gcode.register_command("HD_IIC_LCD_BACKLIGHT",
+                                    self.cmd_HD_IIC_LCD_BACKLIGHT,
+                                    desc=self.cmd_HD_IIC_LCD_BACKLIGHT_help)
 
     def send_4_bits(self, cmd, is_data, minclock):
         if is_data:

--- a/klippy/extras/display/hd44780_i2c.py
+++ b/klippy/extras/display/hd44780_i2c.py
@@ -1,0 +1,148 @@
+# Support for HD44780 (20x4 text) LCD displays
+#
+# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018  Eric Callahan <arksine.code@gmail.com>
+# Copyright (C) 2021  Marc-Andre Denis <marcadenis@msn.com>
+# Copiright (C) 2021  Olivier Bossi <olivier.bossi@protonmail.ch>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from .. import bus
+
+LINE_LENGTH_DEFAULT=20
+LINE_LENGTH_OPTIONS={16:16, 20:20}
+
+TextGlyphs = { 'right_arrow': '\x7e' }
+
+
+
+class hd44780_i2c:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.hd44780_protocol_init = config.getboolean('hd44780_protocol_init',
+                                                       True)
+        self.backlight = config.getboolean('backlight',
+                       True)
+        # spi config
+        self.i2c = bus.MCU_I2C_from_config(
+            config, 0x40)
+        self.mcu = self.i2c.get_mcu()
+        #self.spi.spi_send([0x01,0xa0])
+        self.data_mask = (1<<0)
+        self.command_mask = (0<<0)
+        self.enable_mask = (1<<2)
+        self.backlight_mask = (1<<3)
+
+        self.set_backlight_mask(self.backlight)
+
+        self.icons = {}
+        self.line_length = config.getchoice('line_length', LINE_LENGTH_OPTIONS,
+                                            LINE_LENGTH_DEFAULT)
+
+        # framebuffers
+        self.text_framebuffers = [bytearray(' '*2*self.line_length),
+                                  bytearray(' '*2*self.line_length)]
+        self.glyph_framebuffer = bytearray(64)
+        self.all_framebuffers = [
+            # Text framebuffers
+            (self.text_framebuffers[0], bytearray('~'*2*self.line_length),
+             0x80),
+            (self.text_framebuffers[1], bytearray('~'*2*self.line_length),
+             0xc0),
+            # Glyph framebuffer
+            (self.glyph_framebuffer, bytearray('~'*64), 0x40) ]
+
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command("HD_IIC_LCD_BACKLIGHT", self.cmd_HD_IIC_LCD_BACKLIGHT,
+                                   desc=self.cmd_HD_IIC_LCD_BACKLIGHT_help)
+
+    def send_4_bits(self, cmd, is_data, minclock):
+        if is_data:
+            mask = self.data_mask
+        else:
+            mask = self.command_mask
+        mask = mask | self.backlight_mask
+        self.i2c.i2c_write([(cmd & 0xF0) | mask], minclock)
+        self.i2c.i2c_write([(cmd & 0xF0) | mask | self.enable_mask], minclock)
+        self.i2c.i2c_write([(cmd & 0xF0) | mask], minclock)
+    def send(self, cmds, is_data=False, minclock=0):
+        for data in cmds:
+            self.send_4_bits(data,is_data,minclock)
+            self.send_4_bits(data<<4,is_data,minclock)
+    def flush(self):
+        # Find all differences in the framebuffers and send them to the chip
+        for new_data, old_data, fb_id in self.all_framebuffers:
+            if new_data == old_data:
+                continue
+            # Find the position of all changed bytes in this framebuffer
+            diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
+                     if n != o]
+            # Batch together changes that are close to each other
+            for i in range(len(diffs)-2, -1, -1):
+                pos, count = diffs[i]
+                nextpos, nextcount = diffs[i+1]
+                if pos + 4 >= nextpos and nextcount < 16:
+                    diffs[i][1] = nextcount + (nextpos - pos)
+                    del diffs[i+1]
+            # Transmit changes
+            for pos, count in diffs:
+                chip_pos = pos
+                self.send([fb_id + chip_pos])
+                self.send(new_data[pos:pos+count], is_data=True)
+            old_data[:] = new_data
+    def init(self):
+        curtime = self.printer.get_reactor().monotonic()
+        print_time = self.mcu.estimated_print_time(curtime)
+        # Program 4bit / 2-line mode and then issue 0x02 "Home" command
+        if self.hd44780_protocol_init:
+            init = [[0x33], [0x33], [0x32], [0x28, 0x28, 0x02]]
+        else:
+            init = [[0x02]]
+        # Reset (set positive direction ; enable display and hide cursor)
+        init.append([0x06, 0x0c])
+        for i, cmds in enumerate(init):
+            minclock = self.mcu.print_time_to_clock(print_time + i * .100)
+            self.send(cmds, minclock=minclock)
+        self.flush()
+    def write_text(self, x, y, data):
+        if x + len(data) > self.line_length:
+            data = data[:self.line_length - min(x, self.line_length)]
+        pos = x + ((y & 0x02) >> 1) * self.line_length
+        self.text_framebuffers[y & 1][pos:pos+len(data)] = data
+    def set_glyphs(self, glyphs):
+        for glyph_name, glyph_data in glyphs.items():
+            data = glyph_data.get('icon5x8')
+            if data is not None:
+                self.icons[glyph_name] = data
+    def write_glyph(self, x, y, glyph_name):
+        data = self.icons.get(glyph_name)
+        if data is not None:
+            slot, bits = data
+            self.write_text(x, y, [slot])
+            self.glyph_framebuffer[slot * 8:(slot + 1) * 8] = bits
+            return 1
+        char = TextGlyphs.get(glyph_name)
+        if char is not None:
+            # Draw character
+            self.write_text(x, y, char)
+            return 1
+        return 0
+    def write_graphics(self, x, y, data):
+        pass
+    def clear(self):
+        spaces = ' ' * 2*self.line_length
+        self.text_framebuffers[0][:] = spaces
+        self.text_framebuffers[1][:] = spaces
+    def get_dimensions(self):
+        return (self.line_length, 4)
+    def set_backlight_mask(self,value):
+        if value:
+            self.backlight_mask = (1<<3)
+        else:
+            self.backlight_mask = (0<<3)
+
+    cmd_HD_IIC_LCD_BACKLIGHT_help = "Set I2C HD44780 backlight value"
+    def cmd_HD_IIC_LCD_BACKLIGHT(self, gcmd):
+        value = gcmd.get_int('VALUE', 1, minval=0, maxval=1)
+        self.set_backlight_mask(value==1)
+        self.i2c.i2c_write([self.backlight_mask])


### PR DESCRIPTION
This is an adaptation of the hd44780_spi class for use of HD44780 based LCDs with widely available jellybean PCF8574 based I2C adapters.

Signed-off-by: Olivier Bossi <olivier.bossi@protonmail.ch>