### PR TITLE
module: filament_switch_sensor

### DIFF
--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -101,6 +101,7 @@ class RunoutHelper:
         gcmd.respond_info(msg)
     cmd_SET_FILAMENT_SENSOR_help = "Sets the filament sensor on/off"
     def cmd_SET_FILAMENT_SENSOR(self, gcmd):
+        self.min_event_systime = self.reactor.NEVER
         self.sensor_enabled = gcmd.get_int("ENABLE", 1)
 
 class SwitchSensor:


### PR DESCRIPTION
reset min_event_systime on sensor enable/disable

this significantly helps motion encoder sensors, as when prints
start or resume a sensor enable starts fresh (rather than in
the middle of a cycle)

Signed-off-by: Geoffrey Young <geoffrey.young@gmail.com>