### PR TITLE
Update Resonance_Compensation.md to recommend SET_VELOCITY_LIMIT

### DIFF
--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -23,9 +23,8 @@ of the stealthChop mode of Trinamic stepper drivers.
 
 ## Tuning
 
-Basic tuning requires measuring the ringing frequencies of the printer and
-adding a few parameters to `printer.cfg` file.
-
+Basic tuning requires measuring the ringing frequencies of the printer
+by printing a test model.
 
 Slice the ringing test model, which can be found in
 [docs/prints/ringing_tower.stl](prints/ringing_tower.stl), in the slicer:
@@ -45,31 +44,28 @@ Slice the ringing test model, which can be found in
 
 First, measure the **ringing frequency**.
 
-1. Increase `max_accel` and `max_accel_to_decel` parameters in your
-   `printer.cfg` to 7000. Note that this is only needed for tuning, and more
-   proper value will be selected in the corresponding
-   [section](#selecting-max_accel).
-2. If `square_corner_velocity` parameter was changed, revert it back to 5.0.
-   It is not advised to increase it when using the input shaper because it can
-   cause more smoothing in parts - it is better to use higher acceleration
-   value instead.
-3. Restart the firmware: `RESTART`.
-4. Disable Pressure Advance: `SET_PRESSURE_ADVANCE ADVANCE=0`.
-5. If you have already added `[input_shaper]` section to the printer.cfg,
+1. If `square_corner_velocity` parameter was changed, revert it back
+   to 5.0. It is not advised to increase it when using input shaper
+   because it can cause more smoothing in parts - it is better to use
+   higher acceleration value instead.
+2. Increase `max_accel_to_decel` by issuing the following command:
+   `SET_VELOCITY_LIMIT ACCEL_TO_DECEL=7000`
+3. Disable Pressure Advance: `SET_PRESSURE_ADVANCE ADVANCE=0`
+4. If you have already added `[input_shaper]` section to the printer.cfg,
    execute `SET_INPUT_SHAPER SHAPER_FREQ_X=0 SHAPER_FREQ_Y=0` command. If you
    get "Unknown command" error, you can safely ignore it at this point and
    continue with the measurements.
-6. Execute the command
-   `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
+5. Execute the command:
+   `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
    Basically, we try to make ringing more pronounced by setting different large
    values for acceleration. This command will increase the acceleration every
    5 mm starting from 1500 mm/sec^2: 1500 mm/sec^2, 2000 mm/sec^2, 2500 mm/sec^2
    and so forth up until 7000 mm/sec^2 at the last band.
-7. Print the test model sliced with the suggested parameters.
-8. You can stop the print earlier if the ringing is clearly visible and you see
+6. Print the test model sliced with the suggested parameters.
+7. You can stop the print earlier if the ringing is clearly visible and you see
    that acceleration gets too high for your printer (e.g. printer shakes too
    much or starts skipping steps).
-9. Use X and Y marks at the back of the model for reference. The measurements
+8. Use X and Y marks at the back of the model for reference. The measurements
    from the side with X mark should be used for X axis *configuration*, and
    Y mark - for Y axis configuration. Measure the distance *D* (in mm) between
    several oscillations on the part with X mark, near the notches, preferably
@@ -79,14 +75,14 @@ First, measure the **ringing frequency**.
 
     |![Mark ringing](img/ringing-mark.jpg)|![Measure ringing](img/ringing-measure.jpg)|
 
-10. Count how many oscillations *N* the measured distance *D* corresponds to.
-    If you are unsure how to count the oscillations, refer to the picture
-    above, which shows *N* = 6 oscillations.
-11. Compute the ringing frequency of X axis as *V* &middot; *N* / *D* (Hz),
+9. Count how many oscillations *N* the measured distance *D* corresponds to.
+   If you are unsure how to count the oscillations, refer to the picture
+   above, which shows *N* = 6 oscillations.
+10. Compute the ringing frequency of X axis as *V* &middot; *N* / *D* (Hz),
     where *V* is the velocity for outer perimeters (mm/sec). For the example
     above, we marked 6 oscillations, and the test was printed at 100 mm/sec
     velocity, so the frequency is 100 * 6 / 12.14 ≈ 49.4 Hz.
-12. Do (9) - (11) for Y mark as well.
+11. Do (8) - (10) for Y mark as well.
 
 Note that ringing on the test print should follow the pattern of the curved
 notches, as in the picture above. If it doesn't, then this defect is not really
@@ -150,16 +146,15 @@ For most of the printers, either MZV or EI shapers can be recommended. This
 section describes a testing process to choose between them, and figure out
 a few other related parameters.
 
-Print the ringing test model as follows (assuming you already have
-shaper_freq_x/y set and max_accel/max_accel_to_decel increased to 7000 in
-printer.cfg file):
+Print the ringing test model as follows:
 
-1. Restart the firmware: `RESTART`.
-2. Disable Pressure Advance: `SET_PRESSURE_ADVANCE ADVANCE=0`.
-3. Execute `SET_INPUT_SHAPER SHAPER_TYPE=MZV`.
-4. Execute the command
-   `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
-5. Print the test model sliced with the suggested parameters.
+1. Restart the firmware: `RESTART`
+2. Prepare for test: `SET_VELOCITY_LIMIT ACCEL_TO_DECEL=7000`
+3. Disable Pressure Advance: `SET_PRESSURE_ADVANCE ADVANCE=0`
+4. Execute: `SET_INPUT_SHAPER SHAPER_TYPE=MZV`
+5. Execute the command:
+   `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
+6. Print the test model sliced with the suggested parameters.
 
 If you see no ringing at this point, then MZV shaper can be recommended for use.
 
@@ -169,8 +164,8 @@ differ significantly from the values you obtained earlier, a more complex input
 shaper configuration is needed. You can refer to Technical details of
 [Input shapers](#input-shapers) section. Otherwise, proceed to the next step.
 
-Now try EI input shaper. To try it, repeat steps (1)-(5) from above, but
-executing at step 3 the following command instead:
+Now try EI input shaper. To try it, repeat steps (1)-(6) from above, but
+executing at step 4 the following command instead:
 `SET_INPUT_SHAPER SHAPER_TYPE=EI`.
 
 Compare two prints with MZV and EI input shaper. If EI shows noticeably better
@@ -207,7 +202,7 @@ You should have a printed test for the shaper you chose from the previous step
 (if you don't, print the test model sliced with the
 [suggested parameters](#tuning) with the pressure advance disabled
 `SET_PRESSURE_ADVANCE ADVANCE=0` and with the tuning tower enabled as
-`TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`).
+`TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`).
 Note that at very high accelerations, depending on the resonance frequency and
 the input shaper you chose (e.g. EI shaper creates more smoothing than MZV),
 input shaping may cause too much smoothing and rounding of the parts. So,
@@ -242,8 +237,7 @@ It may also be a result of a miscalibrated (too high) filament flow, so it is
 a good idea to check that too.
 
 Choose the minimum out of the two acceleration values (from ringing and
-smoothing), and put it as max_accel into printer.cfg (you can delete
-max_accel_to_decel or revert it to the old value).
+smoothing), and put it as `max_accel` into printer.cfg.
 
 
 As a note, it may happen - especially at low ringing frequencies - that EI
@@ -273,29 +267,29 @@ your choice with the same frequencies as you have measured earlier), you can
 follow the steps in this section. Note that if you see ringing at different
 frequencies after enabling [input_shaper], this section will not help with that.
 
