### PR TITLE
BUGFIX: Fix the GPIO register for stm32h7

### DIFF
--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -100,9 +100,9 @@ get_pclock_frequency(uint32_t periph_base)
 void
 gpio_clock_enable(GPIO_TypeDef *regs)
 {
-    uint32_t pos = ((uint32_t)regs - D3_APB1PERIPH_BASE) / 0x400;
-    RCC->APB4ENR |= (1<<pos);
-    RCC->APB4ENR;
+    uint32_t pos = ((uint32_t)regs - D3_AHB1PERIPH_BASE) / 0x400;
+    RCC->AHB4ENR |= (1<<pos);
+    RCC->AHB4ENR;
 }
 
 #if !CONFIG_STM32_CLOCK_REF_INTERNAL


### PR DESCRIPTION
https://github.com/Klipper3d/klipper/commit/dc3ac2b424dc2f915f825227ac941ab1b982ed21 breaks the STM32H7 processor GPIO because it's using the incorrect register.

This PR fixes the issue.

Signed-off-by: Aaron DeLyser <bluwolf@gmail.com>