### PR TITLE
CFG Elegoo Neptune 2S V1.3 with BLTouch and Mesh

### DIFF
--- a/config/printer-elegoo-neptune2s-v1.3-bltouch.cfg
+++ b/config/printer-elegoo-neptune2s-v1.3-bltouch.cfg
@@ -1,0 +1,164 @@
+# This configuration file seems to work for the Elegoo Neptune 2S
+# with ZNP Robin Nano V1.3.
+# To configure select "extra low-level configuration setup"
+# STM32F407 32 KiB Bootloader and serial on # USART3
+# PB11/PB10 communication.
+# After running make, copy the klipper.bin file and rename as
+# elegoo.bin
+# This configuration file also includes the BLTouch configurations
+# With the mount from Elegoo's site.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+#Mainsail settings
+[include mainsail.cfg]
+
+[stepper_x]
+step_pin: PE3
+dir_pin: PE2
+enable_pin: !PE4
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA15
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PE0
+dir_pin: PB9
+enable_pin: !PE1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: PA12
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+# endstop_pin: PA11
+[stepper_z]
+step_pin: PB5
+dir_pin: !PB4
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe: z_virtual_endstop
+# position_endstop: 0.0
+#position_min: -10
+position_max: 260 #260 Temp limited due to cable
+
+[extruder]
+max_extrude_only_distance: 100.0
+step_pin: PD6
+dir_pin: PD3
+enable_pin: !PB3
+microsteps: 16
+rotation_distance: 23.39608
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC1
+# tuned for stock hardware with 210 degree Celsius target
+#control: pid
+#pid_Kp: 22.2
+#pid_Ki: 1.08
+#pid_Kd: 305.4
+min_temp: 0
+max_temp: 270
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: True
+switch_pin: PA4
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+# tuned for stock hardware with 60 degree Celsius target
+#control: pid
+#pid_Kp: 70.857
+#pid_Ki: 1.221
+#pid_Kd: 1028.316
+min_temp: 0
+max_temp: 130
+
+[heater_fan hotend_fan]
+pin: PB0
+heater: extruder
+heater_temp: 50.0
+
+[fan]
+pin: PB1
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[static_digital_output display_reset]
+# the FSMC touchscreen isn't supported, so we'll just disable it
+pins: !PC6, !PD13
+
+[bltouch]
+sensor_pin: ^PA11 # ^PC4
+control_pin: PA8
+x_offset: 32.55
+y_offset: -7
+#Z_offset: 0
+#  remove position_endstop in the [stepper_z] and add endstop_pin: probe:z_virtual_endstop
+
+[safe_z_home]
+home_xy_position: 115,115
+speed: 40
+z_hop: 5
+Z_hop_speed: 5
+
+[bed_mesh]                            # enable for BLTouch
+speed: 50
+mesh_min: 33.55,28
+mesh_max: 222.5,220
+probe_count: 4,4
+
+
+#*# <---------------------- SAVE_CONFIG ---------------------->
+#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
+#*#
+#*# [extruder]
+#*# control = pid
+#*# pid_kp = 26.211
+#*# pid_ki = 1.574
+#*# pid_kd = 109.102
+#*#
+#*# [heater_bed]
+#*# control = pid
+#*# pid_kp = 70.377
+#*# pid_ki = 1.325
+#*# pid_kd = 934.252
+#*#
+#*# [bltouch]
+#*# z_offset = 1.000
+#*#
+#*# [bed_mesh default]
+#*# version = 1
+#*# points =
+#*# 	  -0.090000, 0.022500, 0.005000, -0.105000
+#*# 	  -0.057500, 0.060000, 0.035000, -0.187500
+#*# 	  -0.090000, -0.012500, -0.017500, -0.207500
+#*# 	  -0.197500, -0.047500, 0.015000, -0.160000
+#*# tension = 0.2
+#*# min_x = 33.55
+#*# algo = lagrange
+#*# y_count = 4
+#*# mesh_y_pps = 2
+#*# min_y = 28.0
+#*# x_count = 4
+#*# max_y = 220.0
+#*# mesh_x_pps = 2
+#*# max_x = 222.49


### PR DESCRIPTION
This adds the configuration file for the Elegoo Neptune 2S on V1.3 with BLTouch and mesh enabled.