### PR TITLE
Config_Reference: Change description in [screws_tilt_adjust]

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -998,7 +998,7 @@ information.
 ```
 [screws_tilt_adjust]
 #screw1:
-#   The (X, Y) coordinate of the first bed leveling screw. This is 
+#   The (X, Y) coordinate of the first bed leveling screw. This is
 #   expressed in nozzle coordinates when the probe is directly
 #   above the bed screw (or as close as possible while still being above the bed).
 #   This parameter must be provided.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -998,11 +998,10 @@ information.
 ```
 [screws_tilt_adjust]
 #screw1:
-#   The (X, Y) coordinate of the first bed leveling screw. This is a
-#   position to command the nozzle to that is directly above the bed
-#   screw (or as close as possible while still being above the bed).
-#   This is the base screw used in calculations. This parameter must
-#   be provided.
+#   The (X, Y) coordinate of the first bed leveling screw. This is 
+#   expressed in nozzle coordinates when the probe is directly
+#   above the bed screw (or as close as possible while still being above the bed).
+#   This parameter must be provided.
 #screw1_name:
 #   An arbitrary name for the given screw. This name is displayed when
 #   the helper script runs. The default is to use a name based upon


### PR DESCRIPTION
Original description for screw1 was ambiguous to the fact that it is the probe that needs to be over the screw and not the nozzle, and that it is expressed in nozzle coordinates.

Signed-off-by: James Hartley <james@hartleyns.com>