### PR TITLE
Allow MAX31865 and ADXL345 to work on same hardware SPI bus on RP2040

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2189,6 +2189,8 @@ sensor_pin:
 #spi_software_miso_pin:
 #   See the "common SPI settings" section for a description of the
 #   above parameters.
+#spi_mode: 1
+#   For MAX31865 only, select SPI mode 1 or 3
 #tc_type: K
 #tc_use_50Hz_filter: False
 #tc_averaging_count: 1

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -277,8 +277,9 @@ class MAX31865(SensorBase):
         rtd_reference_r = config.getfloat('rtd_reference_r', 430., above=0.)
         adc_to_resist = rtd_reference_r / float(MAX31865_ADC_MAX)
         self.adc_to_resist_div_nominal = adc_to_resist / rtd_nominal_r
+        spi_mode=config.getchoice('spi_mode', {1: 1, 3: 3}, default=1)
         SensorBase.__init__(self, config, "MAX31865",
-                            self.build_spi_init(config))
+                            self.build_spi_init(config), spi_mode=spi_mode)
     def calc_temp(self, adc, fault):
         if fault & 0x80:
             self.fault("Max31865 RTD input is disconnected")

--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -19,12 +19,14 @@ DECL_ENUMERATION("spi_bus", "spi0c", 2);
 DECL_CONSTANT_STR("BUS_PINS_spi0c", "gpio16,gpio19,gpio18");
 DECL_ENUMERATION("spi_bus", "spi0d", 3);
 DECL_CONSTANT_STR("BUS_PINS_spi0d", "gpio20,gpio23,gpio22");
+DECL_ENUMERATION("spi_bus", "spi0e", 4);
+DECL_CONSTANT_STR("BUS_PINS_spi0e", "gpio4,gpio3,gpio2");
 
-DECL_ENUMERATION("spi_bus", "spi1a", 4);
+DECL_ENUMERATION("spi_bus", "spi1a", 5);
 DECL_CONSTANT_STR("BUS_PINS_spi1a", "gpio8,gpio11,gpio10");
-DECL_ENUMERATION("spi_bus", "spi1b", 5);
+DECL_ENUMERATION("spi_bus", "spi1b", 6);
 DECL_CONSTANT_STR("BUS_PINS_spi1b", "gpio12,gpio15,gpio14");
-DECL_ENUMERATION("spi_bus", "spi1c", 6);
+DECL_ENUMERATION("spi_bus", "spi1c", 7);
 DECL_CONSTANT_STR("BUS_PINS_spi1c", "gpio24,gpio27,gpio26");
 
 struct spi_info {
@@ -38,6 +40,7 @@ static const struct spi_info spi_bus[] = {
     {spi0_hw, 4,  7,  6,  RESETS_RESET_SPI0_BITS},
     {spi0_hw, 16, 19, 18, RESETS_RESET_SPI0_BITS},
     {spi0_hw, 20, 23, 22, RESETS_RESET_SPI0_BITS},
+    {spi0_hw, 4, 3, 2, RESETS_RESET_SPI0_BITS},
 
     {spi1_hw, 8,  11, 10, RESETS_RESET_SPI1_BITS},
     {spi1_hw, 12, 15, 14, RESETS_RESET_SPI1_BITS},
@@ -73,11 +76,15 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
             break;
     }
 
-    res.cr0 |= postdiv << SPI_SSPCR0_SCR_LSB;
-    res.cr0 |= ((mode & 2) != 0) << SPI_SSPCR0_SPO_LSB;
-    res.cr0 |= ((mode & 1) != 0) << SPI_SSPCR0_SPH_LSB;
-    res.cr0 |= 7 << SPI_SSPCR0_DSS_LSB; // 8bit mode
-    res.cpsr = prescale;
+    uint32_t cr0 = 0;
+    cr0 |= postdiv << SPI_SSPCR0_SCR_LSB;
+    cr0 |= ((mode & 2) != 0) << SPI_SSPCR0_SPO_LSB;
+    cr0 |= ((mode & 1) != 0) << SPI_SSPCR0_SPH_LSB;
+    cr0 |= 7 << SPI_SSPCR0_DSS_LSB; // 8bit mode
+
+    // Configure SPI
+    spi_bus[bus].spi->cr0 = cr0;
+    spi_bus[bus].spi->cpsr = prescale;
 
     // Enable the peripheral
     spi_bus[bus].spi->cr1 = SPI_SSPCR1_SSE_BITS;
@@ -88,9 +95,7 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
 void
 spi_prepare(struct spi_config config)
 {
-    spi_hw_t *spi = config.spi;
-    spi->cr0 = config.cr0;
-    spi->cpsr = config.cpsr;
+    // NOP
 }
 
 void


### PR DESCRIPTION
This allows configuring the MAX31865 to run in Mode 3, so it can share 
a hardware SPI bus with an ADXL345 (which only supports Mode 3).

Separately, this fixes a bug doing this on the RP2040. The RP2040 SPI 
driver previously set the SPI mode on transmit (after the SPI hardware is enabled) 
but that causes problems for some hardware. For instance, trying to run a 
MAX31865 in Mode 3 would fail.

Finally this adds spi0e, which is the SPI pin config for the Seeduino XIAO RP2040
(https://wiki.seeedstudio.com/XIAO-RP2040/)

You might think this patch introduces a regression that prevents running 
different modes or bus speeds on the same hardware SPI bus, but AFAICT 
this was never possible on RP2040 anyway (happy to be corrected if
someone knows better).

Signed-off-by: Hamish Friedlander <hafriedlander@gmail.com>