### PR TITLE
Refactor extruder steppers and extruder_stepper

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1835,8 +1835,9 @@ more information.
 ```
 [extruder_stepper my_extra_stepper]
 #extruder: extruder
-#   The extruder this stepper is synchronized to. The default is
-#   "extruder".
+#   The extruder this stepper is synchronized to. If this is set to an
+#   empty string then the stepper will not be synchronized to an
+#   extruder. The default is "extruder".
 #step_pin:
 #dir_pin:
 #enable_pin:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -182,6 +182,11 @@ The following standard commands are supported:
   result in excessive pressure between extruder and hot end. Do proper
   calibration steps with filament before use. If 'DISTANCE' value is
   not included command will return current step distance.
+- `SYNC_STEPPER_TO_EXTRUDER STEPPER=<name> [EXTRUDER=<name>]`: This
+  command will cause the given extruder STEPPER (as specified in an
+  [extruder](Config_Reference#extruder) or
+  [extruder stepper](Config_Reference#extruder_stepper) config
+  section) to become synchronized to the given EXTRUDER.
 - `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
   disable only the given stepper. This is a diagnostic and debugging
   tool and must be used with care. Disabling an axis motor does not
@@ -343,16 +348,6 @@ enabled:
   move completes, however if a manual stepper move uses SYNC=0 then
   future G-Code movement commands may run in parallel with the stepper
   movement.
