### PR TITLE
Update generic-bigtreetech-skr-v1.4.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for the BIGTREETECH SKR V1.4
 # board. To use this config, the firmware should be compiled for the
-# LPC1768 or LPC1769(Turbo).
+# LPC1768 or LPC1769(Turbo), with smoothieware bootloader enabled.
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
The SKR 1.4 boards use the smoothieware bootloader