### PR TITLE
flash_usb: use sudo for rp2040 flashing

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -163,7 +163,7 @@ def flash_atsamd(options, binfile):
         sys.exit(-1)
 
 # Look for an rp2040 and flash it with rp2040_flash.
-def rp2040_flash(devpath, binfile):
+def rp2040_flash(devpath, binfile, sudo):
     args = ["lib/rp2040_flash/rp2040_flash", binfile]
     if len(devpath) > 0:
         with open(devpath + "/busnum") as f:
@@ -172,6 +172,8 @@ def rp2040_flash(devpath, binfile):
             addr = f.read().strip()
         args += [bus, addr]
     sys.stderr.write(" ".join(args) + '\n\n')
+    if sudo:
+        args.insert(0, "sudo")
     res = subprocess.call(args)
     if res != 0:
         raise error("Error running rp2040_flash")
@@ -268,7 +270,7 @@ device as a usb drive, and copy klipper.uf2 to the device.
 def flash_rp2040(options, binfile):
     try:
         if options.device.lower() == "first":
-            rp2040_flash("", binfile)
+            rp2040_flash("", binfile, options.sudo)
             return
 
         buspath, devpath = translate_serial_to_usb_path(options.device)
@@ -276,7 +278,7 @@ def flash_rp2040(options, binfile):
         devpath = os.path.dirname(devpath)
         enter_bootloader(options.device)
         wait_path(devpath)
-        rp2040_flash(devpath, binfile)
+        rp2040_flash(devpath, binfile, options.sudo)
 
     except error as e:
         sys.stderr.write(RP2040_HELP % (options.device, str(e)))

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -51,4 +51,4 @@ lib/rp2040_flash/rp2040_flash:
 # Flash rules
 flash: $(OUT)klipper.uf2 lib/rp2040_flash/rp2040_flash
 	@echo "  Flashing $< to $(FLASH_DEVICE)"
-	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(OUT)klipper.uf2
+	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(if $(NOSUDO),--no-sudo) $(OUT)klipper.uf2


### PR DESCRIPTION
The rp2040 can be flashed without sudo when using udev rules to give the user permission, but in a standard configuration sudo is required.

Here we make it possible for flash_usb to use sudo for the rp2040 target, and make it the default when using `make flash` for the rp2040. As for other targets, one can set `NOSUDO=1` to not call through sudo.

When I did the `make flash` support I was using a machine with udev rules, and thus never noticed that root is required in the common case.