### PR TITLE
Correct UART pins for Ender 3 S1 display cable

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -7,7 +7,7 @@
 
 # If you prefer a direct serial connection, in "make menuconfig"
 # select "Enable extra low-level configuration options" and select
-# serial (on USB PA10/PA9), which is broken out on the 10 pin IDC
+# Serial (on USART2 PA3/PA2), which is broken out on the 10 pin IDC
 # cable used for the LCD module as follows:
 # 3: Tx, 4: Rx, 9: GND, 10: VCC
 

--- a/config/printer-creality-ender3-s1pro-2022.cfg
+++ b/config/printer-creality-ender3-s1pro-2022.cfg
@@ -7,7 +7,7 @@
 
 # If you prefer a direct serial connection, in "make menuconfig"
 # select "Enable extra low-level configuration options" and select
-# serial (on USB PA10/PA9), which is broken out on the 10 pin IDC
+# Serial (on USART2 PA3/PA2), which is broken out on the 10 pin IDC
 # cable used for the LCD module as follows:
 # 3: Tx, 4: Rx, 9: GND, 10: VCC
 


### PR DESCRIPTION
The display cable on my Ender 3 S1 is connected to `PA3/PA2` instead of `PA10/PA9`. Not sure if this applies to the S1 Pro as well, I guess it does but I don't want to commit anything I can't verify.