### PR TITLE
Update i2c.c to handle RPI 4 extra I2c busses

### DIFF
--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -13,7 +13,7 @@
 #include "internal.h" // report_errno
 #include "sched.h" // sched_shutdown
 
-DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 2);
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 7);
 
 struct i2c_s {
     uint32_t bus;


### PR DESCRIPTION
Similarly to commit 8cf1b512 for SPI, the Rpi4 has more i2c busses to offer
This change allows klipper to use up to I2c bus 6
```
/boot/configtxt 
dtparam=i2c_arm=on
dtoverlay=i2c6
```

and 

```
pi@fluiddpi:~ $ ls -1 /dev/i2c*
/dev/i2c-1
/dev/i2c-6
```