### PR TITLE
hide USB option when using stm32f1 with HSI

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -277,7 +277,7 @@ config CANSERIAL
 choice
     prompt "Communication interface"
     config STM32_USB_PA11_PA12
-        bool "USB (on PA11/PA12)" if HAVE_STM32_USBFS || HAVE_STM32_USBOTG
+        bool "USB (on PA11/PA12)" if (HAVE_STM32_USBFS || HAVE_STM32_USBOTG) && !(STM32_CLOCK_REF_INTERNAL && MACH_STM32F103)
         select USBSERIAL
     config STM32_USB_PA11_PA12_REMAP
         bool "USB (on PA9/PA10)" if LOW_LEVEL_OPTIONS && MACH_STM32F042


### PR DESCRIPTION
When using stm32f1 with internal clock, it is not recommend to use USB. What's more, existing code(may set main clock to 64MHz) may not generate a right clock to USB.

See STM32CubeMX
![F1-HSI-Cube](https://user-images.githubusercontent.com/60053077/167679842-9ca631a5-73ff-4a15-b7be-a189556b77ec.png)
or DataSheet 2.3.24 (DS5792 Page 22)
![F1-HSI-DS](https://user-images.githubusercontent.com/60053077/167680101-636185f2-decc-4a6c-8ee2-c3e202b6029f.png)


Signed-off-by: Kai Ye <2857693944@qq.com>