### PR TITLE
webhooks: create a deep copy for status queries

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -171,7 +171,9 @@ class GCodeMacro:
             literal = ast.literal_eval(value)
         except ValueError as e:
             raise gcmd.error("Unable to parse '%s' as a literal" % (value,))
-        self.variables[variable] = literal
+        v = dict(self.variables)
+        v[variable] = literal
+        self.variables = v
     def cmd(self, gcmd):
         if self.in_script:
             raise gcmd.error("Macro %s called recursively" % (self.alias,))


### PR DESCRIPTION
This resolves an issue where subscriptions will not update because the `last_query` contains a reference to an object returned by `get_status()`.  Currently this is known to affect `gcode_macro` variables.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>