### PR TITLE
Support [extruder] sections without a stepper

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220304: There is no longer a default for the `extruder` parameter of
+[extruder_stepper](Config_Reference.md#extruder_stepper) config
+sections. If desired, specify `extruder: extruder` explicitly to
+associate the stepper motor with the "extruder" motion queue at
+startup.
+
 20220210: The `SYNC_STEPPER_TO_EXTRUDER` command is deprecated; the
 `SET_EXTRUDER_STEP_DISTANCE` command is deprecated; the
 [extruder](Config_Reference.md#extruder) `shared_heater` config option

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1829,10 +1829,10 @@ See the [command reference](G-Codes.md#extruder) for more information.
 
 ```
 [extruder_stepper my_extra_stepper]
-#extruder: extruder
+extruder:
 #   The extruder this stepper is synchronized to. If this is set to an
 #   empty string then the stepper will not be synchronized to an
-#   extruder. The default is "extruder".
+#   extruder. This parameter must be provided.
 #step_pin:
 #dir_pin:
 #enable_pin:

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -638,10 +638,11 @@ max_accel: 1
 
 ### [extruder]
 
-The extruder section is used to describe both the stepper controlling
-the printer extruder and the heater parameters for the nozzle. See the
-[pressure advance guide](Pressure_Advance.md) for information on
-tuning pressure advance.
+The extruder section is used to describe the heater parameters for the
+nozzle hotend along with the stepper controlling the extruder. See the
+[command reference](G-Codes.md#extruder) for additional information.
+See the [pressure advance guide](Pressure_Advance.md) for information
+on tuning pressure advance.
 
 ```
 [extruder]
@@ -652,7 +653,10 @@ microsteps:
 rotation_distance:
 #full_steps_per_rotation:
 #gear_ratio:
-#   See the "stepper" section for a description of the above parameters.
+#   See the "stepper" section for a description of the above
+#   parameters. If none of the above parameters are specified then no
+#   stepper will be associated with the nozzle hotend (though a
+#   SYNC_EXTRUDER_MOTION command may associate one at run-time).
 nozzle_diameter:
 #   Diameter of the nozzle orifice (in mm). This parameter must be
 #   provided.

--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -10,7 +10,7 @@ class PrinterExtruderStepper:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.extruder_stepper = extruder.ExtruderStepper(config)
-        self.extruder_name = config.get('extruder', 'extruder')
+        self.extruder_name = config.get('extruder')
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
     def handle_connect(self):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -79,6 +79,8 @@ class ExtruderStepper:
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
     def cmd_default_SET_PRESSURE_ADVANCE(self, gcmd):
         extruder = self.printer.lookup_object('toolhead').get_extruder()
+        if extruder.extruder_stepper is None:
+            raise gcmd.error("Active extruder does not have a stepper")
         extruder.extruder_stepper.cmd_SET_PRESSURE_ADVANCE(gcmd)
     def cmd_SET_PRESSURE_ADVANCE(self, gcmd):
         pressure_advance = gcmd.get_float('ADVANCE', self.pressure_advance,
@@ -181,12 +183,16 @@ class PrinterExtruder:
         self.trapq_append = ffi_lib.trapq_append
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         # Setup extruder stepper
-        self.extruder_stepper = ExtruderStepper(config)
-        self.extruder_stepper.stepper.set_trapq(self.trapq)
-        pa = config.getfloat('pressure_advance', 0., minval=0.)
-        smooth_time = config.getfloat('pressure_advance_smooth_time',
-                                      0.040, above=0., maxval=.200)
-        self.extruder_stepper._set_pressure_advance(pa, smooth_time)
+        self.extruder_stepper = None
+        if (config.get('step_pin', None) is not None
+            or config.get('dir_pin', None) is not None
+            or config.get('rotation_distance', None) is not None):
+            self.extruder_stepper = ExtruderStepper(config)
+            self.extruder_stepper.stepper.set_trapq(self.trapq)
+            pa = config.getfloat('pressure_advance', 0., minval=0.)
+            smooth_time = config.getfloat('pressure_advance_smooth_time',
+                                          0.040, above=0., maxval=.200)
+            self.extruder_stepper._set_pressure_advance(pa, smooth_time)
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         if self.name == 'extruder':
@@ -201,7 +207,8 @@ class PrinterExtruder:
     def get_status(self, eventtime):
         sts = self.heater.get_status(eventtime)
         sts['can_extrude'] = self.heater.can_extrude
-        sts.update(self.extruder_stepper.get_status(eventtime))
+        if self.extruder_stepper is not None:
+            sts.update(self.extruder_stepper.get_status(eventtime))
         return sts
     def get_name(self):
         return self.name
@@ -259,6 +266,8 @@ class PrinterExtruder:
                           start_v, cruise_v, accel)
         self.last_position = move.end_pos[3]
     def find_past_position(self, print_time):
+        if self.extruder_stepper is None:
+            return 0.
         return self.extruder_stepper.find_past_position(print_time)
     def cmd_M104(self, gcmd, wait=False):
         # Set Extruder Temperature

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -81,6 +81,9 @@ class ExtruderStepper:
         extruder = self.printer.lookup_object('toolhead').get_extruder()
         if extruder.extruder_stepper is None:
             raise gcmd.error("Active extruder does not have a stepper")
+        strapq = extruder.extruder_stepper.stepper.get_trapq()
+        if strapq is not extruder.get_trapq():
+            raise gcmd.error("Unable to infer active extruder stepper")
         extruder.extruder_stepper.cmd_SET_PRESSURE_ADVANCE(gcmd)
     def cmd_SET_PRESSURE_ADVANCE(self, gcmd):
         pressure_advance = gcmd.get_float('ADVANCE', self.pressure_advance,

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -197,6 +197,8 @@ class MCU_stepper:
             raise error("Internal error in stepcompress")
         self._set_mcu_position(last_pos)
         self._mcu.get_printer().send_event("stepper:sync_mcu_position", self)
+    def get_trapq(self):
+        return self._trapq
     def set_trapq(self, tq):
         ffi_main, ffi_lib = chelper.get_ffi()
         if tq is None:

--- a/test/klippy/extruders.cfg
+++ b/test/klippy/extruders.cfg
@@ -50,6 +50,7 @@ min_temp: 0
 max_temp: 210
 
 [extruder_stepper my_extra_stepper]
+extruder: extruder
 step_pin: PH5
 dir_pin: PH6
 enable_pin: !PB5


### PR DESCRIPTION
This PR makes it possible to define an extruder config section without an extruder stepper motor.  This may be useful for dual hotend systems that share a single stepper motor.

A bit unrelated, but I'm also added a commit here that removes the default for the "extruder" parameter of `[extruder_stepper]` config sections.  With the recent extruder changes, I suspect that the default of synchronizing all extruder_stepper motors to the "extruder" motion queue is confusing.  So, after this PR, users will be required to specify the "extruder" parameter of `[extruder_stepper]` config sections (either by setting it to something like `extruder: extruder` to set the default motion queue or set it as `extruder: ` to not set a default motion queue at startup).

@drumclock - fyi.

-Kevin