### PR TITLE
src/linux/i2c: additional busses

### DIFF
--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -14,6 +14,9 @@
 #include "sched.h" // sched_shutdown
 
 DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 2);
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.1", 1, 2);
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.2", 2, 2);
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.3", 3, 2);
 
 struct i2c_s {
     uint32_t bus;


### PR DESCRIPTION
More busses to add multiple sensors with same address.
To activate additional busses /boot/config.txt should contain something like

dtoverlay=i2c-gpio,bus=4,i2c_gpio_delay_us=1,i2c_gpio_sda=23,i2c_gpio_scl=24
dtoverlay=i2c-gpio,bus=3,i2c_gpio_delay_us=1,i2c_gpio_sda=27,i2c_gpio_scl=22
dtoverlay=i2c-gpio,bus=2,i2c_gpio_delay_us=1,i2c_gpio_sda=5,i2c_gpio_scl=6

Signed-off-by: Florian Senn <github@senn.bz>