### PR TITLE
Make input_step templated like the other menu items

### DIFF
--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -447,8 +447,8 @@ class MenuInput(MenuCommand):
                 config, 'input_min', str(self._input_min))
             self._input_max_tpl = manager.gcode_macro.load_template(
                 config, 'input_max', str(self._input_max))
-            self._input_step = config.getfloat(
-                'input_step', self._input_step, above=0.)
+            self._input_step = manager.gcode_macro.load_template(
+                config, 'input_step', str(self._input_step))
 
     def init(self):
         super(MenuInput, self).init()


### PR DESCRIPTION
Very simple change.

Why? I want to move axis from the display as in other GUIs where you first set the step size you want to move, and then move by it. Currently I can hack around it like so (gross, I know, but it works!). 

```
[gcode_macro __STATE]
variable_display_x_delta_mm: 1
gcode: 

[menu __main __motion __x_delta]
type: input
name: X step: {['0.01', '0.1','1','10'][menu.input|int]}
input: {printer['gcode_macro __STATE'].display_x_delta_mm}
input_min: 0
input_max: 3
input_step: 1
gcode:
    SET_GCODE_VARIABLE MACRO=__STATE VARIABLE=display_x_delta_mm VALUE={menu.input}

[menu __main __motion __x_move]
type: input
name: X     : {'%05.1f' % (printer.toolhead.axis_minimum.x + menu.input * [0.01, 0.1, 1, 10][printer['gcode_macro __STATE'].display_x_delta_mm | int]) if 'x' in printer.toolhead.homed_axes else 'unhomed' }
input: { (printer.gcode_move.gcode_position.x - printer.toolhead.axis_minimum.x) / [0.01, 0.1, 1, 10][printer['gcode_macro __STATE'].display_x_delta_mm | int ] }
input_min: 0
input_max: 9999999
input_step: 1
gcode:
    SAVE_GCODE_STATE NAME=__move__axis
    G90
    G1 X{printer.toolhead.axis_minimum.x + menu.input * [0.01, 0.1, 1, 10][printer['gcode_macro __STATE'].display_x_delta_mm | int]}
    RESTORE_GCODE_STATE NAME=__move__axis
```

With this PR I could change the last macro to the below, which is a whole lot nicer:

```
[menu __main __motion __x_move]
type: input
name: X     : {'%05.1f' % menu.input }
input: { printer.toolhead.axis_minimum.x) }
input_min: { printer.toolhead.axis_minimum.x }
input_max: { printer.toolhead.axis_maximum.x }
input_step: { [0.01, 0.1, 1, 10][printer['gcode_macro __STATE'].display_x_delta_mm | int] }
gcode:
    SAVE_GCODE_STATE NAME=__move__axis
    G90
    G1 X{menu.input}
    RESTORE_GCODE_STATE NAME=__move__axis

```