### PR TITLE
New TMC docs: don't use hold_current; avoid interpolate

### DIFF
--- a/config/generic-bigtreetech-e3-rrf-v1.1.cfg
+++ b/config/generic-bigtreetech-e3-rrf-v1.1.cfg
@@ -23,7 +23,6 @@ homing_speed: 50
 [tmc2209 stepper_x]
 uart_pin: PD6
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -40,7 +39,6 @@ homing_speed: 50
 [tmc2209 stepper_y]
 uart_pin: PD1
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -56,7 +54,6 @@ position_max: 250
 [tmc2209 stepper_z]
 uart_pin: PD15
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -80,7 +77,6 @@ max_temp: 250
 [tmc2209 extruder]
 uart_pin: PD11
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-gtr.cfg
+++ b/config/generic-bigtreetech-gtr.cfg
@@ -126,37 +126,31 @@ max_z_accel: 5
 #[tmc2208 stepper_x]
 #uart_pin: PC14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PE1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PB5
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PG10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PD4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PC12
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -167,7 +161,6 @@ max_z_accel: 5
 #[tmc2130 stepper_x]
 #cs_pin: PC14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -177,7 +170,6 @@ max_z_accel: 5
 #cs_pin: PE1
 #sense_resistor: 0.075
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -187,7 +179,6 @@ max_z_accel: 5
 #cs_pin: PB5
 #sense_resistor: 0.075
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -197,7 +188,6 @@ max_z_accel: 5
 #cs_pin: PG10
 #sense_resistor: 0.075
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -207,7 +197,6 @@ max_z_accel: 5
 #cs_pin: PD4
 #sense_resistor: 0.075
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -217,7 +206,6 @@ max_z_accel: 5
 #cs_pin: PC12
 #sense_resistor: 0.075
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -232,7 +220,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 1
-#hold_current: 1
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -243,7 +230,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 1
-#hold_current: 1
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -254,7 +240,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.4
-#hold_current: 0.4
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -265,7 +250,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.5
-#hold_current: 0.5
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -276,7 +260,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6
@@ -287,7 +270,6 @@ max_z_accel: 5
 #sense_resistor: 0.075
 #interpolate: True
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
 #spi_software_miso_pin: PB6

--- a/config/generic-bigtreetech-gtr.cfg
+++ b/config/generic-bigtreetech-gtr.cfg
@@ -218,7 +218,6 @@ max_z_accel: 5
 #[tmc5160 stepper_x]
 #cs_pin: PC14
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 1
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
@@ -228,7 +227,6 @@ max_z_accel: 5
 #[tmc5160 stepper_y]
 #cs_pin: PE1
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 1
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
@@ -238,7 +236,6 @@ max_z_accel: 5
 #[tmc5160 stepper_z]
 #cs_pin: PB5
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 0.4
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
@@ -248,7 +245,6 @@ max_z_accel: 5
 #[tmc5160 extruder]
 #cs_pin: PG10
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 0.5
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
@@ -258,7 +254,6 @@ max_z_accel: 5
 #[tmc5160 extruder1]
 #cs_pin: PD4
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 0.800
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15
@@ -268,7 +263,6 @@ max_z_accel: 5
 #[tmc5160 extruder2]
 #cs_pin: PC12
 #sense_resistor: 0.075
-#interpolate: True
 #run_current: 0.800
 #stealthchop_threshold: 0
 #spi_software_mosi_pin: PG15

--- a/config/generic-bigtreetech-octopus.cfg
+++ b/config/generic-bigtreetech-octopus.cfg
@@ -153,52 +153,44 @@ max_z_accel: 100
 #uart_pin: PC4
 ##diag_pin: PG6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2209 stepper_y]
 #uart_pin: PD11
 ##diag_pin: PG9
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2209 stepper_z]
 #uart_pin: PC6
 ##diag_pin: PG10
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2209 stepper_]
 #uart_pin: PC7
 ##diag_pin: PG11
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2209 extruder]
 #uart_pin: PF2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2209 extruder1]
 #uart_pin: PE4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2209 extruder2]
 #uart_pin: PE1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2209 extruder3]
 #uart_pin: PD3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 ########################################
@@ -210,7 +202,6 @@ max_z_accel: 100
 #spi_bus: spi1
 ##diag1_pin: PG6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -218,7 +209,6 @@ max_z_accel: 100
 #spi_bus: spi1
 ##diag1_pin: PG9
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -226,7 +216,6 @@ max_z_accel: 100
 #spi_bus: spi1
 ##diag1_pin: PG10
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_]
@@ -234,35 +223,30 @@ max_z_accel: 100
 #spi_bus: spi1
 ##diag1_pin: PG11
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
 #cs_pin: PF2
 #spi_bus: spi1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
 #cs_pin: PE4
 #spi_bus: spi1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
 #cs_pin: PE1
 #spi_bus: spi1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder3]
 #cs_pin: PD3
 #spi_bus: spi1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 [board_pins]

