### PR TITLE
Makefile: Allow overriding python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
 CPP=cpp
-PYTHON=python2
+PYTHON?=python2
 
 # Source files
 src-y =


### PR DESCRIPTION
The build system still defaults to Python 2.x, but it's now possible to set PYTHON=python3 when building. This removes the need to install python2 on systems which don't have it by default.