### PR TITLE
toolhead: Fix toolhead stop on SET_VELOCITY_LIMIT

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -552,7 +552,6 @@ class ToolHead:
         self.wait_moves()
     cmd_SET_VELOCITY_LIMIT_help = "Set printer velocity limits"
     def cmd_SET_VELOCITY_LIMIT(self, gcmd):
-        print_time = self.get_last_move_time()
         max_velocity = gcmd.get_float('VELOCITY', None, above=0.)
         max_accel = gcmd.get_float('ACCEL', None, above=0.)
         square_corner_velocity = gcmd.get_float(


### PR DESCRIPTION
This fixes issue #5050

Signed-off-by: Stephen Hurd <deuce@synchro.net>