### PR TITLE
Rework tmc run_current selection to prefer vsense=1

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220116: The tmc2130, tmc2208, tmc2209, and tmc2660 `run_current`
+calculation code has changed. For some `run_current` settings the
+drivers may now be configured differently. This new configuration
+should be more accurate, but it may invalidate previous tmc driver
+tuning.
+
 20211230: Scripts to tune input shaper (`scripts/calibrate_shaper.py`
 and `scripts/graph_accelerometer.py`) were migrated to use Python3
 by default. As a result, users must install Python3 versions of certain

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -136,17 +136,26 @@ class TMC2660CurrentHelper:
 
     def _calc_current_bits(self, current, vsense):
         vref = 0.165 if vsense else 0.310
-        cs = int(32 * current * self.sense_resistor * math.sqrt(2.) / vref
-                 - 1. + .5)
+        sr = self.sense_resistor
+        cs = int(32. * sr * current * math.sqrt(2.) / vref + .5) - 1
         return max(0, min(31, cs))
 
+    def _calc_current_from_bits(self, cs, vsense):
+        vref = 0.165 if vsense else 0.310
+        return (cs + 1) * vref / (32. * self.sense_resistor * math.sqrt(2.))
+
     def _calc_current(self, run_current):
-        vsense = False
-        cs = self._calc_current_bits(run_current, vsense)
-        if cs < 16:
-            vsense = True
-            cs = self._calc_current_bits(run_current, vsense)
-        return vsense, cs
+        vsense = True
+        irun = self._calc_current_bits(run_current, True)
+        if irun == 31:
+            cur = self._calc_current_from_bits(irun, True)
+            if cur < run_current:
+                irun2 = self._calc_current_bits(run_current, False)
+                cur2 = self._calc_current_from_bits(irun2, False)
+                if abs(run_current - cur2) < abs(run_current - cur):
+                    vsense = False
+                    irun = irun2
+        return vsense, irun
 
     def _handle_printing(self, print_time):
         print_time -= 0.100 # Schedule slightly before deadline


### PR DESCRIPTION
It was possible for tmc2130/tmc2208/tmc2209 drivers to be programmed with an irun=16 or irun=17 when it was also possible to configure the driver with irun=31
and vsense=1 instead.  This would occur on tmc2130/tmc2208/tmc2209 drivers for run_current values around 0.900 to 1.000 amps (when using a typical sense_resistor settings of 0.110 Ohms).

Programming the driver with irun=16 or 17 is not ideal as it could result in reduced microstep precision.

A similar issue could impact tmc2660 drivers.

This change updates the code to improve the run_current programming to avoid the above issue.

If one was using one of the impacted run_current settings then it is possible this change may invalidate any previous sensorless homing or spreadcycle tuning.

-Kevin