--- a/config/generic-bigtreetech-skr-2.cfg
+++ b/config/generic-bigtreetech-skr-2.cfg
@@ -132,19 +132,16 @@ aliases:
 #[tmc2209 stepper_x]
 #uart_pin: PE0
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 stepper_y]
 #uart_pin: PD3
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 stepper_z]
 #uart_pin: PD0
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 extruder]

--- a/config/generic-bigtreetech-skr-cr6-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-cr6-v1.0.cfg
@@ -27,7 +27,6 @@ homing_speed: 50
 uart_pin: PC11
 tx_pin: PC10
 run_current: 0.550
-hold_current: 0.450
 stealthchop_threshold: 999999
 uart_address: 0
 
@@ -48,7 +47,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
 run_current: 0.550
-hold_current: 0.450
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -67,7 +65,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
 run_current: 0.550
-hold_current: 0.450
 stealthchop_threshold: 999999
 
 [extruder]
@@ -93,7 +90,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.600
-hold_current: 0.400
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-skr-e3-dip.cfg
+++ b/config/generic-bigtreetech-skr-e3-dip.cfg
@@ -99,25 +99,21 @@ pins: !PC13
 #[tmc2208 stepper_x]
 #uart_pin: PC10
 #run_current: 0.580
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PC11
 #run_current: 0.580
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PC12
 #run_current: 0.580
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PD2
 #run_current: 0.650
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -129,28 +125,24 @@ pins: !PC13
 #cs_pin: PC10
 #spi_bus: spi3
 #run_current: 0.580
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
 #cs_pin: PC11
 #spi_bus: spi3
 #run_current: 0.580
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
 #cs_pin: PC12
 #spi_bus: spi3
 #run_current: 0.580
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
 #cs_pin: PD2
 #spi_bus: spi3
 #run_current: 0.650
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-bigtreetech-skr-e3-turbo.cfg
+++ b/config/generic-bigtreetech-skr-e3-turbo.cfg
@@ -19,7 +19,6 @@ homing_speed: 50
 uart_pin: P1.1
 #diag_pin: P1.29
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -37,7 +36,6 @@ homing_speed: 50
 uart_pin: P1.10
 #diag_pin: P1.28
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -54,7 +52,6 @@ position_max: 250
 uart_pin: P1.17
 #diag_pin: P1.27
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -79,7 +76,6 @@ max_temp: 250
 uart_pin: P0.5
 #diag_pin: P1.26
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 #[extruder1]

--- a/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.0.cfg
@@ -30,7 +30,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -49,7 +48,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -67,7 +65,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -93,7 +90,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v1.2.cfg
@@ -28,7 +28,6 @@ homing_speed: 50
 [tmc2209 stepper_x]
 uart_pin: PB15
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -45,7 +44,6 @@ homing_speed: 50
 [tmc2209 stepper_y]
 uart_pin: PC6
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -61,7 +59,6 @@ position_max: 250
 [tmc2209 stepper_z]
 uart_pin: PC10
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -85,7 +82,6 @@ max_temp: 250
 [tmc2209 extruder]
 uart_pin: PC11
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -27,7 +27,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -46,7 +45,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -64,7 +62,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -90,7 +87,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-skr-mini-mz.cfg
+++ b/config/generic-bigtreetech-skr-mini-mz.cfg
@@ -30,7 +30,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -49,7 +48,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 1
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -67,7 +65,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 2
 run_current: 0.580
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -93,7 +90,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-bigtreetech-skr-pro.cfg
+++ b/config/generic-bigtreetech-skr-pro.cfg
@@ -110,37 +110,31 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PC13
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PE3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PE1
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PD4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PD1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PD6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -153,7 +147,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PB10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -161,7 +154,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PE12
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -169,7 +161,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PG8
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -177,7 +168,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PE15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -185,7 +175,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PE10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
@@ -193,7 +182,6 @@ max_z_accel: 100
 #spi_bus: spi3a
 ##diag1_pin: PG5
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-bigtreetech-skr-v1.3.cfg
+++ b/config/generic-bigtreetech-skr-v1.3.cfg
@@ -95,31 +95,26 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: P1.17
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: P1.15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: P1.10
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: P1.8
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: P1.1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -138,7 +133,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.29
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -148,7 +142,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.27
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -158,7 +151,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.25
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -168,7 +160,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.28
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -178,7 +169,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: P1.26
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -94,31 +94,26 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: P1.10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #
 #[tmc2208 stepper_y]
 #uart_pin: P1.9
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #
 #[tmc2208 stepper_z]
 #uart_pin: P1.8
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 #
 #[tmc2208 extruder]
 #uart_pin: P1.4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #
 #[tmc2208 extruder1]
 #uart_pin: P1.1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -132,7 +127,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #diag1_pin: P1.29
 
