### PR TITLE
HTU21D - SI7021 is has id 0x15

### DIFF
--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -14,7 +14,7 @@ from . import bus
 #       HTU21D - Tested on Linux MCU.
 #       Si7013 - Untested
 #       Si7020 - Untested
-#       Si7021 - Untested
+#       Si7021 - Tested on Pico MCU
 #       SHT21  - Untested
 #
 ######################################################################
@@ -56,7 +56,7 @@ HTU21D_DEVICES = {
         'TEMP13_HUM10':[ .7, .5],
         'TEMP12_HUM08':[ .4, .4],
         'TEMP11_HUM11':[ .3, .7]},
-    'SI7021':{'id':0x14,
+    'SI7021':{'id':0x15,
         'TEMP14_HUM12':[.11,.12],
         'TEMP13_HUM10':[ .7, .5],
         'TEMP12_HUM08':[ .4, .4],


### PR DESCRIPTION
This error was most probably caused by a copy/paste error. All vendor documentation for SI7021 (e.g. https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf) points to 21 and it actually only works when adapted to 0x15 (=21).

This PR was tested in real production on a Raspberry Pico MCU.