-Assuming that you have sliced the ringing model with suggested parameters and
-increased `max_accel` and `max_accel_to_decel` parameters in the `printer.cfg`
-to 7000 already, complete the following steps for each of the axes X and Y:
+Assuming that you have sliced the ringing model with suggested
+parameters, complete the following steps for each of the axes X and Y:
 
-1. Make sure Pressure Advance is disabled: `SET_PRESSURE_ADVANCE ADVANCE=0`.
-2. Execute `SET_INPUT_SHAPER SHAPER_TYPE=ZV`.
-3. From the existing ringing test model with your chosen input shaper select
+1. Prepare for test: `SET_VELOCITY_LIMIT ACCEL_TO_DECEL=7000`
+2. Make sure Pressure Advance is disabled: `SET_PRESSURE_ADVANCE ADVANCE=0`
+3. Execute: `SET_INPUT_SHAPER SHAPER_TYPE=ZV`
+4. From the existing ringing test model with your chosen input shaper select
    the acceleration that shows ringing sufficiently well, and set it with:
-   `SET_VELOCITY_LIMIT ACCEL=...`.
-4. Calculate the necessary parameters for the `TUNING_TOWER` command to tune
+   `SET_VELOCITY_LIMIT ACCEL=...`
+5. Calculate the necessary parameters for the `TUNING_TOWER` command to tune
    `shaper_freq_x` parameter as follows: start = shaper_freq_x * 83 / 132 and
    factor = shaper_freq_x / 66, where `shaper_freq_x` here is the current value
    in `printer.cfg`.
-5. Execute the command
+6. Execute the command:
    `TUNING_TOWER COMMAND=SET_INPUT_SHAPER PARAMETER=SHAPER_FREQ_X START=start FACTOR=factor BAND=5`
