### PR TITLE
Rework CANbus code to use a single function for packet reading

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -56,15 +56,10 @@ config USB_VENDOR_ID
 config USB_DEVICE_ID
     default 0x614e
 config USB_SERIAL_NUMBER_CHIPID
-    depends on HAVE_CHIPID
+    depends on HAVE_CHIPID && USBSERIAL
     default y
 config USB_SERIAL_NUMBER
     default "12345"
-
-# Generic configuration options for CANbus
-config CANBUS_FREQUENCY
-    int "CAN bus speed" if LOW_LEVEL_OPTIONS && CANSERIAL
-    default 500000
 
 menu "USB ids"
     depends on USBSERIAL && LOW_LEVEL_OPTIONS
@@ -78,6 +73,12 @@ config USB_SERIAL_NUMBER
     string "USB serial number" if !USB_SERIAL_NUMBER_CHIPID
 endmenu
 
+# Generic configuration options for CANbus
+config CANBUS_FREQUENCY
+    int "CAN bus speed" if LOW_LEVEL_OPTIONS && CANSERIAL
+    default 500000
+
+# Support setting gpio state at startup
 config INITIAL_PINS
     string "GPIO pins to set at micro-controller startup"
     depends on LOW_LEVEL_OPTIONS

--- a/src/generic/canbus.c
+++ b/src/generic/canbus.c
@@ -13,7 +13,10 @@
 #include "board/misc.h" // console_sendf
 #include "canbus.h" // canbus_set_uuid
 #include "command.h" // DECL_CONSTANT
+#include "fasthash.h" // fasthash64
 #include "sched.h" // sched_wake_task
+
+#define CANBUS_UUID_LEN 6
 
 // Global storage
 static struct canbus_data {
@@ -323,9 +326,10 @@ command_get_canbus_id(uint32_t *args)
 DECL_COMMAND_FLAGS(command_get_canbus_id, HF_IN_SHUTDOWN, "get_canbus_id");
 
 void
-canbus_set_uuid(void *uuid)
+canbus_set_uuid(uint8_t *raw_uuid, uint32_t raw_uuid_len)
 {
-    memcpy(CanData.uuid, uuid, sizeof(CanData.uuid));
+    uint64_t hash = fasthash64(raw_uuid, raw_uuid_len, 0xA16231A7);
+    memcpy(CanData.uuid, &hash, sizeof(CanData.uuid));
     canbus_notify_rx();
 }
 

--- a/src/generic/canbus.h
+++ b/src/generic/canbus.h
@@ -16,6 +16,9 @@ struct canbus_msg {
     };
 };
 
+#define CANMSG_ID_RTR (1<<30)
+#define CANMSG_ID_EFF (1<<31)
+
 #define CANMSG_DATA_LEN(msg) ((msg)->dlc > 8 ? 8 : (msg)->dlc)
 
 // callbacks provided by board specific code

--- a/src/generic/canbus.h
+++ b/src/generic/canbus.h
@@ -5,7 +5,6 @@
 
 #define CANBUS_ID_ADMIN 0x3f0
 #define CANBUS_ID_ADMIN_RESP 0x3f1
