### PR TITLE
arc_move: detect CW / CCW move with renamed G2/G3 command

### DIFF
--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -40,7 +40,7 @@ class ArcSupport:
             raise gcmd.error("G2/G3 neither I nor J given")
         asE = gcmd.get_float("E", None)
         asF = gcmd.get_float("F", None)
-        clockwise = (gcmd.get_command() == 'G2')
+        clockwise = gcmd.get_command().startswith("G2")
 
         # Build list of linear coordinates to move to
         coords = self.planArc(currentPos, [asX, asY, asZ], [asI, asJ],

--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -20,9 +20,15 @@ class ArcSupport:
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("G2", self.cmd_G2)
-        self.gcode.register_command("G3", self.cmd_G2)
+        self.gcode.register_command("G3", self.cmd_G3)
 
     def cmd_G2(self, gcmd):
+        self._cmd_inner(gcmd, True)
+
+    def cmd_G3(self, gcmd):
+        self._cmd_inner(gcmd, False)
+
+    def _cmd_inner(self, gcmd, clockwise):
         gcodestatus = self.gcode_move.get_status()
         if not gcodestatus['absolute_coordinates']:
             raise gcmd.error("G2/G3 does not support relative move mode")
@@ -40,7 +46,6 @@ class ArcSupport:
             raise gcmd.error("G2/G3 neither I nor J given")
         asE = gcmd.get_float("E", None)
         asF = gcmd.get_float("F", None)
-        clockwise = gcmd.get_command().startswith("G2")
 
         # Build list of linear coordinates to move to
         coords = self.planArc(currentPos, [asX, asY, asZ], [asI, asJ],


### PR DESCRIPTION
The G2 / G3 command might be renamed using `gcode_macro` + `rename_existing`. This change allow detecting clockwise / anti-clockwise moves when the command gets renamed to G2.1, or anything else that uses G2 as prefix.

I chose this approach, because the documentation contains an example for renaming the M117 command, and it gets renamed to M117.1 . I've used renamed G0/G1/G2/G3 commands in the past to allow for extra debug information in the Klipper console. G0/G1/G3 work fine with this approach, but G2 breaks because of the way the clockwise detection works.