### PR TITLE
Implement option for retraction after homing

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -195,6 +195,11 @@ position_max:
 #   better to use the default than to specify this parameter. The
 #   default is true if position_endstop is near position_max and false
 #   if near position_min.
+#homing_final_retract:
+#   Set to true to enable retraction after homing. This is useful for 
+#   sensorless homing, where you want to prevent the stepper from 
+#   pressing the carriage into the frame after homing. Uses 
+#   homing_retract_dist and homing_retract_speed.
 ```
 
 ### Cartesian Kinematics

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -196,9 +196,9 @@ position_max:
 #   default is true if position_endstop is near position_max and false
 #   if near position_min.
 #homing_final_retract:
-#   Set to true to enable retraction after homing. This is useful for 
-#   sensorless homing, where you want to prevent the stepper from 
-#   pressing the carriage into the frame after homing. Uses 
+#   Set to true to enable retraction after homing. This is useful for
+#   sensorless homing, where you want to prevent the stepper from
+#   pressing the carriage into the frame after homing. Uses
 #   homing_retract_dist and homing_retract_speed.
 ```
 

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -194,16 +194,17 @@ class Homing:
             retractpos = [hp - ad * retract_r
                           for hp, ad in zip(homepos, axes_d)]
             self.toolhead.move(retractpos, hi.retract_speed)
-            # Home again
-            startpos = [rp - ad * retract_r
-                        for rp, ad in zip(retractpos, axes_d)]
-            self.toolhead.set_position(startpos)
-            hmove = HomingMove(self.printer, endstops)
-            hmove.homing_move(homepos, hi.second_homing_speed)
-            if hmove.check_no_movement() is not None:
-                raise self.printer.command_error(
-                    "Endstop %s still triggered after retract"
-                    % (hmove.check_no_movement(),))
+            if not hi.final_retract:
+                # Home again
+                startpos = [rp - ad * retract_r
+                            for rp, ad in zip(retractpos, axes_d)]
+                self.toolhead.set_position(startpos)
+                hmove = HomingMove(self.printer, endstops)
+                hmove.homing_move(homepos, hi.second_homing_speed)
+                if hmove.check_no_movement() is not None:
+                    raise self.printer.command_error(
+                        "Endstop %s still triggered after retract"
+                        % (hmove.check_no_movement(),))
         # Signal home operation complete
         self.toolhead.flush_step_generation()
         self.trigger_mcu_pos = {sp.stepper_name: sp.trig_pos

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -336,6 +336,7 @@ class PrinterRail:
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
             'homing_positive_dir', None)
+        self.homing_final_retract = config.getboolean('homing_final_retract', False)
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min
             if self.position_endstop <= self.position_min + axis_len / 4.:
@@ -359,10 +360,11 @@ class PrinterRail:
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
             'speed', 'position_endstop', 'retract_speed', 'retract_dist',
-            'positive_dir', 'second_homing_speed'])(
+            'positive_dir', 'second_homing_speed', 'final_retract'])(
                 self.homing_speed, self.position_endstop,
                 self.homing_retract_speed, self.homing_retract_dist,
-                self.homing_positive_dir, self.second_homing_speed)
+                self.homing_positive_dir, self.second_homing_speed,
+                self.homing_final_retract)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -336,7 +336,8 @@ class PrinterRail:
             'homing_retract_dist', 5., minval=0.)
         self.homing_positive_dir = config.getboolean(
             'homing_positive_dir', None)
-        self.homing_final_retract = config.getboolean('homing_final_retract', False)
+        self.homing_final_retract = config.getboolean(
+            'homing_final_retract', False)
         if self.homing_positive_dir is None:
             axis_len = self.position_max - self.position_min
             if self.position_endstop <= self.position_min + axis_len / 4.:


### PR DESCRIPTION
When using sensorless homing, the carriage will be pressed into the frame after being stopped (as documented [here](https://github.com/Klipper3d/klipper/blob/master/docs/TMC_Drivers.md#using-macros-when-homing)). The suggested fix is to create a macro for homing or using homing overrides. This is a bad approach because it harms maintainability, disables compatibility with firmware features (such as safe z homing), and is not beginner-friendly. This PR adds a `homing_final_retract` setting to the stepper configuration. It uses the regular homing retract but stops before performing the actual second home. This disables second homing, but it is not needed when using sensorless homing anyway. Tested the code on my machine for a few days now and had no problems.