### PR TITLE
config: update mks rumba32 example config

### DIFF
--- a/config/generic-mks-rumba32-v1.0.cfg
+++ b/config/generic-mks-rumba32-v1.0.cfg
@@ -1,6 +1,7 @@
 # This file contains common pin mappings for MKS RUMBA32 boards.  To use
 # this config, the firmware should be compiled for the STMicroelectronics STM32,
-# Processor model STM32F446, Clock Reference 12 MHz crystal.
+# Processor model STM32F446, Clock Reference 12 MHz crystal, 
+# Bootloader offset (No bootloader)
 
 # See docs/Config_Reference.md for a description of parameters.
 

--- a/config/generic-mks-rumba32-v1.0.cfg
+++ b/config/generic-mks-rumba32-v1.0.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for MKS RUMBA32 boards.  To use
 # this config, the firmware should be compiled for the STMicroelectronics STM32,
-# Processor model STM32F446, Clock Reference 12 MHz crystal, 
+# Processor model STM32F446, Clock Reference 12 MHz crystal,
 # Bootloader offset (No bootloader)
 
 # See docs/Config_Reference.md for a description of parameters.


### PR DESCRIPTION
Makerbase Rumba32 needs a bootloader offset of 0kb, added information to config example 

Signed-off-by: Daniel Bergsch <Danielbergsch@hotmail.de>