### PR TITLE
Update generic-duet3-mini.cfg to include Tacho pins 

### DIFF
--- a/config/generic-duet3-mini.cfg
+++ b/config/generic-duet3-mini.cfg
@@ -26,6 +26,7 @@
 # SBC SPISS pin:PA6, SBCTfrReady:PA3, SerComPins:{PA4, PA5, PA6, PA7}
 # CAN Pins - TX:PB14 RX:PB15
 # Heaters, Fan outputs - {Out0:PB17 Out1:PC10 Out2:PB13 Out3:PB11 Out4:PA11, Out5:PB2, Out6:PB1} | Out6 is shared with VFD_Out
+# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26}
 # GPIO_out - {IO1:PB31 IO2:PD9 IO3:PB12 IO4:PD10} IO4 is shared with PSON
 # GPIO_in - {IO1:PB30 IO2:PD8 IO3:PB7 IO4:PC5 IO5:PC4 IO6:PC31}
 # Driver Diag - {D0:PA10, D1:PB8, D2:PA22, D3:PA23, D4:PC21, D5:PB10, D6:PA27}

--- a/config/generic-duet3-mini.cfg
+++ b/config/generic-duet3-mini.cfg
@@ -26,7 +26,7 @@
 # SBC SPISS pin:PA6, SBCTfrReady:PA3, SerComPins:{PA4, PA5, PA6, PA7}
 # CAN Pins - TX:PB14 RX:PB15
 # Heaters, Fan outputs - {Out0:PB17 Out1:PC10 Out2:PB13 Out3:PB11 Out4:PA11, Out5:PB2, Out6:PB1} | Out6 is shared with VFD_Out
-# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26} 
+# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26}
 # GPIO_out - {IO1:PB31 IO2:PD9 IO3:PB12 IO4:PD10} IO4 is shared with PSON
 # GPIO_in - {IO1:PB30 IO2:PD8 IO3:PB7 IO4:PC5 IO5:PC4 IO6:PC31}
 # Driver Diag - {D0:PA10, D1:PB8, D2:PA22, D3:PA23, D4:PC21, D5:PB10, D6:PA27}

--- a/config/generic-duet3-mini.cfg
+++ b/config/generic-duet3-mini.cfg
@@ -26,7 +26,7 @@
 # SBC SPISS pin:PA6, SBCTfrReady:PA3, SerComPins:{PA4, PA5, PA6, PA7}
 # CAN Pins - TX:PB14 RX:PB15
 # Heaters, Fan outputs - {Out0:PB17 Out1:PC10 Out2:PB13 Out3:PB11 Out4:PA11, Out5:PB2, Out6:PB1} | Out6 is shared with VFD_Out
-# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26}
+# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26} 
 # GPIO_out - {IO1:PB31 IO2:PD9 IO3:PB12 IO4:PD10} IO4 is shared with PSON
 # GPIO_in - {IO1:PB30 IO2:PD8 IO3:PB7 IO4:PC5 IO5:PC4 IO6:PC31}
 # Driver Diag - {D0:PA10, D1:PB8, D2:PA22, D3:PA23, D4:PC21, D5:PB10, D6:PA27}


### PR DESCRIPTION
Hi.

Just add the pins for the onboard tacho reading pins.
# Tach Pins for Fans - {Out3.Tach:PB27 Out4.Tach:PB26}

Based on: https://github.com/Duet3D/RepRapFirmware/blob/3.3-dev/src/Duet3Mini/Pins_Duet3Mini.h
Lines 494-495. 

Tested and working.
