### PR TITLE
Unify enable_pclock() code on stm32

### DIFF
--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -27,7 +27,7 @@ CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 
 # Add source files
-src-y += stm32/watchdog.c stm32/gpio.c generic/crc16_ccitt.c
+src-y += stm32/watchdog.c stm32/gpio.c stm32/clockline.c generic/crc16_ccitt.c
 src-y += generic/armcm_boot.c generic/armcm_irq.c generic/armcm_reset.c
 src-$(CONFIG_MACH_STM32F0) += ../lib/stm32f0/system_stm32f0xx.c
 src-$(CONFIG_MACH_STM32F0) += generic/timer_irq.c stm32/stm32f0_timer.c

--- a/src/stm32/clockline.c
+++ b/src/stm32/clockline.c
@@ -1,0 +1,32 @@
+// Code to enable clock lines on stm32
+//
+// Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "board/irq.h" // irq_save
+#include "internal.h" // struct cline
+
+// Enable a peripheral clock
+void
+enable_pclock(uint32_t periph_base)
+{
+    struct cline cl = lookup_clock_line(periph_base);
+    irqstatus_t flag = irq_save();
+    *cl.en |= cl.bit;
+    *cl.en; // Pause 2 cycles to ensure peripheral is enabled
+    if (cl.rst) {
+        // Reset peripheral
+        *cl.rst = cl.bit;
+        *cl.rst = 0;
+    }
+    irq_restore(flag);
+}
+
+// Check if a peripheral clock has been enabled
+int
+is_enabled_pclock(uint32_t periph_base)
+{
+    struct cline cl = lookup_clock_line(periph_base);
+    return *cl.en & cl.bit;
+}

--- a/src/stm32/internal.h
+++ b/src/stm32/internal.h
@@ -18,22 +18,28 @@
 #include "stm32h7xx.h"
 #endif
 
+// gpio.c
 extern GPIO_TypeDef * const digital_regs[];
-
 #define GPIO(PORT, NUM) (((PORT)-'A') * 16 + (NUM))
 #define GPIO2PORT(PIN) ((PIN) / 16)
 #define GPIO2BIT(PIN) (1<<((PIN) % 16))
 
+// gpioperiph.c
 #define GPIO_INPUT 0
 #define GPIO_OUTPUT 1
 #define GPIO_OPEN_DRAIN 0x100
 #define GPIO_FUNCTION(fn) (2 | ((fn) << 4))
 #define GPIO_ANALOG 3
+void gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup);
 
+// clockline.c
 void enable_pclock(uint32_t periph_base);
 int is_enabled_pclock(uint32_t periph_base);
+
+// stm32??.c
+struct cline { volatile uint32_t *en, *rst; uint32_t bit; };
+struct cline lookup_clock_line(uint32_t periph_base);
 uint32_t get_pclock_frequency(uint32_t periph_base);
 void gpio_clock_enable(GPIO_TypeDef *regs);
-void gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup);
 
 #endif // internal.h

--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -18,38 +18,19 @@
 
 #define FREQ_PERIPH 48000000
 
-// Enable a peripheral clock
-void
-enable_pclock(uint32_t periph_base)
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
 {
-    if (periph_base < SYSCFG_BASE) {
-        uint32_t pos = (periph_base - APBPERIPH_BASE) / 0x400;
-        RCC->APB1ENR |= 1 << pos;
-        RCC->APB1ENR;
-    } else if (periph_base < AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - SYSCFG_BASE) / 0x400;
-        RCC->APB2ENR |= 1 << pos;
-        RCC->APB2ENR;
+    if (periph_base >= AHB2PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - AHB2PERIPH_BASE) / 0x400 + 17);
+        return (struct cline){.en=&RCC->AHBENR, .rst=&RCC->AHBRSTR, .bit=bit};
+    } else if (periph_base >= SYSCFG_BASE) {
+        uint32_t bit = 1 << ((periph_base - SYSCFG_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB2ENR, .rst=&RCC->APB2RSTR, .bit=bit};
     } else {
-        uint32_t pos = (periph_base - AHB2PERIPH_BASE) / 0x400;
-        RCC->AHBENR |= 1 << (pos + 17);
-        RCC->AHBENR;
-    }
-}
-
-// Check if a peripheral clock has been enabled
-int
-is_enabled_pclock(uint32_t periph_base)
-{
-    if (periph_base < SYSCFG_BASE) {
-        uint32_t pos = (periph_base - APBPERIPH_BASE) / 0x400;
-        return RCC->APB1ENR & (1 << pos);
-    } else if (periph_base < AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - SYSCFG_BASE) / 0x400;
-        return RCC->APB2ENR & (1 << pos);
-    } else {
-        uint32_t pos = (periph_base - AHB2PERIPH_BASE) / 0x400;
-        return RCC->AHBENR & (1 << (pos + 17));
+        uint32_t bit = 1 << ((periph_base - APBPERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB1ENR, .rst=&RCC->APB1RSTR, .bit=bit};
     }
 }
 