-#define CANBUS_UUID_LEN 6
 
 struct canbus_msg {
     uint32_t id;
@@ -28,6 +27,6 @@ void canbus_set_filter(uint32_t id);
 // canbus.c
 void canbus_notify_tx(void);
 void canbus_process_data(struct canbus_msg *msg);
-void canbus_set_uuid(void *data);
+void canbus_set_uuid(uint8_t *raw_uuid, uint32_t raw_uuid_len);
 
 #endif // canbus.h

--- a/src/generic/canbus.h
+++ b/src/generic/canbus.h
@@ -7,15 +7,24 @@
 #define CANBUS_ID_ADMIN_RESP 0x3f1
 #define CANBUS_UUID_LEN 6
 
+struct canbus_msg {
+    uint32_t id;
+    uint32_t dlc;
+    union {
+        uint8_t data[8];
+        uint32_t data32[2];
+    };
+};
+
+#define CANMSG_DATA_LEN(msg) ((msg)->dlc > 8 ? 8 : (msg)->dlc)
+
 // callbacks provided by board specific code
-int canbus_read(uint32_t *id, uint8_t *data);
-int canbus_send(uint32_t id, uint32_t len, uint8_t *data);
+int canbus_send(struct canbus_msg *msg);
 void canbus_set_filter(uint32_t id);
 
 // canbus.c
 void canbus_notify_tx(void);
-void canbus_notify_rx(void);
-void canbus_process_data(uint32_t id, uint32_t len, uint8_t *data);
+void canbus_process_data(struct canbus_msg *msg);
 void canbus_set_uuid(void *data);
 
 #endif // canbus.h

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -322,7 +322,7 @@ choice
         select SERIAL
     config STM32_CANBUS_PA11_PA12
         bool "CAN bus (on PA11/PA12)"
-        depends on HAVE_STM32_CANBUS
+        depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS
         select CANSERIAL
     config STM32_CANBUS_PA11_PA12_REMAP
         bool "CAN bus (on PA9/PA10)" if LOW_LEVEL_OPTIONS
@@ -330,7 +330,7 @@ choice
         select CANSERIAL
     config STM32_CANBUS_PB8_PB9
         bool "CAN bus (on PB8/PB9)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS
+        depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS
         select CANSERIAL
     config STM32_CANBUS_PI9_PH13
         bool "CAN bus (on PI9/PH13)" if LOW_LEVEL_OPTIONS

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -62,7 +62,7 @@ src-$(CONFIG_SERIAL) += $(serial-src-y) generic/serial_irq.c
 canbus-src-y := generic/canbus.c ../lib/fast-hash/fasthash.c
 canbus-src-$(CONFIG_HAVE_STM32_CANBUS) += stm32/can.c
 canbus-src-$(CONFIG_HAVE_STM32_FDCANBUS) += stm32/fdcan.c
-src-$(CONFIG_CANSERIAL) += $(canbus-src-y)
+src-$(CONFIG_CANSERIAL) += $(canbus-src-y) stm32/chipid.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += stm32/hard_pwm.c
 
 # Binary output file rules

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -10,7 +10,6 @@
 #include "autoconf.h" // CONFIG_MACH_STM32F1
 #include "board/irq.h" // irq_disable
 #include "command.h" // DECL_CONSTANT_STR
-#include "fasthash.h" // fasthash64
 #include "generic/armcm_boot.h" // armcm_enable_irq
 #include "generic/canbus.h" // canbus_notify_tx
 #include "internal.h" // enable_pclock
@@ -272,9 +271,5 @@ can_init(void)
     if (CAN_RX0_IRQn != CAN_TX_IRQn)
         armcm_enable_irq(CAN_IRQHandler, CAN_TX_IRQn, 0);
     SOC_CAN->IER = CAN_IER_FMPIE0;
-
-    // Convert unique 96-bit chip id into 48 bit representation
-    uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);
-    canbus_set_uuid(&hash);
 }
 DECL_INIT(can_init);

--- a/src/stm32/can.c
+++ b/src/stm32/can.c
@@ -91,41 +91,9 @@
  #error No known CAN device for configured MCU
 #endif
 
-// Read the next CAN packet
-int
-canbus_read(uint32_t *id, uint8_t *data)
-{
-    if (!(SOC_CAN->RF0R & CAN_RF0R_FMP0)) {
-        // All rx mboxes empty, enable wake on rx IRQ
-        irq_disable();
-        SOC_CAN->IER |= CAN_IER_FMPIE0;
-        irq_enable();
-        return -1;
-    }
-
-    // Read and ack packet
-    CAN_FIFOMailBox_TypeDef *mb = &SOC_CAN->sFIFOMailBox[0];
-    uint32_t rir_id = (mb->RIR >> CAN_RI0R_STID_Pos) & 0x7FF;
-    uint32_t dlc = mb->RDTR & CAN_RDT0R_DLC;
-    uint32_t rdlr = mb->RDLR, rdhr = mb->RDHR;
-    SOC_CAN->RF0R = CAN_RF0R_RFOM0;
-
-    // Return packet
-    *id = rir_id;
-    data[0] = (rdlr >>  0) & 0xff;
-    data[1] = (rdlr >>  8) & 0xff;
-    data[2] = (rdlr >> 16) & 0xff;
-    data[3] = (rdlr >> 24) & 0xff;
-    data[4] = (rdhr >>  0) & 0xff;
-    data[5] = (rdhr >>  8) & 0xff;
-    data[6] = (rdhr >> 16) & 0xff;
-    data[7] = (rdhr >> 24) & 0xff;
-    return dlc;
-}
-
 // Transmit a packet
 int
