### PR TITLE
Update printer-creality-ender3-s1-2021.cfg

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -13,14 +13,10 @@
 
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware
-# filename must changed to "firmware.bin"
+# filename must be changed to "firmware.bin"
 
 # On the STM32F401 board, you may need to place the firmware file in a
-# folder on the SD card called "STM32F4_UPDATE". The firmware
-# filename must end in ".bin" and must not match the last filename
-# that was flashed.
-
-# You may need to disconnect your printer's screen before inserting the SD card.
+# folder on the SD card called "STM32F4_UPDATE".
 
 # See docs/Config_Reference.md for a description of parameters.
 

--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -15,6 +15,13 @@
 # turning on the printer with the card inserted. The firmware
 # filename must changed to "firmware.bin"
 
+# On the STM32F401 board, you may need to place the firmware file in a
+# folder on the SD card called "STM32F4_UPDATE". The firmware
+# filename must end in ".bin" and must not match the last filename
+# that was flashed.
+
+# You may need to disconnect your printer's screen before inserting the SD card. 
+
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]

--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -20,7 +20,7 @@
 # filename must end in ".bin" and must not match the last filename
 # that was flashed.
 
-# You may need to disconnect your printer's screen before inserting the SD card. 
+# You may need to disconnect your printer's screen before inserting the SD card.
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
Added additional comment detailing requirements (root folder needed on the SD card, adjusting the name of the firmware file) when saving firmware to flash to the STM32F401.

This is consistent with the findings from [mriscoc ](https://github.com/mriscoc/Ender3V2S1/wiki/How-to-install-the-firmware) as well as independent testing. 