### PR TITLE
adxl345: Added automatic accelerometer calibration

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1500,12 +1500,30 @@ cs_pin:
 #   example, one could set this to "y, x, z" to swap the X and Y axes.
 #   It is also possible to negate an axis if the accelerometer
 #   direction is reversed (eg, "x, z, -y"). The default is "x, y, z".
+#   Instead of providing this parameter, the user can run a command
+#   `ACCELEROMETER_CALIBRATE` to automatically detect accelerometer
+#   orientation and save it as `axes_transform` and `gravity` options.
 #rate: 3200
 #   Output data rate for ADXL345. ADXL345 supports the following data
 #   rates: 3200, 1600, 800, 400, 200, 100, 50, and 25. Note that it is
 #   not recommended to change this rate from the default 3200, and
 #   rates below 800 will considerably affect the quality of resonance
 #   measurements.
+#offset: 0, 0, 0
+#   Offset that will be subtracted from accelerometer readings. Can be
+#   useful to subtract freefall acceleration or any other accelerometer
+#   readings offsets resulting from the internal stresses of the chip.
+#   Can be automatically detected by running `ACCELEROMETER_CALIBRATE`
+#   command. Default is 0, 0, 0 which means no acceleration adjustments.
+#axes_transform:
+#   A 3x3 matrix indicating the transformation from the accelerometer
+#   into the printer coordinate system. Replaces axes_map option. Can be
+#   automatically detected by running `ACCELEROMETER_CALIBRATE` command.
+#   If unset, defaults to
+#   1, 0, 0
+#   0, 1, 0
+#   0, 0, 1
+#   which means 1:1 mapping between X, Y, Z accelerometer and printer axes.
 ```
 
 ### [resonance_tester]
@@ -1541,6 +1559,11 @@ section of the measuring resonances guide for more information on
 #   and on the toolhead (for X axis). These parameters have the same
 #   format as 'accel_chip' parameter. Only 'accel_chip' or these two
 #   parameters must be provided.
+#autocalibrate: False
+#   If set to True, Klipper will run accelerometer autocalibration before
+#   each resonance testing. Useful if the accelerometer(s) is/are mounted
+#   temporarily for each resonance testing to a new location and in a
+#   new orientation onto the printer. Default is False.
 #max_smoothing:
 #   Maximum input shaper smoothing to allow for each axis during shaper
 #   auto-calibration (with 'SHAPER_CALIBRATE' command). By default no

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -73,6 +73,13 @@ modules are automatically loaded.
 The following commands are available when an
 [adxl345 config section](Config_Reference.md#adxl345) is enabled.
 
+#### ACCELEROMETER_CALIBRATE
+`ACCELEROMETER_CALIBRATE [CHIP=<config_name>]`: runs an automatic
+calibration test to detect chip orientation and freefall acceleration.
+The results of the calibration are applied to all subsequent measurements,
+and can be persisted in `printer.cfg` by issuing `SAVE_CONFIG` command.
+If CHIP is not specified it defaults to "adxl345".
+
 #### ACCELEROMETER_MEASURE
 `ACCELEROMETER_MEASURE [CHIP=<config_name>] [NAME=<value>]`: Starts
 accelerometer measurements at the requested number of samples per

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -87,7 +87,7 @@ Afterwards, check and follow the instructions in the
 Make sure the Linux SPI driver is enabled by running `sudo
 raspi-config` and enabling SPI under the "Interfacing options" menu.
 
-Add the following to the printer.cfg file:
+Add the following to the printer.cfg file (if not already there):
 ```
 [mcu rpi]
 serial: /tmp/klipper_host_mcu
@@ -109,31 +109,42 @@ Restart Klipper via the `RESTART` command.
 
 ### Checking the setup
 
-Now you can test a connection.
+Now you can test a connection and calibrate the accelerometer. Home
+the printer, move the toolhead far away from the corners in X,Y plane
+(e.g. move it to the center of the print bed), and then:
 
 - For "non bed-slingers" (e.g. one accelerometer), in Octoprint,
-  enter `ACCELEROMETER_QUERY`
+  enter `ACCELEROMETER_CALIBRATE`
 - For "bed-slingers" (e.g. more than one accelerometer), enter
