### PR TITLE
Update printer-tronxy-x5sa-v6-2019.cfg

### DIFF
--- a/config/printer-tronxy-x5sa-v6-2019.cfg
+++ b/config/printer-tronxy-x5sa-v6-2019.cfg
@@ -91,11 +91,9 @@ pid_Kd: 898.279
 
 [heater_fan hotend_fan]
 pin: PG14
-fan_speed: 0.5
 
 [fan]
 pin: PG13
-max_power: 0.5
 
 [controller_fan drivers_fan]
 pin: PD6


### PR DESCRIPTION
Lines 94 and 98. Fan speed and max power should be 1 and not 0.5
removed lines to use default settings. 

[heater_fan hotend_fan]
pin: PG14

[fan]
pin: PG13

Signed off by: Scott Schering sschering@gmail.com