### PR TITLE
DS18B20: fix string conversion error on startup

### DIFF
--- a/klippy/extras/ds18b20.py
+++ b/klippy/extras/ds18b20.py
@@ -32,8 +32,9 @@ class DS18B20:
 
     def _build_config(self):
         sid = "".join(["%02x" % (x,) for x in self.sensor_id])
-        self._mcu.add_config_cmd("config_ds18b20 oid=%d serial=%s"
-                                 % (self.oid, sid, DS18_MAX_CONSECUTIVE_ERRORS))
+        self._mcu.add_config_cmd(
+            "config_ds18b20 oid=%d serial=%s max_error_count=%d"
+            % (self.oid, sid, DS18_MAX_CONSECUTIVE_ERRORS))
 
         clock = self._mcu.get_query_slot(self.oid)
         self._report_clock = self._mcu.seconds_to_clock(self.report_time)


### PR DESCRIPTION
Unfortunately while applying https://github.com/Klipper3d/klipper/pull/5233 one change was missed, so klipper now fails to start.