### PR TITLE
temperature_sensors: add ATC Semitec 104NT-4-R025H42G thermistor

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -701,10 +701,11 @@ heater_pin:
 #   periods) to the heater. The default is 1.0.
 sensor_type:
 #   Type of sensor - common thermistors are "EPCOS 100K B57560G104F",
-#   "ATC Semitec 104GT-2", "Generic 3950", "Honeywell 100K
-#   135-104LAG-J01", "NTC 100K MGB18-104F39050L32", "SliceEngineering
-#   450", and "TDK NTCG104LH104JT1". See the "Temperature sensors"
-#   section for other sensors. This parameter must be provided.
+#   "ATC Semitec 104GT-2", "ATC Semitec 104NT-4-R025H42G", "Generic
+#   3950","Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
+#   "SliceEngineering 450", and "TDK NTCG104LH104JT1". See the
+#   "Temperature sensors" section for other sensors. This parameter
+#   must be provided.
 sensor_pin:
 #   Analog input pin connected to the sensor. This parameter must be
 #   provided.
@@ -2058,9 +2059,9 @@ sections that use one of these sensors.
 ```
 sensor_type:
 #   One of "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2",
-#   "Generic 3950", "Honeywell 100K 135-104LAG-J01",
-#   "NTC 100K MGB18-104F39050L32", "SliceEngineering 450", or
-#   "TDK NTCG104LH104JT1"
+#   "ATC Semitec 104NT-4-R025H42G", "Generic 3950",
+#   "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
+#   "SliceEngineering 450", or "TDK NTCG104LH104JT1"
 sensor_pin:
 #   Analog input pin connected to the thermistor. This parameter must
 #   be provided.

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -44,6 +44,15 @@ resistance2: 1360
 temperature3: 300
 resistance3: 80.65
 
+# Definition from (20211112): https://atcsemitec.co.uk/wp-content/uploads/2019/01/Semitec-NT-4-Glass-NTC-Thermistor.pdf
+[thermistor ATC Semitec 104NT-4-R025H42G]
+temperature1: 25
+resistance1: 100000
+temperature2: 160
+resistance2: 1074
+temperature3: 300
+resistance3: 82.78
+
 # Definition from (20211101): https://www.tdk-electronics.tdk.com/inf/50/db/ntc_09/Glass_enc_Sensors__B57560__G560__G1560.pdf
 # (B57560G104 is same definition as B57560G1104)
 [thermistor EPCOS 100K B57560G104F]


### PR DESCRIPTION
module: extras/temperature_sensors.cfg

this thermistor is the 104NT-4 resold by Trianglelab (and others on Ali),
as well as the 300 degree resold by Slice Engineering, both of which use the
same RT table (TL even links to the ATC Semitec website)

see the 300 C tab on the Slice spreadsheet:
  https://docs.google.com/spreadsheets/d/1904x5JK-Sup-cX5DqHiiZWaFVTK6_PQBFxgi_6yXEJw/edit#gid=934228925
as well as the TL product page:
  https://www.aliexpress.com/item/32843785247.html
in addition to the RT table link provided in temperature_sensors.cfg

Signed-off-by: Geoffrey Young <geoffrey.young@gmail.com>