### PR TITLE
Pin markupsafe < 2.1, to fix python3

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -7,4 +7,4 @@ pyserial==3.4
 greenlet==1.1.2
 Jinja2==2.11.3
 python-can==3.3.4
-markupsafe<2.1
+markupsafe==1.1.1

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -7,3 +7,4 @@ pyserial==3.4
 greenlet==1.1.2
 Jinja2==2.11.3
 python-can==3.3.4
+markupsafe==2.0.1

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -7,4 +7,4 @@ pyserial==3.4
 greenlet==1.1.2
 Jinja2==2.11.3
 python-can==3.3.4
-markupsafe==2.0.1
+markupsafe<2.1


### PR DESCRIPTION
Fixes #5284 

Markupsafe updated and the latest version no longer includes `soft_unicode`, so here I pin the transitive dependency