@@ -142,7 +136,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #diag1_pin: P1.28
 
@@ -152,7 +145,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 #diag1_pin: P1.27
 
@@ -162,7 +154,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #diag1_pin: P1.26
 
@@ -172,7 +163,6 @@ max_z_accel: 100
 #spi_software_mosi_pin: P1.17
 #spi_software_sclk_pin: P0.4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 #diag1_pin: P1.25
 

--- a/config/generic-duet2-duex.cfg
+++ b/config/generic-duet2-duex.cfg
@@ -96,7 +96,6 @@ position_max: 250
 [tmc2660 stepper_x]
 cs_pin: PD14 # X_SPI_EN Required for communication
 spi_bus: usart1 # All TMC2660 drivers are connected to USART1
-interpolate: True # 1/16 micro-steps interpolated to 1/256
 run_current: 1.000
 sense_resistor: 0.051
 idle_current_percent: 20
@@ -114,7 +113,6 @@ position_max: 210
 [tmc2660 stepper_y]
 cs_pin: PC9
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 idle_current_percent: 20
@@ -132,7 +130,6 @@ position_max: 200
 [tmc2660 stepper_z]
 cs_pin: PC10
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -147,7 +144,6 @@ rotation_distance: 8
 [tmc2660 stepper_z1]
 cs_pin: PD25
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -162,7 +158,6 @@ rotation_distance: 8
 [tmc2660 stepper_z2]
 cs_pin: PD26
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -177,7 +172,6 @@ rotation_distance: 8
 [tmc2660 stepper_z3]
 cs_pin: PB14
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -203,7 +197,6 @@ max_temp: 250
 [tmc2660 extruder]
 cs_pin: PC17
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -229,7 +222,6 @@ max_temp: 250
 [tmc2660 extruder1]
 cs_pin: PC25
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -255,7 +247,6 @@ max_temp: 250
 [tmc2660 extruder2]
 cs_pin: PD23
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 
@@ -281,7 +272,6 @@ max_temp: 250
 [tmc2660 extruder3]
 cs_pin: PD24
 spi_bus: usart1
-interpolate: True
 run_current: 1.000
 sense_resistor: 0.051
 

--- a/config/generic-flyboard.cfg
+++ b/config/generic-flyboard.cfg
@@ -144,55 +144,46 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PG13
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PG10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PD5
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PD1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PA14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PG6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder3]
 #uart_pin: PG3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder4]
 #uart_pin: PD10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder5]
 #uart_pin: PB12
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -204,63 +195,54 @@ max_z_accel: 100
 #cs_pin: PG13
 ##diag1_pin: PC3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
 #cs_pin: PG10
 ##diag1_pin: PF2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
 #cs_pin: PBD5
 ##diag1_pin: PF0
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
 #cs_pin: PD1
 ##diag1_pin: PE15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
 #cs_pin: PA14
 ##diag1_pin: PE10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
 #cs_pin: PG6
 ##diag1_pin: PC15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder3]
 #cs_pin: PG3
 ##diag1_pin: PC15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder4]
 #cs_pin: PD10
 ##diag1_pin: PC15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder5]
 #cs_pin: PB12
 ##diag1_pin: PC15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-fysetc-cheetah-v1.1.cfg
+++ b/config/generic-fysetc-cheetah-v1.1.cfg
@@ -25,7 +25,6 @@ uart_pin: PA3
 tx_pin: PA2
 uart_address: 0
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -44,7 +43,6 @@ uart_pin: PA3
 tx_pin: PA2
 uart_address: 2
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -62,7 +60,6 @@ uart_pin: PA3
 tx_pin: PA2
 uart_address: 1
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -88,7 +85,6 @@ uart_pin: PA3
 tx_pin: PA2
 uart_address: 3
 run_current: 1.0
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-fysetc-cheetah-v1.2.cfg
+++ b/config/generic-fysetc-cheetah-v1.2.cfg
@@ -24,7 +24,6 @@ homing_speed: 50
 uart_pin: PA12
 tx_pin: PA11
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -42,7 +41,6 @@ homing_speed: 50
 uart_pin: PB7
 tx_pin: PB6
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -59,7 +57,6 @@ position_max: 200
 uart_pin: PB11
 tx_pin: PB10
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [extruder]
@@ -84,7 +81,6 @@ max_temp: 250
 uart_pin: PA3
 tx_pin: PA2
 run_current: 1.0
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/generic-fysetc-f6.cfg
+++ b/config/generic-fysetc-f6.cfg
@@ -112,42 +112,36 @@ pins: PB0
 #uart_pin: PG3
 #tx_pin: PJ2
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PJ3
 #tx_pin: PJ4
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PE2
 #tx_pin: PE6
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PJ5
 #tx_pin: PJ6
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PE7
 #tx_pin: PD4
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PA1
 #tx_pin: PD5
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 ########################################
@@ -166,42 +160,36 @@ pins: PB0
 #cs_pin: PG4
 #diag1_pin: PK1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
 #cs_pin: PG2
 #diag1_pin: PJ1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
 #cs_pin: PJ7
 #diag1_pin: PB6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
 #cs_pin: PL2
 #diag1_pin: PE4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
 #cs_pin: PC5
 #diag1_pin: PJ0
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
 #cs_pin: PL7
 #diag1_pin: PK2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 ########################################

