### PR TITLE
atsam: Fix typo in sam4e_afec

### DIFF
--- a/src/atsam/sam4e_afec.c
+++ b/src/atsam/sam4e_afec.c
@@ -112,7 +112,7 @@ init_afec(Afec* afec) {
     afec->AFE_EMR = AFE_EMR_TAG | \
                      AFE_EMR_RES_NO_AVERAGE | \
                      AFE_EMR_STM;
-    afec->AFE_ACR = CFG_AFE_MR;
+    afec->AFE_ACR = CFG_AFE_ACR;
 
     // Disable interrupts
     afec->AFE_IDR = CFG_AFE_IDR;


### PR DESCRIPTION
Accidentally introduced in 80492432210f1cf7817b7808245d196f3420021e,
renders the AFE non-functional on SAME70. Should have had little impact
on SAM4E.

Signed-off-by: Alex Maclean <monkeh@monkeh.net>