### PR TITLE
Update neopixel.py to add BGR color order

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2560,7 +2560,7 @@ pin:
 #   Neopixel is connected to the pin).
 #color_order: GRB
 #   Set the pixel order required by the LED hardware. Options are GRB,
-#   RGB, BRG, GRBW, or RGBW. The default is GRB.
+#   RGB, BRG, BGR, GRBW, or RGBW. The default is GRB.
 #initial_RED: 0.0
 #initial_GREEN: 0.0
 #initial_BLUE: 0.0

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -24,7 +24,7 @@ class PrinterNeoPixel:
         self.oid = self.mcu.create_oid()
         self.pin = pin_params['pin']
         self.mcu.register_config_callback(self.build_config)
-        formats = {v: v for v in ["RGB", "GRB", "BRG", "RGBW", "GRBW"]}
+        formats = {v: v for v in ["RGB", "GRB", "BRG", "BGR", "RGBW", "GRBW"]}
         self.color_order = config.getchoice("color_order", formats, "GRB")
         elem_size = len(self.color_order)
         self.chain_count = config.getint('chain_count', 1, minval=1,
@@ -69,6 +69,8 @@ class PrinterNeoPixel:
             color_data = [red, green, blue]
         elif self.color_order == "BRG":
             color_data = [blue, red, green]
+        elif self.color_order == "BGR":
+            color_data = [blue, green, red]
         elif self.color_order == "GRBW":
             color_data = [green, red, blue, white]
         else:


### PR DESCRIPTION
Neopixel: Add BGR color order + documentation update

I discovered a problem with an other unusual color order for WS2812B 5050 SMD LED stripes. The stripe uses "BGR" color order. Color order and documentation has been updated.

Signed-off-by: Thomas Liebold electron2410@gmail.com