### PR TITLE
printer-creality-ender3pro-2020: Update info on chip types

### DIFF
--- a/config/printer-creality-ender3pro-2020.cfg
+++ b/config/printer-creality-ender3pro-2020.cfg
@@ -3,6 +3,12 @@
 # "make menuconfig" select the STM32F103 with a "28KiB bootloader" and
 # serial (on USART1 PA10/PA9) communication.
 
+# It should be noted that newer variations of this printer shipping in
+# 2022 may have GD32F103 chips installed and not STM32F103. You may
+# have to inspect the mainboard to ascertain which one you have. If it
+# is the GD32F103 then please select Disable SWD at startup in the
+# "make menuconfig" along with the same settings for STM32F103.
+
 # If you prefer a direct serial connection, in "make menuconfig"
 # select "Enable extra low-level configuration options" and select
 # serial (on USART3 PB11/PB10), which is broken out on the 10 pin IDC


### PR DESCRIPTION
Added flash info that some Ender 3 Pro's shipped in 2022 have the GD32F103 chip

Signed-off-by: James Hartley <james@hartleyns.com>