--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -106,37 +106,31 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PE8
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PC4
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PD12
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PA15
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PC5
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PE0
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 
@@ -149,7 +143,6 @@ max_z_accel: 100
 #cs_pin: PE7
 #diag1_pin: PB14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -157,7 +150,6 @@ max_z_accel: 100
 #cs_pin: PE15
 #diag1_pin: PB13
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -165,7 +157,6 @@ max_z_accel: 100
 #cs_pin: PD10
 #diag1_pin: PA0
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -173,7 +164,6 @@ max_z_accel: 100
 #cs_pin: PD7
 #diag1_pin: PA3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -181,7 +171,6 @@ max_z_accel: 100
 #cs_pin: PC14
 #diag1_pin: PA2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
@@ -189,7 +178,6 @@ max_z_accel: 100
 #cs_pin: PC15
 #diag1_pin: PA1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -113,42 +113,36 @@ max_z_accel: 100
 #uart_pin: PE8
 #tx_pin: PE9
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PE13
 #tx_pin: PE14
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PD12
 #tx_pin: PD11
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PA15
 #tx_pin: PD3
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PC5
 #tx_pin: PC4
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PE0
 #tx_pin: PE1
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 ########################################
@@ -171,7 +165,6 @@ max_z_accel: 100
 #cs_pin: PE7
 #diag1_pin: PB14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -179,7 +172,6 @@ max_z_accel: 100
 #cs_pin: PE15
 #diag1_pin: PB13
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -187,7 +179,6 @@ max_z_accel: 100
 #cs_pin: PD10
 #diag1_pin: PA0
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -195,7 +186,6 @@ max_z_accel: 100
 #cs_pin: PD7
 #diag1_pin: PA3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -203,7 +193,6 @@ max_z_accel: 100
 #cs_pin: PC14
 #diag1_pin: PA2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
@@ -211,7 +200,6 @@ max_z_accel: 100
 #cs_pin: PC15
 #diag1_pin: PA1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 ########################################

--- a/config/generic-fysetc-spider.cfg
+++ b/config/generic-fysetc-spider.cfg
@@ -129,50 +129,42 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PE7
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PE15
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PD10
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PD7
 #run_current: 0.8
-#hold_current: 0.5
 #sense_resistor: 0.110
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PC14
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PC15
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder3]
 #uart_pin: PA15
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder4]
 #uart_pin: PD11
 #run_current: 0.8
-#hold_current: 0.5
 #stealthchop_threshold: 999999
 
 ########################################
@@ -184,7 +176,6 @@ max_z_accel: 100
 #cs_pin: PE7
 #diag1_pin: PB14
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -192,7 +183,6 @@ max_z_accel: 100
 #cs_pin: PE15
 #diag1_pin: PB13
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -200,7 +190,6 @@ max_z_accel: 100
 #cs_pin: PD10
 #diag1_pin: PA0
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -208,7 +197,6 @@ max_z_accel: 100
 #cs_pin: PD7
 #diag1_pin: PA3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -216,7 +204,6 @@ max_z_accel: 100
 #cs_pin: PC14
 #diag1_pin: PA2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder2]
@@ -224,21 +211,18 @@ max_z_accel: 100
 #cs_pin: PC15
 #diag1_pin: PA1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder3]
 #spi_bus: spi4
 #cs_pin: PA15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder4]
 #spi_bus: spi4
 #cs_pin: PD11
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 ########################################

--- a/config/generic-mellow-super-infinty-hv.cfg
+++ b/config/generic-mellow-super-infinty-hv.cfg
@@ -188,49 +188,41 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: PC4
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: PF12
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: PF15
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: PE7
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: PE10
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder2]
 #uart_pin: PF1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder3]
 #uart_pin: PG2
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder4]
 #uart_pin: PG5
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -253,7 +245,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PG12
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 stepper_y]
@@ -263,7 +254,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PG11
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 stepper_z]
@@ -273,7 +263,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PG10
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc5160 extruder]
@@ -283,7 +272,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PG9
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 extruder1]
@@ -293,7 +281,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PD7
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 extruder2]
@@ -303,7 +290,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PD6
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 extruder3]
@@ -313,7 +299,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PA8
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc5160 extruder4]
@@ -323,7 +308,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: PB3
 ##diag1_pin: PF3
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-mks-robin-e3.cfg
+++ b/config/generic-mks-robin-e3.cfg
@@ -70,25 +70,21 @@ max_temp: 250
 [tmc2209 stepper_x]
 uart_pin: PC7
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [tmc2209 stepper_y]
 uart_pin: PD2
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [tmc2209 stepper_z]
 uart_pin: PC12
 run_current: 0.650
