### PR TITLE
neopixel: Support multiple color orders in one chain

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2629,8 +2629,11 @@ pin:
 #   Neopixel is connected to the pin).
 #color_order: GRB
 #   Set the pixel order required by the LED hardware (using a string
-#   containing the letters R, G, B, W with W optional). The default is
-#   GRB.
+#   containing the letters R, G, B, W with W optional). Can also be 
+#   set to a comma separated list of color orders for different LEDs 
+#   in one chain. Segments can be defined by "<n> * color_order", e.g. 
+#   "8 * GRB, 2 * GRBW". If chain_count is greater than the color order 
+#   list, it is filled with the last value. The default is GRB. 
 #initial_RED: 0.0
 #initial_GREEN: 0.0
 #initial_BLUE: 0.0

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2629,11 +2629,11 @@ pin:
 #   Neopixel is connected to the pin).
 #color_order: GRB
 #   Set the pixel order required by the LED hardware (using a string
-#   containing the letters R, G, B, W with W optional). Can also be 
-#   set to a comma separated list of color orders for different LEDs 
-#   in one chain. Segments can be defined by "<n> * color_order", e.g. 
-#   "8 * GRB, 2 * GRBW". If chain_count is greater than the color order 
-#   list, it is filled with the last value. The default is GRB. 
+#   containing the letters R, G, B, W with W optional). Can also be
+#   set to a comma separated list of color orders for different LEDs
+#   in one chain. Segments can be defined by "<n> * color_order", e.g.
+#   "8 * GRB, 2 * GRBW". If chain_count is greater than the color order
+#   list, it is filled with the last value. The default is GRB.
 #initial_RED: 0.0
 #initial_GREEN: 0.0
 #initial_BLUE: 0.0

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -11,7 +11,7 @@ RENDER_TIME = 0.500
 
 # Helper code for common LED initialization and control
 class LEDHelper:
-    def __init__(self, config, update_func, led_count=1, has_white=False):
+    def __init__(self, config, update_func, led_count=1):
         self.printer = config.get_printer()
         self.update_func = update_func
         self.led_count = led_count
@@ -19,9 +19,7 @@ class LEDHelper:
         red = config.getfloat('initial_RED', 0., minval=0., maxval=1.)
         green = config.getfloat('initial_GREEN', 0., minval=0., maxval=1.)
         blue = config.getfloat('initial_BLUE', 0., minval=0., maxval=1.)
-        white = 0.
-        if has_white:
-            white = config.getfloat('initial_WHITE', 0., minval=0., maxval=1.)
+        white = config.getfloat('initial_WHITE', 0., minval=0., maxval=1.)
         self.led_state = [(red, green, blue, white)] * led_count
         # Register commands
         name = config.get_name().split()[-1]
@@ -49,8 +47,7 @@ class LEDHelper:
             else:
                 if self.led_state[index - 1] == color:
                     return
-                self.led_state = led_state = list(self.led_state)
-                led_state[index - 1] = color
+                self.led_state[index - 1] = color
             if transmit:
                 try:
                     self.update_func(self.led_state, print_time)
@@ -82,8 +79,8 @@ class PrinterLED:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("SET_LED_TEMPLATE", self.cmd_SET_LED_TEMPLATE,
                                desc=self.cmd_SET_LED_TEMPLATE_help)
-    def setup_helper(self, config, update_func, led_count=1, has_white=False):
-        led_helper = LEDHelper(config, update_func, led_count, has_white)
+    def setup_helper(self, config, update_func, led_count=1):
+        led_helper = LEDHelper(config, update_func, led_count)
         name = config.get_name().split()[-1]
         self.led_helpers[name] = led_helper
         return led_helper
@@ -204,7 +201,7 @@ class PrinterPWMLED:
         self.last_print_time = 0.
         # Initialize color data
         pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds, 1, True)
+        self.led_helper = pled.setup_helper(config, self.update_leds, 1)
         self.prev_color = color = self.led_helper.get_status()['color_data'][0]
         for idx, mcu_pin in self.pins:
             mcu_pin.setup_start_value(color[idx], 0.)

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -22,7 +22,7 @@ class PrinterNeoPixel:
         self.mcu = pin_params['chip']
         self.oid = self.mcu.create_oid()
         self.pin = pin_params['pin']
-        
+
         self.mcu.register_config_callback(self.build_config)
 
         self.color_maps = []
@@ -43,13 +43,13 @@ class PrinterNeoPixel:
                 color_index = [color_order.index(c) for c in "RGB"]
             for _ in range(count-1):
                 self.color_maps.append(color_index)
-        
+
         self.chain_count = config.getint('chain_count', 1, minval=1)
 
         missing_color_maps = self.chain_count - len(self.color_maps)
         if missing_color_maps > 0:
             self.color_maps += [color_index]*missing_color_maps
-            
+
         self.neopixel_update_cmd = self.neopixel_send_cmd = None
 
         # Initialize color data

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -17,7 +17,7 @@ class PCA9533:
         self.printer = config.get_printer()
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
         pled = self.printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds, 1, True)
+        self.led_helper = pled.setup_helper(config, self.update_leds, 1)
         self.i2c.i2c_write([PCA9533_PWM0, 85])
         self.i2c.i2c_write([PCA9533_PWM1, 170])
         self.update_leds(self.led_helper.get_status()['color_data'], None)

--- a/klippy/extras/pca9632.py
+++ b/klippy/extras/pca9632.py
@@ -35,7 +35,7 @@ class PCA9632:
         self.color_map = [color_order.index(c) for c in "RGBW"]
         self.prev_regs = {}
         pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds, 1, True)
+        self.led_helper = pled.setup_helper(config, self.update_leds, 1)
         printer.register_event_handler("klippy:connect", self.handle_connect)
     def reg_write(self, reg, val, minclock=0):
         if self.prev_regs.get(reg) == val:


### PR DESCRIPTION
This allows to mix multiple Neopixels with different color orders in one chain. This can be useful for example when running a LED strip and some status LEDs from one pin.

Also very useful for [Rainbow Barf](https://github.com/tanaes/whopping_Voron_mods/tree/main/LEDs/Rainbow_Barf_Logo_LED) in the Voron Stealthburner, which has RGB LEDs with RGBW LEDs at the nozzle.

Configuration can be similar to:

`color_order: GRBW`

OR

`color_order: GRB, GRB, RGB, GRBW`

OR

`color_order: 2 * GRB,  GRBW, 8 * RGB`

I couldn't test the minor changes to pca9533 and pca9633 (the removal of the obsolete "has_white" parameter in led.py), as I don't have this hardware to my disposal. I tested the code with GRB and GRBW neopixels as well as dotstars, though.

Signed-off-by: Julian Schill <j.schill@web.de>