### PR TITLE
flash_usb: Use hexid "2e8a:0003" for rp2040 already in bootloader mode

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220617: It was previously possible to flash an rp2040 in bootloader
+mode by running `make flash FLASH_DEVICE=first`. The equivalent
+command is now `make flash FLASH_DEVICE=2e8a:0003`.
+
 20220612: The rp2040 micro-controller now has a workaround for the
 "rp2040-e5" USB errata. This should make initial USB connections more
 reliable. However, it may result in a change in behavior for the

--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -315,17 +315,19 @@ def flash_stm32f4(options, binfile):
 RP2040_HELP = """
 Failed to flash to %s: %s
 
-If the device is already in bootloader mode, use 'first' as FLASH_DEVICE.
-This will use rp2040_flash to flash the first available rp2040.
+If the device is already in bootloader mode it can be flashed with the
+following command:
+  make flash FLASH_DEVICE=2e8a:0003
 
 Alternatively, one can flash rp2040 boards like the Pico by manually
 entering bootloader mode(hold bootsel button during powerup), mount the
 device as a usb drive, and copy klipper.uf2 to the device.
+
 """
 
 def flash_rp2040(options, binfile):
     try:
-        if options.device.lower() == "first":
+        if options.device.lower() == "2e8a:0003":
             call_picoboot(None, None, binfile, options.sudo)
         else:
             flash_picoboot(options.device, binfile, options.sudo)


### PR DESCRIPTION
Use a USB hex id to indicate that the device is already in bootloader mode.  This makes the rp2040 flashing code similar to the other boards.

@dalegaard - fyi.

-Kevin