### PR TITLE
add stm32f103 low density compiling options

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -75,6 +75,16 @@ choice
         select MACH_STM32H7
 endchoice
 
+choice 
+    prompt "f103 series variants" if MACH_STM32F103
+    config MACH_STM32F103x8
+        bool "STM32F103x8+ -- medium or high density products"
+    config MACH_STM32F103x6
+        bool "STM32F103x6 -- low density products"
+    # config MACH_STM32F103x8  # temperary
+    #     bool "GD32F103 -- for SWD patch"
+endchoice
+
 config MACH_STM32F0
     bool
 config MACH_STM32F1
@@ -96,7 +106,7 @@ config HAVE_STM32_USBFS
     default y if MACH_STM32F103 || MACH_STM32F0x2 || MACH_STM32F070 || MACH_STM32G0
 config HAVE_STM32_USBOTG
     bool
-    default y if MACH_STM32F2 || MACH_STM32F4 || MACH_STM32H7
+    default y if MACH_STM32F2 || MACH_STM32F4 || MACH_STM32H7 || MACH_CH32F103x8
 config HAVE_STM32_CANBUS
     bool
     default y if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F0x2
@@ -107,7 +117,8 @@ config MCU
     default "stm32f042x6" if MACH_STM32F042
     default "stm32f070xb" if MACH_STM32F070
     default "stm32f072xb" if MACH_STM32F072
-    default "stm32f103xe" if MACH_STM32F103
+    default "stm32f103xe" if MACH_STM32F103x8
+    default "stm32f103x6" if MACH_STM32F103x6
     default "stm32f207xx" if MACH_STM32F207
     default "stm32f401xc" if MACH_STM32F401
     default "stm32f405xx" if MACH_STM32F405
@@ -135,7 +146,8 @@ config FLASH_SIZE
     default 0x4000 if MACH_STM32F031
     default 0x8000 if MACH_STM32F042
     default 0x20000 if MACH_STM32F070 || MACH_STM32F072
-    default 0x10000 if MACH_STM32F103 # Flash size of stm32f103x8 (64KiB)
+    default 0x10000 if MACH_STM32F103x8 # Flash size of stm32f103x8 (64KiB)
+    default 0x8000 if MACH_STM32F103x6 # Flash size of stm32f103x6 (32KiB) ~23KiB compiled
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401
     default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x20000 if MACH_STM32G0B1
@@ -152,7 +164,8 @@ config RAM_SIZE
     default 0x1000 if MACH_STM32F031
     default 0x1800 if MACH_STM32F042
     default 0x4000 if MACH_STM32F070 || MACH_STM32F072
-    default 0x5000 if MACH_STM32F103 # Ram size of stm32f103x8 (20KiB)
+    default 0x2800 if MACH_STM32F103x6 # Ram size of stm32f103x6 (10KiB)
+    default 0x5000 if MACH_STM32F103x8 # Ram size of stm32f103x8 (20KiB)
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401
     default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446
@@ -182,26 +195,26 @@ config STM32F103GD_DISABLE_SWD
 choice
     prompt "Bootloader offset"
     config STM32_FLASH_START_2000
-        bool "8KiB bootloader" if MACH_STM32F103 || MACH_STM32F070 || MACH_STM32G0
+        bool "8KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6) || MACH_STM32F070 || MACH_STM32G0
     config STM32_FLASH_START_5000
-        bool "20KiB bootloader" if MACH_STM32F103
+        bool "20KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6)
     config STM32_FLASH_START_7000
-        bool "28KiB bootloader" if MACH_STM32F103
+        bool "28KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6)
     config STM32_FLASH_START_8000
-        bool "32KiB bootloader" if MACH_STM32F103 || MACH_STM32F207 || MACH_STM32F4x5 || MACH_STM32F446
+        bool "32KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6) || MACH_STM32F207 || MACH_STM32F4x5 || MACH_STM32F446
     config STM32_FLASH_START_8800
-        bool "34KiB bootloader (Chitu v6 Bootloader)" if MACH_STM32F103
+        bool "34KiB bootloader (Chitu v6 Bootloader)" if (MACH_STM32F103 && !MACH_STM32F103x6)
     config STM32_FLASH_START_20200
         bool "128KiB bootloader with 512 byte offset (Prusa Buddy)" if MACH_STM32F4x5
     config STM32_FLASH_START_C000
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F4x5
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446
+        bool "64KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6) || MACH_STM32F446
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103
     config STM32_FLASH_START_4000
-        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F4x5 || MACH_STM32F103
+        bool "16KiB bootloader (HID Bootloader)" if MACH_STM32F207 || MACH_STM32F401 || MACH_STM32F4x5 || (MACH_STM32F103 && !MACH_STM32F103x6)
     config STM32_FLASH_START_20000
         bool "128KiB bootloader (SKR SE BX v2.0)" if MACH_STM32H743
 

