### PR TITLE
Update to run with python3

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, logging
 import cffi
 

--- a/klippy/chelper/linux/can.h
+++ b/klippy/chelper/linux/can.h
@@ -1,0 +1,258 @@
+/* SPDX-License-Identifier: ((GPL-2.0-only WITH Linux-syscall-note) OR BSD-3-Clause) */
+/*
+ * linux/can.h
+ *
+ * Definitions for CAN network layer (socket addr / CAN frame / CAN filter)
+ *
+ * Authors: Oliver Hartkopp <oliver.hartkopp@volkswagen.de>
+ *          Urs Thuermann   <urs.thuermann@volkswagen.de>
+ * Copyright (c) 2002-2007 Volkswagen Group Electronic Research
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of Volkswagen nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * Alternatively, provided that this notice is retained in full, this
+ * software may be distributed under the terms of the GNU General
+ * Public License ("GPL") version 2, in which case the provisions of the
+ * GPL apply INSTEAD OF those given above.
+ *
+ * The provided data structures and external interfaces from this code
+ * are not restricted to be used by modules with a GPL compatible license.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _UAPI_CAN_H
+#define _UAPI_CAN_H
+
+#if __APPLE__
+#include <stdint.h>
+typedef uint64_t __u64;
+typedef int64_t __s64;
+
+typedef uint32_t __u32;
+typedef int32_t __s32;
+
+typedef uint16_t __u16;
+typedef int16_t __s16;
+
+typedef uint8_t  __u8;
+typedef int8_t  __s8;
+#else
+#include <linux/types.h>
+#include <linux/socket.h>
+#endif
+
+
+/* controller area network (CAN) kernel definitions */
+
+/* special address description flags for the CAN_ID */
+#define CAN_EFF_FLAG 0x80000000U /* EFF/SFF is set in the MSB */
+#define CAN_RTR_FLAG 0x40000000U /* remote transmission request */
+#define CAN_ERR_FLAG 0x20000000U /* error message frame */
+
+/* valid bits in CAN ID for frame formats */
+#define CAN_SFF_MASK 0x000007FFU /* standard frame format (SFF) */
+#define CAN_EFF_MASK 0x1FFFFFFFU /* extended frame format (EFF) */
+#define CAN_ERR_MASK 0x1FFFFFFFU /* omit EFF, RTR, ERR flags */
+
+/*
+ * Controller Area Network Identifier structure
+ *
+ * bit 0-28	: CAN identifier (11/29 bit)
+ * bit 29	: error message frame flag (0 = data frame, 1 = error message)
+ * bit 30	: remote transmission request flag (1 = rtr frame)
+ * bit 31	: frame format flag (0 = standard 11 bit, 1 = extended 29 bit)
+ */
+typedef __u32 canid_t;
+
+#define CAN_SFF_ID_BITS		11
+#define CAN_EFF_ID_BITS		29
+
+/*
+ * Controller Area Network Error Message Frame Mask structure
+ *
+ * bit 0-28	: error class mask (see include/uapi/linux/can/error.h)
+ * bit 29-31	: set to zero
+ */
+typedef __u32 can_err_mask_t;
+
+/* CAN payload length and DLC definitions according to ISO 11898-1 */
+#define CAN_MAX_DLC 8
+#define CAN_MAX_RAW_DLC 15
+#define CAN_MAX_DLEN 8
+
+/* CAN FD payload length and DLC definitions according to ISO 11898-7 */
+#define CANFD_MAX_DLC 15
+#define CANFD_MAX_DLEN 64
+
+/**
+ * struct can_frame - Classical CAN frame structure (aka CAN 2.0B)
+ * @can_id:   CAN ID of the frame and CAN_*_FLAG flags, see canid_t definition
+ * @len:      CAN frame payload length in byte (0 .. 8)
+ * @can_dlc:  deprecated name for CAN frame payload length in byte (0 .. 8)
+ * @__pad:    padding
+ * @__res0:   reserved / padding
+ * @len8_dlc: optional DLC value (9 .. 15) at 8 byte payload length
+ *            len8_dlc contains values from 9 .. 15 when the payload length is
+ *            8 bytes but the DLC value (see ISO 11898-1) is greater then 8.
+ *            CAN_CTRLMODE_CC_LEN8_DLC flag has to be enabled in CAN driver.
+ * @data:     CAN frame payload (up to 8 byte)
+ */
+struct can_frame {
+	canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
+	union {
+		/* CAN frame payload length in byte (0 .. CAN_MAX_DLEN)
+		 * was previously named can_dlc so we need to carry that
+		 * name for legacy support
+		 */
+		__u8 len;
+		__u8 can_dlc; /* deprecated */
+	} __attribute__((packed)); /* disable padding added in some ABIs */
+	__u8 __pad; /* padding */
+	__u8 __res0; /* reserved / padding */
+	__u8 len8_dlc; /* optional DLC for 8 byte payload length (9 .. 15) */
+	__u8 data[CAN_MAX_DLEN] __attribute__((aligned(8)));
+};
+
+/*
+ * defined bits for canfd_frame.flags
+ *
+ * The use of struct canfd_frame implies the FD Frame (FDF) bit to
+ * be set in the CAN frame bitstream on the wire. The FDF bit switch turns
+ * the CAN controllers bitstream processor into the CAN FD mode which creates
+ * two new options within the CAN FD frame specification:
+ *
+ * Bit Rate Switch - to indicate a second bitrate is/was used for the payload
+ * Error State Indicator - represents the error state of the transmitting node
+ *
+ * As the CANFD_ESI bit is internally generated by the transmitting CAN
+ * controller only the CANFD_BRS bit is relevant for real CAN controllers when
+ * building a CAN FD frame for transmission. Setting the CANFD_ESI bit can make
+ * sense for virtual CAN interfaces to test applications with echoed frames.
+ *
+ * The struct can_frame and struct canfd_frame intentionally share the same
+ * layout to be able to write CAN frame content into a CAN FD frame structure.
+ * When this is done the former differentiation via CAN_MTU / CANFD_MTU gets
+ * lost. CANFD_FDF allows programmers to mark CAN FD frames in the case of
+ * using struct canfd_frame for mixed CAN / CAN FD content (dual use).
+ * N.B. the Kernel APIs do NOT provide mixed CAN / CAN FD content inside of
+ * struct canfd_frame therefore the CANFD_FDF flag is disregarded by Linux.
+ */
+#define CANFD_BRS 0x01 /* bit rate switch (second bitrate for payload data) */
+#define CANFD_ESI 0x02 /* error state indicator of the transmitting node */
+#define CANFD_FDF 0x04 /* mark CAN FD for dual use of struct canfd_frame */
+
+/**
+ * struct canfd_frame - CAN flexible data rate frame structure
+ * @can_id: CAN ID of the frame and CAN_*_FLAG flags, see canid_t definition
+ * @len:    frame payload length in byte (0 .. CANFD_MAX_DLEN)
+ * @flags:  additional flags for CAN FD
+ * @__res0: reserved / padding
+ * @__res1: reserved / padding
+ * @data:   CAN FD frame payload (up to CANFD_MAX_DLEN byte)
+ */
+struct canfd_frame {
+	canid_t can_id;  /* 32 bit CAN_ID + EFF/RTR/ERR flags */
+	__u8    len;     /* frame payload length in byte */
+	__u8    flags;   /* additional flags for CAN FD */
+	__u8    __res0;  /* reserved / padding */
+	__u8    __res1;  /* reserved / padding */
+	__u8    data[CANFD_MAX_DLEN] __attribute__((aligned(8)));
+};
+
+#define CAN_MTU		(sizeof(struct can_frame))
+#define CANFD_MTU	(sizeof(struct canfd_frame))
+
+/* particular protocols of the protocol family PF_CAN */
+#define CAN_RAW		1 /* RAW sockets */
+#define CAN_BCM		2 /* Broadcast Manager */
+#define CAN_TP16	3 /* VAG Transport Protocol v1.6 */
+#define CAN_TP20	4 /* VAG Transport Protocol v2.0 */
+#define CAN_MCNET	5 /* Bosch MCNet */
+#define CAN_ISOTP	6 /* ISO 15765-2 Transport Protocol */
+#define CAN_J1939	7 /* SAE J1939 */
+#define CAN_NPROTO	8
+
+#define SOL_CAN_BASE 100
+
+#if __APPLE__
+#else
+/**
+ * struct sockaddr_can - the sockaddr structure for CAN sockets
+ * @can_family:  address family number AF_CAN.
+ * @can_ifindex: CAN network interface index.
+ * @can_addr:    protocol specific address information
+ */
+struct sockaddr_can {
+	__kernel_sa_family_t can_family;
+	int         can_ifindex;
+	union {
+		/* transport protocol class address information (e.g. ISOTP) */
+		struct { canid_t rx_id, tx_id; } tp;
+
+		/* J1939 address information */
+		struct {
+			/* 8 byte name when using dynamic addressing */
+			__u64 name;
+
+			/* pgn:
+			 * 8 bit: PS in PDU2 case, else 0
+			 * 8 bit: PF
+			 * 1 bit: DP
+			 * 1 bit: reserved
+			 */
+			__u32 pgn;
+
+			/* 1 byte address */
+			__u8 addr;
+		} j1939;
+
+		/* reserved for future CAN protocols address information */
+	} can_addr;
+};
+#endif
+
+/**
+ * struct can_filter - CAN ID based filter in can_register().
+ * @can_id:   relevant bits of CAN ID which are not masked out.
+ * @can_mask: CAN mask (see description)
+ *
+ * Description:
+ * A filter matches, when
+ *
+ *          <received_can_id> & mask == can_id & mask
+ *
+ * The filter can be inverted (CAN_INV_FILTER bit set in can_id) or it can
+ * filter for error message frames (CAN_ERR_FLAG bit set in mask).
+ */
+struct can_filter {
+	canid_t can_id;
+	canid_t can_mask;
+};
+
+#define CAN_INV_FILTER 0x20000000U /* to be set in can_filter.can_id */
+#define CAN_RAW_FILTER_MAX 512 /* maximum number of can_filter set via setsockopt() */
+
+#endif /* !_UAPI_CAN_H */

