### PR TITLE
Replaces all SKR E3 default bed thermistor

### DIFF
--- a/config/generic-bigtreetech-skr-e3-dip.cfg
+++ b/config/generic-bigtreetech-skr-e3-dip.cfg
@@ -66,7 +66,7 @@ max_temp: 250
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC3
 control: pid
 pid_Kp: 54.027

--- a/config/generic-bigtreetech-skr-e3-turbo.cfg
+++ b/config/generic-bigtreetech-skr-e3-turbo.cfg
@@ -97,7 +97,7 @@ stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: P2.5
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: P0.25
 control: pid
 pid_Kp: 54.027

--- a/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
@@ -98,7 +98,7 @@ stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC3
 control: pid
 pid_Kp: 54.027

--- a/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
@@ -90,7 +90,7 @@ stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC3
 control: pid
 pid_Kp: 54.027

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -95,7 +95,7 @@ stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC3
 control: pid
 pid_Kp: 54.027


### PR DESCRIPTION
Since most of people that uses SKR E3 v1, v1.2 and v2 are users that come have Ender 3 (E3 means Ender 3 right?) makes no sense having the default sensor wrong in the bed.

I had seen some people making the same question a few times in the Discord.

Signed-off-by: Tiago Cardoso <tiagocardosoweb@gmail.com>