### PR TITLE
Anycubic 4 Max Pro 2.0: Added two internal systems (beeper and PSU control).

### DIFF
--- a/config/printer-anycubic-4maxpro-2.0-2021.cfg
+++ b/config/printer-anycubic-4maxpro-2.0-2021.cfg
@@ -140,6 +140,16 @@ screw4: 265, 5
 [filament_switch_sensor filament_sensor]
 switch_pin: ^!PC4
 
+[output_pin buzz]
+pin: PC6
+pwm: True
+
+[output_pin AUTO_POWEROFF]
+pin: PD0
+pwm: True
+cycle_time: 0.02
+value: 1
+
 
 # This macro (M300) uses internal integrated beeper
 # Just use it in your G-code for making sounds. Example: M300 S1000 P500

--- a/config/printer-anycubic-4maxpro-2.0-2021.cfg
+++ b/config/printer-anycubic-4maxpro-2.0-2021.cfg
@@ -11,7 +11,7 @@
 
 # For Anycubic 4Max Pro (not 2.0) owners:
 #       Be careful when using this config! This config tested only on Anycubic
-#       4Max Pro 2.0 with klipper v0.9.1-667-g31761500! At first, you should
+#       4Max Pro 2.0! At first, you should
 #       set homing_speed on 5, and run homing and click on the endstops with
 #       your fingers. It is necessary to make sure that all the motors are
 #       spinning in the right direction, all the temperature sensors show the
@@ -139,3 +139,40 @@ screw4: 265, 5
 
 [filament_switch_sensor filament_sensor]
 switch_pin: ^!PC4
+
+
+# This macro (M300) uses internal integrated beeper
+# Just use it in your G-code for making sounds. Example: M300 S1000 P500
+[gcode_macro M300]
+gcode:
+    {% set S = params.S|default(800)|float %}
+    {% set P = params.P|default(100)|int %}
+    SET_PIN PIN=buzz VALUE=0.5 CYCLE_TIME={ 1.0 / S | float }
+    G4 P{P}
+    SET_PIN PIN=buzz VALUE=0
+
+# This macro (M81) uses internal integrated PSU control-relay.
+# Just use M81 in your end_gcode if you want to poweroff your printer after print.
+# Note: as in original Marlin firmware, before powerdown, printer will be cool hotend
+# until temperature will be below 45°С / 113°F.
+
+[gcode_macro M81]
+gcode:
+    {% set required_extruder_temp = params.T|default(45)|int %}
+    {% if printer.extruder.temperature > required_extruder_temp|default(45)|int %}
+            M300
+            M300
+            M300
+            M117 COOLING DOWN BEFORE POWER OFF
+            M109 S{required_extruder_temp}
+            SET_PIN PIN=AUTO_POWEROFF VALUE=0.5
+            G4 P60
+            SET_PIN PIN=AUTO_POWEROFF VALUE=1
+    {% else %}
+            M300
+            M117 POWER OFF SOON
+            G4 P10000
+            SET_PIN PIN=AUTO_POWEROFF VALUE=0.5
+            G4 P60
+            SET_PIN PIN=AUTO_POWEROFF VALUE=1
+    {% endif %}


### PR DESCRIPTION
Hello there! I have added to klipper config for Anycubic 4 Max Pro 2.0 two internal stock systems. First one is internal beeper, and I created M300: "Play Tone" G-Code macro, according to Marlin G-Codes.
Second one, I added M81: "Power Off" G-Code macro, according to Marlin G-Codes. This command will be wait until hotend cool down, and then power off printer. Stock firmware do the same things. 

-- Signed-off-by: Usachev Alexander Valer'evich <int_0x21@protonmail.com>