### PR TITLE
DS18B20: Optionally allow read errors

### DIFF
--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -10,6 +10,7 @@ DS18_REPORT_TIME = 3.0
 # Temperature can be sampled at any time but conversion time is ~750ms, so
 # setting the time too low will not make the reports come faster.
 DS18_MIN_REPORT_TIME = 1.0
+DS18_MAX_CONSECUTIVE_ERRORS = 4
 
 
 class DS18B20:
@@ -31,7 +32,10 @@ class DS18B20:
 
     def _build_config(self):
         sid = "".join(["%02x" % (x,) for x in self.sensor_id])
-        self._mcu.add_config_cmd("config_ds18b20 oid=%d serial=%s" % (self.oid, sid))
+        self._mcu.add_config_cmd(
+            "config_ds18b20 oid=%d serial=%s"
+            " max_error_count=%d" % (self.oid, sid, DS18_MAX_CONSECUTIVE_ERRORS)
+        )
 
         clock = self._mcu.get_query_slot(self.oid)
         self._report_clock = self._mcu.seconds_to_clock(self.report_time)
@@ -51,7 +55,9 @@ class DS18B20:
     def _handle_ds18b20_response(self, params):
         temp = params["value"] / 1000.0
 
-        if temp < self.min_temp or temp > self.max_temp:
+        if params["fault"] != 0:
+            temp = 0  # read error! report 0C and don't check temp range
+        elif temp < self.min_temp or temp > self.max_temp:
             self.printer.invoke_shutdown(
                 "DS18B20 temperature %0.1f outside range of %0.1f:%.01f"
                 % (temp, self.min_temp, self.max_temp)

--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -11,6 +11,7 @@ DS18_REPORT_TIME = 3.0
 # setting the time too low will not make the reports come faster.
 DS18_MIN_REPORT_TIME = 1.0
 
+
 class DS18B20:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -19,39 +20,46 @@ class DS18B20:
         self.temp = self.min_temp = self.max_temp = 0.0
         self._report_clock = 0
         self.report_time = config.getfloat(
-            'ds18_report_time',
-            DS18_REPORT_TIME,
-            minval=DS18_MIN_REPORT_TIME
+            "ds18_report_time", DS18_REPORT_TIME, minval=DS18_MIN_REPORT_TIME
         )
-        self._mcu = mcu.get_printer_mcu(self.printer, config.get('sensor_mcu'))
+        self._mcu = mcu.get_printer_mcu(self.printer, config.get("sensor_mcu"))
         self.oid = self._mcu.create_oid()
-        self._mcu.register_response(self._handle_ds18b20_response,
-            "ds18b20_result", self.oid)
+        self._mcu.register_response(
+            self._handle_ds18b20_response, "ds18b20_result", self.oid
+        )
         self._mcu.register_config_callback(self._build_config)
 
     def _build_config(self):
         sid = "".join(["%02x" % (x,) for x in self.sensor_id])
-        self._mcu.add_config_cmd("config_ds18b20 oid=%d serial=%s"
-                                 % (self.oid, sid))
+        self._mcu.add_config_cmd("config_ds18b20 oid=%d serial=%s" % (self.oid, sid))
 
         clock = self._mcu.get_query_slot(self.oid)
         self._report_clock = self._mcu.seconds_to_clock(self.report_time)
-        self._mcu.add_config_cmd("query_ds18b20 oid=%d clock=%u rest_ticks=%u"
-            " min_value=%d max_value=%d" % (
-                self.oid, clock, self._report_clock,
-                self.min_temp * 1000, self.max_temp * 1000), is_init=True)
+        self._mcu.add_config_cmd(
+            "query_ds18b20 oid=%d clock=%u rest_ticks=%u"
+            " min_value=%d max_value=%d"
+            % (
+                self.oid,
+                clock,
+                self._report_clock,
+                self.min_temp * 1000,
+                self.max_temp * 1000,
+            ),
+            is_init=True,
+        )
 
     def _handle_ds18b20_response(self, params):
-        temp = params['value'] / 1000.0
+        temp = params["value"] / 1000.0
 
         if temp < self.min_temp or temp > self.max_temp:
             self.printer.invoke_shutdown(
                 "DS18B20 temperature %0.1f outside range of %0.1f:%.01f"
-                % (temp, self.min_temp, self.max_temp))
+                % (temp, self.min_temp, self.max_temp)
+            )
 
-        next_clock      = self._mcu.clock32_to_clock64(params['next_clock'])
+        next_clock = self._mcu.clock32_to_clock64(params["next_clock"])
         last_read_clock = next_clock - self._report_clock
-        last_read_time  = self._mcu.clock_to_print_time(last_read_clock)
+        last_read_time = self._mcu.clock_to_print_time(last_read_clock)
         self._callback(last_read_time, temp)
 
     def setup_minmax(self, min_temp, max_temp):
@@ -69,8 +77,9 @@ class DS18B20:
 
     def get_status(self, eventtime):
         return {
-            'temperature': round(self.temp, 2),
+            "temperature": round(self.temp, 2),
         }
+
 
 def load_config(config):
     # Register sensor

--- a/src/linux/sensor_ds18b20.c
+++ b/src/linux/sensor_ds18b20.c
@@ -181,7 +181,8 @@ fail4:
 fail5:
     shutdown("Could not start DS18B20 reader thread");
 }
-DECL_COMMAND(command_config_ds18b20, "config_ds18b20 oid=%c serial=%*s");
+DECL_COMMAND(command_config_ds18b20,
+             "config_ds18b20 oid=%c serial=%*s");
 
 void
 command_query_ds18b20(uint32_t *args)

--- a/src/linux/sensor_ds18b20.c
+++ b/src/linux/sensor_ds18b20.c
@@ -13,7 +13,6 @@
 #include <time.h> // clock_gettime
 #include "basecmd.h" // oid_alloc
 #include "board/irq.h" // irq_disable
