### PR TITLE
config: Expose options awaiting to be saved

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -41,6 +41,8 @@ The following information is available in the `configfile` object
   here.) All values are returned as strings.
 - `save_config_pending`: Returns true if there are updates that a
   `SAVE_CONFIG` command may persist to disk.
+- `save_config_pending_items`: Contains the sections and options that
+  were changed and would be persisted by a `SAVE_CONFIG`.
 - `warnings`: A list of warnings about config options. Each entry in
   the list will be a dictionary containing a `type` and `message`
   field (both strings). Additional fields may be available depending

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -140,6 +140,7 @@ class PrinterConfig:
         self.autosave = None
         self.deprecated = {}
         self.status_raw_config = {}
+        self.status_save_pending = {}
         self.status_settings = {}
         self.status_warnings = []
         self.save_config_pending = False
@@ -331,17 +332,29 @@ class PrinterConfig:
         return {'config': self.status_raw_config,
                 'settings': self.status_settings,
                 'warnings': self.status_warnings,
-                'save_config_pending': self.save_config_pending}
+                'save_config_pending': self.save_config_pending,
+                'save_config_pending_items': self.status_save_pending}
     # Autosave functions
     def set(self, section, option, value):
         if not self.autosave.fileconfig.has_section(section):
             self.autosave.fileconfig.add_section(section)
         svalue = str(value)
         self.autosave.fileconfig.set(section, option, svalue)
+        pending = dict(self.status_save_pending)
+        if not section in pending:
+            pending[section] = {}
+        else:
+            pending[section] = dict(pending[section])
+        pending[section][option] = svalue
+        self.status_save_pending = pending
         self.save_config_pending = True
         logging.info("save_config: set [%s] %s = %s", section, option, svalue)
     def remove_section(self, section):
         self.autosave.fileconfig.remove_section(section)
+        if section in self.status_save_pending:
+            pending = dict(self.status_save_pending)
+            del pending[section]
+            self.status_save_pending = pending
         self.save_config_pending = True
     def _disallow_include_conflicts(self, regular_data, cfgname, gcode):
         config = self._build_config_wrapper(regular_data, cfgname)


### PR DESCRIPTION
Adds a save_config_pending_items to the status reported by
configfile reflecting the items and values that a future
SAVE_CONFIG would actually persist.

Signed-off-by: Kurt Haenen <kurt.haenen@gmail.com>