### PR TITLE
screws_tilt_adjust: Add ADJUST_TO_Z parameter to SCREWS_TILT_CALCULATE

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -485,14 +485,17 @@ The following commands are available when the
 [screws_tilt_adjust config section](Config_Reference.md#screws_tilt_adjust)
 is enabled (also see the
 [manual level guide](Manual_Level.md#adjusting-bed-leveling-screws-using-the-bed-probe)):
-- `SCREWS_TILT_CALCULATE [DIRECTION=CW|CCW] [<probe_parameter>=<value>]`:
+- `SCREWS_TILT_CALCULATE [ADJUST_TO_Z=<value>] [DIRECTION=CW|CCW] [<probe_parameter>=<value>]`:
   This command will invoke the bed screws adjustment tool. It will command the
   nozzle to different locations (as defined in the config file)
   probing the z height and calculate the number of knob turns to
-  adjust the bed level. If DIRECTION is specified, the knob turns will all
+  adjust the bed level. If ADJUST_TO_Z is specified, the z position
+  to raise or lower the screws will be set to that value of ADJUST_TO_Z.
+  If DIRECTION is specified, the knob turns will all
   be in the same direction, clockwise (CW) or counterclockwise (CCW).
   See the PROBE command for details on the optional probe parameters.
   IMPORTANT: You MUST always do a G28 before using this command.
+  IMPORTANT: ADJUST_TO_Z and DIRECTION can't be used together!
 
 ### Z Tilt
 

--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -210,3 +210,11 @@ turn the screws clockwise, run `SCREWS_TILT_CALCULATE DIRECTION=CW`. If you can
 only turn them counter-clockwise, run `SCREWS_TILT_CALCULATE DIRECTION=CCW`.
 A suitable reference point will be chosen such that the bed can be leveled
 by turning all the screws in the given direction.
+
+The `ADJUST_TO_Z` parameter is useful when you want your bed at a fixed
+level which can be lost from bad bed adjustment screws at drift away slowly.
+For example, if you want the Z position on all the screw points to be 1.5,
+you can run `SCREWS_TILT_CALCULATE ADJUST_TO_Z=1.5` and adjust every point
+per the fixed given position.
+
+Please note that `DIRECTION` and `ADJUST_TO_Z` can't be used together!


### PR DESCRIPTION
I found this quite useful because my bed level drifts away with just time. Having to always go back to the last good position from mind was a bit of a pain so I just introduced ADJUST_TO_Z to always level for a given base if wanted.

Output:
> $ SCREWS_TILT_CALCULATE ADJUST_TO_Z=1.5
> // probe at 32.000,219.000 is z=1.493227
> // probe at 32.000,219.000 is z=1.493422
> // probe at 32.000,219.000 is z=1.493539
> // probe at 32.000,219.000 is z=1.489906
>
> // probe at 200.000,219.000 is z=1.501625
> // probe at 200.000,219.000 is z=1.504672
> // probe at 200.000,219.000 is z=1.500570
> // probe at 200.000,219.000 is z=1.500805
>
> // probe at 32.000,63.000 is z=1.504984
> // probe at 32.000,63.000 is z=1.510414
> // probe at 32.000,63.000 is z=1.510219
> // probe at 32.000,63.000 is z=1.511859
>
> // probe at 200.000,63.000 is z=1.486742
> // probe at 200.000,63.000 is z=1.490258
> // probe at 200.000,63.000 is z=1.485648
> // probe at 200.000,63.000 is z=1.488852
>
> // 01:20 means 1 full turn and 20 minutes, CW=clockwise, CCW=counter-clockwise
>
> // front left screw : x=32.0, y=219.0, z=1.49332 : adjust CW 00:01

> // front right screw : x=200.0, y=219.0, z=1.50121 : adjust CCW 00:00
>
> // rear left screw : x=32.0, y=63.0, z=1.51032 : adjust CCW 00:01
>
> // rear right screw : x=200.0, y=63.0, z=1.48780 : adjust CW 00:01

Signed-off-by: Vlad Adumitroaie <celtare21@gmail.com>