### PR TITLE
Update printer-wanhao-duplicator-i3-v2.1-2017.cfg

### DIFF
--- a/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
+++ b/config/printer-wanhao-duplicator-i3-v2.1-2017.cfg
@@ -168,3 +168,4 @@ sclk_pin: PD3
 sid_pin: PC0
 encoder_pins: ^PA2, ^PA1
 click_pin: ^!PA3
+kill_pin: ^!PD2


### PR DESCRIPTION
Add correct kill_pin for stock Melzi board and LCD.

Signed-off-by: Joshua Whitman <whitmanj@gmail.com>