### PR TITLE
Added Anet alt-wiring display example

### DIFF
--- a/config/sample-lcd.cfg
+++ b/config/sample-lcd.cfg
@@ -95,6 +95,21 @@ click_pin: ^!EXP1_2
 pin: EXP1_1
 
 
+########################################################################################
+# Anet 128x64 LCD with alternative wiring (ANET_FULL_GRAPHICS_LCD_ALT_WIRING in Marlin)
+########################################################################################
+
+[display]
+lcd_type: st7920
+cs_pin: EXP1_8
+sclk_pin: EXP1_4
+sid_pin: EXP1_6
+encoder_pins: ^!EXP1_7, ^!EXP1_5
+click_pin: ^!EXP1_3
+
+[output_pin beeper]
+pin: EXP1_1
+
 ######################################################################
 # Fysetc Mini 12864Panel v2.1 (with neopixel backlight leds)
 ######################################################################


### PR DESCRIPTION
This adds an example of quite common in Anet world display (re)wiring configuration 

Tested on Anet A8 with SKR 1.4 Turbo board.

Signed-off-by: Vladimir Serov <cab404@mailbox.org>