### PR TITLE
manual_stepper: Fix long moves

### DIFF
--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -84,8 +84,8 @@ class ManualStepper:
                 finalize_time = self.reactor.NEVER
             self.trapq_finalize_moves(self.trapq, finalize_time)
             toolhead.note_kinematic_activity(self.next_cmd_time)
+            flush_time = self.next_cmd_time
             for m in self.all_mcus:
-                flush_time = self.next_cmd_time
                 if self.next_cmd_time < next_print_time:
                     flush_time -= self.move_flush_time
                 m.flush_moves(flush_time)


### PR DESCRIPTION
Description of the problem can be found in this thread: https://klipper.discourse.group/t/long-manual-stepper-moves-cause-timer-too-close/2740

Introduces better support for long moves on slow host processors which may otherwise generate a timer too close error when step generation takes too long.

Addresses a problem coming up in the ERCF project somewhat frequently https://github.com/EtteGit/EnragedRabbitProject/issues/75

Tests are passing