--- a/src/stm32/hard_pwm.c
+++ b/src/stm32/hard_pwm.c
@@ -37,6 +37,7 @@ static const struct gpio_pwm_info pwm_regs[] = {
     {TIM3, GPIO('C', 7),  2, GPIO_FUNCTION(2)},
     {TIM3, GPIO('C', 8),  3, GPIO_FUNCTION(2)},
     {TIM3, GPIO('C', 9),  4, GPIO_FUNCTION(2)},
+    #if !CONFIG_MACH_STM32F103x6
     {TIM4, GPIO('D', 12), 1, GPIO_FUNCTION(2)},
     {TIM4, GPIO('D', 13), 2, GPIO_FUNCTION(2)},
     {TIM4, GPIO('D', 14), 3, GPIO_FUNCTION(2)},
@@ -45,6 +46,7 @@ static const struct gpio_pwm_info pwm_regs[] = {
     {TIM4, GPIO('B', 7),  2, GPIO_FUNCTION(2)},
     {TIM4, GPIO('B', 8),  3, GPIO_FUNCTION(2)},
     {TIM4, GPIO('B', 9),  4, GPIO_FUNCTION(2)}
+    #endif
 #elif CONFIG_MACH_STM32F4
   #if CONFIG_MACH_STM32F401
     {TIM3,  GPIO('A',  6),  1, GPIO_FUNCTION(2)},

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -21,13 +21,17 @@ DECL_ENUMERATION("i2c_bus", "i2c1", 0);
 DECL_CONSTANT_STR("BUS_PINS_i2c1", "PB6,PB7");
 DECL_ENUMERATION("i2c_bus", "i2c1a", 1);
 DECL_CONSTANT_STR("BUS_PINS_i2c1a", "PB8,PB9");
+#if !CONFIG_MACH_STM32F103x6
 DECL_ENUMERATION("i2c_bus", "i2c2", 2);
 DECL_CONSTANT_STR("BUS_PINS_i2c2", "PB10,PB11");
+#endif
 
 static const struct i2c_info i2c_bus[] = {
     { I2C1, GPIO('B', 6), GPIO('B', 7) },
     { I2C1, GPIO('B', 8), GPIO('B', 9) },
+#if !CONFIG_MACH_STM32F103x6
     { I2C2, GPIO('B', 10), GPIO('B', 11) },
+#endif
 };
 
 // Work around stm32 errata causing busy bit to be stuck

--- a/src/stm32/spi.c
+++ b/src/stm32/spi.c
@@ -48,10 +48,12 @@ DECL_CONSTANT_STR("BUS_PINS_spi1a", "PB4,PB5,PB3");
 #endif
 
 static const struct spi_info spi_bus[] = {
-    { SPI2, GPIO('B', 14), GPIO('B', 15), GPIO('B', 13), SPI_FUNCTION },
     { SPI1, GPIO('A', 6), GPIO('A', 7), GPIO('A', 5), SPI_FUNCTION },
     { SPI1, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), SPI_FUNCTION },
+#if !CONFIG_MACH_STM32F103x6
+    { SPI2, GPIO('B', 14), GPIO('B', 15), GPIO('B', 13), SPI_FUNCTION },
     { SPI2, GPIO('C', 2), GPIO('C', 3), GPIO('B', 10), SPI_FUNCTION },
+#endif
 #ifdef SPI3
     { SPI3, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), GPIO_FUNCTION(6) },
  #if CONFIG_MACH_STM32F4

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -196,10 +196,12 @@ gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
                  || gpio == GPIO('C', 8) || gpio == GPIO('C', 9))
             stm32f1_alternative_remap(AFIO_MAPR_TIM3_REMAP_Msk,
                                       AFIO_MAPR_TIM3_REMAP_FULLREMAP);
+#if !CONFIG_MACH_STM32F103x6
         else if (gpio == GPIO('D', 12) || gpio == GPIO('D', 13)
                  || gpio == GPIO('D', 14) || gpio == GPIO('D', 15))
             stm32f1_alternative_remap(AFIO_MAPR_TIM4_REMAP_Msk,
                                       AFIO_MAPR_TIM4_REMAP);
+#endif
     } else if (func == 4) {
         // I2C
         if (gpio == GPIO('B', 8) || gpio == GPIO('B', 9))
@@ -219,9 +221,11 @@ gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
         else if (gpio == GPIO('D', 5) || gpio == GPIO('D', 6))
             stm32f1_alternative_remap(AFIO_MAPR_USART2_REMAP_Msk,
                                       AFIO_MAPR_USART2_REMAP);
+#if !CONFIG_MACH_STM32F103x6
         else if (gpio == GPIO('D', 8) || gpio == GPIO('D', 9))
             stm32f1_alternative_remap(AFIO_MAPR_USART3_REMAP_Msk,
                                       AFIO_MAPR_USART3_REMAP_FULLREMAP);
+#endif
     } else if (func == 9) {
         // CAN
         if (gpio == GPIO('B', 8) || gpio == GPIO('B', 9))


### PR DESCRIPTION
add stm32f103 low density compiling options
Tested with stm32f103c6t6 and stm32fEBKc6t6 without issues so far.

signed-off: mirokymac(toufubomb@gmail.com)