### PR TITLE
displaystatus: Allow M73 to unset build percentage

### DIFF
--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -1,5 +1,6 @@
 # Module to handle M73 and M117 display status commands
 #
+# Copyright (C) 2022  Jeremy Ruhland <jeremy-klipper@goopypanther.org>
 # Copyright (C) 2018-2020  Kevin O'Connor <kevin@koconnor.net>
 # Copyright (C) 2018  Eric Callahan <arksine.code@gmail.com>
 #
@@ -30,8 +31,11 @@ class DisplayStatus:
                 progress = sdcard.get_status(eventtime)['progress']
         return { 'progress': progress, 'message': self.message }
     def cmd_M73(self, gcmd):
-        progress = gcmd.get_float('P', 0.) / 100.
-        self.progress = min(1., max(0., progress))
+        if not gcmd.get_raw_command_parameters():
+            self.progress = None
+        else:
+            progress = gcmd.get_float('P', 0.) / 100.
+            self.progress = min(1., max(0., progress))
         curtime = self.printer.get_reactor().monotonic()
         self.expire_progress = curtime + M73_TIMEOUT
     def cmd_M117(self, gcmd):


### PR DESCRIPTION
Running M73 without additional parameters will now null the progress variable, mirroring the behavior of M117. This permits control of the progress variable to be returned to virtual_sdcard after it has been modified by an `M73 P<percent>` command.

Previously there was no way to release control of the progress percentage variable back to virtual_sdcard once an `M73 P<percent>` command was issued.

An example use case: A print_start macro may update the progress percentage using `M73 P<percent>` to indicate how close the homing, heating and priming process is to completion. At the end of the macro an `M73` command can be issued allowing virtual_sdcard to automatically update the progress bar during the print to reflect how close it is to completion.

Code has been tested on my voron 2.4.

Signed-off-by: Jeremy Ruhland <jeremy-klipper@goopypanther.org>