### PR TITLE
Adding bed_screws to Ender 3

### DIFF
--- a/config/printer-creality-ender3-2018.cfg
+++ b/config/printer-creality-ender3-2018.cfg
@@ -88,6 +88,12 @@ max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
 
+[bed_screws]
+screw1: 30.5, 37
+screw2: 30.5, 207
+screw3: 204.5, 207
+screw4: 204.5, 37
+
 [display]
 lcd_type: st7920
 cs_pin: PA3


### PR DESCRIPTION
Adding the bed_screws to Ender 3 by what I could measure mine.
This enables `BED_SCREWS_ADJUST`.

https://github.com/Klipper3d/klipper/blob/master/docs/Manual_Level.md#adjusting-bed-leveling-screws

Signed-off-by: Ofir Petrushka <ofir.petrushka@gmail.com>