-hold_current: 0.450
 stealthchop_threshold: 999999
 
 [tmc2209 extruder]
 uart_pin: PC11
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [fan]

--- a/config/generic-mks-rumba32-v1.0.cfg
+++ b/config/generic-mks-rumba32-v1.0.cfg
@@ -119,21 +119,18 @@ aliases:
 #uart_pin: PC14
 ##tx_pin: PA3
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 stepper_y]
 #uart_pin: PE4
 ##tx_pin: PA4
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 stepper_z]
 #uart_pin: PE0
 ##tx_pin: PD13
 #run_current: 0.800
-#hold_current: 0.800
 #diag_pin:
 
 #[tmc2209 extruder]

--- a/config/generic-mks-sgenl.cfg
+++ b/config/generic-mks-sgenl.cfg
@@ -90,31 +90,26 @@ max_z_accel: 100
 #[tmc2208 stepper_x]
 #uart_pin: P1.1
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_y]
 #uart_pin: P1.8
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 stepper_z]
 #uart_pin: P1.10
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder]
 #uart_pin: P1.15
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2208 extruder1]
 #uart_pin: P1.17
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 
@@ -129,7 +124,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.29
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_y]
@@ -139,7 +133,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.27
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 stepper_z]
@@ -149,7 +142,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.25
 #run_current: 0.650
-#hold_current: 0.450
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder]
@@ -159,7 +151,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.28
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 #[tmc2130 extruder1]
@@ -169,7 +160,6 @@ max_z_accel: 100
 #spi_software_sclk_pin: P0.4
 ##diag1_pin: ^!P1.26
 #run_current: 0.800
-#hold_current: 0.500
 #stealthchop_threshold: 999999
 
 

--- a/config/generic-th3d-ezboard-lite-v1.2.cfg
+++ b/config/generic-th3d-ezboard-lite-v1.2.cfg
@@ -33,7 +33,6 @@ position_max: 350
 uart_pin: P0.5
 tx_pin: P0.4
 run_current: 0.600
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_y]
@@ -50,7 +49,6 @@ position_max: 350
 uart_pin: P0.11
 tx_pin: P0.10
 run_current: 0.600
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [stepper_z]
@@ -67,7 +65,6 @@ position_max: 400
 uart_pin: P0.20
 tx_pin: P0.19
 run_current: 0.700
-hold_current: 0.600
 stealthchop_threshold: 999999
 
 [extruder]
@@ -92,7 +89,6 @@ max_temp: 210
 uart_pin: P0.21
 tx_pin: P0.22
 run_current: 0.800
-hold_current: 0.700
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/printer-eryone-er20-2021.cfg
+++ b/config/printer-eryone-er20-2021.cfg
@@ -27,7 +27,6 @@ tx_pin: PC10
 diag_pin: ^PD8
 uart_address: 2
 run_current: 0.6
-hold_current: 0.3
 stealthchop_threshold: 999999
 driver_SGTHRS: 80
 
@@ -50,7 +49,6 @@ tx_pin: PC10
 diag_pin: ^PD15
 uart_address: 3
 run_current: 0.7
-hold_current: 0.35
 stealthchop_threshold: 999999
 driver_SGTHRS: 100
 
@@ -70,7 +68,6 @@ tx_pin: PC10
 diag_pin: ^PC9
 uart_address: 1
 run_current: 0.7
-hold_current: 0.35
 stealthchop_threshold: 999999
 driver_SGTHRS: 0
 
@@ -99,7 +96,6 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 0
 run_current: 0.7
-hold_current: 0.35
 stealthchop_threshold: 999999
 
 [heater_bed]

--- a/config/printer-hiprecy-leo-2019.cfg
+++ b/config/printer-hiprecy-leo-2019.cfg
@@ -110,13 +110,13 @@ algorithm: bicubic
 gcode:
     G90
     G1 Z5
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.500 HOLDCURRENT=0.250
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.500
     G28 X ;Zero X
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.600 HOLDCURRENT=0.300
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0.600
     G1 X10 ;Move X 10mm away from the stop so we can home multiple times in a row (needs a bit of space to trigger reliably again)
-    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.500 HOLDCURRENT=0.250
+    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.500
     G28 Y ;Zero Y
-    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.700 HOLDCURRENT=0.350
+    SET_TMC_CURRENT STEPPER=stepper_y CURRENT=0.700
     G1 Y10 ;Move Y 10mm away from the stop so we can home multiple times in a row (needs a bit of space to trigger reliably again)
     G28 Z
     G1 X20 Y5
@@ -163,7 +163,6 @@ max_z_accel: 100
 cs_pin: PG4
 diag1_pin: ^!PK1
 run_current: 0.600
