### PR TITLE
temperature_fan: add missing round function to get_status temperature

### DIFF
--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -72,7 +72,7 @@ class TemperatureFan:
         return self.max_speed
     def get_status(self, eventtime):
         status = self.fan.get_status(eventtime)
-        status["temperature"] = self.last_temp
+        status["temperature"] = round(self.last_temp, 2)
         status["target"] = self.target_temp
         return status
     cmd_SET_TEMPERATURE_FAN_TARGET_help = \


### PR DESCRIPTION
The only thing i noticed about temperature_fan was that the rounding command was missing.