@@ -202,7 +183,6 @@ enable_ram_vectortable(void)
     __builtin_memcpy(&_ram_vectortable_start, &_text_vectortable_start, count);
     barrier();
 
-    enable_pclock(SYSCFG_BASE);
     SYSCFG->CFGR1 |= 3 << SYSCFG_CFGR1_MEM_MODE_Pos;
 }
 
@@ -212,6 +192,8 @@ armcm_main(void)
 {
     check_usb_dfu_bootloader();
     SystemInit();
+
+    enable_pclock(SYSCFG_BASE);
     if (CONFIG_ARMCM_RAM_VECTORTABLE)
         enable_ram_vectortable();
 
@@ -230,11 +212,8 @@ armcm_main(void)
 
     // Support pin remapping USB/CAN pins on low pinout stm32f042
 #ifdef SYSCFG_CFGR1_PA11_PA12_RMP
-    if (CONFIG_STM32_USB_PA11_PA12_REMAP
-        || CONFIG_STM32_CANBUS_PA11_PA12_REMAP) {
-        enable_pclock(SYSCFG_BASE);
+    if (CONFIG_STM32_USB_PA11_PA12_REMAP || CONFIG_STM32_CANBUS_PA11_PA12_REMAP)
         SYSCFG->CFGR1 |= SYSCFG_CFGR1_PA11_PA12_RMP;
-    }
 #endif
 
     sched_main();

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -18,42 +18,19 @@
 
 #define FREQ_PERIPH (CONFIG_CLOCK_FREQ / 2)
 
-// Enable a peripheral clock
-void
-enable_pclock(uint32_t periph_base)
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
 {
-    if (periph_base < APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
-        RCC->APB1ENR |= (1<<pos);
-        RCC->APB1ENR;
-        RCC->APB1RSTR |= (1<<pos);
-        RCC->APB1RSTR &= ~(1<<pos);
-    } else if (periph_base < AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
-        RCC->APB2ENR |= (1<<pos);
-        RCC->APB2ENR;
-        RCC->APB2RSTR |= (1<<pos);
-        RCC->APB2RSTR &= ~(1<<pos);
+    if (periph_base >= AHBPERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - AHBPERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHBENR, .bit=bit};
+    } else if (periph_base >= APB2PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - APB2PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB2ENR, .rst=&RCC->APB2RSTR, .bit=bit};
     } else {
-        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
-        RCC->AHBENR |= (1<<pos);
-        RCC->AHBENR;
-    }
-}
-
-// Check if a peripheral clock has been enabled
-int
-is_enabled_pclock(uint32_t periph_base)
-{
-    if (periph_base < APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
-        return RCC->APB1ENR & (1<<pos);
-    } else if (periph_base < AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
-        return RCC->APB2ENR & (1<<pos);
-    } else {
-        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
-        return RCC->AHBENR & (1<<pos);
+        uint32_t bit = 1 << ((periph_base - APB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB1ENR, .rst=&RCC->APB1RSTR, .bit=bit};
     }
 }
 

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -21,47 +21,23 @@
 #define FREQ_PERIPH (CONFIG_CLOCK_FREQ / FREQ_PERIPH_DIV)
 #define FREQ_USB 48000000
 
-// Enable a peripheral clock
-void
-enable_pclock(uint32_t periph_base)
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
 {
-    if (periph_base < APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
-        RCC->APB1ENR |= (1<<pos);
-        RCC->APB1ENR;
-        RCC->APB1RSTR |= (1<<pos);
-        RCC->APB1RSTR &= ~(1<<pos);
-    } else if (periph_base < AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
-        RCC->APB2ENR |= (1<<pos);
-        RCC->APB2ENR;
-        // Skip ADC peripheral reset as they share a bit
-        if (pos < 8 || pos > 10) {
-            RCC->APB2RSTR |= (1<<pos);
-            RCC->APB2RSTR &= ~(1<<pos);
-        }
-    } else if (periph_base < AHB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - AHB1PERIPH_BASE) / 0x400;
-        RCC->AHB1ENR |= (1<<pos);
-        RCC->AHB1ENR;
+    if (periph_base >= AHB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - AHB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHB1ENR, .rst=&RCC->AHB1RSTR, .bit=bit};
+    } else if (periph_base >= APB2PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - APB2PERIPH_BASE) / 0x400);
+        if (bit & 0x700)
+            // Skip ADC peripheral reset as they share a bit
+            return (struct cline){.en=&RCC->APB2ENR, .bit=bit};
+        return (struct cline){.en=&RCC->APB2ENR, .rst=&RCC->APB2RSTR, .bit=bit};
+    } else {
+        uint32_t bit = 1 << ((periph_base - APB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB1ENR, .rst=&RCC->APB1RSTR, .bit=bit};
     }
-}
-
-// Check if a peripheral clock has been enabled
-int
-is_enabled_pclock(uint32_t periph_base)
-{
-    if (periph_base < APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB1PERIPH_BASE) / 0x400;
-        return RCC->APB1ENR & (1<<pos);
-    } else if (periph_base < AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - APB2PERIPH_BASE) / 0x400;
-        return RCC->APB2ENR & (1<<pos);
-    } else if (periph_base < AHB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - AHB1PERIPH_BASE) / 0x400;
-        return RCC->AHB1ENR & (1<<pos);
-    }
-    return 0;
 }
 
 // Return the frequency of the given peripheral clock

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -19,71 +19,29 @@
 #define FREQ_PERIPH 64000000
 #define FREQ_USB 48000000
 
