### PR TITLE
wrong pin for stepper_z in set gpio pins at boot

### DIFF
--- a/config/printer-monoprice-select-mini-v2-2018.cfg
+++ b/config/printer-monoprice-select-mini-v2-2018.cfg
@@ -13,9 +13,9 @@
 #  and allows easy flashing via SDCard without additional hardware.
 #
 #  Also make sure to use the following string in the low-level configuration
-#  options to set a couple of GPIOs to high when the MCU boots:
+#  options to set a few of the GPIO pins to high when the MCU boots:
 #
-#  PA8, PB5, PB1
+#  PA8, PB11, PB1
 #
 #  This will deactivate the steppers until klippy takes over.
 #


### PR DESCRIPTION
set gpio pins at mcu start up: There is no reason to set PB5 high at mcu startup, and stepper_z enable_pin PB11 is missing from the list.