### PR TITLE
Add beeper pin for GT2560

### DIFF
--- a/config/generic-gt2560.cfg
+++ b/config/generic-gt2560.cfg
@@ -89,3 +89,7 @@ d6_pin: PE3
 d7_pin: PH3
 encoder_pins: ^PL7, ^PG1
 click_pin: ^!PD2
+
+[output_pin BEEPER_pin]
+pin: PD3
+pwm: True


### PR DESCRIPTION
The example config for the GT2560 board lacked the beeper pin assignment.
It works flawlessly on my GT2560 rev A+ board and the printer happily sings the Mario theme song upon print completion.

The pin assignment has also been cross-referenced with Marlin's pin files for [GT2560 rev A](https://github.com/MarlinFirmware/Marlin/blob/2.0.x/Marlin/src/pins/mega/pins_GT2560_REV_A.h#L110) and [GT2560 rev 3  (and 4)](https://github.com/MarlinFirmware/Marlin/blob/2.0.x/Marlin/src/pins/mega/pins_GT2560_V3.h#L161) boards with the use of the [Arduino 2560 to ATmega 2560 pin map](https://www.arduino.cc/en/Hacking/PinMapping2560) and it is the same in all versions.

Signed-off-by: Rosen Stoyanov <me@pockata.org>