-// Map an APB peripheral address to an enable bit
-static int
-lookup_apb_bit(uint32_t periph_base)
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
 {
+    if (periph_base >= IOPORT_BASE) {
+        uint32_t bit = 1 << ((periph_base - IOPORT_BASE) / 0x400);
+        return (struct cline){.en=&RCC->IOPENR, .rst=&RCC->IOPRSTR, .bit=bit};
+    } else if (periph_base >= AHBPERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - AHBPERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHBENR, .rst=&RCC->AHBRSTR, .bit=bit};
+    }
     if (periph_base == USB_BASE)
-        return 13;
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<13};
     if (periph_base == CRS_BASE)
-        return 16;
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<16};
     if (periph_base == SPI1_BASE)
-        return 32 + 12;
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<12};
     if (periph_base == USART1_BASE)
-        return 32 + 14;
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<14};
     if (periph_base == ADC1_BASE)
-        return 32 + 20;
-    return (periph_base - APBPERIPH_BASE) / 0x400;
-}
-
-// Enable a peripheral clock
-void
-enable_pclock(uint32_t periph_base)
-{
-    if (periph_base >= IOPORT_BASE) {
-        uint32_t pos = (periph_base - IOPORT_BASE) / 0x400;
-        RCC->IOPENR |= 1 << pos;
-        RCC->IOPENR;
-        RCC->IOPRSTR |= (1<<pos);
-        RCC->IOPRSTR &= ~(1<<pos);
-    } else if (periph_base >= AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
-        RCC->AHBENR |= 1 << pos;
-        RCC->AHBENR;
-        RCC->AHBRSTR |= (1<<pos);
-        RCC->AHBRSTR &= ~(1<<pos);
-    } else {
-        uint32_t pos = lookup_apb_bit(periph_base);
-        if (pos < 32) {
-            RCC->APBENR1 |= 1 << pos;
-            RCC->APBENR1;
-            RCC->APBRSTR1 |= (1 << pos);
-            RCC->APBRSTR1 &= ~(1 << pos);
-        } else {
-            RCC->APBENR2 |= 1 << (pos - 32);
-            RCC->APBENR2;
-            RCC->APBRSTR2 |= (1 << (pos - 32));
-            RCC->APBRSTR2 &= ~(1 << (pos - 32));
-        }
-    }
-}
-
-// Check if a peripheral clock has been enabled
-int
-is_enabled_pclock(uint32_t periph_base)
-{
-    if (periph_base >= IOPORT_BASE) {
-        uint32_t pos = (periph_base - IOPORT_BASE) / 0x400;
-        return RCC->IOPENR & (1 << pos);
-    } else if (periph_base >= AHBPERIPH_BASE) {
-        uint32_t pos = (periph_base - AHBPERIPH_BASE) / 0x400;
-        return RCC->AHBENR & (1 << pos);
-    } else {
-        uint32_t pos = lookup_apb_bit(periph_base);
-        if (pos < 32)
-            return RCC->APBENR1 & (1 << pos);
-        return RCC->APBENR2 & (1 << (pos - 32));
-    }
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<20};
+    uint32_t bit = 1 << ((periph_base - APBPERIPH_BASE) / 0x400);
+    return (struct cline){.en=&RCC->APBENR1, .rst=&RCC->APBRSTR1, .bit=bit};
 }
 
 // Return the frequency of the given peripheral clock

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -7,7 +7,7 @@
 #include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
 #include "board/armcm_boot.h" // VectorTable
 #include "command.h" // DECL_CONSTANT_STR
-#include "internal.h" // enable_pclock
+#include "internal.h" // get_pclock_frequency
 #include "sched.h" // sched_main
 
 
@@ -17,75 +17,34 @@
 
 #define FREQ_PERIPH (CONFIG_CLOCK_FREQ / 4)
 
