### PR TITLE
Linear fan control for the temperature_fan

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2435,7 +2435,7 @@ watched component.
 
 ### [temperature_fan]
 
-Temperature-triggered cooling fans (one may define any number of
+Temperature-controlled cooling fans (one may define any number of
 sections with a "temperature_fan" prefix). A "temperature fan" is a
 fan that will be enabled whenever its associated sensor is above a set
 temperature. By default, a temperature_fan has a shutdown_speed equal
@@ -2457,14 +2457,20 @@ information.
 #tachometer_ppr:
 #tachometer_poll_interval:
 #   See the "fan" section for a description of the above parameters.
-#sensor_type:
-#sensor_pin:
 #control:
+#   In addition to "watermark" and "pid", temperature_fan has an additional
+#   "linear" control that sets the fan speed to a value between min_speed
+#   and max_speed, starting from a temperature offset below the target_temp.
+#linear_offset: 10.0
+#   on "linear" control, this sets the temperature offset below the
+#   target_temp where the linear scaling starts
 #pid_Kp:
 #pid_Ki:
 #pid_Kd:
 #pid_deriv_time:
 #max_delta:
+#sensor_type:
+#sensor_pin:
 #min_temp:
 #max_temp:
 #   See the "extruder" section for a description of the above parameters.


### PR DESCRIPTION
This adds a "linear" fan control to the temperature_fan. It scales the fan speed according to a linear temperature range. For example if the target_temp is 50° and the linear_offset is 10°, it will start at 40° to raise the fan speed from min_speed to max_speed on 50°.

Context: I have a very loud PSU fan that goes from 0 to 9100 RPM without any steps between. I wanted a better fan control, so i added a thermistor to the PSU's heatsink. While playing around with the temperature_fan settings, i realized that neither watermark nor pid fit for this use-case. Watermark works just like the stock fan behavior and would give no improvement. PID did also not seem like a good fit, as heat generated by the PSU is not constant. I have tried it, but the fan started oscillating in short intervals what is also annoying by itself. With the linear control, the fan slowly speeds up and down as the temperature on the PSU changes, giving a reasonable fan speed and is easily predictable on how it behaves.
