### PR TITLE
Implement rp2040 workaround for USB errata "rp2040-e5"

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220612: The rp2040 micro-controller now has a workaround for the
+"rp2040-e5" USB errata. This should make initial USB connections more
+reliable. However, it may result in a change in behavior for the
+gpio15 pin. It is unlikely the gpio15 behavior change will be
+noticeable.
+
 20220407: The temperature_fan `pid_integral_max` config option has
 been removed (it was deprecated on 20210612).
 


### PR DESCRIPTION
The rp2040 USB may not connect after a reset.  This PR implements the recommended workaround.

This is mostly @dalegaard's code from PR #4748 with some code reorganization.

This change should, hopefully, make the rp2040 USB startup a little more stable.

-Kevin