-
-### Extruder stepper Commands
-
-The following command is available when an
-[extruder_stepper config section](Config_Reference.md#extruder_stepper)
-is enabled:
-- `SYNC_STEPPER_TO_EXTRUDER STEPPER=<extruder_stepper config_name>
-  [EXTRUDER=<extruder config_name>]`: This command will cause the given
-  STEPPER to become synchronized to the given EXTRUDER, overriding
-  the extruder defined in the "extruder_stepper" config section.
 
 ### Probe
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -186,7 +186,9 @@ The following standard commands are supported:
   command will cause the given extruder STEPPER (as specified in an
   [extruder](Config_Reference#extruder) or
   [extruder stepper](Config_Reference#extruder_stepper) config
-  section) to become synchronized to the given EXTRUDER.
+  section) to become synchronized to the given EXTRUDER. If EXTRUDER
+  is an empty string then the stepper will not be synchronized to an
+  extruder.
 - `SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
   disable only the given stepper. This is a diagnostic and debugging
   tool and must be used with care. Disabling an axis motor does not

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -133,8 +133,8 @@ defs_kin_winch = """
 
 defs_kin_extruder = """
     struct stepper_kinematics *extruder_stepper_alloc(void);
-    void extruder_set_smooth_time(struct stepper_kinematics *sk
-        , double smooth_time);
+    void extruder_set_pressure_advance(struct stepper_kinematics *sk
+        , double pressure_advance, double smooth_time);
 """
 
 defs_kin_shaper = """

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -4,36 +4,17 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import stepper
+from kinematics import extruder
 
-class ExtruderStepper:
+class PrinterExtruderStepper:
     def __init__(self, config):
         self.printer = config.get_printer()
-        stepper_name = config.get_name().split()[1]
+        self.extruder_stepper = extruder.ExtruderStepper(config)
         self.extruder_name = config.get('extruder', 'extruder')
-        self.stepper = stepper.PrinterStepper(config)
-        self.stepper.setup_itersolve('extruder_stepper_alloc')
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        gcode = self.printer.lookup_object('gcode')
-        gcode.register_mux_command("SYNC_STEPPER_TO_EXTRUDER", "STEPPER",
-                                   stepper_name,
-                                   self.cmd_SYNC_STEPPER_TO_EXTRUDER,
-                                   desc=self.cmd_SYNC_STEPPER_TO_EXTRUDER_help)
     def handle_connect(self):
-        extruder = self.printer.lookup_object(self.extruder_name)
-        extruder.sync_stepper(self.stepper)
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.register_step_generator(self.stepper.generate_steps)
-    cmd_SYNC_STEPPER_TO_EXTRUDER_help = "Set extruder stepper"
-    def cmd_SYNC_STEPPER_TO_EXTRUDER(self, gcmd):
-        ename = gcmd.get('EXTRUDER')
-        extruder = self.printer.lookup_object(ename, None)
-        if extruder is None:
-            raise gcmd.error("'%s' is not a valid extruder." % (ename,))
-        extruder.sync_stepper(self.stepper)
-        self.extruder_name = ename
-        gcmd.respond_info("Extruder stepper now syncing with '%s'" % (ename,))
+        self.extruder_stepper.sync_to_extruder(self.extruder_name)
 
 def load_config_prefix(config):
-    return ExtruderStepper(config)
+    return PrinterExtruderStepper(config)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -1,15 +1,94 @@
 # Code for handling printer nozzle extruders
 #
-# Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2022  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
 import stepper, chelper
 
+class ExtruderStepper:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+        self.pressure_advance = self.pressure_advance_smooth_time = 0.
+        # Setup stepper
+        self.stepper = stepper.PrinterStepper(config)
+        ffi_main, ffi_lib = chelper.get_ffi()
+        self.sk_extruder = ffi_main.gc(ffi_lib.extruder_stepper_alloc(),
+                                       ffi_lib.free)
+        self.stepper.set_stepper_kinematics(self.sk_extruder)
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_step_generator(self.stepper.generate_steps)
+        # Register commands
+        gcode = self.printer.lookup_object('gcode')
+        if self.name == 'extruder':
+            gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER", None,
+                                       self.cmd_default_SET_PRESSURE_ADVANCE,
+                                       desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
+                                   self.name, self.cmd_SET_PRESSURE_ADVANCE,
+                                   desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+        gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
+                                   self.name, self.cmd_SET_E_STEP_DISTANCE,
+                                   desc=self.cmd_SET_E_STEP_DISTANCE_help)
+    def get_status(self, eventtime):
+        return {'pressure_advance': self.pressure_advance,
+                'smooth_time': self.pressure_advance_smooth_time}
+    def find_past_position(self, print_time):
+        mcu_pos = self.stepper.get_past_mcu_position(print_time)
+        return self.stepper.mcu_to_commanded_position(mcu_pos)
+    def _set_pressure_advance(self, pressure_advance, smooth_time):
+        old_smooth_time = self.pressure_advance_smooth_time
+        if not self.pressure_advance:
+            old_smooth_time = 0.
+        new_smooth_time = smooth_time
+        if not pressure_advance:
+            new_smooth_time = 0.
+        toolhead = self.printer.lookup_object("toolhead")
+        toolhead.note_step_generation_scan_time(new_smooth_time * .5,
+                                                old_delay=old_smooth_time * .5)
+        ffi_main, ffi_lib = chelper.get_ffi()
+        espa = ffi_lib.extruder_set_pressure_advance
+        espa(self.sk_extruder, pressure_advance, new_smooth_time)
+        self.pressure_advance = pressure_advance
+        self.pressure_advance_smooth_time = smooth_time
+    cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
+    def cmd_default_SET_PRESSURE_ADVANCE(self, gcmd):
+        extruder = self.printer.lookup_object('toolhead').get_extruder()
+        extruder.extruder_stepper.cmd_SET_PRESSURE_ADVANCE(gcmd)
+    def cmd_SET_PRESSURE_ADVANCE(self, gcmd):
+        pressure_advance = gcmd.get_float('ADVANCE', self.pressure_advance,
+                                          minval=0.)
+        smooth_time = gcmd.get_float('SMOOTH_TIME',
+                                     self.pressure_advance_smooth_time,
+                                     minval=0., maxval=.200)
+        self._set_pressure_advance(pressure_advance, smooth_time)
+        msg = ("pressure_advance: %.6f\n"
+               "pressure_advance_smooth_time: %.6f"
+               % (pressure_advance, smooth_time))
+        self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
+        gcmd.respond_info(msg, log=False)
+    cmd_SET_E_STEP_DISTANCE_help = "Set extruder step distance"
+    def cmd_SET_E_STEP_DISTANCE(self, gcmd):
+        toolhead = self.printer.lookup_object('toolhead')
+        dist = gcmd.get_float('DISTANCE', None, above=0.)
+        if dist is None:
+            step_dist = self.stepper.get_step_dist()
+            gcmd.respond_info("Extruder '%s' step distance is %0.6f"
+                              % (self.name, step_dist))
+            return
+        toolhead.flush_step_generation()
+        self.stepper.set_step_dist(dist)
+        gcmd.respond_info("Extruder '%s' step distance set to %0.6f"
+                          % (self.name, dist))
+
+# Tracking for hotend heater, extrusion motion queue, and extruder stepper
 class PrinterExtruder:
     def __init__(self, config, extruder_num):
         self.printer = config.get_printer()
         self.name = config.get_name()
+        self.last_position = 0.
+        # Setup hotend heater
         shared_heater = config.get('shared_heater', None)
         pheaters = self.printer.load_object(config, 'heaters')
         gcode_id = 'T%d' % (extruder_num,)
@@ -17,7 +96,7 @@ class PrinterExtruder:
             self.heater = pheaters.setup_heater(config, gcode_id)
         else:
             self.heater = pheaters.lookup_heater(shared_heater)
-        self.stepper = stepper.PrinterStepper(config)
+        # Setup kinematic checks
         self.nozzle_diameter = config.getfloat('nozzle_diameter', above=0.)
         filament_diameter = config.getfloat(
             'filament_diameter', minval=self.nozzle_diameter)
@@ -40,61 +119,34 @@ class PrinterExtruder:
             'max_extrude_only_distance', 50., minval=0.)
         self.instant_corner_v = config.getfloat(
             'instantaneous_corner_velocity', 1., minval=0.)
-        self.pressure_advance = self.pressure_advance_smooth_time = 0.
-        pressure_advance = config.getfloat('pressure_advance', 0., minval=0.)
-        smooth_time = config.getfloat('pressure_advance_smooth_time',
-                                      0.040, above=0., maxval=.200)
-        # Setup iterative solver
+        # Setup extruder trapq (trapezoidal motion queue)
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapq_append = ffi_lib.trapq_append
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
-        self.sk_extruder = ffi_main.gc(ffi_lib.extruder_stepper_alloc(),
-                                       ffi_lib.free)
-        self.stepper.set_stepper_kinematics(self.sk_extruder)
-        self.stepper.set_trapq(self.trapq)
-        toolhead.register_step_generator(self.stepper.generate_steps)
-        self._set_pressure_advance(pressure_advance, smooth_time)
+        # Setup extruder stepper
+        self.extruder_stepper = ExtruderStepper(config)
+        self.extruder_stepper.stepper.set_trapq(self.trapq)
+        pa = config.getfloat('pressure_advance', 0., minval=0.)
+        smooth_time = config.getfloat('pressure_advance_smooth_time',
+                                      0.040, above=0., maxval=.200)
+        self.extruder_stepper._set_pressure_advance(pa, smooth_time)
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         if self.name == 'extruder':
             toolhead.set_extruder(self, 0.)
             gcode.register_command("M104", self.cmd_M104)
             gcode.register_command("M109", self.cmd_M109)
-            gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER", None,
-                                       self.cmd_default_SET_PRESSURE_ADVANCE,
-                                       desc=self.cmd_SET_PRESSURE_ADVANCE_help)
-        gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
-                                   self.name, self.cmd_SET_PRESSURE_ADVANCE,
-                                   desc=self.cmd_SET_PRESSURE_ADVANCE_help)
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
-        gcode.register_mux_command("SET_EXTRUDER_STEP_DISTANCE", "EXTRUDER",
-                                   self.name, self.cmd_SET_E_STEP_DISTANCE,
-                                   desc=self.cmd_SET_E_STEP_DISTANCE_help)
     def update_move_time(self, flush_time):
         self.trapq_finalize_moves(self.trapq, flush_time)
-    def _set_pressure_advance(self, pressure_advance, smooth_time):
-        old_smooth_time = self.pressure_advance_smooth_time
-        if not self.pressure_advance:
-            old_smooth_time = 0.
-        new_smooth_time = smooth_time
-        if not pressure_advance:
-            new_smooth_time = 0.
-        toolhead = self.printer.lookup_object("toolhead")
-        toolhead.note_step_generation_scan_time(new_smooth_time * .5,
-                                                old_delay=old_smooth_time * .5)
-        ffi_main, ffi_lib = chelper.get_ffi()
-        espa = ffi_lib.extruder_set_pressure_advance
-        espa(self.sk_extruder, pressure_advance, new_smooth_time)
-        self.pressure_advance = pressure_advance
-        self.pressure_advance_smooth_time = smooth_time
     def get_status(self, eventtime):
-        return dict(self.heater.get_status(eventtime),
-                    can_extrude=self.heater.can_extrude,
-                    pressure_advance=self.pressure_advance,
-                    smooth_time=self.pressure_advance_smooth_time)
+        sts = self.heater.get_status(eventtime)
+        sts['can_extrude'] = self.heater.can_extrude
+        sts.update(self.extruder_stepper.get_status(eventtime))
+        return sts
     def get_name(self):
         return self.name
     def get_heater(self):
@@ -104,8 +156,7 @@ class PrinterExtruder:
     def sync_stepper(self, stepper):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.flush_step_generation()
-        epos = self.stepper.get_commanded_position()
-        stepper.set_position([epos, 0., 0.])
+        stepper.set_position([self.last_position, 0., 0.])
         stepper.set_trapq(self.trapq)
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
@@ -155,9 +206,9 @@ class PrinterExtruder:
                           move.start_pos[3], 0., 0.,
                           1., can_pressure_advance, 0.,
                           start_v, cruise_v, accel)
+        self.last_position = move.end_pos[3]
     def find_past_position(self, print_time):
-        mcu_pos = self.stepper.get_past_mcu_position(print_time)
-        return self.stepper.mcu_to_commanded_position(mcu_pos)
+        return self.extruder_stepper.find_past_position(print_time)
     def cmd_M104(self, gcmd, wait=False):
         # Set Extruder Temperature
         temp = gcmd.get_float('S', 0.)
@@ -178,35 +229,6 @@ class PrinterExtruder:
     def cmd_M109(self, gcmd):
         # Set Extruder Temperature and Wait
         self.cmd_M104(gcmd, wait=True)
-    cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
-    def cmd_default_SET_PRESSURE_ADVANCE(self, gcmd):
-        extruder = self.printer.lookup_object('toolhead').get_extruder()
-        extruder.cmd_SET_PRESSURE_ADVANCE(gcmd)
-    def cmd_SET_PRESSURE_ADVANCE(self, gcmd):
-        pressure_advance = gcmd.get_float('ADVANCE', self.pressure_advance,
-                                          minval=0.)
-        smooth_time = gcmd.get_float('SMOOTH_TIME',
-                                     self.pressure_advance_smooth_time,
-                                     minval=0., maxval=.200)
-        self._set_pressure_advance(pressure_advance, smooth_time)
-        msg = ("pressure_advance: %.6f\n"
-               "pressure_advance_smooth_time: %.6f"
-               % (pressure_advance, smooth_time))
-        self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
-        gcmd.respond_info(msg, log=False)
-    cmd_SET_E_STEP_DISTANCE_help = "Set extruder step distance"
-    def cmd_SET_E_STEP_DISTANCE(self, gcmd):
-        toolhead = self.printer.lookup_object('toolhead')
-        dist = gcmd.get_float('DISTANCE', None, above=0.)
-        if dist is None:
-            step_dist = self.stepper.get_step_dist()
-            gcmd.respond_info("Extruder '%s' step distance is %0.6f"
-                              % (self.name, step_dist))
-            return
-        toolhead.flush_step_generation()
-        self.stepper.set_step_dist(dist)
-        gcmd.respond_info("Extruder '%s' step distance set to %0.6f"
-                          % (self.name, dist))
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
     def cmd_ACTIVATE_EXTRUDER(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
@@ -215,7 +237,7 @@ class PrinterExtruder:
             return
         gcmd.respond_info("Activating extruder %s" % (self.name,))
         toolhead.flush_step_generation()
-        toolhead.set_extruder(self, self.stepper.get_commanded_position())
+        toolhead.set_extruder(self, self.last_position)
         self.printer.send_event("extruder:activate_extruder")
 
 # Dummy extruder class used when a printer has no extruder at all

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -44,12 +44,15 @@ class ExtruderStepper:
         mcu_pos = self.stepper.get_past_mcu_position(print_time)
         return self.stepper.mcu_to_commanded_position(mcu_pos)
     def sync_to_extruder(self, extruder_name):
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.flush_step_generation()
+        if not extruder_name:
+            self.stepper.set_trapq(None)
+            return
         extruder = self.printer.lookup_object(extruder_name, None)
         if extruder is None or not isinstance(extruder, PrinterExtruder):
             raise self.printer.command_error("'%s' is not a valid extruder."
                                              % (extruder_name,))
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.flush_step_generation()
         self.stepper.set_position([extruder.last_position, 0., 0.])
         self.stepper.set_trapq(extruder.get_trapq())
     def _set_pressure_advance(self, pressure_advance, smooth_time):

--- a/test/klippy/extruders.test
+++ b/test/klippy/extruders.test
@@ -15,3 +15,32 @@ G1 X25 Y25 E7.5
 # Update step_distance
 SET_EXTRUDER_STEP_DISTANCE EXTRUDER=extruder DISTANCE=.005
 G1 X30 Y30 E8.0
+
+# Disable extruder stepper motor
+SYNC_STEPPER_TO_EXTRUDER STEPPER=extruder EXTRUDER=
+G1 X35 Y35 E8.5
+
+# Disable my_extra_stepper stepper motor
+SYNC_STEPPER_TO_EXTRUDER STEPPER=my_extra_stepper EXTRUDER=
+G1 X40 Y40 E9.0
+
+# Enable extruder stepper motor
+SYNC_STEPPER_TO_EXTRUDER STEPPER=extruder EXTRUDER=extruder
+G1 X45 Y45 E9.5
+
+# Switch to just my_extra_stepper stepper motor
+SYNC_STEPPER_TO_EXTRUDER STEPPER=extruder EXTRUDER=
+SYNC_STEPPER_TO_EXTRUDER STEPPER=my_extra_stepper EXTRUDER=extruder
+G1 X50 Y50 E10.0
+
+# Test pressure advance move
+SET_PRESSURE_ADVANCE EXTRUDER=my_extra_stepper ADVANCE=0.020
+G1 X55 Y55 E0
+G1 X55 Y55 E0.5
+G1 X60 Y60 E1.1
+G1 X50 Y50
+SET_PRESSURE_ADVANCE EXTRUDER=extruder ADVANCE=0.025
+G1 X55 Y55 E1.5
+G1 X50 Y50
+G1 X55 Y55 E2.0
+G1 X50 Y50


### PR DESCRIPTION
This PR reworks the extruder stepper logic to make it more flexible.  In particular, it is now possible to use the SYNC_STEPPER_TO_EXTRUDER command on either an `extruder` object or an `extruder_stepper` object.  It is also now possible to call SET_PRESSURE_ADVANCE and SET_EXTRUDER_STEP_DISTANCE on `extruder_stepper` objects.

This may facilitate synchronizing of multiple extruders on idex printers (such that one can print multiple objects simultaneously).  As in #4489.

This may facilitate support for mixing extruders (as in #3920, #4082, #4566).

This PR also deprecates the `shared_heater` support in extruder config sections.  It is thought that one can now obtain the same support by using `extruder_stepper` config sections.

I do not have a good way to test this code.  Feedback and testers would be appreciated.

-Kevin