### PR TITLE
BUG: Fix STM32H7 ADC reset

### DIFF
--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -114,7 +114,9 @@ gpio_adc_setup(uint32_t pin)
     ADC_TypeDef *adc;
     if (chan >= 40){
         adc = ADC3;
-        enable_pclock(ADC3_BASE);
+        if (!is_enabled_pclock(ADC3_BASE)) {
+            enable_pclock(ADC3_BASE);
+        }
         MODIFY_REG(ADC3_COMMON->CCR, ADC_CCR_CKMODE_Msk,
             0b11 << ADC_CCR_CKMODE_Pos);
     } else if (chan >= 20){


### PR DESCRIPTION
module: STM32 ADC
Don't reset the ADC peripheral if the clock is already enabled.

Fixes #5236

Signed-off-by: Aaron DeLyser <bluwolf@gmail.com>