### PR TITLE
Add example to TEMPERATURE_WAIT

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -651,7 +651,8 @@ the config file.
 #### TEMPERATURE_WAIT
 `TEMPERATURE_WAIT SENSOR=<config_name> [MINIMUM=<target>]
 [MAXIMUM=<target>]`: Wait until the given temperature sensor is at or
-above the supplied MINIMUM and/or at or below the supplied MAXIMUM.
+above the supplied MINIMUM and/or at or below the supplied MAXIMUM. An example could be a chamber heater called Chamber of the type Generic heater you want to wait until minimum 45 degrees
+would be `TEMPERATURE_WAIT SENSOR="heater_generic Chamber" MINIMUM=45`
 
 #### SET_HEATER_TEMPERATURE
 `SET_HEATER_TEMPERATURE HEATER=<heater_name>


### PR DESCRIPTION
Small addition to the docs, was missing example of how to reference the sensor