--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -12,7 +12,11 @@
 // clock times, prioritizes commands, and handles retransmissions.  A
 // background thread is launched to do this work and minimize latency.
 
-#include <linux/can.h> // // struct can_frame
+#if __APPLE__
+#include "linux/can.h" // // struct can_frame
+#else
+#include <linux/can.h> 
+#endif
 #include <math.h> // fabs
 #include <pthread.h> // pthread_mutex_lock
 #include <stddef.h> // offsetof

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math
 
 RTT_AGE = .000010 / (60. * 60.)

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -3,7 +3,9 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import sys, os, glob, re, time, logging, configparser, io
+from __future__ import absolute_import
+import sys, os, glob, re, time, logging, six.moves.configparser \
+    as configparser, io
 
 error = configparser.Error
 

--- a/klippy/console.py
+++ b/klippy/console.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, optparse, os, re, logging
 import util, reactor, serialhdl, pins, msgproto, clocksync
 

--- a/klippy/extras/ad5206.py
+++ b/klippy/extras/ad5206.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2017,2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import bus
 
 class ad5206:

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, bisect
 
 

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, time, collections, threading, multiprocessing, os
 from . import bus, motion_report
 

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2018-2019 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math, json, collections
 from . import probe
 

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import mathutil
 from . import probe

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import probe
 

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import bus
 

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018,2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import mcu
 
 def resolve_bus_name(mcu, param, bus):

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Nils Friedchen <nils.friedchen@googlemail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import fan
 
 PIN_MIN_TIME = 0.100

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import logging
 
 class DelayedGcode:

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2017-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging, collections
 import mathutil
 from . import probe

