### PR TITLE
Config: Added new configs to reflect newer hardware revisions

### DIFF
--- a/config/generic-mks-robin-nano-s-v1.3.cfg
+++ b/config/generic-mks-robin-nano-s-v1.3.cfg
@@ -1,0 +1,103 @@
+# This file contains common pin mappings for the Makerbase Robin Nano-S v1.3
+# (TCM2225 drivers for X, Y, Z and E).
+
+# INSTRUCTIONS FOR COMPILING
+# To use this config, the firmware should be compiled for the STM32F407.
+# When running "make menuconfig", enable "extra low-level configuration setup",
+# select the 32KiB bootloader, serial (on USART3 PB11/PB10) to use USB communication
+# or serial (on USART1 PA10/PA9) to use direct UART connection with Raspberry trough wifi pins.
+# Set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13" to turn off display at startup.
+
+# INSTRUCTIONS FOR FLASHING, THE SCRIPT IS COMPULSORY OR IT WON'T WORK!!!
+# Note that the "make flash" command does not work with the Robin Nano!
+# After running "make", run the following command in one row FROM THE KLIPPER FOLDER:
+#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
+# Copy the file out/Robin_nano35.bin (if you can't find the file the script was not executed)
+# to an SD card and then restart the printer with that SD card.
+# Note: You will need to disconnect any display connected to the board for successful flashing to occur.
+# If flashing was succesful, the robin_nan35.bin file on thhe sdcard will now be auto renamed as robin_nano35.CUR.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PE3
+dir_pin: !PE2
+enable_pin: !PE4
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA15
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PE0
+dir_pin: !PB9
+enable_pin: !PE1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA12
+position_endstop: 230
+position_max: 230
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB5
+dir_pin: PB4
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 8
+endstop_pin: !PA11
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PD6
+dir_pin: !PD3
+enable_pin: !PB3
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC1
+control: pid
+pid_Kp: 14.669
+pid_Ki: 0.572
+pid_Kd: 94.068
+min_temp: 0
+max_temp: 250
+
+#[extruder1]
+#step_pin: PA6
+#dir_pin: !PA1
+#enable_pin: !PA3
+#heater_pin: PB0
+#sensor_pin: PC2
+#...
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+control: pid
+pid_Kp: 325.10
+pid_Ki: 63.35
+pid_Kd: 417.10
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PB1
+
+[mcu]
+serial: /dev/ttyUSB0
+restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 250
+max_accel: 4500
+max_z_velocity: 25
+max_z_accel: 100

--- a/config/printer-twotrees-sapphire-pro-sp-3-2022.cfg
+++ b/config/printer-twotrees-sapphire-pro-sp-3-2022.cfg
@@ -1,0 +1,105 @@
+# This file contains common pin mappings for the Two Trees Sapphire
+# Pro (SP-3) printer (Robin Nano-S 1.3, TCM2225 drivers for X, Y, Z and E).
+
+# INSTRUCTIONS FOR COMPILING
+# To use this config, the firmware should be compiled for the STM32F407.
+# When running "make menuconfig", enable "extra low-level configuration setup",
+# select the 32KiB bootloader, serial (on USART3 PB11/PB10) to use USB communication
+# or serial (on USART1 PA10/PA9) to use direct UART connection with Raspberry trough wifi pins.
+# Set "GPIO pins to set at micro-controller startup" to "!PC6,!PD13" to turn off display at startup.
+
+# INSTRUCTIONS FOR FLASHING, THE SCRIPT IS COMPULSORY OR IT WON'T WORK!!!
+# Note that the "make flash" command does not work with the Robin Nano!
+# After running "make", run the following command in one row FROM THE KLIPPER FOLDER:
+#   ./scripts/update_mks_robin.py out/klipper.bin out/Robin_nano35.bin
+# Copy the file out/Robin_nano35.bin (if you can't find the file the script was not executed)
+# to an SD card and then restart the printer with that SD card.
+# Note: You will need to disconnect any display connected to the board for successful flashing to occur.
+# If flashing was succesful, the robin_nan35.bin file on thhe sdcard will now be auto renamed as robin_nano35.CUR.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PE3
+dir_pin: !PE2
+enable_pin: !PE4
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA15
+position_endstop: 0
+position_max: 230
+homing_speed: 50
+
+[stepper_y]
+step_pin: PE0
+dir_pin: !PB9
+enable_pin: !PE1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA12
+position_endstop: 230
+position_max: 230
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB5
+dir_pin: PB4
+enable_pin: !PB8
+microsteps: 16
+rotation_distance: 2
+endstop_pin: !PA11
+position_endstop: 0.5
+position_max: 230
+
+[extruder]
+step_pin: PD6
+dir_pin: !PD3
+enable_pin: !PB3
+microsteps: 16
+gear_ratio: 50:17
+rotation_distance: 23.52
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC3
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC1
+control: pid
+pid_Kp: 14.669
+pid_Ki: 0.572
+pid_Kd: 94.068
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+control: pid
+pid_Kp: 325.10
+pid_Ki: 63.35
+pid_Kd: 417.10
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PB1
+
+[mcu]
+serial: /dev/ttyUSB0
+restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 250
+max_accel: 4500
+max_z_velocity: 10
+max_z_accel: 80
+
+[bed_screws]
+screw1: 15,15
+screw2: 210,15
+screw3: 210,210
+screw4: 15,210
+
+[static_digital_output reset_display]
+pins: !PC6, !PD13


### PR DESCRIPTION
I have added two new configuration files:

1. printer-twotrees-sapphire-pro-sp-3-2022.cfg: Added new config for the latest version of the TwoTrees SP-3 Pro.
The latest printer uses a newer board revision, physically different to previous version, with updated MCU, different driver type, different driver quantity and larger boot offset

- Drivers: 4 x Integrated TCM2225
- MCU: STM32F407
- Boot Offset: 32kb

2. generic-mks-robin-nano-s-v1.3.cfg: Added new config for the latest version of the Makerbase Robin Nano v1.x range.
The newer board revision from Makerbase is physically different to previous version, with updated MCU, different driver type, different driver quantity and larger boot offset.

- Drivers: 4 x Integrated TCM2225
- MCU: STM32F407
- Boot Offset: 32kb
