### PR TITLE
klippy: Reworked the MCU protocol error message

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -145,16 +145,8 @@ class Printer:
             m.add_printer_objects(config)
         # Validate that there are no undefined parameters in the config file
         pconfig.check_unused_options(config)
-    def _get_versions(self):
-        try:
-            parts = ["%s=%s" % (n.split()[-1], m.get_status()['mcu_version'])
-                     for n, m in self.lookup_objects('mcu')]
-            parts.insert(0, "host=%s" % (self.start_args['software_version']))
-            return "\nKnown versions: %s\n" % (", ".join(parts),)
-        except:
-            logging.exception("Error in _get_versions()")
-            return ""
-    def _get_outdated_versions(self):
+
+    def _build_protocol_error_message(self):
         try:
             host_version = self.start_args['software_version']
 
@@ -200,7 +192,7 @@ class Printer:
             msg = [message_protocol_error1,
                    "",
                    ' '.join(message_protocol_error2.splitlines())[1:],
-                   self._get_outdated_versions(),
+                   self._build_protocol_error_message(),
                    ' '.join(message_protocol_error3.splitlines())[1:],
                    "",
                    str(e)]

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -182,7 +182,7 @@ class Printer:
                ' '.join(message_protocol_error3.splitlines())[1:],
                "",
                str(e)]
-        
+
         return "\n".join(msg)
 
     def _connect(self, eventtime):


### PR DESCRIPTION
The MCU protocol error message often confuses users, especially after getting bombarded with the config format error line. This PR tries to improve it and has the following goals:

- Put the technical error at the end to prevent confusion and avoid the immediate jump to help channels instead of continuing to read
- Inform the user first what the type of error is (In this case: MCU Protocol error) and not at the end of the long error message
- Give the users a clear instruction what to do (pretty much unchanged), but possibly more approachable because the user is not confused by the technical error anymore
- Shows the version numbers of Klipper separate from all MCU version numbers so that it is more obvious that this is the version of Klipper
- Separates the version numbers between outdated MCUs and up-to-date MCUs, so that it becomes obvious if a MCU flash failed because the MCU doesn't disappear from the outdated list
- Previously, when viewing the errors in a web frontend, additional line breaks made it extremely hard to read the message, sometimes with as little as one word on one line. The error messages are now formatted to not have rogue line breaks, improving readability.

Signed-off-by: Felicia Alexa Hummel <felicia@drachenkatze.org>