### PR TITLE
temperature_fan: clarification about PID

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2525,6 +2525,8 @@ information.
 #min_temp:
 #max_temp:
 #   See the "extruder" section for a description of the above parameters.
+#   For temperature_fan the PID algorithm is applied in reverse:
+#   fan_speed = fan_max_speed - (Kp*error + Ki*integral(error) - Kd*derivative(error)) / 255
 #target_temp: 40.0
 #   A temperature (in Celsius) that will be the target temperature.
 #   The default is 40 degrees.


### PR DESCRIPTION
Clarified that the temperature_fan operated in reverse compared to a heater.