### PR TITLE
Updated TwoTrees printers configs to avoid confusion

### DIFF
--- a/config/printer-twotrees-sapphire-plus-sp-5-v1.1.cfg
+++ b/config/printer-twotrees-sapphire-plus-sp-5-v1.1.cfg
@@ -1,0 +1,112 @@
+# This file contains common pin mappings for the Two Trees Sapphire
+# Plus V1.1 (SP-5) printer (Robin Nano 1.2, all 2225 drivers at 32 microsteps).
+# To use this config, the firmware should be compiled for the STM32F103.
+# When running "make menuconfig", enable "extra low-level configuration setup",
+# select the 28KiB bootloader, serial (on USART3 PB11/PB10) to use USB communication
+# or serial (on USART1 PA10/PA9) to use direct UART connection with Raspberry,
+# and set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13" to turn off display.
+
+# Note that the "make flash" command does not work with the Robin Nano!
+# After running "make", run the following command in one row FROM THE KLIPPER FOLDER:
+#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
+# Copy the file out/Robin_nano35.bin to an SD card and then restart the
+# printer with that SD card. If you removed the LDC screen rename the file to 
+# "Robin_nano43.bin" for correct flashing without the screen.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PE3
+dir_pin: !PE2
+enable_pin: !PE4
+microsteps: 32
+rotation_distance: 40
+endstop_pin: !PA15
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_y]
+step_pin: PE0
+dir_pin: !PB9
+enable_pin: !PE1
+microsteps: 32
+rotation_distance: 40
+endstop_pin: !PA12
+position_endstop: 300
+position_max: 300
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB5
+dir_pin: PB4
+enable_pin: !PB8
+microsteps: 32
+rotation_distance: 8
+endstop_pin: !PA11
+position_endstop: 0
+position_max: 340
+
+[stepper_z1]
+step_pin: PA6
+dir_pin: PA1
+enable_pin: !PA3
+microsteps: 32
+rotation_distance: 8
+
+[extruder]
+step_pin: PD6
+dir_pin: !PD3
+enable_pin: !PB3
+microsteps: 32
+gear_ratio: 50:17
+rotation_distance: 23.52
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: EPCOS 100K B57560G104F # Stock
+sensor_pin: PC1
+min_temp: 0
+max_temp: 250
+control: pid
+pid_Kp: 17.48
+pid_Ki: 1.32
+pid_Kd: 57.81
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F # Stock
+sensor_pin: PC0
+min_temp: 0
+max_temp: 130
+control: pid
+pid_Kp: 325.10
+pid_Ki: 63.35
+pid_Kd: 417.10
+
+[heater_fan extruder]
+pin: PB0
+max_power: 1
+shutdown_speed: 0
+cycle_time: 0.010
+kick_start_time: 0.1
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
+[fan]
+pin: PB1
+
+[mcu]
+serial: /dev/ttyUSB0
+restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 250
+max_accel: 4500
+max_z_velocity: 15
+max_z_accel: 100
+
+[static_digital_output reset_display]
+pins: !PC6, !PD13

--- a/config/printer-twotrees-sapphire-plus-sp-5-v1.cfg
+++ b/config/printer-twotrees-sapphire-plus-sp-5-v1.cfg
@@ -1,18 +1,17 @@
 # This file contains common pin mappings for the Two Trees Sapphire
-# Plus printer from 2020 (revision 2 with dual Z axis).
-
+# Plus V1 (SP-5) printer (Robin Nano 1.2, 2208 drivers for X,Y and A4988 for Zs,E).
 # To use this config, the firmware should be compiled for the STM32F103.
-# When running "make menuconfig" you have to:
-# - enable "extra low-level configuration setup",
-# - select the 28KiB bootloader,
-# - select serial (on USART3 PB11/PB10) communication
-# - set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13"
+# When running "make menuconfig", enable "extra low-level configuration setup",
+# select the 28KiB bootloader, serial (on USART3 PB11/PB10) to use USB communication
+# or serial (on USART1 PA10/PA9) to use direct UART connection with Raspberry,
+# and set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13" to turn off display.
 
-# Note that the "make flash" command does not work with the Sapphire
-# Pro. After running "make", run the following command:
+# Note that the "make flash" command does not work with the Robin Nano!
+# After running "make", run the following command in one row FROM THE KLIPPER FOLDER:
 #   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
 # Copy the file out/Robin_nano35.bin to an SD card and then restart the
