### PR TITLE
add flash details for STM32F429

### DIFF
--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -1,7 +1,10 @@
 # This file contains common pin mappings for the BigTreeTech SKR 2.
 # To use this config, the firmware should be compiled for the
 # STM32F407 with a "32KiB bootloader".
-
+# In newer versions of this board shipped in late 2021 the STM32F429 
+# is used, if this is the case compile for this with a "32KiB bootloader"
+# You will need to check the chip on your board to identify which you have.
+#
 # The "make flash" command does not work on the SKR 2. Instead,
 # after running "make", copy the generated "out/klipper.bin" file to a
 # file named "firmware.bin" on an SD card and then restart the SKR 2

--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -1,7 +1,8 @@
 # This file contains common pin mappings for the BigTreeTech SKR 2.
 # To use this config, the firmware should be compiled for the
 # STM32F407 with a "32KiB bootloader".
-# In newer versions of this board shipped in late 2021 the STM32F429 
+
+# In newer versions of this board shipped in late 2021 the STM32F429
 # is used, if this is the case compile for this with a "32KiB bootloader"
 # You will need to check the chip on your board to identify which you have.
 #


### PR DESCRIPTION
Updates for generic-bigtreetech-skr-2.cfg to include comment on newly shipped board with STM32F429 instead of the original STM32F407

Signed-off-by: James Hartley james@hartleyns.com