### PR TITLE
KCONFIG: Add remap CAN to PD0/PD1 for stm32f103

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -339,7 +339,7 @@ choice
         select CANSERIAL
     config STM32_CANBUS_PD0_PD1
         bool "CAN bus (on PD0/PD1)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS && MACH_STM32F4
+        depends on HAVE_STM32_CANBUS
         select CANSERIAL
 endchoice
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -204,6 +204,9 @@ gpio_peripheral(uint32_t gpio, uint32_t mode, int pullup)
         if (gpio == GPIO('B', 8) || gpio == GPIO('B', 9))
             stm32f1_alternative_remap(AFIO_MAPR_CAN_REMAP_Msk,
                                       AFIO_MAPR_CAN_REMAP_REMAP2);
+        if (gpio == GPIO('D', 0) || gpio == GPIO('D', 1))
+            stm32f1_alternative_remap(AFIO_MAPR_CAN_REMAP_Msk,
+                                      AFIO_MAPR_CAN_REMAP_REMAP3);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Sergey Terentiev <sergey@terentiev.me>