-# printer with that SD card.
+# printer with that SD card. If you removed the LDC screen rename the file to 
+# "Robin_nano43.bin" for correct flashing without the screen.
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -54,7 +53,6 @@ dir_pin: PA1
 enable_pin: !PA3
 microsteps: 16
 rotation_distance: 8
-endstop_pin: !PC4
 
 [extruder]
 step_pin: PD6
@@ -86,6 +84,16 @@ pid_Kp: 325.10
 pid_Ki: 63.35
 pid_Kd: 417.10
 
+[heater_fan extruder]
+pin: PB0
+max_power: 1
+shutdown_speed: 0
+cycle_time: 0.010
+kick_start_time: 0.1
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
 [fan]
 pin: PB1
 
@@ -97,7 +105,7 @@ restart_method: command
 kinematics: corexy
 max_velocity: 250
 max_accel: 4500
-max_z_velocity: 25
+max_z_velocity: 15
 max_z_accel: 100
 
 [static_digital_output reset_display]

--- a/config/printer-twotrees-sapphire-pro-sp-3.cfg
+++ b/config/printer-twotrees-sapphire-pro-sp-3.cfg
@@ -1,15 +1,17 @@
 # This file contains common pin mappings for the Two Trees Sapphire
-# Pro printer from 2020. To use this config, the firmware should be
-# compiled for the STM32F103. When running "make menuconfig", enable
-# "extra low-level configuration setup", select the 28KiB bootloader,
-# serial (on USART3 PB11/PB10) communication, and set "GPIO pins to
-# set at micro-controller startup" to "!PC6,!PD13".
+# Pro (SP-3) printer (Robin Nano 1.2, 2208 drivers for X,Y and A4988 for Z,E).
+# To use this config, the firmware should be compiled for the STM32F103.
+# When running "make menuconfig", enable "extra low-level configuration setup",
+# select the 28KiB bootloader, serial (on USART3 PB11/PB10) to use USB communication
+# or serial (on USART1 PA10/PA9) to use direct UART connection with Raspberry,
+# and set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13" to turn off display.
 
-# Note that the "make flash" command does not work with the Sapphire
-# Pro. After running "make", run the following command:
+# Note that the "make flash" command does not work with the Robin Nano!
+# After running "make", run the following command in one row FROM THE KLIPPER FOLDER:
 #   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
 # Copy the file out/Robin_nano35.bin to an SD card and then restart the
-# printer with that SD card.
+# printer with that SD card. If you removed the LDC screen rename the file to 
+# "Robin_nano43.bin" for correct flashing without the screen.
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -18,7 +20,7 @@ step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
 microsteps: 16
-rotation_distance: 32
+rotation_distance: 40
 endstop_pin: !PA15
 position_endstop: 0
 position_max: 230
@@ -29,7 +31,7 @@ step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
 microsteps: 16
-rotation_distance: 32
+rotation_distance: 40
 endstop_pin: !PA12
 position_endstop: 230
 position_max: 230
@@ -40,7 +42,7 @@ step_pin: PB5
 dir_pin: PB4
 enable_pin: !PB8
 microsteps: 16
-rotation_distance: 8
+rotation_distance: 2
 endstop_pin: !PA11
 position_endstop: 0.5
 position_max: 230
@@ -50,7 +52,8 @@ step_pin: PD6
 dir_pin: !PD3
 enable_pin: !PB3
 microsteps: 16
-rotation_distance: 6.720
+gear_ratio: 50:17
+rotation_distance: 23.52
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC3
@@ -74,6 +77,16 @@ pid_Kd: 417.10
 min_temp: 0
 max_temp: 130
 
+[heater_fan extruder]
+pin: PB0
+max_power: 1
+shutdown_speed: 0
+cycle_time: 0.010
+kick_start_time: 0.1
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
 [fan]
 pin: PB1
 
@@ -85,8 +98,8 @@ restart_method: command
 kinematics: corexy
 max_velocity: 250
 max_accel: 4500
-max_z_velocity: 25
-max_z_accel: 100
+max_z_velocity: 10
+max_z_accel: 80
 
 [static_digital_output reset_display]
 pins: !PC6, !PD13


### PR DESCRIPTION
I corrected some errors in configs, corrected cinfig names (now are sold with these names) and created 2 versions for Plus (SP-5) since there are V1 and V1.1 now.

Signed-off-by:  Lorenzo Cascone <laurienzudesign@gmail.com>