### PR TITLE
Update generic-mks-robin-nano-v1.cfg

### DIFF
--- a/config/generic-mks-robin-nano-v1.cfg
+++ b/config/generic-mks-robin-nano-v1.cfg
@@ -4,11 +4,20 @@
 # configuration setup", select the 28KiB bootloader, and serial (on
 # USART3 PB11/PB10) communication.
 
+# For MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 boards, the
+# firmware should be compiled for the STM32F1407. When running 
+# "make menuconfig", enable "extra low-level configuration setup", 
+# select the 32KiB bootloader, and serial (on USART3 PB11/PB10) 
+# communication.
+
 # Note that the "make flash" command does not work with MKS Robin
-# boards. After running "make", run the following command:
+# boards. Except for MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3
+# boards, after running "make", run the following command:
 #   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano.bin
-# Copy the file out/Robin_nano.bin to an SD card and then restart the
-# printer with that SD card.
+#
+# Copy the file out/Robin_nano.bin (or properly renamed out/klipper.bin
+# for v1.3 boards) to an SD card and then restart the printer
+# with that SD card.
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
Since the config name is containing v1, many of users are using this config for MKS robin Nano v1.3 as well. However, Nano V1.3 board requires different compile options and python scripts shouldn't be used. Since V1.3 board still uses same pinout (maybe), it may be reasonable to just add description for V1.3 rather than add another config file.