### PR TITLE
flash-sdcard: add support for MPSMv2 and MPMD

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -60,7 +60,12 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
-    }
+    },
+    'monoprice-select-mini-v2': {
+         'mcu': "stm32f070xb",
+         'spi_bus': "spi1",
+         "cs_pin": "PA4"
+     }
 }
 
 ###########################################################
@@ -94,7 +99,8 @@ BOARD_ALIASES = {
     'mks-robin-e3d': BOARD_DEFS['mks-robin-e3'],
     'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
-    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider']
+    'fysetc-s6-v2': BOARD_DEFS['fysetc-spider'],
+    'monoprice-mini-delta': BOARD_DEFS['monoprice-select-mini-v2']
 }
 
 def list_boards():


### PR DESCRIPTION
Add Monoprice Select Mini v2 and Monoprice Mini Delta to scripts/spi_flash/board_defs.py

Signed-off-by: Caylen Kat kittehcream@cat.monster