### PR TITLE
fix integer handling for python3 in bme280.py

### DIFF
--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -437,7 +437,7 @@ class BME280:
         else:
             factor = 0
             while duration_ms > 0x3F:
-                duration_ms /= 4
+                duration_ms //= 4
                 factor += 1
             duration_reg = duration_ms + (factor * 64)
 


### PR DESCRIPTION
Incorrect math in bme280.py was causing issues when using Python 3. This fix should work with both python 3 and python 2.

Singed-off-by: Christopher Conroy <cbc02009@gmail.com>