### PR TITLE
extruder: Add QUIET=1 option to SET_PRESSURE_ADVANCE

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -333,12 +333,13 @@ changes the active hotend.
 #### SET_PRESSURE_ADVANCE
 `SET_PRESSURE_ADVANCE [EXTRUDER=<config_name>]
 [ADVANCE=<pressure_advance>]
-[SMOOTH_TIME=<pressure_advance_smooth_time>]`: Set pressure advance
+[SMOOTH_TIME=<pressure_advance_smooth_time>] [QUIET=0]`: Set pressure advance
 parameters of an extruder stepper (as defined in an
 [extruder](Config_Reference.md#extruder) or
 [extruder_stepper](Config_Reference.md#extruder_stepper) config section).
 If EXTRUDER is not specified, it defaults to the stepper defined in
-the active hotend.
+the active hotend. If "QUIET=1" is specified then the command generates no
+output.
 
 #### SET_EXTRUDER_ROTATION_DISTANCE
 `SET_EXTRUDER_ROTATION_DISTANCE EXTRUDER=<config_name>

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -91,12 +91,14 @@ class ExtruderStepper:
         smooth_time = gcmd.get_float('SMOOTH_TIME',
                                      self.pressure_advance_smooth_time,
                                      minval=0., maxval=.200)
+        quiet = gcmd.get_int('QUIET', 0)
         self._set_pressure_advance(pressure_advance, smooth_time)
         msg = ("pressure_advance: %.6f\n"
                "pressure_advance_smooth_time: %.6f"
                % (pressure_advance, smooth_time))
         self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
-        gcmd.respond_info(msg, log=False)
+        if not quiet:
+          gcmd.respond_info(msg, log=False)
     cmd_SET_E_ROTATION_DISTANCE_help = "Set extruder rotation distance"
     def cmd_SET_E_ROTATION_DISTANCE(self, gcmd):
         rotation_dist = gcmd.get_float('DISTANCE', None)


### PR DESCRIPTION
By adding QUIET=1 to a SET_PRESSURE_ADVANCE command, no output will be
generated. This is useful when automatically modifying values during a
print, as discussed here for example:

https://www.reddit.com/r/klippers/comments/o98xes/pressure_advance_becomes_way_too_aggressive_when/