### PR TITLE
BUG: Fix STM32 SPI CR1

### DIFF
--- a/src/stm32/spi.c
+++ b/src/stm32/spi.c
@@ -100,6 +100,7 @@ void
 spi_prepare(struct spi_config config)
 {
     SPI_TypeDef *spi = config.spi;
+    spi->CR1 &= ~((uint16_t)SPI_CR1_SPE);
     spi->CR1 = config.spi_cr1;
 }
 


### PR DESCRIPTION
STM32 SPI_CR1 should not be changed when communication is ongoing.

fix https://github.com/Klipper3d/klipper/issues/5198