### PR TITLE
docs: Change Bed Slinger to I3 Style

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1533,7 +1533,7 @@ section of the measuring resonances guide for more information on
 #accel_chip_x:
 #accel_chip_y:
 #   Names of the accelerometer chips to use for measurements for each
-#   of the axis. Can be useful, for instance, on bed slinger printer,
+#   of the axis. Can be useful, for instance, on i3 style printer,
 #   if two separate accelerometers are mounted on the bed (for Y axis)
 #   and on the toolhead (for X axis). These parameters have the same
 #   format as 'accel_chip' parameter. Only 'accel_chip' or these two

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -51,9 +51,9 @@ An example of mounting ADXL345 on the SmartEffector:
 
 ![ADXL345 on SmartEffector](img/adxl345-mount.jpg)
 
-Note that on a bed slinger printer one must design 2 mounts: one for the
+Note that on an i3 style printer one must design 2 mounts: one for the
 toolhead and one for the bed, and run the measurements twice. See the
-corresponding [section](#bed-slinger-printers) for more details.
+corresponding [section](#i3-style-printers) for more details.
 
 **Attention:** make sure the accelerometer and any screws that hold it in
 place do not touch any metal parts of the printer. Basically, the mount must
@@ -111,11 +111,11 @@ Restart Klipper via the `RESTART` command.
 
 Now you can test a connection.
 
-- For "non bed-slingers" (e.g. one accelerometer), in Octoprint,
-  enter `ACCELEROMETER_QUERY`
-- For "bed-slingers" (e.g. more than one accelerometer), enter
+- For most printers (with one accelerometer), in Octoprint, enter
+  `ACCELEROMETER_QUERY`.
+- For i3 style printers (or need more than one accelerometer), enter
   `ACCELEROMETER_QUERY CHIP=<chip>` where `<chip>` is the name of the chip
-  as-entered, e.g. `CHIP=bed` (see: [bed-slinger](#bed-slinger-printers))
+  as-entered, e.g. `CHIP=bed` (see: [i3 style](#i3-style-printers))
   for all installed accelerometer chips.
 
 You should see the current measurements from the accelerometer, including the
@@ -209,12 +209,13 @@ from Klipper [directly](#input-shaper-auto-calibration), which can be
 convenient, for example, for the input shaper
 [re-calibration](#input-shaper-re-calibration).
 
-### Bed-slinger printers
+### i3 style printers
 
-If your printer is a bed slinger printer, you will need to change the location
-of the accelerometer between the measurements for X and Y axes: measure the
-resonances of X axis with the accelerometer attached to the toolhead and the
-resonances of Y axis - to the bed (the usual bed slinger setup).
+If your printer is an i3 style printer(usually with a fast moving print bed on y-axis),
+you will need to change the location of the accelerometer between the measurements
+for X and Y axes: measure the resonances of X axis with the accelerometer
+attached to the toolhead and the resonances of Y axis - to the bed (the usual
+i3 style setup).
 
 However, you can also connect two accelerometers simultaneously, though they
 must be connected to different boards (say, to an RPi and printer MCU board), or
@@ -230,7 +231,7 @@ cs_pin: rpi:None
 cs_pin: ...  # Printer board SPI chip select (CS) pin
 
 [resonance_tester]
-# Assuming the typical setup of the bed slinger printer
+# Assuming the typical setup of the i3 style printer
 accel_chip_x: adxl345 hotend
 accel_chip_y: adxl345 bed
 probe_points: ...
@@ -420,7 +421,7 @@ following the considerations in [Selecting max_accel](#selecting-max_accel)
 section.
 
 
-If your printer is a bed slinger printer, you can specify which axis
+If your printer is an i3 style printer, you can specify which axis
 to test, so that you can change the accelerometer mounting point between
 the tests (by default the test is performed for both axes):
 ```
@@ -517,15 +518,15 @@ Providing several inputs to shaper_calibrate.py script can be useful if running
 some advanced tuning of the input shapers, for example:
 
 * Running `TEST_RESONANCES AXIS=X OUTPUT=raw_data` (and `Y` axis) for a single
-  axis twice on a bed slinger printer with the accelerometer attached to the
+  axis twice on an i3 style printer with the accelerometer attached to the
   toolhead the first time, and the accelerometer attached to the bed the
   second time in order to detect axes cross-resonances and attempt to cancel
   them with input shapers.
-* Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on a bed slinger with
-  a glass bed and a magnetic surfaces (which is lighter) to find the input
+* Running `TEST_RESONANCES AXIS=Y OUTPUT=raw_data` twice on an i3 style printer
+  with a glass bed and a magnetic surfaces (which is lighter) to find the input
   shaper parameters that work well for any print surface configuration.
 * Combining the resonance data from multiple test points.
-* Combining the resonance data from 2 axis (e.g. on a bed slinger printer
+* Combining the resonance data from 2 axis (e.g. on an i3 style printer
   to configure X-axis input_shaper from both X and Y axes resonances to
   cancel vibrations of the *bed* in case the nozzle 'catches' a print when
   moving in X axis direction).

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -211,11 +211,11 @@ convenient, for example, for the input shaper
 
 ### i3 style printers
 
-If your printer is an i3 style printer(usually with a fast moving print bed on y-axis),
-you will need to change the location of the accelerometer between the measurements
-for X and Y axes: measure the resonances of X axis with the accelerometer
-attached to the toolhead and the resonances of Y axis - to the bed (the usual
-i3 style setup).
+If your printer is an i3 style printer (a bed-slinger) with a print bed moving on
+y-axis, you will need to change the location of the accelerometer between the
+measurements for X and Y axes: measure the resonances of X axis with the
+accelerometer attached to the toolhead and the resonances of Y axis - to the bed
+(the usual i3 style setup).
 
 However, you can also connect two accelerometers simultaneously, though they
 must be connected to different boards (say, to an RPi and printer MCU board), or

--- a/docs/Resonance_Compensation.md
+++ b/docs/Resonance_Compensation.md
@@ -182,7 +182,7 @@ shaper_type: mzv
 
 A few notes on shaper selection:
 
-* EI shaper may be more suited for bed slinger printers (if the resonance
+* EI shaper may be more suited for i3 style printers (if the resonance
  frequency and resulting smoothing allows): as more filament is deposited
  on the moving bed, the mass of the bed increases and the resonance frequency
  will decrease. Since EI shaper is more robust to resonance frequency


### PR DESCRIPTION
Bed slinger/bed slinger printers/bed-slinger printer/bed-slingers is a less commonly used name (although it itself is more descriptive). There are fewer search results that actually describe this style of printer. Search results using `bed slinger printer` are generally less informative (and Klipper documentation is the only one using it officially compared to Duet and Marlin (which doesn't mention i3 or bed-slinger)). Since i3 style/i3 printers/Prusa i3 style is used more often, I propose the following change:

`bed-slinger -> i3 style`

Admittedly, the i3 style is not a descriptive name and is associated with Prusa I3 and various other brands of printers (and perhaps more/less confusing depending on whether your printer has a `i3` in its name). I'm proposing this change to see if we can solve this historical issue or find a better compromise. Perhaps keep it as-is and provide more descriptions?

Search results:
https://reprap.org/mediawiki/index.php?search=bed+slinger&title=Special%3ASearch&profile=default&fulltext=1
https://reprap.org/mediawiki/index.php?search=i3&title=Special%3ASearch&profile=default&fulltext=1
https://marlinfw.org/meta/search/?q=i3
https://marlinfw.org/meta/search/?q=bed%20slinger
https://marlinfw.org/meta/search/?q=slinger
https://duet3d.dozuki.com/Search?query=slinger
https://duet3d.dozuki.com/Search?query=i3
https://www.google.com/search?q=i3+printer&sxsrf=APq-WBtiCPYvx7VmuHw1_Jd7XbtRbamR9g%3A1648374800516&source=hp&ei=EDRAYtPxHfXJkPIP2-CMmA8&iflsig=AHkkrS4AAAAAYkBCIFBknTn-hc0ZPASI_isRyhzC6wpY&ved=0ahUKEwjTucLTgub2AhX1JEQIHVswA_MQ4dUDCAY&uact=5&oq=i3+printer&gs_lcp=Cgdnd3Mtd2l6EAMyBQgAEMsBMgQIABAeMgQIABAeMgQIABAeMgQIABAeMgQIABAeMgQIABAeMgQIABAeMgQIABAeMgQIABAeOgcIIxDqAhAnOgUIABCABDoLCC4QgAQQxwEQowI6CwguEIAEEMcBENEDOgUILhCABDoICC4QgAQQ1AI6DgguEIAEEMcBENEDENQCOgcIABCABBAKOgcIABAKEMsBOgsILhDHARCvARDLAToGCAAQChAeUP0GWLshYOkiaAdwAHgAgAHQAYgB3w6SAQU3LjguMZgBAKABAbABAQ&sclient=gws-wiz
https://www.google.com/search?q=bed+slinger+printer&sxsrf=APq-WBsEzoLlmJZlSkSj1vmFJk65PxR32w%3A1648374806296&ei=FjRAYtXVEZ6ekPIPocKMiAc&ved=0ahUKEwjVuKTWgub2AhUeD0QIHSEhA3EQ4dUDCA0&uact=5&oq=bed+slinger+printer&gs_lcp=Cgdnd3Mtd2l6EAMyBQgAEMsBOgcIABBHELADOgQIABBDOgsILhCABBDHARCjAjoFCAAQgAQ6CwguEIAEEMcBENEDOg4ILhCABBDHARCjAhDUAjoOCC4QgAQQxwEQ0QMQ1AI6CgguEMcBEKMCEEM6BQguEIAEOgcIABCABBAMOgcILhCABBAMOgUILhDLAToLCC4QxwEQ0QMQywE6BAgAEA06BggAEA0QCjoECAAQHjoGCAAQDRAeOggIABAIEAoQHjoGCAAQCBAeOggIABAMEAoQHjoGCAAQDBAeSgQIQRgASgQIRhgAULsHWMMiYJ4kaARwAXgAgAGSAYgByBGSAQQ2LjE0mAEAoAEByAEKwAEB&sclient=gws-wiz
https://www.google.com/search?q=bed+slinger&sxsrf=APq-WBs9sesfPHj61iJWZ4wffjFa_hXcYg%3A1648374847628&ei=PzRAYtaEJrzHkPIP08m40AE&ved=0ahUKEwiWoP_pgub2AhW8I0QIHdMkDhoQ4dUDCA0&uact=5&oq=bed+slinger&gs_lcp=Cgdnd3Mtd2l6EAMyBggjECcQEzIICAAQDBAKEB4yCAgAEAwQChAeMggIABAMEAoQHjIICAAQDBAKEB4yBggAEAwQHjIICAAQDBAKEB4yCAgAEAwQChAeMgYIABAMEB4yCAgAEAwQChAeOgkIABCwAxAHEB46CQgAELADEAgQHjoOCC4QxwEQ0QMQ1AIQywE6BQgAEMsBOgQIIxAnOgUILhDLAToLCC4QxwEQrwEQywE6BwgjEOoCECc6CwguEIAEEMcBENEDOgUIABCABDoLCC4QgAQQxwEQowI6DgguEIAEEMcBENEDENQCOgQIABBDOgoILhDHARCjAhBDOgcILhCABBAMOgsILhDHARDRAxDLAToICAAQCBAKEB46BggAEAgQHkoECEEYAUoECEYYAFCdBFjyIWCJJ2gDcAB4BIABnwGIAZUPkgEEMy4xNJgBAKABAbABA8gBA8ABAQ&sclient=gws-wiz


Signed-off-by: Yifei Ding<yifeiding@protonmail.com>