### PR TITLE
BTT Octopus generic config: Fixing Driver3 enable pin

### DIFF
--- a/config/generic-bigtreetech-octopus.cfg
+++ b/config/generic-bigtreetech-octopus.cfg
@@ -46,7 +46,7 @@ position_max: 200
 #[stepper_]
 #step_pin: PG4
 #dir_pin: PC1
-#enable_pin: PA0
+#enable_pin: !PA0
 #endstop_pin: PG11
 #...
 


### PR DESCRIPTION
The Driver3's enable pin should be inverted, in same manner as other drivers. For some reason (typo?) in the example config it was not inverted