-canbus_send(uint32_t id, uint32_t len, uint8_t *data)
+canbus_send(struct canbus_msg *msg)
 {
     uint32_t tsr = SOC_CAN->TSR;
     if (!(tsr & (CAN_TSR_TME0|CAN_TSR_TME1|CAN_TSR_TME2))) {
@@ -143,23 +111,15 @@ canbus_send(uint32_t id, uint32_t len, uint8_t *data)
     CAN_TxMailBox_TypeDef *mb = &SOC_CAN->sTxMailBox[mbox];
 
     /* Set up the DLC */
-    mb->TDTR = (mb->TDTR & 0xFFFFFFF0) | (len & 0x0F);
+    mb->TDTR = (mb->TDTR & 0xFFFFFFF0) | (msg->dlc & 0x0F);
 
     /* Set up the data field */
-    if (len) {
-        mb->TDLR = (((uint32_t)data[3] << 24)
-                    | ((uint32_t)data[2] << 16)
-                    | ((uint32_t)data[1] << 8)
-                    | ((uint32_t)data[0] << 0));
-        mb->TDHR = (((uint32_t)data[7] << 24)
-                    | ((uint32_t)data[6] << 16)
-                    | ((uint32_t)data[5] << 8)
-                    | ((uint32_t)data[4] << 0));
-    }
+    mb->TDLR = msg->data32[0];
+    mb->TDHR = msg->data32[1];
 
     /* Request transmission */
-    mb->TIR = (id << CAN_TI0R_STID_Pos) | CAN_TI0R_TXRQ;
-    return len;
+    mb->TIR = (msg->id << CAN_TI0R_STID_Pos) | CAN_TI0R_TXRQ;
+    return CANMSG_DATA_LEN(msg);
 }
 
 // Setup the receive packet filter
@@ -182,9 +142,6 @@ canbus_set_filter(uint32_t id)
     /* 32-bit scale for the filter */
     SOC_CAN->FS1R = (1<<0) | (1<<1) | (1<<2);
 
-    /* FIFO 1 assigned to 'id' */
-    SOC_CAN->FFA1R = (1<<2);
-
     /* Filter activation */
     SOC_CAN->FA1R = (1<<0) | (id ? (1<<1) | (1<<2) : 0);
     /* Leave the initialisation mode for the filter */
@@ -195,27 +152,20 @@ canbus_set_filter(uint32_t id)
 void
 CAN_IRQHandler(void)
 {
-    if (SOC_CAN->RF1R & CAN_RF1R_FMP1) {
+    if (SOC_CAN->RF0R & CAN_RF0R_FMP0) {
         // Read and ack data packet
-        CAN_FIFOMailBox_TypeDef *mb = &SOC_CAN->sFIFOMailBox[1];
-        uint32_t rir_id = (mb->RIR >> CAN_RI0R_STID_Pos) & 0x7FF;
-        uint32_t dlc = mb->RDTR & CAN_RDT0R_DLC;
-        uint32_t rdlr = mb->RDLR, rdhr = mb->RDHR;
-        SOC_CAN->RF1R = CAN_RF1R_RFOM1;
+        CAN_FIFOMailBox_TypeDef *mb = &SOC_CAN->sFIFOMailBox[0];
+        struct canbus_msg msg;
+        msg.id = (mb->RIR >> CAN_RI0R_STID_Pos) & 0x7FF;
+        msg.dlc = mb->RDTR & CAN_RDT0R_DLC;
+        msg.data32[0] = mb->RDLR;
+        msg.data32[1] = mb->RDHR;
+        SOC_CAN->RF0R = CAN_RF0R_RFOM0;
 
         // Process packet
-        union {
-            struct { uint32_t rdlr, rdhr; };
-            uint8_t data[8];
-        } rdata = { .rdlr = rdlr, .rdhr = rdhr };
-        canbus_process_data(rir_id, dlc, rdata.data);
+        canbus_process_data(&msg);
     }
     uint32_t ier = SOC_CAN->IER;
-    if (ier & CAN_IER_FMPIE0 && SOC_CAN->RF0R & CAN_RF0R_FMP0) {
-        // Admin Rx
-        SOC_CAN->IER = ier = ier & ~CAN_IER_FMPIE0;
-        canbus_notify_rx();
-    }
     if (ier & CAN_IER_TMEIE
         && SOC_CAN->TSR & (CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2)) {
         // Tx
@@ -310,7 +260,7 @@ can_init(void)
         armcm_enable_irq(CAN_IRQHandler, CAN_RX1_IRQn, 0);
     if (CAN_RX0_IRQn != CAN_TX_IRQn)
         armcm_enable_irq(CAN_IRQHandler, CAN_TX_IRQn, 0);
-    SOC_CAN->IER = CAN_IER_FMPIE1;
+    SOC_CAN->IER = CAN_IER_FMPIE0;
 
     // Convert unique 96-bit chip id into 48 bit representation
     uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);

--- a/src/stm32/chipid.c
+++ b/src/stm32/chipid.c
@@ -4,6 +4,7 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "generic/canbus.h" // canbus_set_uuid
 #include "generic/usb_cdc.h" // usb_fill_serial
 #include "generic/usbstd.h" // usb_string_descriptor
 #include "internal.h" // UID_BASE
@@ -25,9 +26,10 @@ usbserial_get_serialid(void)
 void
 chipid_init(void)
 {
-    if (!CONFIG_USB_SERIAL_NUMBER_CHIPID)
-        return;
-    usb_fill_serial(&cdc_chipid.desc, ARRAY_SIZE(cdc_chipid.data)
-                    , (void*)UID_BASE);
+    if (CONFIG_USB_SERIAL_NUMBER_CHIPID)
+        usb_fill_serial(&cdc_chipid.desc, ARRAY_SIZE(cdc_chipid.data)
+                        , (void*)UID_BASE);
+    if (CONFIG_CANSERIAL)
+        canbus_set_uuid((void*)UID_BASE, CHIP_UID_LEN);
 }
 DECL_INIT(chipid_init);

--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -10,7 +10,6 @@
 #include "autoconf.h" // CONFIG_MACH_STM32F1
 #include "board/irq.h" // irq_disable
 #include "command.h" // DECL_CONSTANT_STR
-#include "fasthash.h" // fasthash64
 #include "generic/armcm_boot.h" // armcm_enable_irq
 #include "generic/canbus.h" // canbus_notify_tx
 #include "generic/serial_irq.h" // serial_rx_byte
@@ -260,9 +259,5 @@ can_init(void)
     armcm_enable_irq(CAN_IRQHandler, CAN_IT0_IRQn, 0);
     SOC_CAN->ILE = FDCAN_ILE_EINT0;
     SOC_CAN->IE = FDCAN_IE_RF0NE | FDCAN_IE_TC;
-
-    // Convert unique 96-bit chip id into 48 bit representation
-    uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);
-    canbus_set_uuid(&hash);
 }
 DECL_INIT(can_init);

--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -61,23 +61,30 @@ FDCAN_RAM_TypeDef *fdcan_ram = (FDCAN_RAM_TypeDef *)(SRAMCAN_BASE);
 
 #define FDCAN_IE_TC        (FDCAN_IE_TCE | FDCAN_IE_TCFE | FDCAN_IE_TFEE)
 
-#if CONFIG_STM32_CANBUS_PB0_PB1
+#if CONFIG_STM32_CANBUS_PA11_PA12
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "PA11,PA12");
+ #define GPIO_Rx GPIO('A', 11)
+ #define GPIO_Tx GPIO('A', 12)
+#elif CONFIG_STM32_CANBUS_PB8_PB9
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "PB8,PB9");
+ #define GPIO_Rx GPIO('B', 8)
+ #define GPIO_Tx GPIO('B', 9)
+#elif CONFIG_STM32_CANBUS_PB0_PB1
  DECL_CONSTANT_STR("RESERVE_PINS_CAN", "PB0,PB1");
  #define GPIO_Rx GPIO('B', 0)
  #define GPIO_Tx GPIO('B', 1)
 #endif
 
