### PR TITLE
ignore the intimediary files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 .config
 .config.old
 klippy/.version
+klippy/chelper


### PR DESCRIPTION
A housekeeping change. chelper looks like compiled intermediary files and just want to cut down the noise of any changes vs non-changes