### PR TITLE
config: fix processor name in th3d ezboard lite v2.0 config

### DIFF
--- a/config/generic-th3d-ezboard-lite-v2.0.cfg
+++ b/config/generic-th3d-ezboard-lite-v2.0.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for the TH3D EZBoard Lite v2.
 # To use this config, the firmware should be compiled for the
-# STM32F407 with 12mhz Crystal, 48KiB Bootloader, and USB communication.
+# STM32F405 with 12mhz Crystal, 48KiB Bootloader, and USB communication.
 
 # The "make flash" command does not work on this board. Instead,
 # after running "make", copy the generated "out/klipper.bin" file to a


### PR DESCRIPTION
i don't have this board, but a user sent me a picture and also on the website this processor name is listed.

pic from Luissen#7248
![image](https://user-images.githubusercontent.com/8167632/173760165-eebabebe-5f53-44cf-836e-07e63326e227.png)

[link to website](https://www.th3dstudio.com/product/ezboard-v2/)
![image](https://user-images.githubusercontent.com/8167632/173760354-309499cc-524c-40a3-9f8f-253eb733ae0a.png)