-#if CONFIG_MACH_STM32G0
- #if CONFIG_STM32_CANBUS_PB0_PB1
-  #define SOC_CAN FDCAN2
-  #define MSG_RAM fdcan_ram->fdcan2
- #else
-  #error Uknown pins for STMF32G0 CAN
- #endif
-
- #define CAN_IT0_IRQn  TIM16_FDCAN_IT0_IRQn
- #define CAN_FUNCTION  GPIO_FUNCTION(3) // Alternative function mapping number
+#if !CONFIG_STM32_CANBUS_PB0_PB1
+ #define SOC_CAN FDCAN1
+ #define MSG_RAM fdcan_ram->fdcan1
+#else
+ #define SOC_CAN FDCAN2
+ #define MSG_RAM fdcan_ram->fdcan2
 #endif
+
+#define CAN_IT0_IRQn  TIM16_FDCAN_IT0_IRQn
+#define CAN_FUNCTION  GPIO_FUNCTION(3) // Alternative function mapping number
 
 #ifndef SOC_CAN
  #error No known CAN device for configured MCU
@@ -239,9 +246,6 @@ can_init(void)
         ;
     /* Enable configuration change */
     SOC_CAN->CCCR |= FDCAN_CCCR_CCE;
-
-    if (SOC_CAN == FDCAN1)
-        FDCAN_CONFIG->CKDIV = 0;
 
     /* Disable protocol exception handling */
     SOC_CAN->CCCR |= FDCAN_CCCR_PXHD;

