### PR TITLE
filament_motion_sensor: Extended information

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -624,6 +624,10 @@ is enabled.
 - `QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current
   status of the filament sensor. The data displayed on the terminal
   will depend on the sensor type defined in the confguration.
+  In a case when filament montion sensor is set query will retrun
+  information about measured sensitivity. This represent value
+  measured by firmware and could be used to calibration/tune of value
+  set in config file. This should prevent false positive triggering.
 - `SET_FILAMENT_SENSOR SENSOR=<sensor_name> ENABLE=[0|1]`: Sets the
   filament sensor on/off. If ENABLE is set to 0, the filament sensor
   will be disabled, if set to 1 it is enabled.

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -75,8 +75,7 @@ class EncoderSensor:
     def encoder_event(self, eventtime, state):
         if self.extruder is not None:
             self._update_filament_runout_pos(eventtime)
-            # Check for filament insertion
-            # Filament is always assumed to be present on an encoder event
+            # Measured sensor sensitivity based on mean value
             self.measured_sensitivity += (self.filament_runout_pos -
                                           self.extruder_pos)
             self.measured_sensitivity /= 2.0

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -77,14 +77,18 @@ class EncoderSensor:
             self._update_filament_runout_pos(eventtime)
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
-            self.measured_sensitivity = (self.measured_sensitivity + (self.filament_runout_pos - self.extruder_pos)) / 2
+            self.measured_sensitivity = (
+                self.measured_sensitivity + (self.filament_runout_pos - self.extruder_pos)) / 2
             self.runout_helper.note_filament_present(True)
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
         if self.runout_helper.filament_present:
-            msg = "Filament Sensor %s: filament detected" % (self.runout_helper.name)
+            msg = "Filament Sensor %s: filament detected" % (
+                self.runout_helper.name)
         else:
-            msg = "Filament Sensor %s: filament not detected" % (self.runout_helper.name)
-        msg += "\n measured sensitivity %r over %r" %(self.measured_sensitivity, self.extruder_pos)
+            msg = "Filament Sensor %s: filament not detected" % (
+                self.runout_helper.name)
+        msg += "\n measured sensitivity %r over %r" % (
+            self.measured_sensitivity, self.extruder_pos)
         gcmd.respond_info(msg)
 
 def load_config_prefix(config):

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -77,8 +77,9 @@ class EncoderSensor:
             self._update_filament_runout_pos(eventtime)
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
-            self.measured_sensitivity = (
-                self.measured_sensitivity + (self.filament_runout_pos - self.extruder_pos)) / 2
+            self.measured_sensitivity += (self.filament_runout_pos -
+                                          self.extruder_pos)
+            self.measured_sensitivity /= 2.0
             self.runout_helper.note_filament_present(True)
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
         if self.runout_helper.filament_present:
@@ -89,6 +90,8 @@ class EncoderSensor:
                 self.runout_helper.name)
         msg += "\n measured sensitivity %r over %r" % (
             self.measured_sensitivity, self.extruder_pos)
+        msg += "last measured %r" % (self.filament_runout_pos -
+                                     self.extruder_pos)
         gcmd.respond_info(msg)
 
 def load_config_prefix(config):

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -109,9 +109,11 @@ class SwitchSensor:
         self.runout_helper.note_filament_present(state)
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
         if self.runout_helper.filament_present:
-            msg = "Filament Sensor %s: filament detected" % (self.runout_helper.name)
+            msg = "Filament Sensor %s: filament detected" % (
+                self.runout_helper.name)
         else:
-            msg = "Filament Sensor %s: filament not detected" % (self.runout_helper.name)
+            msg = "Filament Sensor %s: filament not detected" % (
+                self.runout_helper.name)
         gcmd.respond_info(msg)
 
 def load_config_prefix(config):


### PR DESCRIPTION
Added support for semiautomatic calibration for motion filament sensor

Hi I have more advanced filament motion sensor ([my design](https://www.prusaprinters.org/prints/112108-optical-filament-sensor-v21-with-drive-gear-for-17)) which has much higher resolution (0.239mm per state change) that other sensors on the market. My sensor is detecting also jamming and slipping filament which could be used to checking flow without additional equipment. Problem was that there was no implementation for calibration. My change could be used to do that.

I also changed CHECK_RUNOUT_TIMEOUT which is shouldn't be done but, it was to high and introduce big fluctuation of measurements.
Examples for 0.250:
> measured sensitivity 1.4366624980506812 over 35.87850745479
>  G1 E5.9797 F120
> measured sensitivity 1.4110518778766523 over 29.898168435135
> G1 E5.9797 F120
> G1 E5.9797 F120
> measured sensitivity 1.4786398526478919 over 23.918711081265


for 0.05
> measured sensitivity 1.2339777544849444 over 59.79898186762499
> G1 E5.9797 F120
> measured sensitivity 1.26369648992579 over 53.819524513755
> G1 E5.9797 F120
> measured sensitivity 1.2483245301150614 over 47.840067159884995
> G1 E23.92 F120
> measured sensitivity 1.2506111232890826 over 23.919592747049997

My proposal is to make it configurable in section for filament motion sensor.

When we will get conclusion of proper solutions I will also update documentation for those changes in this PR.

I also want to call @TheJoshW to board ;)

Signed-off-by: Michal Sentyrz <sentyrz.m@gmail.com>