### PR TITLE
manual_stepper: add `get_status` method

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -189,6 +189,9 @@ The following information is available in the
 is always available):
 - `enabled`: Returns True if the stepper is currently enabled.
 - `position`: The last commanded position of the stepper.
+- `mcu_position`: The total number of steps the micro-controller
+   has issued in a positive direction minus the number of steps
+  issued in a negative direction since the micro-controller was last reset
 
 ## mcu
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -182,6 +182,14 @@ is always available):
   been in the "Printing" state (as tracked by the idle_timeout
   module).
 
+## manual_steppers
+
+The following information is available in the
+[manual_stepper](Config_Reference.md#manual_stepper) object (this object
+is always available):
+- `enabled`: Returns True if the stepper is currently enabled.
+- `position`: The last commanded position of the stepper.
+
 ## mcu
 
 The following information is available in

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -103,6 +103,13 @@ class ManualStepper:
             self.do_move(movepos, speed, accel, sync)
         elif gcmd.get_int('SYNC', 0):
             self.sync_print_time()
+    def get_status(self, eventtime):
+        stepper_enable = self.printer.lookup_object('stepper_enable')
+        se = stepper_enable.lookup_enable(self.rail.get_name())
+        return {
+            'enabled': se.is_motor_enabled(),
+            'position': self.rail.get_commanded_position()
+        }
     # Toolhead wrappers to support homing
     def flush_step_generation(self):
         self.sync_print_time()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -108,8 +108,13 @@ class ManualStepper:
         se = stepper_enable.lookup_enable(self.rail.get_name())
         return {
             'enabled': se.is_motor_enabled(),
-            'position': self.rail.get_commanded_position()
+            'position': self.get_position()[0],
+            'mcu_position': self.get_mcu_position()
         }
+    def get_mcu_position(self):
+        for stepper in self.steppers:
+            return stepper.get_mcu_position()
+        return 0
     # Toolhead wrappers to support homing
     def flush_step_generation(self):
         self.sync_print_time()


### PR DESCRIPTION
This exposes two additional informations on `manual_steppers`:

- `enabled`
- `position`
- `mcu_position`

This is status returned by Moonraker `/printer/objects/query?manual_stepper idler_stepper`:

```json
{
  "result": {
    "eventtime": 1628.386874847,
    "status": {
      "manual_stepper idler_stepper": {
        "enabled": false,
        "position": 0.0,
        "mcu_position": -231
      }
    }
  }
}
```
