### PR TITLE
docs: Drop duplicated firmware_retraction G-Codes section

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -337,6 +337,24 @@ enabled.
 `SET_FAN_SPEED FAN=config_name SPEED=<speed>` This command sets the
 speed of a fan. "speed" must be between 0.0 and 1.0.
 
+### [filament_switch_sensor]
+
+The following command is available when a
+[filament_switch_sensor](Config_Reference.md#filament_switch_sensor)
+or
+[filament_motion_sensor](Config_Reference.md#filament_motion_sensor)
+config section is enabled.
+
+#### QUERY_FILAMENT_SENSOR
+`QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current
+status of the filament sensor. The data displayed on the terminal will
+depend on the sensor type defined in the configuration.
+
+#### SET_FILAMENT_SENSOR
+`SET_FILAMENT_SENSOR SENSOR=<sensor_name> ENABLE=[0|1]`: Sets the
+filament sensor on/off. If ENABLE is set to 0, the filament sensor
+will be disabled, if set to 1 it is enabled.
+
 ### [firmware_retraction]
 
 The following standard G-Code commands are available when the
@@ -370,32 +388,6 @@ settings.
 #### GET_RETRACTION
 `GET_RETRACTION`: Queries the current parameters used by firmware
 retraction and displays them on the terminal.
-
-### [filament_switch_sensor]
-
-The following command is available when a
-[filament_switch_sensor](Config_Reference.md#filament_switch_sensor)
-or
-[filament_motion_sensor](Config_Reference.md#filament_motion_sensor)
-config section is enabled.
-
-#### QUERY_FILAMENT_SENSOR
-`QUERY_FILAMENT_SENSOR SENSOR=<sensor_name>`: Queries the current
-status of the filament sensor. The data displayed on the terminal will
-depend on the sensor type defined in the configuration.
-
-#### SET_FILAMENT_SENSOR
-`SET_FILAMENT_SENSOR SENSOR=<sensor_name> ENABLE=[0|1]`: Sets the
-filament sensor on/off. If ENABLE is set to 0, the filament sensor
-will be disabled, if set to 1 it is enabled.
-
-### [firmware_retraction]
-
-The following standard G-Code commands are available if a
-[firmware_retraction config section](Config_Reference.md#firmware_retraction)
-is enabled:
-- Retract: `G10`
-- Unretract: `G11`
 
 ### [force_move]
 


### PR DESCRIPTION
Diff may look a bit unintuitive, but previously there were two `[firmware_retraction]` sections in the G-Codes docs.