-   using `start` and `factor` values calculated at step (4).
-6. Print the test model.
-7. Reset the original frequency value:
+   using `start` and `factor` values calculated at step (5).
+7. Print the test model.
+8. Reset the original frequency value:
    `SET_INPUT_SHAPER SHAPER_FREQ_X=...`.
-8. Find the band which shows ringing the least and count its number from the
+9. Find the band which shows ringing the least and count its number from the
    bottom starting at 1.
-9. Calculate the new shaper_freq_x value via old
-   shaper_freq_x * (39 + 5 * #band-number) / 66.
+10. Calculate the new shaper_freq_x value via old
+    shaper_freq_x * (39 + 5 * #band-number) / 66.
 
 Repeat these steps for the Y axis in the same manner, replacing references to X
 axis with the axis Y (e.g. replace `shaper_freq_x` with `shaper_freq_y` in
@@ -312,16 +306,12 @@ After both new `shaper_freq_x` and `shaper_freq_y` parameters have been
 calculated, you can update `[input_shaper]` section in `printer.cfg` with the
 new `shaper_freq_x` and `shaper_freq_y` values.
 
-Do not forget to revert the changes to `max_accel` and `max_accel_to_decel`
-parameters in the `printer.cfg` after finishing this section.
-
 ### Pressure Advance
 
 If you use Pressure Advance, it may need to be re-tuned. Follow the
-[instructions](Pressure_Advance.md#tuning-pressure-advance) to find the
-new value, if it differs from the previous one. Make sure to restore the
-original values of `max_accel` and `max_accel_to_decel` parameters in the
-`printer.cfg` and restart Klipper before tuning Pressure Advance.
+[instructions](Pressure_Advance.md#tuning-pressure-advance) to find
+the new value, if it differs from the previous one. Make sure to
+restart Klipper before tuning Pressure Advance.
 
 ### Unreliable measurements of ringing frequencies
 
@@ -335,26 +325,26 @@ accelerometer and measure the resonances with it (refer to the
 process) - but this option requires some crimping and soldering.
 
 
-For tuning, add empty `[input_shaper]` section to your `printer.cfg`. Then,
-assuming that you have sliced the ringing model with suggested parameters and
-increased `max_accel` and `max_accel_to_decel` parameters in the `printer.cfg`
-to 7000 already, print the test model 3 times as follows. First time, prior to
-printing, run
+For tuning, add empty `[input_shaper]` section to your
+`printer.cfg`. Then, assuming that you have sliced the ringing model
+with suggested parameters, print the test model 3 times as
+follows. First time, prior to printing, run
 
 1. `RESTART`
-2. `SET_PRESSURE_ADVANCE ADVANCE=0`.
-3. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=60 SHAPER_FREQ_Y=60`.
-4. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
+2. `SET_VELOCITY_LIMIT ACCEL_TO_DECEL=7000`
+3. `SET_PRESSURE_ADVANCE ADVANCE=0`
+4. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=60 SHAPER_FREQ_Y=60`
+5. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
 
 and print the model. Then print the model again, but before printing run instead
 
-1. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=50 SHAPER_FREQ_Y=50`.
-2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
+1. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=50 SHAPER_FREQ_Y=50`
+2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
 
 Then print the model for the 3rd time, but now run
 
-1. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=40 SHAPER_FREQ_Y=40`.
-2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
+1. `SET_INPUT_SHAPER SHAPER_TYPE=2HUMP_EI SHAPER_FREQ_X=40 SHAPER_FREQ_Y=40`
+2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
 
 Essentially, we are printing the ringing test model with TUNING_TOWER using
 2HUMP_EI shaper with shaper_freq = 60 Hz, 50 Hz, and 40 Hz.
@@ -377,8 +367,8 @@ frequency based on the frequency of 2HUMP_EI shaper you chose:
 
 Now print the test model one more time, running
 
-1. `SET_INPUT_SHAPER SHAPER_TYPE=EI SHAPER_FREQ_X=... SHAPER_FREQ_Y=...`.
-2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1250 FACTOR=100 BAND=5`.
+1. `SET_INPUT_SHAPER SHAPER_TYPE=EI SHAPER_FREQ_X=... SHAPER_FREQ_Y=...`
+2. `TUNING_TOWER COMMAND=SET_VELOCITY_LIMIT PARAMETER=ACCEL START=1500 STEP_DELTA=500 STEP_HEIGHT=5`
 
 providing the shaper_freq_x=... and shaper_freq_y=... as determined previously.
 


### PR DESCRIPTION
I noticed that Resonance_Compensation.md was still recommending updating the printer.cfg file to set max_accel=7000.  It's simpler to make all those adjustments by issuing a `SET_VELOCITY_LIMIT` command.  This PR updates the document.

@dmbutyugin - FYI.

-Kevin