### PR TITLE
fix(probe): update probe response message

### DIFF
--- a/docs/Probe_Calibrate.md
+++ b/docs/Probe_Calibrate.md
@@ -100,16 +100,16 @@ to the following:
 ```
 Recv: // probe accuracy: at X:0.000 Y:0.000 Z:10.000
 Recv: // and read 10 times with speed of 5 mm/s
-Recv: // probe at -0.003,0.005 is z=2.506948
-Recv: // probe at -0.003,0.005 is z=2.519448
-Recv: // probe at -0.003,0.005 is z=2.519448
-Recv: // probe at -0.003,0.005 is z=2.506948
-Recv: // probe at -0.003,0.005 is z=2.519448
-Recv: // probe at -0.003,0.005 is z=2.519448
-Recv: // probe at -0.003,0.005 is z=2.506948
-Recv: // probe at -0.003,0.005 is z=2.506948
-Recv: // probe at -0.003,0.005 is z=2.519448
-Recv: // probe at -0.003,0.005 is z=2.506948
+Recv: // nozzle at -0.003,0.005 is z=2.506948
+Recv: // nozzle at -0.003,0.005 is z=2.519448
+Recv: // nozzle at -0.003,0.005 is z=2.519448
+Recv: // nozzle at -0.003,0.005 is z=2.506948
+Recv: // nozzle at -0.003,0.005 is z=2.519448
+Recv: // nozzle at -0.003,0.005 is z=2.519448
+Recv: // nozzle at -0.003,0.005 is z=2.506948
+Recv: // nozzle at -0.003,0.005 is z=2.506948
+Recv: // nozzle at -0.003,0.005 is z=2.519448
+Recv: // nozzle at -0.003,0.005 is z=2.506948
 Recv: // probe accuracy results: maximum 2.519448, minimum 2.506948, range 0.012500, average 2.513198, median 2.513198, standard deviation 0.006250
 ```
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -127,7 +127,7 @@ class PrinterProbe:
             if "Timeout during endstop homing" in reason:
                 reason += HINT_TIMEOUT
             raise self.printer.command_error(reason)
-        self.gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
+        self.gcode.respond_info("nozzle at %.3f,%.3f is z=%.6f"
                                 % (epos[0], epos[1], epos[2]))
         return epos[:3]
     def _move(self, coord, speed):


### PR DESCRIPTION
Whilst working on a new probe and using `SCREWS_TILT_CALCULATE` I noticed that the response message from the probe is returning the toolhead (nozzle) position and not the probe position. 

