### PR TITLE
Update printer-tronxy-x5sa-v6-2019.cfg

### DIFF
--- a/config/printer-tronxy-x5sa-v6-2019.cfg
+++ b/config/printer-tronxy-x5sa-v6-2019.cfg
@@ -91,11 +91,11 @@ pid_Kd: 898.279
 
 [heater_fan hotend_fan]
 pin: PG14
-fan_speed: 0.5
+fan_speed: 1
 
 [fan]
 pin: PG13
-max_power: 0.5
+max_power: 1
 
 [controller_fan drivers_fan]
 pin: PD6


### PR DESCRIPTION
Lines 94 and 98..  
[heater_fan] and [fan] max_power was set to 0.5
This should be 1 for both.


Signed-off-by: Scott Schering sschering@gmail.com