-#include "board/misc.h" // output
 #include "command.h" // DECL_COMMAND
 #include "internal.h" // report_errno
 #include "sched.h" // DECL_SHUTDOWN
@@ -51,17 +50,23 @@ struct ds18_s {
     int temperature;
     struct timespec request_time;
     uint8_t status;
-    const char* error;
+    uint8_t error_count;
+    uint8_t max_error_count;
 };
 
-// Lock ds18_s mutex, set error status and message, unlock mutex.
+// Lock ds18_s mutex, set error status, unlock mutex.
 static void
-locking_set_read_error(struct ds18_s *d, const char *error)
+locking_handle_read_error(struct ds18_s *d)
 {
     pthread_mutex_lock(&d->lock);
-    d->error = error;
     d->status = W1_ERROR;
-    pthread_mutex_unlock(&d->lock);
+    d->error_count++;
+    if (d->error_count <= d->max_error_count) {
+        pthread_mutex_unlock(&d->lock);
+    } else {
+        pthread_mutex_unlock(&d->lock);
+        pthread_exit(NULL);
+    }
 }
 
 // The kernel interface to DS18B20 sensors is a sysfs entry that blocks for
@@ -89,15 +94,14 @@ reader_start_routine(void *param) {
         int ret = read(d->fd, data, sizeof(data)-1);
         if (ret < 0) {
             report_errno("read DS18B20", ret);
-            locking_set_read_error(d, "Unable to read DS18B20");
-            pthread_exit(NULL);
+            locking_handle_read_error(d);
+            continue;
         }
         data[ret] = '\0';
         char *temp_string = strstr(data, "t=");
         if (temp_string == NULL || temp_string[2] == '\0') {
-            locking_set_read_error(d,
-            "Unable to find temperature value in DS18B20 report");
-            pthread_exit(NULL);
+            locking_handle_read_error(d);
+            continue;
         }
         // Don't pass 't' and '=' to atoi
         temp_string += 2;
@@ -113,8 +117,8 @@ reader_start_routine(void *param) {
         ret = lseek(d->fd, 0, SEEK_SET);
         if (ret < 0) {
             report_errno("seek DS18B20", ret);
-            locking_set_read_error(d, "Unable to seek DS18B20");
-            pthread_exit(NULL);
+            locking_handle_read_error(d);
+            continue;
         }
     }
     pthread_exit(NULL);
@@ -151,6 +155,8 @@ command_config_ds18b20(uint32_t *args)
     }
 
     struct ds18_s *d = oid_alloc(args[0], command_config_ds18b20, sizeof(*d));
+    d->max_error_count = args[3];
+    d->error_count = 0;
     d->timer.func = ds18_event;
     d->fd = fd;
     d->status = W1_IDLE;
@@ -182,7 +188,7 @@ fail5:
     shutdown("Could not start DS18B20 reader thread");
 }
 DECL_COMMAND(command_config_ds18b20,
-             "config_ds18b20 oid=%c serial=%*s");
+             "config_ds18b20 oid=%c serial=%*s max_error_count=%c");
 
 void
 command_query_ds18b20(uint32_t *args)
@@ -216,12 +222,15 @@ ds18_send_and_request(struct ds18_s *d, uint32_t next_begin_time, uint8_t oid)
 
     pthread_mutex_lock(&d->lock);
     if (d->status == W1_ERROR) {
-        // try_shutdown expects a static string. Output the specific error,
-        // then shut down with a generic error.
-        output("Error: %s", d->error);
-        pthread_mutex_unlock(&d->lock);
-        try_shutdown("Error reading DS18B20 sensor");
-        return;
+        if (d->error_count > d->max_error_count) {
+            try_shutdown("Error reading DS18B20 sensor");
+            pthread_mutex_unlock(&d->lock);
+            return;
+        } else {
+          sendf("ds18b20_result oid=%c next_clock=%u value=%i fault=%u"
+                  , oid, next_begin_time, d->temperature, d->error_count);
+          d->status = W1_READ_REQUESTED;
+        }
     } else if (d->status == W1_IDLE) {
         // This happens the first time requesting a temperature.
         // Nothing to report yet.
@@ -229,8 +238,8 @@ ds18_send_and_request(struct ds18_s *d, uint32_t next_begin_time, uint8_t oid)
         d->status = W1_READ_REQUESTED;
     } else if (d->status == W1_READY) {
         // Report the previous temperature and request a new one.
-        sendf("ds18b20_result oid=%c next_clock=%u value=%i"
-              , oid, next_begin_time, d->temperature);
+        sendf("ds18b20_result oid=%c next_clock=%u value=%i fault=%u"
+              , oid, next_begin_time, d->temperature, 0);
         if (d->temperature < d->min_value || d->temperature > d->max_value) {
             pthread_mutex_unlock(&d->lock);
             try_shutdown("DS18B20 out of range");
@@ -238,6 +247,7 @@ ds18_send_and_request(struct ds18_s *d, uint32_t next_begin_time, uint8_t oid)
         }
         d->request_time = request_time;
         d->status = W1_READ_REQUESTED;
+        d->error_count = 0; //successful reading, reset error count
     } else if (d->status == W1_READ_REQUESTED) {
         // Reader thread is already reading (or will be soon).
         // This can happen if two queries come in quick enough


### PR DESCRIPTION
My Voron would fail because my DS18B20 chamber temp sensor has intermittent failures, even when powered by 5V.
So i made klipper tolerate the error.

This PR adds a configuration option that allows read errors from DS18B20.
When activated, read errors won't emergency-stop the printer.
Instead it will just report 0C.

The PR also improves error reporting of the sensor a little bit.