### PR TITLE
spi_flash: resolve configuration issues

### DIFF
--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -119,6 +119,9 @@ FINALIZE_CFG_CMD = "finalize_config crc=%d"
 class SPIFlashError(Exception):
     pass
 
+class MCUConfigError(SPIFlashError):
+    pass
+
 class SPIDirect:
     def __init__(self, ser):
         self.oid = SPI_OID
@@ -862,8 +865,7 @@ class MCUConnection:
         self._serial.disconnect()
         self.connected = False
 
-    def check_need_restart(self):
-        output("Checking Current MCU Configuration...")
+    def get_mcu_config(self):
         # Iterate through backwards compatible response strings
         for response in GET_CFG_RESPONSES:
             try:
@@ -875,7 +877,11 @@ class MCUConnection:
                 if response == GET_CFG_RESPONSES[-1]:
                     raise err
                 output("Trying fallback...")
-        params = get_cfg_cmd.send()
+        return get_cfg_cmd.send()
+
+    def check_need_restart(self):
+        output("Checking Current MCU Configuration...")
+        params = self.get_mcu_config()
         output_line("Done")
         if params['is_config'] or params['is_shutdown']:
             output_line("MCU needs restart: is_config=%d, is_shutdown=%d"
@@ -926,9 +932,12 @@ class MCUConnection:
         self._serial.send(bus_cmd)
         config_crc = zlib.crc32('\n'.join(cfg_cmds).encode()) & 0xffffffff
         self._serial.send(FINALIZE_CFG_CMD % (config_crc,))
+        config = self.get_mcu_config()
+        if not config["is_config"] or config["is_shutdown"]:
+            raise MCUConfigError("Failed to configure MCU")
+        printfunc("Initializing SD Card and Mounting file system...")
         self.fatfs = FatFS(self._serial)
         self.reactor.pause(self.reactor.monotonic() + .5)
-        printfunc("Initializing SD Card and Mounting file system...")
         try:
             self.fatfs.mount(printfunc)
         except OSError:
@@ -1098,7 +1107,14 @@ class SPIFlash:
         if not self.mcu_conn.connected:
             self.mcu_conn.connect()
         self.old_dictionary = self.mcu_conn.raw_dictionary
-        self.mcu_conn.configure_mcu(printfunc=output_line)
+        try:
+            self.mcu_conn.configure_mcu(printfunc=output_line)
+        except MCUConfigError:
+            output_line("MCU configuration failed, attempting restart")
+            self.need_upload = True
+            self.mcu_conn.reset()
+            self.task_complete = True
+            return
         self.firmware_checksum = self.mcu_conn.sdcard_upload()
         self.mcu_conn.reset()
         self.task_complete = True

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -95,7 +95,7 @@ def check_need_convert(board_name, config):
 
 SPI_OID = 0
 SPI_MODE = 0
-SD_SPI_SPEED = 4000000
+SD_SPI_SPEED = 400000
 # MCU Command Constants
 RESET_CMD = "reset"
 GET_CFG_CMD = "get_config"


### PR DESCRIPTION
This patch should resolve the issues previously discussed.  Two changes are added:
1) The `spi_flash` module now validates that the MCU is configured after sending a configuration.
2) The SPI frequency is reduced to 400kHz, which is within the recommended guidelines for SD Card initialization.  While a typical sd card would increase the frequency after init, it isn't necessary for our application.

I have tested these changes on an SKR Pro v1.1 and SKR Mini E3 v1.2.   I plan to test on an SKR 1.3 and Flyboard Mini as well, however I wanted to get this PR up to give the opportunity for others to test.  In particular it would be good to make sure that the SPI frequency change doesn't negatively impact other boards, if necessary we can specify the frequency on a per-board basis.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>