### PR TITLE
Add configuration item to enable / disable bilateral step pulse optimization

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -158,6 +158,11 @@ microsteps:
 #   following "unstep" signal edge. This is also used to set the
 #   minimum time between a step pulse and a direction change signal.
 #   The default is 0.000002 (which is 2us).
+#step_bothedges_optimized: True
+#   Enable the optimization of double side stepping pulse of stepping
+#   driver. This function may appear offset on some boards (UART or SPI
+#   mode). If so, please turn off this function.The default is True (Is
+#   enabled)
 endstop_pin:
 #   Endstop switch detection pin. If this endstop pin is on a
 #   different mcu than the stepper motor then it enables "multi-mcu


### PR DESCRIPTION
After several days of testing, I found that if the motherboard with level conversion (to prevent short circuit from burning the main control) is updated to the new version of klipper (the newly added double-edge stepping pulse optimized version), there will be a stepper motor offset It’s not just me.
I tried to turn off the double edge stepping pulse optimization, yes, everything is normal after turning it off. Therefore I added a configuration item in'[stepper_x,y,z]', which is very useful for our users who use these motherboards .
thanks
Of course, it would be best if there is a better solution, thanks again.