### PR TITLE
klippy: properly set log level when logging to stderr

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -342,7 +342,7 @@ def main():
         start_args['log_file'] = options.logfile
         bglogger = queuelogger.setup_bg_logging(options.logfile, debuglevel)
     else:
-        logging.basicConfig(level=debuglevel)
+        logging.getLogger().setLevel(debuglevel)
     logging.info("Starting Klippy...")
     start_args['software_version'] = util.get_git_version()
     start_args['cpu_info'] = util.get_cpu_info()


### PR DESCRIPTION
The `logging.basicConfig` does not reconfigure default logger.
This results in printing only `warnings`/`errors` to stderr
instead of also `info` (or `debug`).

This fixes the issue by setting log level on root logger.

I use `systemd` journal logging (to memory) instead of logging to file.

## Before

Klipper would output only:

```
WARNING:root:No log file specified! Severe timing issues may result!
```

## After

```
INFO:root:Starting Klippy...
WARNING:root:No log file specified! Severe timing issues may result!
INFO:root:Start printer at Fri Jun 24 13:20:41 2022 (1656069641.7 2579.4)
...
INFO:root:Configured MCU 'mcu' (1024 moves)
```

Signed-off-by: Kamil Trzciński <ayufan@ayufan.eu>