### PR TITLE
extras/tmc.py: Fix number of arguments in phase endstop

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -313,7 +313,7 @@ class TMCCommandHelper:
         moff = (phase - stepper.get_mcu_position()) % phases
         if self.mcu_phase_offset is not None and self.mcu_phase_offset != moff:
             logging.warning("Stepper %s phase change (was %d now %d)",
-                            self.mcu_phase_offset, moff)
+                            self.stepper_name, self.mcu_phase_offset, moff)
         self.mcu_phase_offset = moff
     # Stepper enable/disable tracking
     def _do_enable(self, print_time):


### PR DESCRIPTION
Found this error.

Also i tested a tmc261 chip with the tmc2660 code, it is fully compatible except for the lower current limit of 1.4A. Maybe this can be noted somewhere. The tmc261 is interesting because it supports up to 60v.