### PR TITLE
Update neopixel.py to add BRG color order

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2560,7 +2560,7 @@ pin:
 #   Neopixel is connected to the pin).
 #color_order: GRB
 #   Set the pixel order required by the LED hardware. Options are GRB,
-#   RGB, GRBW, or RGBW. The default is GRB.
+#   RGB, BRG, GRBW, or RGBW. The default is GRB.
 #initial_RED: 0.0
 #initial_GREEN: 0.0
 #initial_BLUE: 0.0

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -24,7 +24,7 @@ class PrinterNeoPixel:
         self.oid = self.mcu.create_oid()
         self.pin = pin_params['pin']
         self.mcu.register_config_callback(self.build_config)
-        formats = {v: v for v in ["RGB", "GRB", "RGBW", "GRBW"]}
+        formats = {v: v for v in ["RGB", "GRB", "BRG", "RGBW", "GRBW"]}
         self.color_order = config.getchoice("color_order", formats, "GRB")
         elem_size = len(self.color_order)
         self.chain_count = config.getint('chain_count', 1, minval=1,
@@ -67,6 +67,8 @@ class PrinterNeoPixel:
             color_data = [green, red, blue]
         elif self.color_order == "RGB":
             color_data = [red, green, blue]
+        elif self.color_order == "BRG":
+            color_data = [blue, red, green]
         elif self.color_order == "GRBW":
             color_data = [green, red, blue, white]
         else:


### PR DESCRIPTION
Neopixel: Add "BRG" color order and documentation update

User "Lanman1#5094" on the Voron Discord discovered that their addressable RGB strip used the unusual "BRG" color order and this was verified using an WLED module to control them as well. Color order and documentation has been updated to support this obscure but still valid color order.

Signed-off-by: Timothy Abraham timothyabe93@gmail.com