### PR TITLE
stm32: Add initial support for stm32g0

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -244,7 +244,7 @@ MCUTYPES = {
     'sam3': flash_atsam3, 'sam4': flash_atsam4, 'samd': flash_atsamd,
     'lpc176': flash_lpc176x, 'stm32f103': flash_stm32f1,
     'stm32f4': flash_stm32f4, 'stm32f042': flash_stm32f4,
-    'stm32f072': flash_stm32f4
+    'stm32f072': flash_stm32f4, 'stm32g0b1': flash_stm32f4
 }
 
 

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -26,6 +26,11 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4"
     },
+    'btt-skr-mini-v3': {
+        'mcu': "stm32g0b1xx",
+        'spi_bus': "spi1",
+        "cs_pin": "PA4"
+    },
     'flyboard-mini': {
         'mcu': "stm32f103xe",
         'spi_bus': "spi2",
@@ -78,6 +83,7 @@ BOARD_ALIASES = {
     'btt-skr-mini-e3-v1': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-mini-e3-v1.2': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-mini-e3-v2': BOARD_DEFS['btt-skr-mini'],
+    'btt-skr-mini-e3-v3': BOARD_DEFS['btt-skr-mini-v3'],
     'btt-skr-mini-mz': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -64,6 +64,9 @@ choice
         bool "STM32F072"
         select MACH_STM32F0
         select MACH_STM32F0x2
+    config MACH_STM32G0B1
+        bool "STM32G0B1"
+        select MACH_STM32G0
     config MACH_STM32H743
         bool "STM32H743"
         select MACH_STM32H7
@@ -73,6 +76,8 @@ choice
 endchoice
 
 config MACH_STM32F0
+    bool
+config MACH_STM32G0
     bool
 config MACH_STM32F1
     bool
@@ -102,6 +107,7 @@ config MCU
     default "stm32f042x6" if MACH_STM32F042
     default "stm32f070xb" if MACH_STM32F070
     default "stm32f072xb" if MACH_STM32F072
+    default "stm32g0b1xx" if MACH_STM32G0B1
     default "stm32f103xe" if MACH_STM32F103
     default "stm32f207xx" if MACH_STM32F207
     default "stm32f401xc" if MACH_STM32F401
@@ -115,7 +121,7 @@ config MCU
 config CLOCK_FREQ
     int
     default 48000000 if MACH_STM32F0
-    default 64000000 if MACH_STM32F103 && STM32_CLOCK_REF_INTERNAL
+    default 64000000 if (MACH_STM32F103 && STM32_CLOCK_REF_INTERNAL) || MACH_STM32G0B1
     default 72000000 if MACH_STM32F103
     default 120000000 if MACH_STM32F207
     default 84000000 if MACH_STM32F401
@@ -130,7 +136,7 @@ config FLASH_SIZE
     default 0x20000 if MACH_STM32F070 || MACH_STM32F072
     default 0x10000 if MACH_STM32F103 # Flash size of stm32f103x8 (64KiB)
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401
-    default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
+    default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446 || MACH_STM32G0B1
     default 0x20000 if MACH_STM32H750
     default 0x200000 if MACH_STM32H743
 
@@ -147,7 +153,7 @@ config RAM_SIZE
     default 0x5000 if MACH_STM32F103 # Ram size of stm32f103x8 (20KiB)
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401
-    default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446
+    default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446 || MACH_STM32G0B1
     default 0x20000 if MACH_STM32H750
     default 0x80000 if MACH_STM32H743
 
@@ -171,9 +177,9 @@ config STM32F103GD_DISABLE_SWD
 ######################################################################
 
 choice
-    prompt "Bootloader offset" if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F070 || MACH_STM32H743
+    prompt "Bootloader offset" if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F070 || MACH_STM32H743 || MACH_STM32G0B1
     config STM32_FLASH_START_2000
-        bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070
+        bool "8KiB bootloader (stm32duino)" if MACH_STM32F103 || MACH_STM32F070 || MACH_STM32G0B1
     config STM32_FLASH_START_5000
         bool "20KiB bootloader" if MACH_STM32F103
     config STM32_FLASH_START_7000

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -150,10 +150,11 @@ config RAM_SIZE
     default 0x1000 if MACH_STM32F031
     default 0x1800 if MACH_STM32F042
     default 0x4000 if MACH_STM32F070 || MACH_STM32F072
+    default 0x24000 if MACH_STM32G0B1
     default 0x5000 if MACH_STM32F103 # Ram size of stm32f103x8 (20KiB)
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401
-    default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446 || MACH_STM32G0B1
+    default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x20000 if MACH_STM32H750
     default 0x80000 if MACH_STM32H743
 

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -5,6 +5,7 @@ CROSS_PREFIX=arm-none-eabi-
 
 dirs-y += src/stm32 src/generic
 dirs-$(CONFIG_MACH_STM32F0) += lib/stm32f0
+dirs-$(CONFIG_MACH_STM32G0) += lib/stm32g0
 dirs-$(CONFIG_MACH_STM32F1) += lib/stm32f1
 dirs-$(CONFIG_MACH_STM32F2) += lib/stm32f2
 dirs-$(CONFIG_MACH_STM32F4) += lib/stm32f4
@@ -14,6 +15,7 @@ MCU := $(shell echo $(CONFIG_MCU))
 MCU_UPPER := $(shell echo $(CONFIG_MCU) | tr a-z A-Z | tr X x)
 
 CFLAGS-$(CONFIG_MACH_STM32F0) += -mcpu=cortex-m0 -Ilib/stm32f0/include
+CFLAGS-$(CONFIG_MACH_STM32G0) += -mcpu=cortex-m0plus -Ilib/stm32g0/include
 CFLAGS-$(CONFIG_MACH_STM32F1) += -mcpu=cortex-m3 -Ilib/stm32f1/include
 CFLAGS-$(CONFIG_MACH_STM32F2) += -mcpu=cortex-m3 -Ilib/stm32f2/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mcpu=cortex-m4 -Ilib/stm32f4/include
@@ -31,6 +33,10 @@ src-$(CONFIG_MACH_STM32F0) += ../lib/stm32f0/system_stm32f0xx.c
 src-$(CONFIG_MACH_STM32F0) += generic/timer_irq.c stm32/stm32f0_timer.c
 src-$(CONFIG_MACH_STM32F0) += stm32/stm32f0.c stm32/stm32f0_adc.c
 src-$(CONFIG_MACH_STM32F0) += stm32/stm32f0_i2c.c
+src-$(CONFIG_MACH_STM32G0) += ../lib/stm32g0/system_stm32g0xx.c
+src-$(CONFIG_MACH_STM32G0) += generic/timer_irq.c stm32/stm32f0_timer.c
+src-$(CONFIG_MACH_STM32G0) += stm32/stm32g0.c stm32/stm32g0_adc.c
+src-$(CONFIG_MACH_STM32G0) += stm32/stm32f0_i2c.c
 src-$(CONFIG_MACH_STM32F1) += ../lib/stm32f1/system_stm32f1xx.c
 src-$(CONFIG_MACH_STM32F1) += stm32/stm32f1.c generic/armcm_timer.c
 src-$(CONFIG_MACH_STM32F1) += stm32/adc.c stm32/i2c.c
@@ -51,6 +57,7 @@ usb-src-$(CONFIG_HAVE_STM32_USBOTG) := stm32/usbotg.c
 src-$(CONFIG_USBSERIAL) += $(usb-src-y) stm32/chipid.c generic/usb_cdc.c
 serial-src-y := stm32/serial.c
 serial-src-$(CONFIG_MACH_STM32F0) := stm32/stm32f0_serial.c
+serial-src-$(CONFIG_MACH_STM32G0) := stm32/stm32f0_serial.c
 serial-src-$(CONFIG_MACH_STM32H7) := stm32/stm32h7_serial.c
 src-$(CONFIG_SERIAL) += $(serial-src-y) generic/serial_irq.c
 src-$(CONFIG_CANSERIAL) += stm32/can.c ../lib/fast-hash/fasthash.c

--- a/src/stm32/internal.h
+++ b/src/stm32/internal.h
@@ -6,6 +6,8 @@
 
 #if CONFIG_MACH_STM32F0
 #include "stm32f0xx.h"
+#elif CONFIG_MACH_STM32G0
+#include "stm32g0xx.h"
 #elif CONFIG_MACH_STM32F1
 #include "stm32f1xx.h"
 #elif CONFIG_MACH_STM32F2

--- a/src/stm32/spi.c
+++ b/src/stm32/spi.c
@@ -21,7 +21,8 @@ DECL_ENUMERATION("spi_bus", "spi1", 1);
 DECL_CONSTANT_STR("BUS_PINS_spi1", "PA6,PA7,PA5");
 DECL_ENUMERATION("spi_bus", "spi1a", 2);
 DECL_CONSTANT_STR("BUS_PINS_spi1a", "PB4,PB5,PB3");
-#if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
+#if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32G0 \
+ || CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
  DECL_ENUMERATION("spi_bus", "spi2a", 3);
  DECL_CONSTANT_STR("BUS_PINS_spi2a", "PC2,PC3,PB10");
 #endif
@@ -41,7 +42,11 @@ DECL_CONSTANT_STR("BUS_PINS_spi1a", "PB4,PB5,PB3");
  #endif
 #endif
 
-#define SPI_FUNCTION GPIO_FUNCTION(CONFIG_MACH_STM32F0 ? 0 : 5)
+#if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32G0
+    #define SPI_FUNCTION GPIO_FUNCTION(0)
+#else
+    #define SPI_FUNCTION GPIO_FUNCTION(5)
+#endif
 
 static const struct spi_info spi_bus[] = {
     { SPI2, GPIO('B', 14), GPIO('B', 15), GPIO('B', 13), SPI_FUNCTION },
@@ -75,8 +80,8 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
         gpio_peripheral(spi_bus[bus].mosi_pin, spi_bus[bus].function, 0);
         gpio_peripheral(spi_bus[bus].sck_pin, spi_bus[bus].function, 0);
 
-        // Configure CR2 on stm32f0
-#if CONFIG_MACH_STM32F0
+        // Configure CR2 on stm32f0 and stm32g0
+#if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32G0
         spi->CR2 = SPI_CR2_FRXTH | (7 << SPI_CR2_DS_Pos);
 #endif
     }

--- a/src/stm32/stm32f0_serial.c
+++ b/src/stm32/stm32f0_serial.c
@@ -43,9 +43,20 @@
 #endif
 
 #if CONFIG_MACH_STM32F031
-// The stm32f031 has same pins for USART2, but everything is routed to USART1
-#define USART2 USART1
-#define USART2_IRQn USART1_IRQn
+  // The stm32f031 has same pins for USART2, but everything is routed to USART1
+  #define USART2 USART1
+  #define USART2_IRQn USART1_IRQn
+#endif
+
+#if CONFIG_MACH_STM32G0
+  /* Aliases for STM32G0 */
+  #define USART2_IRQn USART2_LPUART2_IRQn
+  #define USART_CR1_RXNEIE USART_CR1_RXNEIE_RXFNEIE
+  #define USART_CR1_TXEIE USART_CR1_TXEIE_TXFNFIE
+  #define USART_ISR_RXNE USART_ISR_RXNE_RXFNE
+  #define USART_ISR_TXE USART_ISR_TXE_TXFNF
+  #define USART_BRR_DIV_MANTISSA_Pos 4
+  #define USART_BRR_DIV_FRACTION_Pos 0
 #endif
 
 #define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -209,6 +209,8 @@ armcm_main(void)
     RCC->PLLCFGR = 0x00001000;
     RCC->CFGR = 0x00000000;
     RCC->CR = 0x00000500;
+    // Disable SPI1 CLK (enabled from bootloader)
+    RCC->APBENR2 &= ~(1 << 12);
 
     if (CONFIG_USBSERIAL && *(uint64_t*)USB_BOOT_FLAG_ADDR == USB_BOOT_FLAG) {
         *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -206,9 +206,11 @@ void
 armcm_main(void)
 {
     // Reset clock cfg from bootloader
-    RCC->PLLCFGR = 0x00001000;
+    RCC->CR = 0x00000100;
     RCC->CFGR = 0x00000000;
-    RCC->CR = 0x00000500;
+    while (!(RCC->CR & RCC_CR_HSIRDY))
+        ;
+    RCC->PLLCFGR = 0x00001000;
     // Disable SPI1 CLK (enabled from bootloader)
     RCC->APBENR2 &= ~(1 << 12);
 

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -1,0 +1,227 @@
+// Code to setup clocks and gpio on stm32f0
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
+#include "board/armcm_boot.h" // armcm_main
+#include "board/irq.h" // irq_disable
+#include "command.h" // DECL_CONSTANT_STR
+#include "internal.h" // enable_pclock
+#include "sched.h" // sched_main
+
+#define FREQ_PERIPH 64000000
+
+typedef struct
+{
+    uint32_t periph_addr;
+    volatile uint32_t* rcc_src;
+    uint8_t rcc_bit;
+}periph_map_t;
+
+const periph_map_t apb_mess_map[] = {
+    {LPUART2_BASE, &RCC->APBENR1, 7},
+    {USART5_BASE, &RCC->APBENR1, 8},
+    {USART6_BASE, &RCC->APBENR1, 9}, // > SYSCFG_BASE but in APB1
+    {FDCAN1_BASE, &RCC->APBENR1, 12},
+    {FDCAN2_BASE, &RCC->APBENR1, 12},
+    {USB_BASE, &RCC->APBENR1, 13},
+    {CRS_BASE, &RCC->APBENR1, 16},
+    {LPUART1_BASE, &RCC->APBENR1, 20},
+    {I2C3_BASE, &RCC->APBENR1, 23},
+    {CEC_BASE, &RCC->APBENR1, 24},
+    {UCPD1_BASE, &RCC->APBENR1, 25},
+    {UCPD2_BASE, &RCC->APBENR1, 26},
+    {DBG_BASE, &RCC->APBENR1, 27}, // > SYSCFG_BASE but in APB1
+    {LPTIM2_BASE, &RCC->APBENR1, 30},
+
+    {TIM14_BASE, &RCC->APBENR2, 15}, // < SYSCFG_BASE but in APB2
+    {ADC1_BASE, &RCC->APBENR2, 20},
+};
+
+// Enable a peripheral clock
+void
+enable_pclock(uint32_t periph_base)
+{
+    for (uint8_t i = 0; i < ARRAY_SIZE(apb_mess_map); i++) {
+        if (periph_base == apb_mess_map[i].periph_addr) {
+            *apb_mess_map[i].rcc_src |= 1 << apb_mess_map[i].rcc_bit;
+            return;
+        }
+    }
+    if (periph_base < SYSCFG_BASE) {
+        uint32_t pos = (periph_base - APBPERIPH_BASE) / 0x400;
+        RCC->APBENR1 |= 1 << pos;
+        RCC->APBENR1;
+    } else if (periph_base < AHBPERIPH_BASE) {
+        uint32_t pos = (periph_base - SYSCFG_BASE) / 0x400;
+        RCC->APBENR2 |= 1 << pos;
+        RCC->APBENR2;
+    } else if (periph_base < IOPORT_BASE){
+        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
+        RCC->AHBENR |= 1 << pos;
+        RCC->AHBENR;
+    } else{
+        uint32_t pos = (periph_base - IOPORT_BASE) / 0x400;
+        RCC->IOPENR |= 1 << pos;
+        RCC->IOPENR;
+    }
+}
+
+// Check if a peripheral clock has been enabled
+int
+is_enabled_pclock(uint32_t periph_base)
+{
+    if (periph_base < SYSCFG_BASE) {
+        uint32_t pos = (periph_base - APBPERIPH_BASE) / 0x400;
+        return RCC->APBENR1 & (1 << pos);
+    } else if (periph_base < AHBPERIPH_BASE) {
+        uint32_t pos = (periph_base - SYSCFG_BASE) / 0x400;
+        return RCC->APBENR2 & (1 << pos);
+    } else if (periph_base < IOPORT_BASE){
+        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
+        return RCC->AHBENR & 1 << pos;
+    } else{
+        uint32_t pos = (periph_base - IOPORT_BASE) / 0x400;
+        return RCC->IOPENR & 1 << pos;
+    }
+}
+
+// Return the frequency of the given peripheral clock
+uint32_t
+get_pclock_frequency(uint32_t periph_base)
+{
+    return FREQ_PERIPH;
+}
+
+// Enable a GPIO peripheral clock
+void
+gpio_clock_enable(GPIO_TypeDef *regs)
+{
+    uint32_t rcc_pos = ((uint32_t)regs - IOPORT_BASE) / 0x400;
+    RCC->IOPENR |= 1 << rcc_pos;
+    RCC->IOPENR;
+}
+
+// Set the mode and extended function of a pin
+void
+gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
+{
+    GPIO_TypeDef *regs = digital_regs[GPIO2PORT(gpio)];
+
+    // Enable GPIO clock
+    gpio_clock_enable(regs);
+
+    // Configure GPIO
+    uint32_t mode_bits = mode & 0xf, func = (mode >> 4) & 0xf, od = mode >> 8;
+    uint32_t pup = pullup ? (pullup > 0 ? 1 : 2) : 0;
+    uint32_t pos = gpio % 16, af_reg = pos / 8;
+    uint32_t af_shift = (pos % 8) * 4, af_msk = 0x0f << af_shift;
+    uint32_t m_shift = pos * 2, m_msk = 0x03 << m_shift;
+
+    regs->AFR[af_reg] = (regs->AFR[af_reg] & ~af_msk) | (func << af_shift);
+    regs->MODER = (regs->MODER & ~m_msk) | (mode_bits << m_shift);
+    regs->PUPDR = (regs->PUPDR & ~m_msk) | (pup << m_shift);
+    regs->OTYPER = (regs->OTYPER & ~(1 << pos)) | (od << pos);
+    regs->OSPEEDR = (regs->OSPEEDR & ~m_msk) | (0x02 << m_shift);
+}
+
+#define USB_BOOT_FLAG_ADDR (CONFIG_RAM_START + CONFIG_RAM_SIZE - 1024)
+#define USB_BOOT_FLAG 0x55534220424f4f54 // "USB BOOT"
+
+// Handle USB reboot requests
+void
+usb_request_bootloader(void)
+{
+    irq_disable();
+    *(uint64_t*)USB_BOOT_FLAG_ADDR = USB_BOOT_FLAG;
+    NVIC_SystemReset();
+}
+
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL
+DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PF0,PF1");
+#endif
+
+// Configure and enable the PLL as clock source
+static void
+clock_setup(void)
+{
+    // Modify voltage scaling range
+    PWR->CR1 &= (~PWR_CR1_VOS | PWR_CR1_VOS_0);
+    // Wait until VOSF is reset
+    while (PWR->SR2 & PWR_SR2_VOSF)
+        ;
+
+    // Reset clock cfg from bootloader
+    RCC->PLLCFGR = 0x00001000;
+    RCC->CFGR = 0x00000000;
+    RCC->CR = 0x00000500;
+
+    // Disable PLL
+    RCC->CR &= ~RCC_CR_PLLON;
+    while (RCC->CR & RCC_CR_PLLRDY)
+        ;
+    uint32_t pll_base = 4000000, pll_freq = CONFIG_CLOCK_FREQ * 2, pllcfgr;
+    if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
+        // Configure 64Mhz PLL from external crystal (HSE)
+        uint32_t div = CONFIG_CLOCK_REF_FREQ / pll_base;
+        // Enable HSE
+        RCC->CR |= RCC_CR_HSEON;
+        while (!(RCC->CR & RCC_CR_HSERDY))
+            ;
+        pllcfgr = RCC_PLLCFGR_PLLSRC_HSE | (div << RCC_PLLCFGR_PLLM_Pos);
+    } else {
+        // Configure 64Mhz PLL from internal 16Mhz oscillator (HSI)
+        uint32_t div = 16000000 / pll_base;
+        pllcfgr = RCC_PLLCFGR_PLLSRC_HSI | (div << RCC_PLLCFGR_PLLM_Pos);
+    }
+    RCC->PLLCFGR |= (pllcfgr | ((pll_freq/pll_base) << RCC_PLLCFGR_PLLN_Pos))
+                    | (uint32_t) (1 << RCC_PLLCFGR_PLLR_Pos) // R div = 2
+                    | (uint32_t) (1 << RCC_PLLCFGR_PLLP_Pos) // P div = 2
+                    | (uint32_t) (1 << RCC_PLLCFGR_PLLQ_Pos); // Q div = 2
+    // Enable PLLR Clock output
+    RCC->PLLCFGR |= RCC_PLLCFGR_PLLREN;
+    // Enable PLL
+    RCC->CR |=RCC_CR_PLLON;
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+    // Enable HSI48 for USB
+    RCC->CR |= RCC_CR_HSI48ON;
+    while (!(RCC->CR &RCC_CR_HSI48RDY))
+        ;
+
+    // Flash memory access latency two wait states
+    FLASH->ACR &= ~(FLASH_ACR_LATENCY);
+    FLASH->ACR |= FLASH_ACR_LATENCY_1;
+    while ((FLASH->ACR & FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_1)
+        ;
+
+    // APB div = 1
+    RCC->CFGR |= (0 << RCC_CFGR_PPRE_Pos);
+    // AHB div = 1
+    RCC->CFGR |= (0 << RCC_CFGR_HPRE_Pos);
+    // Set PLLRCLK for SYSCLK
+    RCC->CFGR |= (2 << RCC_CFGR_SW_Pos);
+    while ((RCC->CFGR & RCC_CFGR_SWS) != (2 << RCC_CFGR_SWS_Pos))
+        ;
+}
+
+void
+armcm_main(void)
+{
+    if (CONFIG_USBSERIAL && *(uint64_t*)USB_BOOT_FLAG_ADDR == USB_BOOT_FLAG) {
+        *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
+        uint32_t *sysbase = (uint32_t*)0x1fff0000;
+        asm volatile("mov sp, %0\n bx %1"
+                     : : "r"(sysbase[0]), "r"(sysbase[1]));
+    }
+
+    // Run SystemInit() and then restore VTOR
+    SystemInit();
+    SCB->VTOR = (uint32_t)VectorTable;
+
+    clock_setup();
+
+    sched_main();
+}

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -153,11 +153,6 @@ clock_setup(void)
     while (PWR->SR2 & PWR_SR2_VOSF)
         ;
 
-    // Reset clock cfg from bootloader
-    RCC->PLLCFGR = 0x00001000;
-    RCC->CFGR = 0x00000000;
-    RCC->CR = 0x00000500;
-
     // Disable PLL
     RCC->CR &= ~RCC_CR_PLLON;
     while (RCC->CR & RCC_CR_PLLRDY)
@@ -210,6 +205,11 @@ clock_setup(void)
 void
 armcm_main(void)
 {
+    // Reset clock cfg from bootloader
+    RCC->PLLCFGR = 0x00001000;
+    RCC->CFGR = 0x00000000;
+    RCC->CR = 0x00000500;
+
     if (CONFIG_USBSERIAL && *(uint64_t*)USB_BOOT_FLAG_ADDR == USB_BOOT_FLAG) {
         *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
         uint32_t *sysbase = (uint32_t*)0x1fff0000;

--- a/src/stm32/stm32g0_adc.c
+++ b/src/stm32/stm32g0_adc.c
@@ -1,0 +1,139 @@
+// ADC functions on STM32
+//
+// Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "board/irq.h" // irq_save
+#include "board/misc.h" // timer_from_us
+#include "command.h" // shutdown
+#include "compiler.h" // ARRAY_SIZE
+#include "generic/armcm_timer.h" // udelay
+#include "gpio.h" // gpio_adc_setup
+#include "internal.h" // GPIO
+#include "sched.h" // sched_shutdown
+
+DECL_CONSTANT("ADC_MAX", 4095);
+
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
+static const uint8_t adc_pins[] = {
+    GPIO('A', 0), GPIO('A', 1), GPIO('A', 2), GPIO('A', 3),
+    GPIO('A', 4), GPIO('A', 5), GPIO('A', 6), GPIO('A', 7),
+    GPIO('B', 0), GPIO('B', 1), GPIO('B', 2), GPIO('B', 10),
+    0x00, 0x00, 0x00,
+    GPIO('B', 11), GPIO('B', 12), GPIO('C', 4), GPIO('C', 5),
+    ADC_TEMPERATURE_PIN
+};
+
+static inline void
+init_delay(void)
+{
+    volatile uint32_t wait_loop_index = 200;
+    while(wait_loop_index != 0)
+        wait_loop_index--;
+}
+
+struct gpio_adc
+gpio_adc_setup(uint32_t pin)
+{
+    // Find pin in adc_pins table
+    int chan;
+    for (chan=0; ; chan++) {
+        if (chan >= ARRAY_SIZE(adc_pins))
+            shutdown("Not a valid ADC pin");
+        if (adc_pins[chan] == pin)
+            break;
+    }
+
+    // Determine which ADC block to use
+    ADC_TypeDef *adc = ADC1;
+    uint32_t adc_base = ADC1_BASE;
+
+    // Enable the ADC
+    if (!is_enabled_pclock(adc_base)) {
+        enable_pclock(adc_base);
+
+        // All channel use the setting of SMP1[2:0] register
+        adc->SMPR &= ~ADC_SMPR_SMPSEL;
+        adc->SMPR &= ~ADC_SMPR_SMP1_Msk;
+        // 101: 39.5 ADC clock cycles
+        adc->SMPR |= (ADC_SMPR_SMP1_2 | ADC_SMPR_SMP1_0);
+        adc->CFGR1 &= ~ADC_CFGR1_CHSELRMOD;
+        adc->CFGR1 |= ADC_CFGR1_OVRMOD;
+        // PCLK / 2
+        adc->CFGR2 |= ADC_CFGR2_CKMODE_0;
+
+        // do not enable ADC before calibration
+        if (adc->CR & ADC_CR_ADEN)
+            adc->CR |= ADC_CR_ADDIS;  // Disable ADC
+        while (adc->CR & ADC_CR_ADEN)
+               ;
+        adc->CR |= ADC_CR_ADVREGEN; // Enable ADC internal voltage regulator
+        init_delay();
+
+        // start calibration and wait for completion
+        adc->CR |= ADC_CR_ADCAL;
+        while (adc->CR & ADC_CR_ADCAL)
+            ;
+        init_delay();
+
+        // if not enabled
+        if (!(adc->CR & ADC_CR_ADEN)){
+            adc->ISR |= ADC_ISR_ADRDY;
+            adc->CR |= ADC_CR_ADEN;
+            while (!(adc->ISR & ADC_ISR_ADRDY))
+                ;
+        }
+    }
+
+    if (pin == ADC_TEMPERATURE_PIN) {
+        ADC1_COMMON->CCR = ADC_CCR_TSEN;
+    } else {
+        gpio_peripheral(pin, GPIO_ANALOG, 0);
+    }
+
+    return (struct gpio_adc){ .adc = adc, .chan = 1 << chan };
+}
+
+// Try to sample a value. Returns zero if sample ready, otherwise
+// returns the number of clock ticks the caller should wait before
+// retrying this function.
+uint32_t
+gpio_adc_sample(struct gpio_adc g)
+{
+    ADC_TypeDef *adc = g.adc;
+    if ((adc->ISR & ADC_ISR_EOC) && (adc->CHSELR == g.chan)){
+        return 0;
+    }
+    if (adc->CR & ADC_CR_ADSTART){
+       goto need_delay;
+    }
+    adc->CHSELR = g.chan;
+    adc->CR |= ADC_CR_ADSTART;
+
+need_delay:
+    return timer_from_us(10);
+}
+
+// Read a value; use only after gpio_adc_sample() returns zero
+uint16_t
+gpio_adc_read(struct gpio_adc g)
+{
+    ADC_TypeDef *adc = g.adc;
+    adc->ISR &= ~ADC_ISR_EOSEQ;
+    return adc->DR;
+}
+
+// Cancel a sample that may have been started with gpio_adc_sample()
+void
+gpio_adc_cancel_sample(struct gpio_adc g)
+{
+    ADC_TypeDef *adc = g.adc;
+    irqstatus_t flag = irq_save();
+    if (!(adc->ISR & ADC_ISR_EOC) && (adc->CHSELR == g.chan)){
+        adc->CR |= ADC_CR_ADSTP;
+    }
+    irq_restore(flag);
+}


### PR DESCRIPTION
Initialization support for new MCU `STM32G0B1` (USBFS support is not included because the USB register address of STM32G0 is 16 bits wide, but can only be read or written 32 bits.  It can only be assigned by `a &= b << 16`, can not by force conversion bits wide `(uint16_t *) a = b`. Therefore, it is quite different from the existing USBFS source code, which needs to be further sorted and submitted to PR separately)

Signed-off-by: Alan.Ma from BigTreeTech tech@biqu3d.com