### PR TITLE
Kconfig: Add 64kib bootloader offset option to STM32F401

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -196,7 +196,7 @@ choice
     config STM32_FLASH_START_C000
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F4x5
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446
+        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446 || MACH_STM32F401
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103


### PR DESCRIPTION
This is needed for the Creality Ender 3 S1 with the STM32F401 chips to enable a 64kib bootloader offset

Signed-off-by: James Hartley <james@hartleyns.com>