### PR TITLE
config: Pull up endstop_pins on Fysetc S6/Spider

### DIFF
--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -11,7 +11,7 @@ dir_pin: PE10
 enable_pin: !PE9
 microsteps: 16
 rotation_distance: 40
-endstop_pin: PB14  # PA1 for X-max
+endstop_pin: ^PB14  # PA1 for X-max
 position_endstop: 0
 position_max: 200
 
@@ -21,7 +21,7 @@ dir_pin: PB12
 enable_pin: !PD9
 microsteps: 16
 rotation_distance: 40
-endstop_pin: PB13  # PA2 for Y-max
+endstop_pin: ^PB13  # PA2 for Y-max
 position_endstop: 0
 position_max: 200
 
@@ -31,7 +31,7 @@ dir_pin: PD13
 enable_pin: !PD15
 microsteps: 16
 rotation_distance: 8
-endstop_pin: PA0  # PA3 for Z-max
+endstop_pin: ^PA0  # PA3 for Z-max
 position_endstop: 0
 position_max: 400
 

--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -11,7 +11,7 @@ dir_pin: PE10
 enable_pin: !PE12
 microsteps: 16
 rotation_distance: 40
-endstop_pin: PB14  # PA1 for X-max
+endstop_pin: ^PB14  # PA1 for X-max
 position_endstop: 0
 position_max: 200
 
@@ -21,7 +21,7 @@ dir_pin: PB12
 enable_pin: !PD9
 microsteps: 16
 rotation_distance: 40
-endstop_pin: PB13  # PA2 for Y-max
+endstop_pin: ^PB13  # PA2 for Y-max
 position_endstop: 0
 position_max: 200
 
@@ -31,7 +31,7 @@ dir_pin: PD13
 enable_pin: !PD15
 microsteps: 16
 rotation_distance: 8
-endstop_pin: PA0  # PA3 for Z-max (and servo)
+endstop_pin: ^PA0  # PA3 for Z-max (and servo)
 position_endstop: 0
 position_max: 400
 

--- a/config/generic-fysetc-spider.cfg
+++ b/config/generic-fysetc-spider.cfg
@@ -12,7 +12,7 @@ dir_pin: PE10
 enable_pin: !PE9
 microsteps: 16
 rotation_distance: 40
-endstop_pin: PB14  # PA1 for X-max
+endstop_pin: ^PB14  # PA1 for X-max
 position_endstop: 0
 position_max: 200
 
@@ -32,7 +32,7 @@ dir_pin: PD13
 enable_pin: !PD15
 microsteps: 16
 rotation_distance: 8
-endstop_pin: PA0  # PA3 for Z-max
+endstop_pin: ^PA0  # PA3 for Z-max
 position_endstop: 0
 position_max: 400
 


### PR DESCRIPTION
My Fysetc S6 V2.1 (essentially the same as V2) needed software pull-ups to make the endstops work. After checking the schematics for S6 V1.2 and Spider, those boards need software pull-ups as well.