### PR TITLE
scripts: Migrated shaper calibration scripts to Python3

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,16 @@ All dates in this document are approximate.
 
 ## Changes
 
+20211230: Scripts to tune input shaper (`scripts/calibrate_shaper.py`
+and `scripts/graph_accelerometer.py`) were migrated to use Python3
+by default. As a result, users must install Python3 versions of certain
+packages (e.g. `sudo apt install python3-numpy python3-matplotlib`) to
+continue using these scripts. For more details, refer to
+[Software installation](Measuring_Resonances.md#software-installation).
+Alternatively, users can temporarily force the execution of these scripts
+under Python 2 by explicitly calling Python2 interpretor in the console:
+`python2 ~/klipper/scripts/calibrate_shaper.py ...`
+
 20211110: The "NTC 100K beta 3950" temperature sensor is deprecated.
 This sensor will be removed in the near future.  Most users will find
 the "Generic 3950" temperature sensor more accurate.  To continue to

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -77,7 +77,7 @@ too little RAM, the installation may fail and you will need to enable swap.
 Next, run the following commands to install the additional dependencies:
 ```
 sudo apt update
-sudo apt install python-numpy python-matplotlib
+sudo apt install python3-numpy python3-matplotlib
 ```
 
 Afterwards, check and follow the instructions in the

--- a/scripts/calibrate_shaper.py
+++ b/scripts/calibrate_shaper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Shaper auto-calibration script
 #
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>

--- a/scripts/graph_accelerometer.py
+++ b/scripts/graph_accelerometer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Generate adxl345 accelerometer graphs
 #
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>


### PR DESCRIPTION
Also updated instructions to install python3-numpy and
python3-matplotlib Python packages.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>