-hold_current: 0.300
 stealthchop_threshold: 999999
 driver_SGT: 3
 
@@ -171,19 +170,16 @@ driver_SGT: 3
 cs_pin: PG2
 diag1_pin: ^!PJ1
 run_current: 0.700
-hold_current: 0.350
 stealthchop_threshold: 999999
 driver_SGT: 3
 
 [tmc2130 stepper_z]
 cs_pin: PJ7
 run_current: 0.800
-hold_current: 0.400
 stealthchop_threshold: 999999
 
 [tmc2130 extruder]
 cs_pin: PL2
 diag1_pin: PE4
 run_current: 0.600
-hold_current: 0.300
 stealthchop_threshold: 999999

--- a/config/sample-bigtreetech-exp-mot.cfg
+++ b/config/sample-bigtreetech-exp-mot.cfg
@@ -34,7 +34,6 @@ position_max: 400
 uart_pin: EXP1_6
 microsteps: 16
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 diag_pin: EXP1_5
 
@@ -42,7 +41,6 @@ diag_pin: EXP1_5
 uart_pin: EXP1_4
 microsteps: 16
 run_current: 0.800
-hold_current: 0.500
 stealthchop_threshold: 999999
 diag_pin: EXP1_3
 
@@ -50,6 +48,5 @@ diag_pin: EXP1_3
 uart_pin: EXP1_2
 microsteps: 16
 run_current: 0.650
-hold_current: 0.450
 stealthchop_threshold: 999999
 diag_pin: EXP1_1

--- a/config/sample-bigtreetech-hermit-crab-canbus.cfg
+++ b/config/sample-bigtreetech-hermit-crab-canbus.cfg
@@ -35,7 +35,6 @@ max_temp: 250
 [tmc2209 extruder]
 uart_pin: HermitCrab: PB0
 run_current: 0.650
-hold_current: 0.500
 stealthchop_threshold: 999999
 
 [fan]

--- a/config/sample-mmu2s-diy.cfg
+++ b/config/sample-mmu2s-diy.cfg
@@ -36,7 +36,6 @@ endstop_pin: ^mmboard:PC2 # PINDA X+
 [tmc2208 manual_stepper gear_stepper]
 uart_pin: mmboard:PC14
 run_current: 1.000
-hold_current: 0.600
 interpolate: True
 sense_resistor: 0.110
 
@@ -53,7 +52,6 @@ accel: 80
 [tmc2209 manual_stepper idler_stepper]
 uart_pin: mmboard:PB7
 run_current: 0.800
-hold_current: 0.800
 interpolate: True
 sense_resistor: 0.110
 stealthchop_threshold: 999999
@@ -73,7 +71,6 @@ endstop_pin: !mmboard:PC0 # switch endstop on the left Z-
 [tmc2209 manual_stepper selector_stepper]
 uart_pin: mmboard:PC12
 run_current: 1.000
-hold_current: 0.400
 interpolate: True
 sense_resistor: 0.110
 stealthchop_threshold: 999999

--- a/config/sample-mmu2s-diy.cfg
+++ b/config/sample-mmu2s-diy.cfg
@@ -36,7 +36,6 @@ endstop_pin: ^mmboard:PC2 # PINDA X+
 [tmc2208 manual_stepper gear_stepper]
 uart_pin: mmboard:PC14
 run_current: 1.000
-interpolate: True
 sense_resistor: 0.110
 
 # Y : MMU2S idler with the 5 ball bearings
@@ -52,7 +51,6 @@ accel: 80
 [tmc2209 manual_stepper idler_stepper]
 uart_pin: mmboard:PB7
 run_current: 0.800
-interpolate: True
 sense_resistor: 0.110
 stealthchop_threshold: 999999
 
@@ -71,7 +69,6 @@ endstop_pin: !mmboard:PC0 # switch endstop on the left Z-
 [tmc2209 manual_stepper selector_stepper]
 uart_pin: mmboard:PC12
 run_current: 1.000
-interpolate: True
 sense_resistor: 0.110
 stealthchop_threshold: 999999
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2767,7 +2767,9 @@ cs_pin:
 #   The default is to not use an SPI daisy chain.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
-#   step at a rate of 256 micro-steps). The default is True.
+#   step at a rate of 256 micro-steps). This interpolation does
+#   introduce a small systemic positional deviation - see
+#   TMC_Drivers.md for details. The default is True.
 run_current:
 #   The amount of current (in amps RMS) to configure the driver to use
 #   during stepper movement. This parameter must be provided.
@@ -2834,7 +2836,9 @@ uart_pin:
 #   UART communication. The default is to not configure any pins.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
-#   step at a rate of 256 micro-steps). The default is True.
+#   step at a rate of 256 micro-steps). This interpolation does
+#   introduce a small systemic positional deviation - see
+#   TMC_Drivers.md for details. The default is True.
 run_current:
 #   The amount of current (in amps RMS) to configure the driver to use
 #   during stepper movement. This parameter must be provided.
