### PR TITLE
Correct Fan Pin for the CR-6 SE 2021 Example Config

### DIFF
--- a/config/printer-creality-cr6se-2021.cfg
+++ b/config/printer-creality-cr6se-2021.cfg
@@ -80,7 +80,7 @@ min_temp: 0
 max_temp: 120
 
 [fan]
-pin: PA0
+pin: PB15
 kick_start_time: 0.5
 
 [mcu]


### PR DESCRIPTION
The fan pin PA0 is not correct for the 2021 revision of the CR-6 SE using the
4.5.3 revision of the Creality board. Changed the pin to PB15 in order to
get it working

Signed-off-by: Filip Trplan <filip@trplan.si>