### PR TITLE
stm32: stm32g0/h7 dfu support

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -339,7 +339,8 @@ MCUTYPES = {
     'sam3': flash_atsam3, 'sam4': flash_atsam4, 'samd': flash_atsamd,
     'same70': flash_atsam4, 'lpc176': flash_lpc176x, 'stm32f103': flash_stm32f1,
     'stm32f4': flash_stm32f4, 'stm32f042': flash_stm32f4,
-    'stm32f072': flash_stm32f4, 'rp2040': flash_rp2040
+    'stm32f072': flash_stm32f4, 'stm32g0b1': flash_stm32f4,
+    'stm32h7': flash_stm32f4, 'rp2040': flash_rp2040
 }
 
 

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -147,7 +147,6 @@ usb_request_bootloader(void)
 void
 armcm_main(void)
 {
-    check_usb_dfu_bootloader();
     SCB->VTOR = (uint32_t)VectorTable;
 
     // Reset clock registers (in case bootloader has changed them)
@@ -163,6 +162,8 @@ armcm_main(void)
     RCC->AHBENR = 0x00000100;
     RCC->APBENR1 = 0x00000000;
     RCC->APBENR2 = 0x00000000;
+
+    check_usb_dfu_bootloader();
 
     // Set flash latency
     FLASH->ACR = (2<<FLASH_ACR_LATENCY_Pos) | FLASH_ACR_ICEN | FLASH_ACR_PRFTEN;

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -6,6 +6,7 @@
 
 #include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
 #include "board/armcm_boot.h" // VectorTable
+#include "board/irq.h" // irq_disable
 #include "board/armcm_reset.h" // try_request_canboot
 #include "command.h" // DECL_CONSTANT_STR
 #include "internal.h" // get_pclock_frequency
@@ -187,11 +188,36 @@ clock_setup(void)
  * USB bootloader
  ****************************************************************/
 
+#define USB_BOOT_FLAG_ADDR (CONFIG_RAM_START + CONFIG_RAM_SIZE - 1024)
+#define USB_BOOT_FLAG 0x55534220424f4f54 // "USB BOOT"
+
+// Flag that bootloader is desired and reboot
+static void
+usb_reboot_for_dfu_bootloader(void)
+{
+    irq_disable();
+    *(uint64_t*)USB_BOOT_FLAG_ADDR = USB_BOOT_FLAG;
+    NVIC_SystemReset();
+}
+
+// Check if rebooting into system DFU Bootloader
+static void
+check_usb_dfu_bootloader(void)
+{
+    if (!CONFIG_USBSERIAL || *(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
+        return;
+    *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
+    uint32_t *sysbase = (uint32_t*)0x1FF09800;
+    asm volatile("mov sp, %0\n bx %1"
+                 : : "r"(sysbase[0]), "r"(sysbase[1]));
+}
+
 // Handle USB reboot requests
 void
 usb_request_bootloader(void)
 {
     try_request_canboot();
+    usb_reboot_for_dfu_bootloader();
 }
 
 
@@ -205,7 +231,13 @@ armcm_main(void)
 {
     // Run SystemInit() and then restore VTOR
     SystemInit();
+    RCC->D1CCIPR = 0x00000000;
+    RCC->D2CCIP1R = 0x00000000;
+    RCC->D2CCIP2R = 0x00000000;
+    RCC->D3CCIPR = 0x00000000;
     SCB->VTOR = (uint32_t)VectorTable;
+
+    check_usb_dfu_bootloader();
 
     clock_setup();
 


### PR DESCRIPTION
### Description
As described in part `4.1 Bootloader activation` of [AN2606](https://www.st.com/content/ccc/resource/technical/document/application_note/b9/9b/16/3a/12/1e/40/0c/CD00167594.pdf/files/CD00167594.pdf/jcr:content/translations/en.CD00167594.pdf) manual.  Before jumping to bootloader user must:
* Disable all peripheral clocks
* Disable used PLL
* Disable interrupts
* Clear pending interrupts

![image](https://user-images.githubusercontent.com/38851044/175185975-4d2ed51b-e33a-46d2-9100-071048b4e68a.png)

So `check_usb_dfu_bootloader();` of STM32G0 is moved behind Reset clock registers, and add Reset clock part for STM32H7 


### now Issues
`dfu-util: Error during download get_status` will appear after `make flash`. 
`sudo dfu-util -p 1-1.2 -R -a 0 -s 0x8020000 -D out/klipper.bin` No error message
`sudo dfu-util -p 1-1.2 -R -a 0 -s 0x8020000:leave -D out/klipper.bin` has error message, So the error  is reported in the `:leave` process. But in fact, the MCU has normally left the DFU mode and entered the klipper application. We can completely ignore this error message.
And I upgraded `dfu-util` to 0.11, which is still the same error in `:leave` 
