### PR TITLE
Updated filament_motion_sensor.py

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3712,6 +3712,12 @@ detection_length: 7.0
 #   The minimum length of filament pulled through the sensor to trigger
 #   a state change on the switch_pin
 #   Default is 7 mm.
+consecutive_count: 1
+#   The number of consecutive times that the trigger don't change
+#   before the filament is considered to have run out.
+#   Default is 1.
+check_runout_timeout: 0.250
+#   The interval of time in seconds to check for runout.
 extruder:
 #   The name of the extruder section this sensor is associated with.
 #   This parameter must be provided.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -628,6 +628,14 @@ is enabled.
   filament sensor on/off. If ENABLE is set to 0, the filament sensor
   will be disabled, if set to 1 it is enabled.
 
+The following command is available when the
+[filament_motion_sensor config section](Config_Reference.md#filament_motion_sensor)
+is enabled.
+- `SET_FILAMENT_MOTION_SENSOR VERBOSE=[0|1]`: Sets the verbosity of
+  the filament motion sensor. If VERBOSE is set to 0, the filament
+  sensor will not report any motion, if set to 1 it will report
+  motion. 
+
 ### Firmware Retraction
 
 The following commands are available when the

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -631,9 +631,9 @@ is enabled.
 The following command is available when the
 [filament_motion_sensor config section](Config_Reference.md#filament_motion_sensor)
 is enabled.
-- `SET_FILAMENT_MOTION_SENSOR VERBOSE=[0|1]`: Sets the verbosity of
+- `SET_FILAMENT_MOTION_SENSOR SENSOR=<sensor_name> VERBOSE=[0|1]`: Sets the verbosity of
   the filament motion sensor. If VERBOSE is set to 0, the filament
-  sensor will not report any motion, if set to 1 it will report motion.
+  sensor will not report any motion, if set to 1 it will report motions.
 
 ### Firmware Retraction
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -633,8 +633,7 @@ The following command is available when the
 is enabled.
 - `SET_FILAMENT_MOTION_SENSOR VERBOSE=[0|1]`: Sets the verbosity of
   the filament motion sensor. If VERBOSE is set to 0, the filament
-  sensor will not report any motion, if set to 1 it will report
-  motion. 
+  sensor will not report any motion, if set to 1 it will report motion. 
 
 ### Firmware Retraction
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -633,7 +633,7 @@ The following command is available when the
 is enabled.
 - `SET_FILAMENT_MOTION_SENSOR VERBOSE=[0|1]`: Sets the verbosity of
   the filament motion sensor. If VERBOSE is set to 0, the filament
-  sensor will not report any motion, if set to 1 it will report motion. 
+  sensor will not report any motion, if set to 1 it will report motion.
 
 ### Firmware Retraction
 

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -45,8 +45,9 @@ class EncoderSensor:
                 self._handle_not_printing)
         # Register GCODE commands
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command(
-            'SET_FILAMENT_MOTION_SENSOR', self.cmd_SET_FILAMENT_MOTION_SENSOR,
+        self.gcode.register_mux_command(
+            'SET_FILAMENT_MOTION_SENSOR', 'SENSOR',
+            self.runout_helper.name, self.cmd_SET_FILAMENT_MOTION_SENSOR,
             desc=self.cmd_SET_FILAMENT_MOTION_SENSOR_help)
     cmd_SET_FILAMENT_MOTION_SENSOR_help = \
         "Enable debug logging for the encoder event"

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2021 Joshua Wherrett <thejoshw.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
+import logging, collections
 from . import filament_switch_sensor
 
 CHECK_RUNOUT_TIMEOUT = .250
@@ -16,6 +16,8 @@ class EncoderSensor:
         self.extruder_name = config.get('extruder')
         self.detection_length = config.getfloat(
                 'detection_length', 7., above=0.)
+        self.consecutive_count = config.getint('consecutive_count', 3, minval=1)
+        self.current_count = 0
         # Configure pins
         buttons = self.printer.load_object(config, 'buttons')
         buttons.register_buttons([switch_pin], self.encoder_event)
@@ -27,6 +29,8 @@ class EncoderSensor:
         self.estimated_print_time = None
         # Initialise internal state
         self.filament_runout_pos = None
+        self.verbose = False
+        self.verbose_gcmd = None
         # Register commands and event handlers
         self.printer.register_event_handler('klippy:ready',
                 self._handle_ready)
@@ -36,12 +40,31 @@ class EncoderSensor:
                 self._handle_not_printing)
         self.printer.register_event_handler('idle_timeout:idle',
                 self._handle_not_printing)
+        # Register GCODE commands
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command(
+            'FILAMENT_MOTION_SENSOR', self.cmd_FILAMENT_MOTION_SENSOR,
+            desc=self.cmd_FILAMENT_MOTION_SENSOR_help)
+    cmd_FILAMENT_MOTION_SENSOR_help = "Enable debug logging for the encoder event"
+    def cmd_FILAMENT_MOTION_SENSOR(self, gcmd):
+        options = collections.OrderedDict({
+            'VERBOSE': None
+        })
+        for key in options:
+            name = gcmd.get(key,None)
+            if name is not None:
+                name = name.lower()
+                if name == "1" or name == "on" or name == "true":
+                    self.verbose = True
+                    self.verbose_gcmd = gcmd
+                else:
+                    self.verbose = False
+                    self.verbose_gcmd = None
+            gcmd.respond_info("Filament Motion Verbose is %s" % ("On" if self.verbose else "Off"))
     def _update_filament_runout_pos(self, eventtime=None):
         if eventtime is None:
             eventtime = self.reactor.monotonic()
-        self.filament_runout_pos = (
-                self._get_extruder_pos(eventtime) +
-                self.detection_length)
+        self.filament_runout_pos = self._get_extruder_pos(eventtime)
     def _handle_ready(self):
         self.extruder = self.printer.lookup_object(self.extruder_name)
         self.estimated_print_time = (
@@ -50,6 +73,7 @@ class EncoderSensor:
         self._extruder_pos_update_timer = self.reactor.register_timer(
                 self._extruder_pos_update_event)
     def _handle_printing(self, print_time):
+        self.current_count = 0
         self.reactor.update_timer(self._extruder_pos_update_timer,
                 self.reactor.NOW)
     def _handle_not_printing(self, print_time):
@@ -63,8 +87,18 @@ class EncoderSensor:
     def _extruder_pos_update_event(self, eventtime):
         extruder_pos = self._get_extruder_pos(eventtime)
         # Check for filament runout
-        self.runout_helper.note_filament_present(
-                extruder_pos < self.filament_runout_pos)
+        diff_pos = abs(extruder_pos - self.filament_runout_pos)
+        it_fail = diff_pos > self.detection_length
+        is_filament_present = True
+        if it_fail:
+            self.current_count += 1
+            if self.current_count >= self.consecutive_count:
+                is_filament_present = False
+        self.runout_helper.note_filament_present(is_filament_present)
+        if self.verbose:
+            self.verbose_gcmd.respond_info(
+                "Filament Motion: Update Event pos %s present %s" %
+                diff_pos, "true" if is_filament_present else "false")
         return eventtime + CHECK_RUNOUT_TIMEOUT
     def encoder_event(self, eventtime, state):
         if self.extruder is not None:
@@ -72,6 +106,7 @@ class EncoderSensor:
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
             self.runout_helper.note_filament_present(True)
+            self.current_count = 0
 
 def load_config_prefix(config):
     return EncoderSensor(config)

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -17,7 +17,7 @@ class EncoderSensor:
         self.detection_length = config.getfloat(
                 'detection_length', 7., above=0.)
         self.check_runout_timeout = config.getfloat('check_runout_timeout',
-                                    DEFAULT_CHECK_RUNOUT_TIMEOUT, minval=0.050)
+                            DEFAULT_CHECK_RUNOUT_TIMEOUT, minval=0.050)
         self.consecutive_count = config.getint('consecutive_count', 1, minval=1)
         self.current_count = 0
         # Configure pins

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -45,7 +45,8 @@ class EncoderSensor:
         self.gcode.register_command(
             'FILAMENT_MOTION_SENSOR', self.cmd_FILAMENT_MOTION_SENSOR,
             desc=self.cmd_FILAMENT_MOTION_SENSOR_help)
-    cmd_FILAMENT_MOTION_SENSOR_help = "Enable debug logging for the encoder event"
+    cmd_FILAMENT_MOTION_SENSOR_help = \
+        "Enable debug logging for the encoder event"
     def cmd_FILAMENT_MOTION_SENSOR(self, gcmd):
         options = collections.OrderedDict({
             'VERBOSE': None
@@ -60,7 +61,8 @@ class EncoderSensor:
                 else:
                     self.verbose = False
                     self.verbose_gcmd = None
-            gcmd.respond_info("Filament Motion Verbose is %s" % ("On" if self.verbose else "Off"))
+            gcmd.respond_info("Filament Motion Verbose is %s" %
+                              ("On" if self.verbose else "Off"))
     def _update_filament_runout_pos(self, eventtime=None):
         if eventtime is None:
             eventtime = self.reactor.monotonic()

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -18,7 +18,8 @@ class EncoderSensor:
                 'detection_length', 7., above=0.)
         self.check_runout_timeout = config.getfloat('check_runout_timeout',
                             DEFAULT_CHECK_RUNOUT_TIMEOUT, minval=0.050)
-        self.consecutive_count = config.getint('consecutive_count', 1, minval=1)
+        self.consecutive_count = config.getint('consecutive_count', 1,
+                                               minval=1)
         self.current_count = 0
         # Configure pins
         buttons = self.printer.load_object(config, 'buttons')

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -51,19 +51,8 @@ class EncoderSensor:
     cmd_SET_FILAMENT_MOTION_SENSOR_help = \
         "Enable debug logging for the encoder event"
     def cmd_SET_FILAMENT_MOTION_SENSOR(self, gcmd):
-        options = collections.OrderedDict({
-            'VERBOSE': None
-        })
-        for key in options:
-            name = gcmd.get(key,None)
-            if name is not None:
-                name = name.lower()
-                if name == "1" or name == "on" or name == "true":
-                    self.verbose = True
-                    self.verbose_gcmd = gcmd
-                else:
-                    self.verbose = False
-                    self.verbose_gcmd = None
+            self.verbose = True if gcmd.getInt('Verbose', 0) == 1 else False
+            self.verbose_gcmd = gcmd if self.verbose else None
             gcmd.respond_info("Filament Motion Verbose is %s" %
                               ("On" if self.verbose else "Off"))
     def _update_filament_runout_pos(self, eventtime=None):

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -17,7 +17,7 @@ class EncoderSensor:
         self.detection_length = config.getfloat(
                 'detection_length', 7., above=0.)
         self.check_runout_timeout = config.getfloat('check_runout_timeout',
-                                                    DEFAULT_CHECK_RUNOUT_TIMEOUT, minval=0.050)
+                                    DEFAULT_CHECK_RUNOUT_TIMEOUT, minval=0.050)
         self.consecutive_count = config.getint('consecutive_count', 1, minval=1)
         self.current_count = 0
         # Configure pins


### PR DESCRIPTION
added option: consecutive_count (default 3)
added gcode: FILAMENT_MOTION_SENSOR VERBOSE=[1/0] in order to enable the verbose
Changed the check _extruder_pos_update_event in order set filament not present when the filament difference beetwen the runnout sensor and the extruder position is greater than the detection_length for consecutive_count times.

In my test with this mode i can use the detection_lenght to 4mm (my sensor have 3mm + some margin seen with verbose) and trigger the runout early in case of clogs