### PR TITLE
Add Ender 3 S1 Plus config & Fix max temp for S1

### DIFF
--- a/config/printer-creality-ender3-s1plus-2022.cfg
+++ b/config/printer-creality-ender3-s1plus-2022.cfg
@@ -1,5 +1,5 @@
-# This file contains pin mappings for the stock 2021 Creality Ender 3
-# S1. To use this config, check the STM32 Chip on the V2.4S1 Board
+# This file contains pin mappings for the stock 2022 Creality Ender 3
+# S1 Plus. To use this config check the STM32 Chip on the V2.4S1 Board
 # then during "make menuconfig" select either the STM32F103 with a
 # "28KiB bootloader" or select the STM32F401 with a "64KiB bootloader"
 # and serial (on USB PA10/PA9) communication for both depending on the
@@ -25,7 +25,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA5
 position_endstop: -10
-position_max: 235
+position_max: 315
 position_min: -15
 homing_speed: 50
 
@@ -37,7 +37,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
 position_endstop: -10
-position_max: 241
+position_max: 321
 position_min: -15
 homing_speed: 50
 
@@ -48,7 +48,7 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
-position_max: 270
+position_max: 300
 position_min: -4
 
 [extruder]
@@ -110,12 +110,12 @@ stow_on_each_sample: false
 [bed_mesh]
 speed: 120
 mesh_min: 20, 20
-mesh_max: 200, 200
+mesh_max: 280, 280
 probe_count: 4,4
 algorithm: bicubic
 
 [safe_z_home]
-home_xy_position: 147, 154
+home_xy_position: 187, 194
 speed: 75
 z_hop: 5
 z_hop_speed: 5

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -160,6 +160,7 @@ CONFIG ../../config/printer-creality-cr6se-2020.cfg
 CONFIG ../../config/printer-creality-cr6se-2021.cfg
 CONFIG ../../config/printer-creality-ender2pro-2021.cfg
 CONFIG ../../config/printer-creality-ender3-s1-2021.cfg
+CONFIG ../../config/printer-creality-ender3-s1plus-2022.cfg
 CONFIG ../../config/printer-creality-ender3-s1pro-2022.cfg
 CONFIG ../../config/printer-creality-ender3-v2-2020.cfg
 CONFIG ../../config/printer-creality-ender3max-2021.cfg


### PR DESCRIPTION
Signed-off-by: Rob Casper [myallneedsemail@gmail.com](mailto:myallneedsemail@gmail.com)

The [Ender 3 S1 Plus](https://www.creality3dofficial.com/products/ender-3s1-plus-3d-printer-us-direct) has been released although I have yet to see any reviews over it or much talk but thought I might as well get the config added for when people do start to review it and talk about it (hopefully soon), I also fixed the max temperature for the hotend and bed for the S1 non-pro based off the [official diagram](https://www.creality3dofficial.com/files/goods/20220531/s1vsprovsPlus11.jpg) on the Creality website. 