### PR TITLE
display_status: stops M73 from setting progress to 0 if P missing

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,8 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220307: `M73` will no longer set print progress to 0 if `P` is missing.
+
 20220304: There is no longer a default for the `extruder` parameter of
 [extruder_stepper](Config_Reference.md#extruder_stepper) config
 sections. If desired, specify `extruder: extruder` explicitly to

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -30,10 +30,12 @@ class DisplayStatus:
                 progress = sdcard.get_status(eventtime)['progress']
         return { 'progress': progress, 'message': self.message }
     def cmd_M73(self, gcmd):
-        progress = gcmd.get_float('P', 0.) / 100.
-        self.progress = min(1., max(0., progress))
-        curtime = self.printer.get_reactor().monotonic()
-        self.expire_progress = curtime + M73_TIMEOUT
+        progress = gcmd.get_float('P', None)
+        if progress is not None:
+            progress = progress / 100.
+            self.progress = min(1., max(0., progress))
+            curtime = self.printer.get_reactor().monotonic()
+            self.expire_progress = curtime + M73_TIMEOUT
     def cmd_M117(self, gcmd):
         msg = gcmd.get_raw_command_parameters() or None
         self.message = msg


### PR DESCRIPTION
Following up on discussion in Discord, this PR is to ensure that an `M73` command with no `P` parameter does not set progress to 0 as it currently does.

This issue is easily reproducible in Prusa/SuperSlicer by enabling the "Firmware: Stealth mode" option together with "Firmware: Print remaining times" option:

![image](https://user-images.githubusercontent.com/85504/157082031-abe59ce7-03bb-413f-b1c2-80ebc45259a8.png)

After slicing, the g-code output will have 2 consecutive `M73` lines, but only the first line has a `P` param, and the second line will then set progress to 0.

![image](https://user-images.githubusercontent.com/85504/157082152-1fb38983-54ad-45a9-94cf-cf81230c8281.png)

Neither [Marlin](https://marlinfw.org/docs/gcode/M073.html) nor [RepRap](https://www.reprap.org/wiki/G-code#M73:_Set.2FGet_build_percentage) have any indication to assume `P0` if `P` is missing, so I believe this should be a safe fix to apply.

Issue was first reported here: https://github.com/fluidd-core/fluidd/issues/449

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>