### PR TITLE
feat(Makefile): determine available python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
 CPP=cpp
-PYTHON=python2
+
+# Determine python version
+PYTHON=$(shell if [ -n "$(command -v python2)" ]; then echo "python2"; \
+    else echo "python3"; fi)
 
 # Source files
 src-y =


### PR DESCRIPTION
Instead hardcoding python version let make see what version is available.

According to your discussion in https://github.com/Klipper3d/klipper/pull/4957, especcially
https://github.com/Klipper3d/klipper/pull/4957#issuecomment-1003405059

I understand your concerns using Global Variables from the OS might cause unwanted side effects.
But, obviously runs klipper very well with python3, only the crutial `make menuconfig` needs python2.

In my opinion it doesn't make much sense to install an outdated package to have the possibilty to use klipper on
modern OSes without even having python2 packages. So, if there are no reasons besides backwards compatibilty,
let make determine what is installed. This negotiates the unwanted Global Variables behavior but doesnt limit to install py2.

To see if klipper is working with python3 use the early image of MainsailOS (working on bullseye and ne Framework).

https://github.com/KwadFan/MainsailOS-ng/actions/runs/2271418151

feel free to test the Image.

As said to force users and maintainers to use outdated interpreter is not a good option.
In my opinion, you have to go with the development of OSes because your software is great but depends on a good maintained and running OS :) So, please accept that PR or get it fixed ASAP please.

Regards

Signed-off-by: Stephan Wendel <me@stephanwe.de>