### PR TITLE
Implement HX711 load cell sensor.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3929,6 +3929,22 @@ adc2:
 #   above parameters.
 ```
 
+### [hx711]
+
+HX711 Load Cell Sensor (see
+[HX711 Load Cell Sensor](HX711_Load_Cell_Sensor.md)).
+
+```
+[hx711 my_sensor]
+dout_pin:
+# Pin connected to hx711's DOUT pin
+sclk_pin:
+# Pin connected to hx711's PD_SCK pin
+#calib_data: 0,0;1,1
+#   A semicolon ';' separated list of <raw_value>,<value> pairs to form the conversion.
+#   Default: 0,0;1,1
+```
+
 ## Board specific hardware support
 
 ### [sx1509]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -607,6 +607,16 @@ above the supplied MINIMUM and/or at or below the supplied MAXIMUM.
 [TARGET=<target_temperature>]`: Sets the target temperature for a
 heater. If a target temperature is not supplied, the target is 0.
 
+### [hx711]
+
+The following command is available when a
+[hx711](Config_Reference.md#hx711)
+config section is enabled.
+
+#### QUERY_HX711
+`QUERY_HX711 NAME=<sensor_name>`: Queries last obtained value and
+raw value of the hx711 sensor.
+
 ### [idle_timeout]
 
 The idle_timeout module is automatically loaded.

--- a/docs/HX711_Load_Cell_Sensor.md
+++ b/docs/HX711_Load_Cell_Sensor.md
@@ -6,6 +6,8 @@ To use the HX711 load cell sensor, read
 [Config Reference](Config_Reference.md#hx711) and
 [G-Code documentation](G-Codes.md#hx711).
 
+HX711 is only supported on MCUs with bitbanging support.
+
 ## Calibration procedure
 
 To get sensor value you can use **QUERY_HX711** command in terminal.

--- a/docs/HX711_Load_Cell_Sensor.md
+++ b/docs/HX711_Load_Cell_Sensor.md
@@ -1,0 +1,43 @@
+# HX711 load cell sensor
+
+This document describes HX711 load cell sensor module.
+
+To use the HX711 load cell sensor, read
+[Config Reference](Config_Reference.md#hx711) and
+[G-Code documentation](G-Codes.md#hx711).
+
+## Calibration procedure
+
+To get sensor value you can use **QUERY_HX711** command in terminal.
+
+1. Load the cell with a known weight.
+
+2. Query the latest raw value.
+
+3. Repeat steps 1 and 2 at least one time with a different weight.
+
+4. When you have enought calibration points you can create the calibration.
+The format is a list of <raw_value>,<value> pairs separated by semicolons ';'.
+e.g.: 0,10;100;1010;1050;10510
+
+5. Save the calibration data in config parameter `calib_data`.
+
+The conversion is unit agnostic. This means you can convert the
+raw values in grams, pounds, or even percentage if you like.
+
+For example:
+Let's assume you are weighing your filament spool with this sensor.
+You gather calibration data with an empty spool(520) and with a full(18657) spool.
+When you enter `520,0;18657,100` as `calib_data`, you will receive a
+percentage value indicating how full the spool is.
+
+## Example
+A simple example to read the latest value of 'hx711 test':
+
+```
+[gcode_macro hx711]
+gcode:
+  {% set res = printer["hx711 test"] %}
+  { action_respond_info(res.value) }
+  { action_respond_info(res.raw_value) }
+```

--- a/klippy/extras/hx711.py
+++ b/klippy/extras/hx711.py
@@ -1,0 +1,87 @@
+# Support for hx711 load cell sensor
+#
+# Copyright (C) 2022  Jochen Loeser <jochen_loeser@trimble.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class SensorHx711(object):
+    def __init__(self, config):
+        try:
+            import numpy as np
+        except:
+            raise config.error("HX711 requires numpy module")
+        self.printer = config.get_printer()
+        self._name = config.get_name().split()[-1]
+        self._last_value = None
+        # Create polynom
+        try:
+            data_str = config.get('calib_data', '0,0;1,1')
+            data = np.array(np.mat(data_str))
+            fit = np.polyfit(data[:,0], data[:,1], 1)
+            self._line = np.poly1d(fit)
+        except:
+            raise config.error("HX711: There is an error with your calib_data.")
+        # Setup pins
+        ppins = self.printer.lookup_object('pins')
+        self._sclk_pinparam = ppins.lookup_pin(config.get('sclk_pin'))
+        self._dout_pinparam = ppins.lookup_pin(config.get('dout_pin'))
+        self._mcu = None
+        for pin in [self._sclk_pinparam, self._dout_pinparam]:
+            if self._mcu is not None and pin['chip'] != self._mcu:
+                raise ppins.error("button pins must be on same mcu")
+            self._mcu = pin['chip']
+        # Create an OID
+        self._oid = self._mcu.create_oid()
+        # Register commands
+        self._query_hx711_value_cmd = None
+        self._mcu.register_config_callback(self._build_config)
+        self._mcu.register_response(self._handle_hx711_value,
+            "hx711_value", oid=self._oid)
+        # Register event handler
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        # Register GCODE command
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("QUERY_HX711", "NAME", self._name,
+                                   self.cmd_QUERY_HX711,
+                                   desc=self.cmd_QUERY_HX711_help)
+    def _handle_ready(self):
+        self._start_measurement()
+    def _build_config(self):
+        self._mcu.add_config_cmd("config_hx711 oid=%d sclk_pin=%s dout_pin=%s"
+            % (self._oid, self._sclk_pinparam['pin'],
+                self._dout_pinparam['pin']))
+        self._query_hx711_value_cmd = self._mcu.lookup_command(
+            "query_hx711_value oid=%c clock=%u rest_ticks=%u")
+    def _handle_hx711_value(self, params):
+        self._last_value = params['value']
+        self._start_measurement()
+    def _start_measurement(self):
+        clock = self._mcu.get_query_slot(self._oid)
+        rest_ticks = self._mcu.seconds_to_clock(0.001)
+        if self._query_hx711_value_cmd is not None:
+            self._query_hx711_value_cmd.send([self._oid, clock, rest_ticks],
+                reqclock=clock)
+    def get_status(self, eventtime):
+        if self._last_value is None:
+            return {
+                'raw_value': None,
+                'value':     None,
+            }
+        raw_value = self._last_value
+        value = self._line(raw_value)
+        return {
+            'raw_value': str(raw_value),
+            'value':     str(value),
+        }
+    cmd_QUERY_HX711_help = "Query hx711 for the current values"
+    def cmd_QUERY_HX711(self, gcmd):
+        if self._last_value is None:
+            gcmd.respond_info("hx711 value(raw_value): no value queried")
+            return
+        raw_value = self._last_value
+        value = self._line(raw_value)
+        gcmd.respond_info("hx711 value(raw_value): %.6f(%u)"
+            % (value, raw_value))
+
+def load_config_prefix(config):
+    return SensorHx711(config)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 
 src-y += sched.c command.c basecmd.c debugcmds.c
 src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c \
-    trsync.c
+    trsync.c sensor_hx711.c
 src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,11 +2,11 @@
 
 src-y += sched.c command.c basecmd.c debugcmds.c
 src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c \
-    trsync.c sensor_hx711.c
+    trsync.c
 src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c
 bb-src-$(CONFIG_HAVE_GPIO_SPI) := spi_software.c sensor_adxl345.c sensor_angle.c
 src-$(CONFIG_HAVE_GPIO_BITBANGING) += $(bb-src-y) lcd_st7920.c lcd_hd44780.c \
-    buttons.c tmcuart.c neopixel.c pulse_counter.c
+    buttons.c tmcuart.c neopixel.c pulse_counter.c sensor_hx711.c

--- a/src/sensor_hx711.c
+++ b/src/sensor_hx711.c
@@ -1,0 +1,186 @@
+// Support for hx711 load cell sensor
+//
+// Copyright (C) 2022  Jochen Loeser <jochen_loeser@trimble.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_MACH_AVR
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // gpio_out_write
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_from_us
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_TASK
+
+enum hx_state {
+    HX_IDLE,
+    HX_START,
+    HX_VALIDATE,
+    HX_READING,
+    HX_DONE,
+};
+
+struct hx711 {
+    struct gpio_in  dout_pin;   // pin used to receive data from the hx711
+    struct gpio_out sclk_pin;   // pin used to generate clock for the hx711
+    struct timer    timer;      // time to trigger hx711_task()
+    uint32_t        rest_ticks; //
+    enum hx_state   state;      // contains the current state
+    int32_t         data;       // received data
+};
+
+static struct task_wake hx711_wake;
+
+// Event handler that wakes hx711_task() periodically
+static uint_fast8_t
+hx711_event(struct timer *timer)
+{
+    sched_wake_task(&hx711_wake);
+    return SF_DONE;
+}
+
+static uint32_t
+nsecs_to_ticks(uint32_t ns)
+{
+    return timer_from_us(ns * 1000) / 1000000;
+}
+
+static inline void
+ndelay(uint32_t nsecs)
+{
+    if (CONFIG_MACH_AVR)
+    {
+        // Slower MCUs don't require a delay
+        return;
+    }
+    uint32_t end = timer_read_time() + nsecs_to_ticks(nsecs);
+    while (timer_is_before(timer_read_time(), end))
+    {
+        irq_poll();
+    }
+}
+
+static inline uint32_t
+hx711_read_dout(struct hx711 *hx)
+{
+    return gpio_in_read(hx->dout_pin);
+}
+
+static inline void
+hx711_set_sclk(struct hx711 *hx, uint32_t value)
+{
+    gpio_out_write(hx->sclk_pin, value);
+}
+
+static inline uint32_t
+hx711_receive_bit(struct hx711 *hx)
+{
+    hx711_set_sclk(hx, 1);
+    ndelay(250);
+    uint32_t result = hx711_read_dout(hx);
+    hx711_set_sclk(hx, 0);
+    ndelay(250);
+    return result;
+}
+
+static inline uint32_t
+hx711_rdy(struct hx711 *hx)
+{
+    return !hx711_read_dout(hx);
+}
+
+void
+command_config_hx711(uint32_t *args)
+{
+    struct hx711 *hx = oid_alloc(args[0], command_config_hx711, sizeof(*hx));
+    hx->sclk_pin = gpio_out_setup(args[1], 0);
+    hx->dout_pin = gpio_in_setup(args[2], 0);
+    hx->timer.func = hx711_event;
+    hx->state = HX_IDLE;
+    hx->data = 0;
+}
+DECL_COMMAND(command_config_hx711,
+    "config_hx711 oid=%c sclk_pin=%u dout_pin=%u");
+
+// Helper code to reschedule the hx711_event() timer
+static void
+hx711_reschedule_timer(struct hx711 *hx)
+{
+    irq_disable();
+    sched_del_timer(&hx->timer);
+    hx->timer.waketime = timer_read_time() + hx->rest_ticks;
+    sched_add_timer(&hx->timer);
+    irq_enable();
+}
+
+void
+command_query_hx711_value(uint32_t *args)
+{
+    struct hx711 *hx = oid_lookup(args[0], command_config_hx711);
+    if(hx->state == HX_IDLE)
+    {
+        irq_disable();
+        if(hx->state == HX_IDLE)
+        {
+            sched_del_timer(&hx->timer);
+            hx->timer.waketime = args[1];
+            hx->rest_ticks = args[2];
+            hx->state = HX_START;
+            sched_add_timer(&hx->timer);
+        }
+        irq_enable();
+    }
+}
+DECL_COMMAND(command_query_hx711_value,
+    "query_hx711_value oid=%c clock=%u rest_ticks=%u");
+
+void
+hx711_task(void)
+{
+    if (!sched_check_wake(&hx711_wake))
+    {
+        return;
+    }
+    uint8_t oid;
+    struct hx711 *hx;
+    foreach_oid(oid, hx, command_config_hx711) {
+        switch(hx->state)
+        {
+            case HX_IDLE:
+                return;
+            case HX_START:
+                hx711_set_sclk(hx, 0);
+                hx->data = 0;
+                hx->state = HX_VALIDATE;
+                hx711_reschedule_timer(hx);
+                break;
+            case HX_VALIDATE:
+                if(hx711_rdy(hx))
+                {
+                    hx->state = HX_READING;
+                }
+                hx711_reschedule_timer(hx);
+                break;
+            case HX_READING:
+                for(uint32_t i = 0; i < 24; i++)
+                {
+                    hx->data <<=1;
+                    hx->data |= hx711_receive_bit(hx);
+                }
+                if(hx->data & 0x00800000)
+                {
+                    hx->data |= 0xFF000000;
+                }
+                hx->state = HX_DONE;
+                hx711_reschedule_timer(hx);
+                break;
+            case HX_DONE:
+                sendf("hx711_value oid=%c value=%i", oid, hx->data);
+                hx711_receive_bit(hx);
+                hx711_set_sclk(hx, 1);
+                hx->state = HX_IDLE;
+                break;
+        }
+    }
+}
+DECL_TASK(hx711_task);


### PR DESCRIPTION
First of all thanks everybody for this amazing piece of software. I really love using it and it wanted to give something back to the community.

This is my first pull request ever. So please bear with me. I think, I have read and followed all the contributing guide lines.

I want to use a [HX711](http://en.aviaic.com/detail/730856.html) to read a load cell. This load cell will be mounted beneath my filament spool. The goal, at least for me, is to check at the start of a print if I have still got enough filament remaining to finish the print. I have seen some other pull request to use a load cell as a probe sensor. This is definitely not the possible with this code.

I have implemented a C code module to read the latest value via an mcu. I have implemented python code. The python code periodically queries the mcu for the latest value. Additionally:
* Calibration/Conversion from raw_value into user defined value. The conversion is unit agnostic. So it can be weight, percentage or whatever the user wants.
* New G code (QUERY_HX711 NAME=<sensor>) to query the latest value.
*  get_status() returns the latest raw_value and converted value.

I have tested the mcu code on an Raspberry PI and an BTT Octopus. I'm not sure if the code works on an AVR. For the communication I am creating my own clock signal. That's because it has some timing constrains and it needs 25 cycles. So I could not use SPI.  I have borrowed some code from the lcd_hd44780 source and adapted it. But in line 51 of my sensor_hx711.c there is now code to skip the delays if it is an AVR. Assuming, the AVR is clocked with 16MHz the total delay must be between 4 and 800 instructions.

Signed-off-by: Jochen Loeser <jochen_loeser@trimble.com>