### PR TITLE
Fix incorrect default value for max_freq in [resonance_tester] documentation

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1545,8 +1545,8 @@ section of the measuring resonances guide for more information on
 #   for more details on using this feature.
 #min_freq: 5
 #   Minimum frequency to test for resonances. The default is 5 Hz.
-#max_freq: 120
-#   Maximum frequency to test for resonances. The default is 120 Hz.
+#max_freq: 133.33
+#   Maximum frequency to test for resonances. The default is 133.33 Hz.
 #accel_per_hz: 75
 #   This parameter is used to determine which acceleration to use to
 #   test a specific frequency: accel = accel_per_hz * freq. Higher the


### PR DESCRIPTION
module: Documentation

According to [resonance_tester.py](https://github.com/Klipper3d/klipper/blob/master/klippy/extras/resonance_tester.py#L54) the default value for max_freq is actually 133.3333... Hz and not 120 like the docs say. Updated the docs to match the code.

Signed-off-by: Christopher Conroy <cbc02009@gmail.com>