-// Enable a peripheral clock
-void
-enable_pclock(uint32_t periph_base)
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
 {
-    // periph_base determines in which bitfield at wich position to set a bit
-    // E.g. D2_AHB1PERIPH_BASE is the adress offset of the given bitfield
-    if (periph_base < D2_APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_APB1PERIPH_BASE) / 0x400;
-        RCC->APB1LENR |= (1<<pos); // we assume it is not in APB1HENR
-        RCC->APB1LENR;
-    } else if (periph_base < D2_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_APB2PERIPH_BASE) / 0x400;
-        RCC->APB2ENR |= (1<<pos);
-        RCC->APB2ENR;
-    } else if (periph_base < D2_AHB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_AHB1PERIPH_BASE) / 0x400;
-        RCC->AHB1ENR |= (1<<pos);
-        RCC->AHB1ENR;
-    } else if (periph_base < D1_APB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_AHB2PERIPH_BASE) / 0x400;
-        RCC->AHB2ENR |= (1<<pos);
-        RCC->AHB2ENR;
-    } else if (periph_base < D1_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D1_APB1PERIPH_BASE) / 0x400;
-        RCC->APB3ENR |= (1<<pos);
-        RCC->APB3ENR;
-    } else if (periph_base < D3_APB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D1_AHB1PERIPH_BASE) / 0x400;
-        RCC->AHB3ENR |= (1<<pos);
-        RCC->AHB3ENR;
-    } else if (periph_base < D3_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D3_APB1PERIPH_BASE) / 0x400;
-        RCC->APB4ENR |= (1<<pos);
-        RCC->APB4ENR;
+    if (periph_base >= D3_AHB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D3_AHB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHB4ENR, .rst=&RCC->AHB4RSTR, .bit=bit};
+    } else if (periph_base >= D3_APB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D3_APB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB4ENR, .rst=&RCC->APB4RSTR, .bit=bit};
+    } else if (periph_base >= D1_AHB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D1_AHB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHB3ENR, .rst=&RCC->AHB3RSTR, .bit=bit};
+    } else if (periph_base >= D1_APB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D1_APB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB3ENR, .rst=&RCC->APB3RSTR, .bit=bit};
+    } else if (periph_base >= D2_AHB2PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D2_AHB2PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHB2ENR, .rst=&RCC->AHB2RSTR, .bit=bit};
+    } else if (periph_base >= D2_AHB1PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D2_AHB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHB1ENR, .rst=&RCC->AHB1RSTR, .bit=bit};
+    } else if (periph_base >= D2_APB2PERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - D2_APB2PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB2ENR, .rst=&RCC->APB2RSTR, .bit=bit};
     } else {
-        uint32_t pos = (periph_base - D3_AHB1PERIPH_BASE) / 0x400;
-        RCC->AHB4ENR |= (1<<pos);
-        RCC->AHB4ENR;
-    }
-}
-
-// Check if a peripheral clock has been enabled
-int
-is_enabled_pclock(uint32_t periph_base)
-{
-    if (periph_base < D2_APB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_APB1PERIPH_BASE) / 0x400;
-        return RCC->APB1LENR & (1<<pos); // we assume it is not in APB1HENR
-    } else if (periph_base < D2_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_APB2PERIPH_BASE) / 0x400;
-        return RCC->APB2ENR & (1<<pos);
-    } else if (periph_base < D2_AHB2PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_AHB1PERIPH_BASE) / 0x400;
-        return RCC->AHB1ENR & (1<<pos);
-    } else if (periph_base < D1_APB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D2_AHB2PERIPH_BASE) / 0x400;
-        return RCC->AHB2ENR & (1<<pos);
-    } else if (periph_base < D1_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D1_APB1PERIPH_BASE) / 0x400;
-        return RCC->APB3ENR & (1<<pos);
-    } else if (periph_base < D3_APB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D1_AHB1PERIPH_BASE) / 0x400;
-        return RCC->AHB3ENR & (1<<pos);
-    } else if (periph_base < D3_AHB1PERIPH_BASE) {
-        uint32_t pos = (periph_base - D3_APB1PERIPH_BASE) / 0x400;
-        return RCC->APB4ENR & (1<<pos);
-    } else {
-        uint32_t pos = (periph_base - D3_AHB1PERIPH_BASE) / 0x400;
-        return RCC->AHB4ENR & (1<<pos);
+        uint32_t bit = 1 << ((periph_base - D2_APB1PERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->APB1LENR,.rst=&RCC->APB1LRSTR,.bit=bit};
     }
 }
 


### PR DESCRIPTION
Unify the handling of the enable_pclock() and is_enabled_pclock() code
across all stm32 chips.  All chips will now perform a peripheral reset
on enable_pclock() (this is a change for stm32f0 and stm32h7).  The
enable_pclock() code will now also disable irqs during the enable.

It is hoped this will make the code a little simpler and a little easier to maintain.

-Kevin