### PR TITLE
Add MCU temp for Stm32h7

### DIFF
--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -72,6 +72,7 @@ class PrinterTemperatureMCU:
             ('stm32f070', self.config_stm32f070),
             ('stm32f072', self.config_stm32f0x2),
             ('stm32g0', self.config_stm32g0),
+            ('stm32h7', self.config_stm32h7),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -142,6 +143,11 @@ class PrinterTemperatureMCU:
         cal_adc_30 = self.read16(0x1FFF75A8) * 3.0 / (3.3 * 4095.)
         cal_adc_130 = self.read16(0x1FFF75CA) * 3.0 / (3.3 * 4095.)
         self.slope = (130. - 30.) / (cal_adc_130 - cal_adc_30)
+        self.base_temperature = self.calc_base(30., cal_adc_30)
+    def config_stm32h7(self):
+        cal_adc_30 = self.read16(0x1FF1E820) / 65535.
+        cal_adc_110 = self.read16(0x1FF1E840) / 65535.
+        self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def read16(self, addr):
         params = self.debug_read_cmd.send([1, addr])

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -22,6 +22,9 @@
 #define ADC_ISR_LDORDY_Msk                 (0x1UL << ADC_ISR_LDORDY_Pos)
 #define ADC_ISR_LDORDY                     ADC_ISR_LDORDY_Msk
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 DECL_CONSTANT("ADC_MAX", 4095);
 
 // GPIOs like A0_C are not covered!
@@ -88,7 +91,7 @@ static const uint8_t adc_pins[] = {
     GPIO('H', 4),  //          ADC3_INP15
     GPIO('H', 5),  //          ADC3_INP16
     0,             //              Vbat/4
-    0,             //              VSENSE
+    ADC_TEMPERATURE_PIN,//         VSENSE
     0,             //             VREFINT
 };
 
@@ -185,7 +188,13 @@ gpio_adc_setup(uint32_t pin)
         MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSS_Msk,
             OVERSAMPLES_EXPONENT << ADC_CFGR2_OVSS_Pos);
     }
-    gpio_peripheral(pin, GPIO_ANALOG, 0);
+
+    if (pin == ADC_TEMPERATURE_PIN) {
+        ADC3_COMMON->CCR = ADC_CCR_TSEN;
+    } else {
+        gpio_peripheral(pin, GPIO_ANALOG, 0);
+    }
+
     // Preselect (connect) channel
     adc->PCSEL |= (1 << chan);
     return (struct gpio_adc){ .adc = adc, .chan = chan };


### PR DESCRIPTION
module: stm32h7 ADC
Add support for reading the mcu temp on the stm32h7

Signed-off-by: Aaron DeLyser [bluwolf@gmail.com](mailto:bluwolf@gmail.com)