### PR TITLE
Added layer_height to the pressure advance formula

### DIFF
--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -60,8 +60,8 @@ height.
 ![tune_pa](img/tune_pa.jpg)
 
 The pressure_advance value can then be calculated as `pressure_advance
-= <start> + <measured_height> * <factor>`. (For example, `0 + 12.90 *
-.020` would be `.258`.)
+= <start> + <measured_height> / <layer_height> * <factor>`. (For example, `0 + 12.90 / 0.3 *
+.020` would be `.86`.)
 
 It is possible to choose custom settings for START and FACTOR if that
 helps identify the best pressure advance setting. When doing this, be


### PR DESCRIPTION
In the TUNING TOWER the pressure advance setting is changing every layer, but it was calculated like it's changing every 1 mm.