### PR TITLE
fix rotation_distance for sapphire pro

### DIFF
--- a/config/printer-twotrees-sapphire-pro-2020.cfg
+++ b/config/printer-twotrees-sapphire-pro-2020.cfg
@@ -18,7 +18,8 @@ step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
 microsteps: 16
-rotation_distance: 32
+rotation_distance: 40
+#rotation_distance: 32
 endstop_pin: !PA15
 position_endstop: 0
 position_max: 230
@@ -29,7 +30,8 @@ step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
 microsteps: 16
-rotation_distance: 32
+rotation_distance: 40
+#rotation_distance: 32
 endstop_pin: !PA12
 position_endstop: 230
 position_max: 230
@@ -40,7 +42,8 @@ step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
 microsteps: 16
-rotation_distance: 8
+rotation_distance: 2
+#rotation_distance: 8
 endstop_pin: !PA11
 position_endstop: 0.5
 position_max: 230

--- a/config/printer-twotrees-sapphire-pro-2020.cfg
+++ b/config/printer-twotrees-sapphire-pro-2020.cfg
@@ -18,7 +18,7 @@ step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
 microsteps: 16
-rotation_distance: 40
+rotation_distance: 40 # more common. Please try this value first!
 #rotation_distance: 32
 endstop_pin: !PA15
 position_endstop: 0
@@ -30,7 +30,7 @@ step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
 microsteps: 16
-rotation_distance: 40
+rotation_distance: 40 # more common. Please try this value first!
 #rotation_distance: 32
 endstop_pin: !PA12
 position_endstop: 230
@@ -42,7 +42,7 @@ step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
 microsteps: 16
-rotation_distance: 2
+rotation_distance: 2 # more common. Please try this value first!
 #rotation_distance: 8
 endstop_pin: !PA11
 position_endstop: 0.5


### PR DESCRIPTION
Hi, the sapphire pro config contains wrong rotation_distance values for X, Y and Z. I have changed them and it works perfectly. TwoTrees must have decided to use 20T instead of 16T pulleys and T8x2 lead screw instead of T8x8.

For this reason I have started the PR :)