--- a/klippy/extras/dotstar.py
+++ b/klippy/extras/dotstar.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import bus
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000

--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020 Alan Lord <alanslists@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import mcu
 

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 import stepper
 

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019 Simo Apell <simo.apell@live.fi>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from kinematics import extruder
 

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import pulse_counter
 
 FAN_MIN_TIME = 0.100

--- a/klippy/extras/fan_generic.py
+++ b/klippy/extras/fan_generic.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import fan
 
 class PrinterFanGeneric:

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 Joshua Wherrett <thejoshw.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import filament_switch_sensor
 

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 class RunoutHelper:

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 import chelper
 

--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math
 
 # Coordinates created by this are converted into G1 commands.

--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019 Alec Plumb <alec@etherwalker.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 class GCodeButton:

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import traceback, logging, ast, copy
 import jinja2
 

--- a/klippy/extras/gcode_move.py
+++ b/klippy/extras/gcode_move.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 class GCodeMove:

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Mustafa YILDIZ <mydiz@hotmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import filament_switch_sensor
 
 ADC_REPORT_TIME = 0.500

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import fan
 
 PIN_MIN_TIME = 0.100

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, logging, threading
 
 

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math
 
 HOMING_START_DELAY = 0.001

--- a/klippy/extras/homing_heaters.py
+++ b/klippy/extras/homing_heaters.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import logging
 
 class HomingHeaters:

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Lucio Tarantino <lucio.tarantino@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import bus
 

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 DEFAULT_IDLE_GCODE = """

--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import collections
 import chelper
 from . import shaper_defs

--- a/klippy/extras/lm75.py
+++ b/klippy/extras/lm75.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Boleslaw Ciesielski <combolek@users.noreply.github.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import bus
 

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, bisect
 
 class ManualProbe:

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import stepper, chelper
 from . import force_move
 

--- a/klippy/extras/mcp4451.py
+++ b/klippy/extras/mcp4451.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import bus
 
 WiperRegisters = [0x00, 0x01, 0x06, 0x07]

--- a/klippy/extras/mcp4728.py
+++ b/klippy/extras/mcp4728.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import bus
 
 class mcp4728:

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000

--- a/klippy/extras/palette2.py
+++ b/klippy/extras/palette2.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import logging
 import os
 import serial

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021  Marc-Andre Denis <marcadenis@msn.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import bus
 

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 from . import heaters
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import pins
 from . import manual_probe

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Maks Zolin <mzolin@vorondesign.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import probe, z_tilt
 

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2017-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, os
 import pins, mcu
 from . import bus

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math, os, time
 from . import shaper_calibrate
 

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -4,7 +4,8 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, logging, ast, configparser
+from __future__ import absolute_import
+import os, logging, ast, ConfigParser as configparser
 
 class SaveVariables:
     def __init__(self, config):

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021  Matthew Lloyd <github@matthewlloyd.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math
 from . import probe
 

--- a/klippy/extras/sdcard_loop.py
+++ b/klippy/extras/sdcard_loop.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import logging
 
 class SDCardLoop:

--- a/klippy/extras/shaper_calibrate.py
+++ b/klippy/extras/shaper_calibrate.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import collections, importlib, logging, math, multiprocessing
 shaper_defs = importlib.import_module('.shaper_defs', 'extras')
 

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -9,6 +9,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import math
 
 def calc_skew_factor(ac, bd, ad):

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math
 from . import bus
 

--- a/klippy/extras/statistics.py
+++ b/klippy/extras/statistics.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, time, logging
 
 class PrinterSysStats:

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 DISABLE_STALL_TIME = 0.100

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Florian Heilmann <Florian.Heilmann@gmx.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import pins
 from . import bus
 

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import fan
 
 KELVIN_TO_CELSIUS = -273.15

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from __future__ import absolute_import
 import logging
 
 HOST_REPORT_TIME = 1.0

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import mcu
 

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 from . import adc_temperature
 

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, collections
 import stepper
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 from . import bus, tmc
 

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 from . import tmc, tmc_uart, tmc2130
 

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Stephan Oelze <stephan.oelze@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 from . import tmc2208, tmc2130, tmc, tmc_uart
 
 TMC_FREQUENCY=12000000.

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 from . import bus, tmc, tmc2130
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 from . import bus, tmc, tmc2130
 

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 

--- a/klippy/extras/tuning_tower.py
+++ b/klippy/extras/tuning_tower.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 
 CANCEL_Z_DELTA=2.0

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 
 HINT_THERMAL = """

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, logging
 
 VALID_GCODE_EXTS = ['gcode', 'g', 'gco']

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import mathutil
 from . import probe

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, re, logging, collections, shlex
 
 class CommandError(Exception):

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import stepper
 

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math
 import stepper
 

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Maks Zolin <mzolin@vorondesign.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math
 import stepper
 

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 import stepper, mathutil
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2022  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 import stepper, chelper
 

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import stepper
 from . import idex_modes

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging
 import stepper
 from . import idex_modes

