### PR TITLE
Corrected name of "rear left" bed screw

### DIFF
--- a/config/printer-creality-cr10-v3-2020.cfg
+++ b/config/printer-creality-cr10-v3-2020.cfg
@@ -145,7 +145,7 @@ screw2_name: front right screw
 screw3: 273,269
 screw3_name: rear right screw
 screw4: 33,269
-screw4_name: rear right screw
+screw4_name: rear left screw
 
 #Uncomment the following lines if you have a BL-Touch
 #[screws_tilt_adjust]
@@ -156,7 +156,7 @@ screw4_name: rear right screw
 #screw3: 228,269
 #screw3_name: rear right screw
 #screw4: 0,269
-#screw4_name: rear right screw
+#screw4_name: rear left screw
 #speed: 50
 #horizontal_move_z: 10
 #screw_thread: CW-M3


### PR DESCRIPTION
The `bed_screw` and `screws_tilt_adjust` sections had screw4_name labeled incorrectly.