The (docs)[https://www.klipper3d.org/Config_Reference.html?h=screws#screws_tilt_adjust] explicitly mention to position the toolhead such that the probe is directly over the screws.

The return message should return "nozzle" or "toolhead" position as it does not display the probe position.

Machine I tested on: Voron Switchwire with a Y offset of 25mm between the nozzle and probe.

Relevant printer.cfg sections

```ini

[stepper_y]
...
position_endstop: 242
position_min: -10
position_max: 242 # 235 in the slicer
homing_positive_dir: true

[probe]
x_offset: 0
y_offset: 25.0

[screws_tilt_adjust]
# SW Nylock Mod: Screw 1 uses the 6mm metallic spacer so its
# height is considered the baseline. For tilt adjust using the
# command SCREWS_TILT_CALCULATE, this has to be your Screw 1:
#           Screw Position              Probe Position
#         ******************  ********************************
#         * S7    S8    S9 *  * [17,233] [127,233] [232,233] *
#         *                *
#   Bed:  * S5    S1    S6 *  * [17,123] [127,123] [232,123] *
#         *                *
#         * S2    S3    S4 *  * [17,13]   [127,13]  [232,13] *
#         ******************  ********************************
#
# Positions are the Nozzle position - the Y offset will be added to bring the probe over the bed screw
# It would make more sense to define these values as the probe position - more intuitive
screw1: 127,98
screw1_name: center
screw2: 17,-8
screw2_name: front_left
screw3: 127,-8
screw3_name: front_center
screw4: 232,-8
screw4_name: front_right
screw5: 17,98
screw5_name: middle_left
screw6: 232,98
screw6_name: middle_right
screw7: 17,208
screw7_name: rear_left
screw8: 127,208
screw8_name: rear_center
screw9: 232,208
screw9_name: rear_right
horizontal_move_z: 10.
speed: 150.
screw_thread: CCW-M3

```

Actual output:

```text

16:02:15 
$ G28
16:02:24 
$ SCREWS_TILT_CALCULATE
16:02:26 
// probe at 127.000,98.000 is z=1.072500
16:02:28 
// probe at 127.000,98.000 is z=1.085000
16:02:31 
// probe  at 127.000,98.000 is z=1.097500
16:02:36 
// probe at 17.000,-8.000 is z=1.085000
16:02:38 
// probe at 17.000,-8.000 is z=1.097500
16:02:40 
// probe  at 17.000,-8.000 is z=1.097500
16:02:45 
// probe  at 127.000,-8.000 is z=1.110000
16:02:47 
// probe  at 127.000,-8.000 is z=1.122500
16:02:50 
// probe at 127.000,-8.000 is z=1.122500
16:02:54 
// probe at 232.000,-8.000 is z=1.135000
16:02:57 
// probe at 232.000,-8.000 is z=1.160000
16:02:59 
// probe at 232.000,-8.000 is z=1.147500
16:03:05 
// probe at 17.000,98.000 is z=1.072500
16:03:07 
// probe at 17.000,98.000 is z=1.097500
16:03:09 
// probe at 17.000,98.000 is z=1.085000
16:03:15 
// probe at 232.000,98.000 is z=1.085000
16:03:17 
// probe at 232.000,98.000 is z=1.110000
16:03:19 
// probe  at 232.000,98.000 is z=1.085000
16:03:25 
// probe at 17.000,208.000 is z=1.072500
16:03:27 
// probe at 17.000,208.000 is z=1.072500
```

From the diagram in the `printer.cfg` with the Y offset applied, we can see that the values returned by the probe are the nozzle positions and not the probe positions. Therefore, the message should read.

Expected output:

```text

16:02:15 
$ G28
16:02:24 
$ SCREWS_TILT_CALCULATE
16:02:26 
// nozzle at 127.000,98.000 is z=1.072500
16:02:28 
// nozzle at 127.000,98.000 is z=1.085000
16:02:31 
// nozzle at 127.000,98.000 is z=1.097500
16:02:36 
// nozzle at 17.000,-8.000 is z=1.085000
16:02:38 
// nozzle at 17.000,-8.000 is z=1.097500
16:02:40 
// nozzle at 17.000,-8.000 is z=1.097500
16:02:45 
// nozzle at 127.000,-8.000 is z=1.110000
16:02:47 
// nozzle at 127.000,-8.000 is z=1.122500
16:02:50 
// nozzle at 127.000,-8.000 is z=1.122500
16:02:54 
// nozzle at 232.000,-8.000 is z=1.135000
16:02:57 
// nozzle at 232.000,-8.000 is z=1.160000
16:02:59 
// nozzle at 232.000,-8.000 is z=1.147500
16:03:05 
// nozzle at 17.000,98.000 is z=1.072500
16:03:07 
// nozzle at 17.000,98.000 is z=1.097500
16:03:09 
// nozzle at 17.000,98.000 is z=1.085000
16:03:15 
// nozzle at 232.000,98.000 is z=1.085000
16:03:17 
// nozzle at 232.000,98.000 is z=1.110000
16:03:19 
// nozzle at 232.000,98.000 is z=1.085000
16:03:25 
// nozzle at 17.000,208.000 is z=1.072500
16:03:27 
// nozzle at 17.000,208.000 is z=1.072500.
.... etc ....
```