--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021  Fabrice Gallet <tircown@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math
 
 class DualCarriages:

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, math
 import stepper
 

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging
 import stepper, mathutil, chelper
 

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import stepper, mathutil
 
 class WinchKinematics:

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, gc, optparse, logging, time, collections, importlib
 import util, reactor, queuelogger, msgproto
 import gcode, configfile, pins, mcu, toolhead, webhooks

--- a/klippy/mathutil.py
+++ b/klippy/mathutil.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging, multiprocessing, traceback
 import queuelogger
 

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, zlib, logging, math
 import serialhdl, msgproto, pins, chelper, clocksync
 

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import json, zlib, logging
 
 DefaultMessages = {

--- a/klippy/parsedump.py
+++ b/klippy/parsedump.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, sys, logging
 import msgproto
 

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import re
 
 class error(Exception):

--- a/klippy/queuelogger.py
+++ b/klippy/queuelogger.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, logging.handlers, threading, queue, time
 
 # Class to forward all messages through a queue to a background thread

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os, gc, select, math, time, logging, queue
 import greenlet
 import chelper, util

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import logging, threading, os
 import serial
 

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -3,8 +3,10 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging, collections
 import chelper
+from six.moves import range
 
 class error(Exception):
     pass

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -3,8 +3,10 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, logging, importlib
 import mcu, chelper, kinematics.extruder
+from six.moves import range
 
 # Common suffixes: _d is distance (in mm), _v is velocity (in
 #   mm/second), _v2 is velocity squared (mm^2/s^2), _t is time (in

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, pty, fcntl, termios, signal, logging, json, time
 import subprocess, traceback, shlex
 

--- a/lib/kconfiglib/genconfig.py
+++ b/lib/kconfiglib/genconfig.py
@@ -32,6 +32,7 @@ See https://www.gnu.org/software/make/manual/make.html#Multi_002dLine for a
 handy way to define multi-line variables in makefiles, for use with custom
 headers. Remember to export the variable to the environment.
 """
+from __future__ import absolute_import
 import argparse
 import os
 import sys

--- a/lib/kconfiglib/kconfiglib.py
+++ b/lib/kconfiglib/kconfiglib.py
@@ -543,6 +543,8 @@ Feedback
 Send bug reports, suggestions, and questions to ulfalizer a.t Google's email
 service, or open a ticket on the GitHub page.
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import errno
 import importlib
 import os
@@ -6263,17 +6265,17 @@ def load_allconfig(kconf, filename):
 
     if allconfig in ("", "1"):
         try:
-            print(kconf.load_config(filename, False))
+            print((kconf.load_config(filename, False)))
         except EnvironmentError as e1:
             try:
-                print(kconf.load_config("all.config", False))
+                print((kconf.load_config("all.config", False)))
             except EnvironmentError as e2:
                 sys.exit("error: KCONFIG_ALLCONFIG is set, but neither {} "
                          "nor all.config could be opened: {}, {}"
                          .format(filename, std_msg(e1), std_msg(e2)))
     else:
         try:
-            print(kconf.load_config(allconfig, False))
+            print((kconf.load_config(allconfig, False)))
         except EnvironmentError as e:
             sys.exit("error: KCONFIG_ALLCONFIG is set to '{}', which "
                      "could not be opened: {}"
@@ -6763,7 +6765,7 @@ def _lineno_fn(kconf, _):
 
 
 def _info_fn(kconf, _, msg):
-    print("{}:{}: {}".format(kconf.filename, kconf.linenr, msg))
+    print(("{}:{}: {}".format(kconf.filename, kconf.linenr, msg)))
 
     return ""
 

--- a/lib/kconfiglib/menuconfig.py
+++ b/lib/kconfiglib/menuconfig.py
@@ -185,6 +185,7 @@ See the https://github.com/zephyrproject-rtos/windows-curses repository.
 """
 from __future__ import print_function
 
+from __future__ import absolute_import
 import os
 import sys
 

--- a/lib/kconfiglib/olddefconfig.py
+++ b/lib/kconfiglib/olddefconfig.py
@@ -15,13 +15,15 @@ passed in the KCONFIG_CONFIG environment variable.
 When overwriting a configuration file, the old version is saved to
 <filename>.old (e.g. .config.old).
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import kconfiglib
 
 
 def main():
     kconf = kconfiglib.standard_kconfig(__doc__)
-    print(kconf.load_config())
-    print(kconf.write_config())
+    print((kconf.load_config()))
+    print((kconf.write_config()))
 
 
 if __name__ == "__main__":

--- a/scripts/avrsim.py
+++ b/scripts/avrsim.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2015-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, optparse, time, os, pty, fcntl, termios, errno
 import pysimulavr
 

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, subprocess, optparse, logging, shlex, socket, time, traceback
 import json, zlib
 sys.path.append('./klippy')

--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, optparse, time
 import can
 

--- a/scripts/check_whitespace.py
+++ b/scripts/check_whitespace.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os.path, unicodedata
 
 HaveError = False

--- a/scripts/checkstack.py
+++ b/scripts/checkstack.py
@@ -9,6 +9,8 @@
 # Usage:
 #   avr-objdump -d out/klipper.elf | scripts/checkstack.py
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import re
 
@@ -180,7 +182,7 @@ def main():
             elif insn in ('rcall', 'call'):
                 cur.noteCall(insnaddr, calladdr, stackusage + 2)
             else:
-                print("unknown call", ref)
+                print(("unknown call", ref))
                 cur.noteCall(insnaddr, calladdr, stackusage)
         # Reset stack usage to preamble usage
         stackusage = cur.basic_stack_usage
@@ -227,17 +229,17 @@ def main():
         yieldstr = ""
         if info.max_yield_usage >= 0:
             yieldstr = ",%d" % info.max_yield_usage
-        print("\n%s[%d,%d%s]:" % (info.funcname, info.basic_stack_usage
-                                  , info.max_stack_usage, yieldstr))
+        print(("\n%s[%d,%d%s]:" % (info.funcname, info.basic_stack_usage
+                                  , info.max_stack_usage, yieldstr)))
         for insnaddr, calladdr, stackusage in info.called_funcs:
             callinfo = funcs.get(calladdr, unknownfunc)
             yieldstr = ""
             if callinfo.max_yield_usage >= 0:
                 yieldstr = ",%d" % (stackusage + callinfo.max_yield_usage)
-            print("    %04s:%-40s [%d+%d,%d%s]" % (
+            print(("    %04s:%-40s [%d+%d,%d%s]" % (
                 insnaddr, callinfo.funcname, stackusage
                 , callinfo.basic_stack_usage
-                , stackusage+callinfo.max_stack_usage, yieldstr))
+                , stackusage+callinfo.max_stack_usage, yieldstr)))
 
 if __name__ == '__main__':
     main()

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -55,7 +55,7 @@ fi
 echo -e "\n\n=============== Install python3 virtualenv\n\n"
 cd ${MAIN_DIR}
 virtualenv -p python3 ${BUILD_DIR}/python-env
-${BUILD_DIR}/python-env/bin/pip install -r ${MAIN_DIR}/scripts/klippy-requirements.txt
+${BUILD_DIR}/python-env/bin/pip3 install -r ${MAIN_DIR}/scripts/klippy-requirements.txt
 
 
 ######################################################################
@@ -65,4 +65,4 @@ ${BUILD_DIR}/python-env/bin/pip install -r ${MAIN_DIR}/scripts/klippy-requiremen
 echo -e "\n\n=============== Install python2 virtualenv\n\n"
 cd ${MAIN_DIR}
 virtualenv -p python2 ${BUILD_DIR}/python2-env
-${BUILD_DIR}/python2-env/bin/pip install -r ${MAIN_DIR}/scripts/klippy-requirements.txt
+${BUILD_DIR}/python2-env/bin/pip3 install -r ${MAIN_DIR}/scripts/klippy-requirements.txt

--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, re, subprocess, optparse, time, fcntl, termios, struct
 
 class error(Exception):

--- a/scripts/graph_accelerometer.py
+++ b/scripts/graph_accelerometer.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import importlib, optparse, os, sys
 from textwrap import wrap
 import numpy as np, matplotlib

--- a/scripts/graph_extruder.py
+++ b/scripts/graph_extruder.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import math, optparse, datetime
 import matplotlib
 

--- a/scripts/graph_motion.py
+++ b/scripts/graph_motion.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import optparse, datetime, math
 import matplotlib
 

--- a/scripts/graph_shaper.py
+++ b/scripts/graph_shaper.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import optparse, math
 import matplotlib
 

--- a/scripts/graph_temp_sensor.py
+++ b/scripts/graph_temp_sensor.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, optparse
 import matplotlib
 

--- a/scripts/graphstats.py
+++ b/scripts/graphstats.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import optparse, datetime
 import matplotlib
 

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -38,7 +38,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv2 ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+    ${PYTHONDIR}/bin/pip3 install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 
 # Step 3: Install startup script

--- a/scripts/install-centos.sh
+++ b/scripts/install-centos.sh
@@ -34,7 +34,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+    ${PYTHONDIR}/bin/pip3 install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 
 # Step 3: Install startup script

--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -40,7 +40,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+    ${PYTHONDIR}/bin/pip3 install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 
 # Step 3: Install startup script

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -37,7 +37,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+    ${PYTHONDIR}/bin/pip3 install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 
 # Step 3: Install startup script

--- a/scripts/install-ubuntu-18.04.sh
+++ b/scripts/install-ubuntu-18.04.sh
@@ -39,7 +39,7 @@ create_virtualenv()
     [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+    ${PYTHONDIR}/bin/pip3 install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 
 # Step 3: Install startup script

--- a/scripts/logextract.py
+++ b/scripts/logextract.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2017  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, re, collections, ast
 
 def format_comment(line_num, line):

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+from __future__ import absolute_import
 import argparse
 import os
 import sys

--- a/scripts/spi_flash/fatfs_lib.py
+++ b/scripts/spi_flash/fatfs_lib.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import os
 import sys
 KLIPPER_DIR = os.path.abspath(os.path.join(

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys
 import argparse
 import os

--- a/scripts/stepstats.py
+++ b/scripts/stepstats.py
@@ -4,6 +4,8 @@
 # Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
+from __future__ import print_function
 import optparse
 
 def main():
@@ -33,8 +35,8 @@ def main():
             so[2] += 1
             so[{'0': 3, '1': 4}[so[1]]] += int(args['count'])
     for oid, so in sorted([(int(i[0]), i[1]) for i in steppers.items()]):
-        print "oid:%3d dir_cmds:%6d queue_cmds:%7d (%8d -%8d = %8d)" % (
-            oid, so[0], so[2], so[4], so[3], so[4]-so[3])
+        print("oid:%3d dir_cmds:%6d queue_cmds:%7d (%8d -%8d = %8d)" % (
+            oid, so[0], so[2], so[4], so[3], so[4]-so[3]))
 
 if __name__ == '__main__':
     main()

--- a/scripts/test_klippy.py
+++ b/scripts/test_klippy.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, optparse, logging, subprocess
 
 TEMP_GCODE_FILE = "_test_.gcode"

--- a/scripts/update_chitu.py
+++ b/scripts/update_chitu.py
@@ -5,6 +5,8 @@
 # Copied from Marlin and modified.
 # Licensed under GPL-3.0
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import struct
 import uuid
@@ -90,7 +92,7 @@ def encode_file(input, output_file, file_length):
 
     #TODO - how to enforce that the firmware aligns to block boundaries?
     block_count = int(len(input_file) / block_size)
-    print("Block Count is ", block_count)
+    print(("Block Count is ", block_count))
     for block_number in range(0, block_count):
         block_offset = (block_number * block_size)
         block_end = block_offset + block_size
@@ -118,7 +120,7 @@ def main():
 
     if not os.path.isfile(fw):
         print("Usage: update_chitu <input_file> <output_file>")
-        print("Firmware file", fw, "does not exist")
+        print(("Firmware file", fw, "does not exist"))
         exit(1)
 
     firmware = open(fw, "rb")

--- a/scripts/update_mks_robin.py
+++ b/scripts/update_mks_robin.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import optparse
 
 XOR_PATTERN = [

--- a/scripts/whconsole.py
+++ b/scripts/whconsole.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import absolute_import
 import sys, os, optparse, socket, fcntl, select, json, errno, time
 
 # Set a file-descriptor as non-blocking


### PR DESCRIPTION
Added a header file (from linux) to aide in building of tests on mac.  Added pre-compiler switches to use said file with its adjustments for mac only on __APPLE__ builds.

Made the minimal changes to allow Klipper to run on Python3.  It passes all tests provided in repo thus far.

Note mac users:  Your environment must be adjusted such that /usr/bin/gcc and /usr/bin/g++ link to /usr/local/bin/gcc-11 and /usr/local/bin/g++-11 for this repo to build cleanly with compiler installed from homebrew. (SIP must be disabled so you can modify 'system' file system too ... or, adjust your path variables, possibly).