### PR TITLE
print_stats: Fix exception when canceling in/as first G-code

### DIFF
--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -48,6 +48,8 @@ class PrintStats:
     def note_cancel(self):
         self._note_finish("cancelled")
     def _note_finish(self, state, error_message = ""):
+        if self.print_start_time is None:
+            return
         self.state = state
         self.error_message = error_message
         eventtime = self.reactor.monotonic()


### PR DESCRIPTION
When executing `CANCEL_PRINT` (directly or as part of a macro) as the first G-code instruction Klipper crashes with the following:
```
Traceback (most recent call last):
  File "/home/pi/klipper/klippy/klippy.py", line 201, in run
    self.reactor.run()
  File "/home/pi/klipper/klippy/reactor.py", line 269, in run
    g_next.switch()
  File "/home/pi/klipper/klippy/reactor.py", line 310, in _dispatch_loop
    timeout = self._check_timers(eventtime, busy)
  File "/home/pi/klipper/klippy/reactor.py", line 156, in _check_timers
    t.waketime = waketime = t.callback(eventtime)
  File "/home/pi/klipper/klippy/extras/virtual_sdcard.py", line 291, in work_handler
    self.print_stats.note_complete()
  File "/home/pi/klipper/klippy/extras/print_stats.py", line 45, in note_complete
    self._note_finish("complete")
  File "/home/pi/klipper/klippy/extras/print_stats.py", line 54, in _note_finish
    self.total_duration = eventtime - self.print_start_time
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

It seems that while a `None` check is present around other uses of `print_start_time`, one was missing in `_note_finish`. By adding this check the canceling now works correctly, and the printer no longer enters emergency mode. I also verified that `total_duration` correctly shows a (very small) non-zero value.

### Reproducing the issue

Print a file with only one `CANCEL_PRINT` instruction:

`cancel.gcode`:
```
CANCEL_PRINT
```