--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -17,13 +17,6 @@
 #include "internal.h" // enable_pclock
 #include "sched.h" // DECL_INIT
 
-/*
- FDCAN max date length = 64bytes
- data_len[] is the data length & DLC mapping table
- Required when the data length exceeds 64bytes
- */
-uint8_t data_len[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
-
 typedef struct
 {
        uint32_t RESERVED0 : 18;
@@ -38,7 +31,7 @@ typedef struct
        uint32_t RESERVED1 : 2;
   __IO uint32_t FIDX : 7;
   __IO uint32_t ANMF : 1;
-  __IO uint8_t  data[64];
+  __IO uint32_t data[64 / 4];
 }FDCAN_RX_FIFO_TypeDef;
 
 typedef struct
@@ -66,8 +59,6 @@ typedef struct
 
 FDCAN_RAM_TypeDef *fdcan_ram = (FDCAN_RAM_TypeDef *)(SRAMCAN_BASE);
 
-#define FDCAN_IE_RX_FIFO0  (FDCAN_IE_RF0NE | FDCAN_IE_RF0FE | FDCAN_IE_RF0LE)
-#define FDCAN_IE_RX_FIFO1  (FDCAN_IE_RF1NE | FDCAN_IE_RF1FE | FDCAN_IE_RF1LE)
 #define FDCAN_IE_TC        (FDCAN_IE_TCE | FDCAN_IE_TCFE | FDCAN_IE_TFEE)
 
 #if CONFIG_STM32_CANBUS_PB0_PB1
@@ -85,7 +76,6 @@ FDCAN_RAM_TypeDef *fdcan_ram = (FDCAN_RAM_TypeDef *)(SRAMCAN_BASE);
  #endif
 
  #define CAN_IT0_IRQn  TIM16_FDCAN_IT0_IRQn
- #define CAN_IT1_IRQn  TIM17_FDCAN_IT1_IRQn
  #define CAN_FUNCTION  GPIO_FUNCTION(3) // Alternative function mapping number
 #endif
 
@@ -93,35 +83,9 @@ FDCAN_RAM_TypeDef *fdcan_ram = (FDCAN_RAM_TypeDef *)(SRAMCAN_BASE);
  #error No known CAN device for configured MCU
 #endif
 
-// Read the next CAN packet
-int
-canbus_read(uint32_t *id, uint8_t *data)
-{
-    if (!(SOC_CAN->RXF0S & FDCAN_RXF0S_F0FL)) {
-        // All rx mboxes empty, enable wake on rx IRQ
-        irq_disable();
-        SOC_CAN->IE |= FDCAN_IE_RF0NE;
-        irq_enable();
-        return -1;
-    }
-
-    // Read and ack packet
-    uint32_t r_index = ((SOC_CAN->RXF0S & FDCAN_RXF0S_F0GI)
-                        >> FDCAN_RXF0S_F0GI_Pos);
-    FDCAN_RX_FIFO_TypeDef *rxf0 = &MSG_RAM.RXF0[r_index];
-    uint32_t dlc = rxf0->DLC;
-    *id = rxf0->ID;
-    for (uint8_t i = 0; i < dlc; i++) {
-        data[i] = rxf0->data[i];
-    }
-    SOC_CAN->RXF0A = r_index;
-
-    return dlc;
-}
-
 // Transmit a packet
 int
-canbus_send(uint32_t id, uint32_t len, uint8_t *data)
+canbus_send(struct canbus_msg *msg)
 {
     uint32_t txfqs = SOC_CAN->TXFQS;
     if (txfqs & FDCAN_TXFQS_TFQF) {
@@ -134,23 +98,16 @@ canbus_send(uint32_t id, uint32_t len, uint8_t *data)
 
     uint32_t w_index = ((txfqs & FDCAN_TXFQS_TFQPI) >> FDCAN_TXFQS_TFQPI_Pos);
     FDCAN_TX_FIFO_TypeDef *txfifo = &MSG_RAM.TXFIFO[w_index];
-    txfifo->id_section = id << 18;
-    txfifo->dlc_section = len << 16;
-    if (len) {
-        txfifo->data[0] = (((uint32_t)data[3] << 24)
-                           | ((uint32_t)data[2] << 16)
-                           | ((uint32_t)data[1] << 8)
-                           | ((uint32_t)data[0] << 0));
-        txfifo->data[1] = (((uint32_t)data[7] << 24)
-                           | ((uint32_t)data[6] << 16)
-                           | ((uint32_t)data[5] << 8)
-                           | ((uint32_t)data[4] << 0));
-    }
+    txfifo->id_section = (msg->id & 0x1fffffff) << 18;
+    txfifo->dlc_section = (msg->dlc & 0x0f) << 16;
+    txfifo->data[0] = msg->data32[0];
+    txfifo->data[1] = msg->data32[1];
     SOC_CAN->TXBAR = ((uint32_t)1 << w_index);
-    return len;
+    return CANMSG_DATA_LEN(msg);
 }
 
-void can_filter(uint32_t id, uint8_t index)
+static void
+can_filter(uint32_t index, uint32_t id)
 {
     MSG_RAM.FLS[index] = ((0x2 << 30) // Classic filter
                           | (0x1 << 27) // Store in Rx FIFO 0 if filter matches
@@ -170,17 +127,12 @@ canbus_set_filter(uint32_t id)
     /* Enable configuration change */
     SOC_CAN->CCCR |= FDCAN_CCCR_CCE;
 
-    can_filter(CANBUS_ID_ADMIN, 0);
-
-    /*  List size standard */
-    SOC_CAN->RXGFC &= ~(FDCAN_RXGFC_LSS);
-    SOC_CAN->RXGFC |= 1 << FDCAN_RXGFC_LSS_Pos;
-
-    /* Filter remote frames with 11-bit standard IDs
-       Non-matching frames standard reject or accept in Rx FIFO 1 */
-    SOC_CAN->RXGFC &= ~(FDCAN_RXGFC_RRFS | FDCAN_RXGFC_ANFS);
-    SOC_CAN->RXGFC |= ((0 << FDCAN_RXGFC_RRFS_Pos)
-                       | ((id ? 0x01 : 0x02) << FDCAN_RXGFC_ANFS_Pos));
+    // Load filter
+    can_filter(0, CANBUS_ID_ADMIN);
+    can_filter(1, id);
+    can_filter(2, id + 1);
+    SOC_CAN->RXGFC = ((id ? 3 : 1) << FDCAN_RXGFC_LSS_Pos
+                      | 0x02 << FDCAN_RXGFC_ANFS_Pos);
 
     /* Leave the initialisation mode for the filter */
     SOC_CAN->CCCR &= ~FDCAN_CCCR_CCE;
@@ -191,36 +143,28 @@ canbus_set_filter(uint32_t id)
 void
 CAN_IRQHandler(void)
 {
-    uint32_t ir = SOC_CAN->IR;
-    uint32_t ie = SOC_CAN->IE;
+    uint32_t ir = SOC_CAN->IR & SOC_CAN->IE;
 
-    if (ir & FDCAN_IE_RX_FIFO1 && ie & FDCAN_IE_RX_FIFO1) {
-        SOC_CAN->IR = FDCAN_IE_RX_FIFO1;
+    if (ir & FDCAN_IE_RF0NE) {
+        SOC_CAN->IR = FDCAN_IE_RF0NE;
 
-        if (SOC_CAN->RXF1S & FDCAN_RXF1S_F1FL) {
+        uint32_t rxf0s = SOC_CAN->RXF0S;
+        if (rxf0s & FDCAN_RXF0S_F0FL) {
             // Read and ack data packet
-            uint32_t r_index = ((SOC_CAN->RXF1S & FDCAN_RXF1S_F1GI)
-                                >> FDCAN_RXF1S_F1GI_Pos);
-            FDCAN_RX_FIFO_TypeDef *rxf1 = &MSG_RAM.RXF1[r_index];
-
-            uint32_t rir_id = rxf1->ID;
-            uint32_t dlc = rxf1->DLC;
-            uint8_t data[8];
-            for (uint8_t i = 0; i < dlc; i++) {
-                data[i] = rxf1->data[i];
-            }
-            SOC_CAN->RXF1A = r_index;
+            uint32_t idx = (rxf0s & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos;
+            FDCAN_RX_FIFO_TypeDef *rxf0 = &MSG_RAM.RXF0[idx];
+            struct canbus_msg msg;
+            msg.id = rxf0->ID;
+            msg.dlc = rxf0->DLC;
+            msg.data32[0] = rxf0->data[0];
+            msg.data32[1] = rxf0->data[1];
+            SOC_CAN->RXF0A = idx;
 
             // Process packet
-            canbus_process_data(rir_id, dlc, data);
+            canbus_process_data(&msg);
         }
     }
-    if (ie & FDCAN_IE_RX_FIFO0 && ir & FDCAN_IE_RX_FIFO0) {
-        // Admin Rx
-        SOC_CAN->IR = FDCAN_IE_RX_FIFO0;
-        canbus_notify_rx();
-    }
-    if (ie & FDCAN_IE_TC && ir & FDCAN_IE_TC) {
+    if (ir & FDCAN_IE_TC) {
         // Tx
         SOC_CAN->IR = FDCAN_IE_TC;
         canbus_notify_tx();
@@ -317,10 +261,8 @@ can_init(void)
 
     /*##-3- Configure Interrupts #################################*/
     armcm_enable_irq(CAN_IRQHandler, CAN_IT0_IRQn, 0);
-    if (CAN_IT0_IRQn != CAN_IT1_IRQn)
-        armcm_enable_irq(CAN_IRQHandler, CAN_IT1_IRQn, 0);
-    SOC_CAN->ILE |= 0x03;
-    SOC_CAN->IE |= FDCAN_IE_RX_FIFO0 | FDCAN_IE_RX_FIFO1;
+    SOC_CAN->ILE = FDCAN_ILE_EINT0;
+    SOC_CAN->IE = FDCAN_IE_RF0NE;
 
     // Convert unique 96-bit chip id into 48 bit representation
     uint64_t hash = fasthash64((uint8_t*)UID_BASE, 12, 0xA16231A7);


### PR DESCRIPTION
The existing canbus code has two mechanisms for reading messages - one for admin messages and one for data messages.  This PR changes the canbus code to use a single read mechanism.  This simplifies the low-level canbus code and should make it easier to port to new MCUs.

As part of this change, I've also extended the stm32g0 code to support canbus on PB8/PB9 pins.  I needed this to test the changes.

@bigtreetech - fyi.

-Kevin