### PR TITLE
Ender2-Pro

### DIFF
--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -44,8 +44,10 @@ dir_pin: !PB5
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 8
-endstop_pin: ^PA7
-position_endstop: 0.0
+endstop_pin: ^PA7                         # disable to use BLTouch
+position_endstop: 0.0                     # disable to use BLTouch
+# endstop_pin: probe:z_virtual_endstop    # enable to use BLTouch
+# position_min: -5.0                      # enable to use BLTouch
 position_max: 180
 
 [extruder]
@@ -93,3 +95,18 @@ max_velocity: 300
 max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
+
+# # Uncomment to enable BLTouch
+# [bltouch]
+# sensor_pin: ^PB1
+# control_pin: PB0
+# x_offset: 10
+# z_offset: 0
+# z_offset: 0
+
+# # Uncomment to enable BLTouch
+# [safe_z_home]
+# home_xy_position: 83, 83 # Change coordinates to the center of your print bed
+# speed: 50
+# z_hop: 10                 # Move up 10mm
+# z_hop_speed: 5

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -62,10 +62,10 @@ filament_diameter: 1.750
 heater_pin: PA1
 sensor_type: EPCOS 100K B57560G104F #TODO verify actual sensor https://github.com/Klipper3d/klipper/issues/1125
 control: pid
-# tuned for stock hardware with 200 degree Celsius target
-pid_Kp: 21.527
-pid_Ki: 1.063
-pid_Kd: 108.982
+# PID_CALIBRATE HEATER=extruder TARGET=220
+pid_Kp: 29.634
+pid_Ki: 2.102 
+pid_Kd: 104.459
 min_temp: 0
 max_temp: 260
 min_extrude_temp: 150 # Temporarially set to 0 for tuning, set to >150 for safety
@@ -76,9 +76,10 @@ sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC4
 control: pid
 # tuned for stock hardware with 50 degree Celsius target
-pid_Kp: 54.027
-pid_Ki: 0.770
-pid_Kd: 948.182
+# PID_CALIBRATE HEATER=heater_bed TARGET=50
+pid_Kp: 72.921
+pid_Ki: 1.594
+pid_Kd: 834.031
 min_temp: 0
 max_temp: 80
 

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -56,7 +56,7 @@ step_pin: PB4
 dir_pin: PB3
 enable_pin: !PC3
 microsteps: 16
-rotation_distance: 34.406
+rotation_distance: 27.53480577
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -1,0 +1,95 @@
+# This file contains pin mappings for the stock 2021 Creality
+# Ender2 Pro. To use this config, during "make menuconfig" select
+# the STM32F103 with a "28KiB bootloader" and serial
+# (on USART1 PA10/PA9) communication.
+
+# If you prefer a direct serial connection, in "make menuconfig"
+# select "Enable extra low-level configuration options" and select
+# serial (on USART3 PB11/PB*), which is broken out on the 10 pin IDC
+# cable used for the LCD module as follows:
+# 3: Tx, 4: Rx, 9: GND, 10: VCC
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning on the printer with the card inserted. The firmware
+# filename must end in ".bin" and must not match the last filename
+# that was flashed.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PC2
+dir_pin: PB9
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA5
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA6
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PA7
+position_endstop: 0.0
+position_max: 250
+
+[extruder]
+max_extrude_only_distance: 100.0
+step_pin: PB4
+dir_pin: PB3
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 34.406
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC5
+control: pid
+# tuned for stock hardware with 200 degree Celsius target
+pid_Kp: 21.527
+pid_Ki: 1.063
+pid_Kd: 108.982
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PB10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+control: pid
+# tuned for stock hardware with 50 degree Celsius target
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA0
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -60,8 +60,7 @@ rotation_distance: 27.53480577
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PA1
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: PC5
+sensor_type: EPCOS 100K B57560G104F #TODO verify actual sensor https://github.com/Klipper3d/klipper/issues/1125
 control: pid
 # tuned for stock hardware with 200 degree Celsius target
 pid_Kp: 21.527
@@ -69,6 +68,7 @@ pid_Ki: 1.063
 pid_Kd: 108.982
 min_temp: 0
 max_temp: 250
+min_extrude_temp: 150 # Temporarially set to 0 for tuning, set to >150 for safety
 
 [heater_bed]
 heater_pin: PB10

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -24,7 +24,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PA5
 position_endstop: 0
-position_max: 235
+position_max: 165
 homing_speed: 50
 
 [stepper_y]
@@ -35,7 +35,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PA6
 position_endstop: 0
-position_max: 235
+position_max: 165
 homing_speed: 50
 
 [stepper_z]
@@ -46,7 +46,7 @@ microsteps: 16
 rotation_distance: 8
 endstop_pin: ^PA7
 position_endstop: 0.0
-position_max: 250
+position_max: 180
 
 [extruder]
 max_extrude_only_distance: 100.0

--- a/config/printer-creality-ender2pro-2021.cfg
+++ b/config/printer-creality-ender2pro-2021.cfg
@@ -67,7 +67,7 @@ pid_Kp: 21.527
 pid_Ki: 1.063
 pid_Kd: 108.982
 min_temp: 0
-max_temp: 250
+max_temp: 260
 min_extrude_temp: 150 # Temporarially set to 0 for tuning, set to >150 for safety
 
 [heater_bed]
@@ -80,7 +80,7 @@ pid_Kp: 54.027
 pid_Ki: 0.770
 pid_Kd: 948.182
 min_temp: 0
-max_temp: 130
+max_temp: 80
 
 [fan]
 pin: PA0


### PR DESCRIPTION
Adds Ender2 pro config. Copied from ender3 v2

The [Ender 2 pro](https://www.creality3dofficial.com/products/creality-ender-2-3d-printer) is a new printer from creality that uses the Creality Silent Motherboard version 4.2.3 

The only real difference between an Ender 3 (using 4.2.2. board) and Ender2-Pro (4.2.3 board) is the following pins have been changed

| PIN | 4.2.2 | 4.2.3| 
| --- | --- | ---| 
| Heater Bed Pin | PA2 | PB10 | 
| Button Encoder 1 | PB10  |PA2|

# Resources
- https://github.com/MarlinFirmware/Marlin/pull/23307
- https://github.com/MarlinFirmware/Configurations/pull/633

Marking as 'Draft' as this hasn't yet been tested

