### PR TITLE
Support multiple motors for any axis in corexy

### DIFF
--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -9,8 +9,8 @@ import stepper
 class CoreXYKinematics:
     def __init__(self, toolhead, config):
         # Setup axis rails
-        self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
-                       stepper.PrinterRail(config.getsection('stepper_y')),
+        self.rails = [ stepper.LookupMultiRail(config.getsection('stepper_x')),
+                       stepper.LookupMultiRail(config.getsection('stepper_y')),
                        stepper.LookupMultiRail(config.getsection('stepper_z')) ]
         self.rails[0].get_endstops()[0][0].add_stepper(
             self.rails[1].get_steppers()[0])


### PR DESCRIPTION
The z axis supports multiple motors defined as stepper_z, stepper_z1, stepper_z2, ...
This allows the same thing for X and Y so stepper_x1, stepper_x2 ... and stepper_y1, ... will work.
This fixes issue https://github.com/Klipper3d/klipper/issues/4915