### PR TITLE
gcode_macro: Add 'repr' and 'shell_quote' jinja2 filters and 'do' extension

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback, logging, ast, copy
 import jinja2
+import pipes
 
 
 ######################################################################
@@ -72,6 +73,9 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
+        self.env.add_extension("jinja2.ext.do")
+        self.env.filters["repr"] = repr
+        self.env.filters["shell_quote"] = pipes.quote
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:


### PR DESCRIPTION
Passing a variable through both these filters makes it easy to store any type of value, including
dictionaries and lists, using commands such as `SET_GCODE_VARIABLE` and `SAVE_VARIABLE`. The first filter `repr` simply calls the python function of the same name, and the second calls
`pipes.quote`.

Enabling the `jinja2.ext.do` extension makes it easier to work with these values, for example you
can set a dictionary member with `{% do d.update ({k: v}) %}`.

Here's an example to manage a saved dictionary of string values:

```
[gcode_macro DATA_SET]
gcode:
  {% set data = printer.save_variables.variables.data | default ({}) %}
  {% do data.update ({ params.NAME: params.VALUE }) %}
  SAVE_VARIABLE VARIABLE=data VALUE={data | repr | shell_quote}
```

In my case, I am trying to set up print profiles for different printer configurations, filament types, and print styles. Without this type of support I might use separate named variables, eg `PROFILE_{profile_name}_{key}`, which doesn't seem ideal. Alternatively I might try and do all the escaping myself which would likely be very messy and either incomplete (ie incorrect in edge cases) or overly complicated.

The `shell_quote` filter should also be useful for calling other extended gcode commands safely with runtime-generated parameter values.