-  `ACCELEROMETER_QUERY CHIP=<chip>` where `<chip>` is the name of the chip
+  `ACCELEROMETER_CALIBRATE CHIP=<chip>` where `<chip>` is the name of the chip
   as-entered, e.g. `CHIP=bed` (see: [bed-slinger](#bed-slinger-printers))
   for all installed accelerometer chips.
 
-You should see the current measurements from the accelerometer, including the
-free-fall acceleration, e.g.
-```
-Recv: // adxl345 values (x, y, z): 470.719200, 941.438400, 9728.196800
-```
+This will run a basic calibration of the accelerometer and detect
+accelerometer orientation. It also runs some basic sanity checks
+and can detect some issues with the accelerometer or your setup
+(e.g. too noisy unbalanced fans).
 
 If you get an error like `Invalid adxl345 id (got xx vs e5)`, where `xx`
 is some other ID, it is indicative of the connection problem with ADXL345,
 or the faulty sensor. Double-check the power, the wiring (that it matches
 the schematics, no wire is broken or loose, etc.), and soldering quality.
 
-Next, try running `MEASURE_AXES_NOISE` in Octoprint, you should get some
-baseline numbers for the noise of accelerometer on the axes (should be
-somewhere in the range of ~1-100). Too high axes noise (e.g. 1000 and more)
-can be indicative of the sensor issues, problems with its power, or too
-noisy imbalanced fans on a 3D printer.
+Note that if the accelerometer is installed permenantly, or temporarily on
+a fixed location (e.g. into the fixed holes on the hotend), it is sufficient
+to run accelerometer calibration only one time for each board. In this case,
+you can save the calibration results by issuing `SAVE_CONFIG` command after
+the calibration is done. If it is mounted each time to a new location
+(e.g. glued onto the bed of the bed slinger printer), it may be helpful to add
+`autocalibrate` option to `[resonance_tester]` section, as
+```
+[resonance_tester]
+accel_chip: ...
+autocalibrate: True
+...
+```
+Then, Klipper will run a calibration test prior to each resonance testing
+automatically.
 
 ### Measuring the resonances
 

--- a/klippy/extras/background_process.py
+++ b/klippy/extras/background_process.py
@@ -1,0 +1,43 @@
+# Background execution of calculations in a separate process
+#
+# Copyright (C) 2018-2022  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2022  Dmitry Butyugin <dmbutyugin@google.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import multiprocessing, traceback
+import queuelogger
+
+def background_process_exec(printer, method, args):
+    if printer is None:
+        return method(*args)
+    parent_conn, child_conn = multiprocessing.Pipe()
+    def wrapper():
+        queuelogger.clear_bg_logging()
+        try:
+            res = method(*args)
+        except:
+            child_conn.send((True, traceback.format_exc()))
+            child_conn.close()
+            return
+        child_conn.send((False, res))
+        child_conn.close()
+    # Start a process to perform the calculation
+    calc_proc = multiprocessing.Process(target=wrapper)
+    calc_proc.daemon = True
+    calc_proc.start()
+    # Wait for the process to finish
+    reactor = printer.get_reactor()
+    gcode = printer.lookup_object("gcode")
+    eventtime = last_report_time = reactor.monotonic()
+    while calc_proc.is_alive():
+        if eventtime > last_report_time + 5.:
+            last_report_time = eventtime
+            gcode.respond_info("Wait for calculations..", log=False)
+        eventtime = reactor.pause(eventtime + .1)
+    # Return results
+    is_err, res = parent_conn.recv()
+    if is_err:
+        raise printer.command_error("Error in remote calculation: %s" % (res,))
+    calc_proc.join()
+    parent_conn.close()
+    return res

--- a/klippy/extras/shaper_calibrate.py
+++ b/klippy/extras/shaper_calibrate.py
@@ -3,7 +3,8 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import collections, importlib, logging, math, multiprocessing, traceback
+import collections, functools, importlib, logging, math, multiprocessing
+background_process = importlib.import_module('.background_process', 'extras')
 shaper_defs = importlib.import_module('.shaper_defs', 'extras')
 
 MIN_FREQ = 5.
@@ -61,6 +62,8 @@ class ShaperCalibrate:
     def __init__(self, printer):
         self.printer = printer
         self.error = printer.command_error if printer else Exception
+        self.background_process_exec = functools.partial(
+                background_process.background_process_exec, printer)
         try:
             self.numpy = importlib.import_module('numpy')
         except ImportError:
@@ -68,42 +71,6 @@ class ShaperCalibrate:
                     "Failed to import `numpy` module, make sure it was "
                     "installed via `~/klippy-env/bin/pip install` (refer to "
                     "docs/Measuring_Resonances.md for more details).")
-
-    def background_process_exec(self, method, args):
-        if self.printer is None:
-            return method(*args)
-        import queuelogger
-        parent_conn, child_conn = multiprocessing.Pipe()
-        def wrapper():
-            queuelogger.clear_bg_logging()
-            try:
-                res = method(*args)
-            except:
-                child_conn.send((True, traceback.format_exc()))
-                child_conn.close()
-                return
-            child_conn.send((False, res))
-            child_conn.close()
-        # Start a process to perform the calculation
-        calc_proc = multiprocessing.Process(target=wrapper)
-        calc_proc.daemon = True
-        calc_proc.start()
-        # Wait for the process to finish
-        reactor = self.printer.get_reactor()
-        gcode = self.printer.lookup_object("gcode")
-        eventtime = last_report_time = reactor.monotonic()
-        while calc_proc.is_alive():
-            if eventtime > last_report_time + 5.:
-                last_report_time = eventtime
-                gcode.respond_info("Wait for calculations..", log=False)
-            eventtime = reactor.pause(eventtime + .1)
-        # Return results
-        is_err, res = parent_conn.recv()
-        if is_err:
-            raise self.error("Error in remote calculation: %s" % (res,))
-        calc_proc.join()
-        parent_conn.close()
-        return res
 
     def _split_into_windows(self, x, window_size, overlap):
         # Memory-efficient algorithm to split an input 'x' into a series

--- a/klippy/extras/shaper_calibrate.py
+++ b/klippy/extras/shaper_calibrate.py
@@ -44,6 +44,8 @@ class CalibrationData:
         self.data_sets = joined_data_sets
     def set_numpy(self, numpy):
         self.numpy = numpy
+    def get_numpy(self):
+        return self.numpy
     def normalize_to_frequencies(self):
         for psd in self._psd_list:
             # Avoid division by zero errors
@@ -52,6 +54,8 @@ class CalibrationData:
             psd[self.freq_bins < MIN_FREQ] = 0.
     def get_psd(self, axis='all'):
         return self._psd_map[axis]
+    def get_freq_bins(self):
+        return self.freq_bins
 
 
 CalibrationResult = collections.namedtuple(


### PR DESCRIPTION
This adds `ACCELEROMETER_CALIBRATE` command and a lightweight calibration test,
which runs some sanity checks, detects the accelerometer orientation, required axes scaling, etc.
The results of the calibrations can be persisted in printer.cfg instead of deducing axes_map.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>