### PR TITLE
gcode_macro: Enable jinja2.ext.do extension

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -71,7 +71,7 @@ class TemplateWrapper:
 class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.env = jinja2.Environment('{%', '%}', '{', '}')
+        self.env = jinja2.Environment('{%', '%}', '{', '}', extensions=['jinja2.ext.do'])
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:


### PR DESCRIPTION
This adds a 'do' tag that works like a normal expression but ignores the return value.
Useful for avoiding running the output of an expression as a command when it is the only thing on a line.

### Example scenarios:

Without extension enabled:
```
[gcode_macro NONE_TEST]
gcode:
  { [1,2].append(3) }
```

Console output: `Unknown command:"NONE"`

```
[gcode_macro NONE_TEST]
gcode:
  {% do [1,2].append(3) %}
```

Klippy error: `TemplateSyntaxError: Encountered unknown tag 'do'.`

---

With extension enabled:

```
[gcode_macro NONE_TEST]
gcode:
  {% do [1,2].append(3) %}
```

No console output


I don't know how needed this is since I couldn't find anyone else complaining about `Unknown command:"NONE"` in the console, and there are workarounds to avoid it (`{% set _ = [1,2].append(3) %}`) but it is a very simple feature so it shouldn't hurt anything.

Signed-off-by: Morten Lindhardt <r3fuze@gmail.com>