### PR TITLE
docs: Add missing lift_speed option to [bltouch]

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1734,6 +1734,7 @@ control_pin:
 #y_offset:
 #z_offset:
 #speed:
+#lift_speed:
 #samples:
 #sample_retract_dist:
 #samples_result:


### PR DESCRIPTION
The option `lift_speed` was listed in the documentation for `[probe]` but not in `[bltouch]`, so I missed it at first when searching for it.