### PR TITLE
docs: Specify the meaning of minutes for bed tramming

### DIFF
--- a/docs/Manual_Level.md
+++ b/docs/Manual_Level.md
@@ -179,6 +179,9 @@ Recv: // rear right screw : y=155.0, y=190.0, z=2.71500 : adjust CCW 00:50
 Recv: // read left screw : x=-5.0, y=190.0, z=2.47250 : adjust CW 00:02
 Recv: ok
 ```
+**Note that** minutes in the output refer to minutes of a clock face (1 minute =
+6 degrees), not minutes of a degree (1 minute = 1/60 degree).
+
 This means that:
 
 - front left screw is the reference point you must not change it.


### PR DESCRIPTION
The documentation does not specify whether the "minutes" in the output of `SCREWS_TILT_CALCULATE` mean minutes of a degree (1/60th of a degree) or minutes of a clock-face (6 degrees). The commit in this PR notes this distinction.

Personally, I just encountered this and was wondering how the hell am I supposed to turn the wheel by 7', as that is an incredibly small angle :sweat_smile: I was told that it is obvious that the output of the command means minutes of a clock-face (e.g. 1 minute = 6 degrees), but I don't agree and hence this PR.