@@ -2946,7 +2950,9 @@ cs_pin:
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This only works if microsteps
-#   is set to 16. The default is True.
+#   is set to 16. Interpolation does introduce a small systemic
+#   positional deviation - see TMC_Drivers.md for details. The default
+#   is True.
 run_current:
 #   The amount of current (in amps RMS) used by the driver during
 #   stepper movement. This parameter must be provided.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2773,8 +2773,9 @@ run_current:
 #   during stepper movement. This parameter must be provided.
 #hold_current:
 #   The amount of current (in amps RMS) to configure the driver to use
-#   when the stepper is not moving. The default is to not reduce the
-#   current.
+#   when the stepper is not moving. Setting a hold_current is not
+#   recommended (see TMC_Drivers.md for details). The default is to
+#   not reduce the current.
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -2839,8 +2840,9 @@ run_current:
 #   during stepper movement. This parameter must be provided.
 #hold_current:
 #   The amount of current (in amps RMS) to configure the driver to use
-#   when the stepper is not moving. The default is to use the same
-#   value as run_current.
+#   when the stepper is not moving. Setting a hold_current is not
+#   recommended (see TMC_Drivers.md for details). The default is to
+#   not reduce the current.
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -3022,8 +3024,9 @@ run_current:
 #   during stepper movement. This parameter must be provided.
 #hold_current:
 #   The amount of current (in amps RMS) to configure the driver to use
-#   when the stepper is not moving. The default is to use the same
-#   value as run_current.
+#   when the stepper is not moving. Setting a hold_current is not
+#   recommended (see TMC_Drivers.md for details). The default is to
+#   not reduce the current.
 #sense_resistor: 0.075
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.075 ohms.

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -317,9 +317,7 @@ for the driver's internal stall flag to still be set from a previous
 move.
 
 It can also be useful to have that macro set the driver current before
-homing and set a new current after the carriage has moved away. This
-also allows a hold_current to be set during prints (a hold_current
-is not recommended during sensorless homing).
+homing and set a new current after the carriage has moved away.
 
 An example macro might look something like:
 ```
@@ -328,9 +326,8 @@ gcode:
     {% set HOME_CUR = 0.700 %}
     {% set driver_config = printer.configfile.settings['tmc2209 stepper_x'] %}
     {% set RUN_CUR = driver_config.run_current %}
-    {% set HOLD_CUR = driver_config.hold_current %}
     # Set current for sensorless homing
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={HOME_CUR} HOLDCURRENT={HOME_CUR}
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={HOME_CUR}
     # Pause to ensure driver stall flag is clear
     G4 P2000
     # Home
@@ -339,7 +336,7 @@ gcode:
     G90
     G1 X5 F1200
     # Set current during print
-    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CUR} HOLDCURRENT={HOLD_CUR}
+    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CUR}
 ```
 
 The resulting macro can be called from a
@@ -360,7 +357,7 @@ Use the tuning guide described above to find the appropriate "stall
 sensitivity" for each carriage, but be aware of the following
 restrictions:
 1. When using sensorless homing on CoreXY, make sure there is no
