### PR TITLE
display_status: add SET_DISPLAY_TEXT extended gcode

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -138,8 +138,13 @@ This is quite useful if you want to change the behavior of certain commands like
 [gcode_macro M117]
 rename_existing: M117.1
 gcode:
-  M117.1 { rawparams }
-  M118 { rawparams }
+  {% if rawparams %}
+    {% set escaped_msg = rawparams|replace('"', '\\"') %}
+    SET_DISPLAY_TEXT MSG="{escaped_msg}"
+    RESPOND TYPE=command MSG="{escaped_msg}"
+  {% else %}
+    SET_DISPLAY_TEXT
+  {% endif %}
 ```
 
 ### The "printer" Variable

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -295,6 +295,11 @@ provides the following standard G-Code commands:
 - Display Message: `M117 <message>`
 - Set build percentage: `M73 P<percent>`
 
+Also provided is the following extended G-Code command:
+- `SET_DISPLAY_TEXT MSG=<message>`: Performs the equivalent of M117,
+  setting the supplied `MSG` as the current display message.  If
+  `MSG` is omitted the display will be cleared.
+
 ### [dual_carriage]
 
 The following command is available when the

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -16,6 +16,9 @@ class DisplayStatus:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('M73', self.cmd_M73)
         gcode.register_command('M117', self.cmd_M117)
+        gcode.register_command(
+            'SET_DISPLAY_TEXT', self.cmd_SET_DISPLAY_TEXT,
+            desc=self.cmd_SET_DISPLAY_TEXT_help)
     def get_status(self, eventtime):
         progress = self.progress
         if progress is not None and eventtime > self.expire_progress:
@@ -39,6 +42,9 @@ class DisplayStatus:
     def cmd_M117(self, gcmd):
         msg = gcmd.get_raw_command_parameters() or None
         self.message = msg
+    cmd_SET_DISPLAY_TEXT_help = "Set or clear the display message"
+    def cmd_SET_DISPLAY_TEXT(self, gcmd):
+        self.message = gcmd.get("MSG", None)
 
 def load_config(config):
     return DisplayStatus(config)


### PR DESCRIPTION
This is the alternative solution to #5527 as discussed in #5528.  The `SET_DISPLAY_TEXT` extended gcode may be used  to correctly set the message of an overridden M117 command when the message begins with a special character.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>