### PR TITLE
Add dedicated hardware pins on generic-bigtreetech-skr-mini-e3-v2.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -126,3 +126,32 @@ aliases:
     EXP1_2=PA15, EXP1_4=<RST>, EXP1_6=PB9,  EXP1_8=PB15, EXP1_10=<5V>
 
 # See the sample-lcd.cfg file for definitions of common LCD displays.
+
+# This is the pin config for a 128x64 display as found on the ender3(pro)
+#[display]
+#lcd_type: st7920
+#cs_pin: PB8
+#sclk_pin: PB9
+#sid_pin: PB15
+#encoder_pins: ^PA10, ^PA9
+#click_pin: ^!PA15
+
+# [filament_switch_sensor spool]
+# pause_on_runout: True
+# switch_pin: ^!PC15
+
+# Neopixel LED support
+# [neopixel led_neopixel]
+# pin: PA8
+
+# BL-touch
+#[bltouch]
+#sensor_pin: ^PC14
+#control_pin: PA1
+
+# [output_pin beeper]
+# pin: PB5
+
+# Additional pins available
+# PC13  // Power Supply Switch
+# PC12  // Power Loss Sense

--- a/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v2.0.cfg
@@ -119,6 +119,10 @@ max_z_accel: 100
 [static_digital_output usb_pullup_enable]
 pins: !PA14
 
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
 [board_pins]
 aliases:
     # EXP1 header
@@ -127,31 +131,43 @@ aliases:
 
 # See the sample-lcd.cfg file for definitions of common LCD displays.
 
-# This is the pin config for a 128x64 display as found on the ender3(pro)
 #[display]
 #lcd_type: st7920
-#cs_pin: PB8
-#sclk_pin: PB9
-#sid_pin: PB15
-#encoder_pins: ^PA10, ^PA9
-#click_pin: ^!PA15
+#cs_pin: EXP1_7
+#sclk_pin: EXP1_6
+#sid_pin: EXP1_8
+#encoder_pins: ^EXP1_5, ^EXP1_3
+#click_pin: ^!EXP1_2
 
-# [filament_switch_sensor spool]
-# pause_on_runout: True
-# switch_pin: ^!PC15
+# [output_pin beeper]
+# pin: EXP1_1
 
-# Neopixel LED support
-# [neopixel led_neopixel]
-# pin: PA8
+########################################
+# Optional Peripherals
+########################################
+
+[board_pins]
+aliases:
+    # Neopixel Support
+    NEOPIXEL_1=<GND>, NEOPIXEL_2=PA8, NEOPIXEL_3=<5V>,
+    # Power Supply Switch
+    PS_ON_1=<GND>, PS_ON_2=PC13,
+    # Power Loss Sense
+    PT_DET_1=PC12, PT_DET_2=<GND>, PT_DET_3=<NC>,
+     # Runout sensor
+    E_STOP_1=PC15, E0_STOP_2=<GND>, E0_STOP_3=<5V>,
+    # Z-Probe (BL-Touch)
+    Z_PROBE_1=<GND>, Z_PROBE_2=<5V>, Z_PROBE_3=PA1, Z_PROBE_4=<GND>, Z_PROBE_5=PC14
 
 # BL-touch
 #[bltouch]
-#sensor_pin: ^PC14
-#control_pin: PA1
+#sensor_pin: ^Z_PROBE_5
+#control_pin: Z_PROBE_3
 
-# [output_pin beeper]
-# pin: PB5
+# [filament_switch_sensor spool]
+# pause_on_runout: True
+# switch_pin: ^E0_STOP_2
 
-# Additional pins available
-# PC13  // Power Supply Switch
-# PC12  // Power Loss Sense
+# Neopixel LED support
+# [neopixel led_neopixel]
+# pin: NEOPIXEL_2


### PR DESCRIPTION
Added display, runout, neopixel, beeper and bltouch dedicated ports to config.

These definitions are in the pinout availabe at https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/hardware/BTT%20SKR%20MINI%20E3%20V2.0/Hardware/BTT%20SKR%20MINI%20E3%20V2.0-PIN.pdf

I'm fielding a lot of requests for help on r/klippers related to pins that aren't mentioned in the sample configs, i'd like to update these for the boards I'm familiar with and I'd like feedback on how i've done it, and the devs preferred style for this. 

I don't think it's reasonable to ask the current influx of new users with badly documented boards to find the correct pinout diagram or read through marlin sourcecode in order to use off-the-shelf accessory kits on boards with **clearly labelled sockets that are intended for this additinal hardware**. It's quite common to start with a cheap creality, throw in a bltouch, filament sensor, this board that is sold as a drop-in upgrade and then try klipper.

I've copied the style of the creality 4.2.10 board and all my additions are comments so will not cause issues if the sample config is used as-is.

I intend to replicate this for the other boards i am familiar with if appropriate.

I'm not sure how to document pins intended for functionality that isn't supported by klipper like power loss detection.

Should there be a link in the configs to manufacturer's pinouts where they exist?

Signed-off-by: Rowland Straylight rowlandstraylight@gmail.com