### PR TITLE
gcode: add Gcode group feature

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -230,6 +230,15 @@ might return:
 saved G-Code state", "PID_CALIBRATE": "Run PID calibration test",
 "QUERY_ADC": "Report the last value of an analog pin", ...}}`
 
+### gcode/groups
+
+This endpoint allows one to query the associated group for G-Code commands that have
+one defined. G-Codes delivered by Klipper itself do not have a group defined.
+Example:
+`{"id": 123, "method": "gcode/groups"}`
+might return:
+`{"id": 123, "result": {"MY_CUSTOM_GCODE": "Group1", "MY_CUSTOM_GCODE_2": "Group2", ...}}`
+
 ### gcode/script
 
 This endpoint allows one to run a series of G-Code commands. For example:

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -48,6 +48,20 @@ gcode:
 This will be showing is you use the `HELP` command or use the autocomplete
 function.
 
+## Add a group to your macro
+
+You can also define a group for each G-Code macro. These can be used by front-end clients
+in order to group all your G-Codes automatically.
+Add `group:` with a concise group name in order to associate a macro with a group.
+For example:
+
+```
+[gcode_macro turn_on_led]
+group: lights
+gcode:
+  SET_PIN PIN=my_led VALUE=1
+```
+
 ## Save/Restore state for G-Code moves
 
 Unfortunately, the G-Code command language can be challenging to use.

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -125,6 +125,7 @@ class GCodeMacro:
         self.gcode = printer.lookup_object('gcode')
         self.rename_existing = config.get("rename_existing", None)
         self.cmd_desc = config.get("description", "G-Code macro")
+        self.cmd_group = config.get("group", "")
         if self.rename_existing is not None:
             if (self.gcode.is_traditional_gcode(self.alias)
                 != self.gcode.is_traditional_gcode(self.rename_existing)):
@@ -135,7 +136,8 @@ class GCodeMacro:
                                            self.handle_connect)
         else:
             self.gcode.register_command(self.alias, self.cmd,
-                                        desc=self.cmd_desc)
+                                        desc=self.cmd_desc,
+                                        group=self.cmd_group)
         self.gcode.register_mux_command("SET_GCODE_VARIABLE", "MACRO",
                                         name, self.cmd_SET_GCODE_VARIABLE,
                                         desc=self.cmd_SET_GCODE_VARIABLE_help)
@@ -158,7 +160,8 @@ class GCodeMacro:
                 % (self.alias,))
         pdesc = "Renamed builtin of '%s'" % (self.alias,)
         self.gcode.register_command(self.rename_existing, prev_cmd, desc=pdesc)
-        self.gcode.register_command(self.alias, self.cmd, desc=self.cmd_desc)
+        self.gcode.register_command(self.alias, self.cmd,
+                                    desc=self.cmd_desc, group=self.cmd_group)
     def get_status(self, eventtime):
         return self.variables
     cmd_SET_GCODE_VARIABLE_help = "Set the value of a G-Code macro variable"

--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -403,6 +403,7 @@ class GCodeHelper:
         # Register webhooks
         wh = printer.lookup_object('webhooks')
         wh.register_endpoint("gcode/help", self._handle_help)
+        wh.register_endpoint("gcode/groups", self._handle_groups)
         wh.register_endpoint("gcode/script", self._handle_script)
         wh.register_endpoint("gcode/restart", self._handle_restart)
         wh.register_endpoint("gcode/firmware_restart",
@@ -411,6 +412,8 @@ class GCodeHelper:
                              self._handle_subscribe_output)
     def _handle_help(self, web_request):
         web_request.send(self.gcode.get_command_help())
+    def _handle_groups(self, web_request):
+        web_request.send(self.gcode.get_command_groups())
     def _handle_script(self, web_request):
         self.gcode.run_script(web_request.get_str('script'))
     def _handle_restart(self, web_request):


### PR DESCRIPTION
This allows to assign a group to Gcode macros. This could be used by frontends to automatically group macros in the UI.

Theres quite a lot of stuff out there (ERCF, Klicky probe etc) adding a lot of macros to Klipper. These also get automatically exposed to the frontends.
Currently only Fluidd allows custom grouping of macros via UI settings. This is quite fiddly and that also has its drawbacks (f.e. renaming the Macro will lead to the macro losing its group)

This PR allows to assign a group directly to each macro, either by adding it to a macro in a .cfg file or via the corresponding methods in python. (ercf for example defines macros via both ways).

Implementation-wise this basically only mirrors how G-Code help strings work.

Signed-off-by: Philipp Temminghoff philipptemminghoff@gmail.com