### PR TITLE
Draft: flash_usb: allow to flash via usb-to-can-bridge

### DIFF
--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -7,10 +7,12 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <string.h> // memcpy
+#include "autoconf.h" // CONFIG_*
 #include "board/armcm_reset.h" // try_request_canboot
 #include "board/io.h" // readb
 #include "board/irq.h" // irq_save
 #include "board/misc.h" // console_sendf
+#include "board/usb_cdc.h" // usb_request_bootloader
 #include "canbus.h" // canbus_set_uuid
 #include "canserial.h" // canserial_notify_tx
 #include "command.h" // DECL_CONSTANT
@@ -188,7 +190,11 @@ can_process_request_bootloader(struct canbus_msg *msg)
 {
     if (!can_check_uuid(msg))
         return;
+#ifdef CONFIG_USBCANBUS
+    usb_request_bootloader();
+#else // CONFIG_USBCANBUS
     try_request_canboot();
+#endif // CONFIG_USBCANBUS
 }
 
 // Handle an "admin" command

--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -149,7 +149,9 @@ usb_reboot_for_dfu_bootloader(void)
 static void
 check_usb_dfu_bootloader(void)
 {
-    if (!CONFIG_USBSERIAL || !CONFIG_MACH_STM32F0x2
+    if (!CONFIG_USBSERIAL && !CONFIG_USBCANBUS)
+        return;
+    if (!CONFIG_MACH_STM32F0x2
         || *(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
         return;
     *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -220,7 +220,9 @@ usb_reboot_for_dfu_bootloader(void)
 static void
 check_usb_dfu_bootloader(void)
 {
-    if (!CONFIG_USBSERIAL || *(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
+    if (!CONFIG_USBSERIAL && !CONFIG_USBCANBUS)
+        return;
+    if (*(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
         return;
     *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
     uint32_t *sysbase = (uint32_t*)0x1fff0000;

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -122,7 +122,9 @@ usb_reboot_for_dfu_bootloader(void)
 static void
 check_usb_dfu_bootloader(void)
 {
-    if (!CONFIG_USBSERIAL || *(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
+    if (!CONFIG_USBSERIAL && !CONFIG_USBCANBUS)
+        return;
+    if (*(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
         return;
     *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
     uint32_t *sysbase = (uint32_t*)0x1fff0000;


### PR DESCRIPTION
This is proof of concept to allow putting device into DFU when using `USBCAN`

This allows to send bootloader command over can bridge
and make the board to enter DFU bootloader
    
To use:
    
```
make flash FLASH_DEVICE=can0:78cc933511c6:0483:df11
```
    
It does work. It will first send bootloader request via `can0`.