### PR TITLE
pause_resume: Do not klobber default state name by accident.

### DIFF
--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -63,7 +63,7 @@ class PauseResume:
             gcmd.respond_info("Print already paused")
             return
         self.send_pause_command()
-        self.gcode.run_script_from_command("SAVE_GCODE_STATE STATE=PAUSE_STATE")
+        self.gcode.run_script_from_command("SAVE_GCODE_STATE NAME=PAUSE_STATE")
         self.is_paused = True
     def send_resume_command(self):
         if self.sd_paused:
@@ -80,7 +80,7 @@ class PauseResume:
             return
         velocity = gcmd.get_float('VELOCITY', self.recover_velocity)
         self.gcode.run_script_from_command(
-            "RESTORE_GCODE_STATE STATE=PAUSE_STATE MOVE=1 MOVE_SPEED=%.4f"
+            "RESTORE_GCODE_STATE NAME=PAUSE_STATE MOVE=1 MOVE_SPEED=%.4f"
             % (velocity))
         self.send_resume_command()
         self.is_paused = False


### PR DESCRIPTION
Previously accidentally used 'default' state name instead of the
stated one ('PAUSE_STATE'). This might collide with user usage of the
SAVE_GCODE_STATE macro.
