### PR TITLE
Fix markforged kinematics name in config reference

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -84,7 +84,7 @@ The printer section controls high level printer settings.
 [printer]
 kinematics:
 #   The type of printer in use. This option may be one of: cartesian,
-#   corexy, corexz, hybrid-corexy, hybrid-corexz, rotary_delta, delta,
+#   corexy, corexz, hybrid_corexy, hybrid_corexz, rotary_delta, delta,
 #   polar, winch, or none. This
 #   parameter must be specified.
 max_velocity:


### PR DESCRIPTION
I was getting unrecognized kinematics error until replaced `-` with `_`.