-   `hold_current` in effect for either stepper during homing.
+   `hold_current` configured for either stepper.
 2. While tuning, make sure both the X and Y carriages are near the
    center of their rails before each home attempt.
 3. After tuning is complete, when homing both X and Y, use macros to

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -11,6 +11,53 @@ this document are not available.
 In addition to this document, be sure to review the
 [TMC driver config reference](Config_Reference.md#tmc-stepper-driver-configuration).
 
+## Tuning motor current
+
+A higher driver current increases positional accuracy and torque.
+However, a higher current also increases the heat produced by the
+stepper motor and the stepper motor driver. If the stepper motor
+driver gets too hot it will disable itself and Klipper will report an
+error. If the stepper motor gets too hot, it loses torque and
+positional accuracy. (If it gets very hot it may also melt plastic
+parts attached to it or near it.)
+
+As a general tuning tip, prefer higher current values as long as the
+stepper motor does not get too hot and the stepper motor driver does
+not report warnings or errors. In general, it is okay for the stepper
+motor to feel warm, but it should not become so hot that it is painful
+to touch.
+
+## Prefer to not specify a hold_current
+
+If one configures a `hold_current` then the TMC driver can reduce
+current to the stepper motor when it detects that the stepper is not
+moving. However, changing motor current may itself introduce motor
+movement. This may occur due to "detent forces" within the stepper
+motor (the permanent magnet in the rotor pulls towards the iron teeth
+in the stator) or due to external forces on the axis carriage.
+
+Most stepper motors will not obtain a significant benefit to reducing
+current during normal prints, because few printing moves will leave a
+stepper motor idle for sufficiently long to activate the
+`hold_current` feature. And, it is unlikely that one would want to
+introduce subtle print artifacts to the few printing moves that do
+leave a stepper idle sufficiently long.
+
+If one wishes to reduce current to motors during print start routines,
+then consider issuing
+[SET_TMC_CURRENT](G-Codes.md#tmc-stepper-drivers) commands in a
+[START_PRINT macro](Slicers.md#klipper-gcode_macro) to adjust the
+current before and after normal printing moves.
+
+Some printers with dedicated Z motors that are idle during normal
+printing moves (no bed_mesh, no bed_tilt, no Z skew_correction, no
+"vase mode" prints, etc.) may find that Z motors do run cooler with a
+`hold_current`. If implementing this then be sure to take into account
+this type of uncommanded Z axis movement during bed leveling, bed
+probing, probe calibration, and similar. The `driver_TPOWERDOWN` and
+`driver_IHOLDDELAY` should also be calibrated accordingly. If unsure,
+prefer to not specify a `hold_current`.
+
 ## Enabling "StealthChop" Mode
 
 By default, Klipper places the TMC drivers in "spreadCycle" mode. If

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -58,11 +58,24 @@ probing, probe calibration, and similar. The `driver_TPOWERDOWN` and
 `driver_IHOLDDELAY` should also be calibrated accordingly. If unsure,
 prefer to not specify a `hold_current`.
 
-## Enabling "StealthChop" Mode
+## Setting "spreadCycle" vs "stealthChop" Mode
 
 By default, Klipper places the TMC drivers in "spreadCycle" mode. If
 the driver supports "stealthChop" then it can be enabled by adding
 `stealthchop_threshold: 999999` to the TMC config section.
+
+In general, spreadCycle mode provides greater torque and greater
+positional accuracy than stealthChop mode. However, stealthChop mode
+may produce significantly lower audible noise on some printers.
+
+Tests comparing modes have shown an increased "positional lag" of
+around 75% of a full-step during constant velocity moves when using
+stealthChop mode (for example, on a printer with 40mm
+rotation_distance and 200 steps_per_rotation, position deviation of
+constant speed moves increased by ~0.150mm). However, this "delay in
+obtaining the requested position" may not manifest as a significant
+print defect and one may prefer the quieter behavior of stealthChop
+mode.
 
 It is recommended to always use "spreadCycle" mode (by not specifying
 `stealthchop_threshold`) or to always use "stealthChop" mode (by

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -83,6 +83,33 @@ setting `stealthchop_threshold` to 999999). Unfortunately, the drivers
 often produce poor and confusing results if the mode changes while the
 motor is at a non-zero velocity.
 
+## TMC interpolate setting introduces small position deviation
+
+The TMC driver `interpolate` setting may reduce the audible noise of
+printer movement at the cost of introducing a small systemic
+positional error. This systemic positional error results from the
+driver's delay in executing "steps" that Klipper sends it. During
+constant velocity moves, this delay results in a positional error of
+nearly half a configured microstep (more precisely, the error is half
+a microstep distance minus a 512th of a full step distance). For
+example, on an axis with a 40mm rotation_distance, 200
+steps_per_rotation, and 16 microsteps, the systemic error introduced
+during constant velocity moves is ~0.006mm.
+
+For best positional accuracy consider using spreadCycle mode and
+disable interpolation (set `interpolate: False` in the TMC driver
+config). When configured this way, one may increase the `microstep`
+setting to reduce audible noise during stepper movement. Typically, a
+microstep setting of `64` or `128` will have similar audible noise as
+interpolation, and do so without introducing a systemic positional
+error.
+
+If using stealthChop mode then the positional inaccuracy from
+interpolation is small relative to the positional inaccuracy
+introduced from stealthChop mode. Therefore tuning interpolation is
+not considered useful when in stealthChop mode, and one can leave
+interpolation in its default state.
+
 ## Sensorless Homing
 
 Sensorless homing allows to home an axis without the need for a


### PR DESCRIPTION
This updates the TMC_Drivers.md document to make two notable recommendations:
1) Don't use `hold_current`.
2) For best positional accuracy, prefer using spreadCycle mode and set `interpolate: False`.

Details are in the proposed document: https://github.com/Klipper3d/klipper/blob/work-tmctuning-20211128/docs/TMC_Drivers.md

These documentation changes are the results of tests I've been running with the magnetic angle sensors and the accelorometer.

Both of the settings above introduce a positional error that is very small (a handful of microns), but there doesn't seem to be a compelling reason to pay a penalty, as there are alternative configurations available.

As part of this PR, I considered changing the `interpolate` default from True to False.  However, I fear doing so may increase the audible noise of printers to the point that some users switch to stealthChop mode.  That would be a net loss, as the positional error introduced by stealthChop mode is significantly larger then the penalty from interpolation (eg, 25x).  So, the default remains `interpolate: True` after this PR.

Comments?
-Kevin