### PR TITLE
Add a new Sponsors.md file to the docs and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ To begin using Klipper start by
 [installing](https://www.klipper3d.org/Installation.html) it.
 
 Klipper is Free Software. See the [license](COPYING) or read the
-[documentation](https://www.klipper3d.org/Overview.html).
+[documentation](https://www.klipper3d.org/Overview.html). We depend on
+the generous support from our
+[sponsors](https://www.klipper3d.org/Sponsors.html).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,8 +2,8 @@
 
 ## How can I donate to the project?
 
-Thanks. Kevin has a Patreon page at:
-[https://www.patreon.com/koconnor](https://www.patreon.com/koconnor)
+Thank you for your support. See the [Sponsors page](Sponsors.md) for
+information.
 
 ## How do I calculate the rotation_distance config parameter?
 

--- a/docs/Sponsors.md
+++ b/docs/Sponsors.md
@@ -1,0 +1,30 @@
+# Sponsors
+
+Klipper is Free Software. We depend on the generous support from
+sponsors. Please consider sponsoring Klipper or supporting our
+sponsors.
+
+## Klipper Developers
+
+### Kevin O'Connor
+
+Kevin is the original author and current maintainer of Klipper.  Kevin
+has a Patreon page at:
+[https://www.patreon.com/koconnor](https://www.patreon.com/koconnor)
+
+### Eric Callahan
+
+Eric is the author of bed_mesh, spi_flash, and several other Klipper
+modules.  Eric has a donations page at:
+[https://ko-fi.com/arksine](https://ko-fi.com/arksine)
+
+## Related Klipper Projects
+
+Klipper is frequently used with other Free Software. Consider using or
+supporting these projects.
+
+* [Moonraker](https://github.com/Arksine/moonraker)
+* [Mainsail](https://github.com/mainsail-crew/mainsail)
+* [Fluidd](https://github.com/fluidd-core/fluidd)
+* [OctoPrint](https://octoprint.org/)
+* [KlipperScreen](https://github.com/jordanruthe/KlipperScreen)

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -135,3 +135,4 @@ nav:
     - CANBUS.md
     - TSL1401CL_Filament_Width_Sensor.md
     - Hall_Filament_Width_Sensor.md
+  - Sponsors.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,4 @@ To begin using Klipper start by [installing](Installation.md) it.
 
 Klipper is Free Software. Read the [documentation](Overview.md) or
 view [the Klipper code on github](https://github.com/Klipper3d/klipper).
+We depend on the generous support from our [sponsors](Sponsors.md).


### PR DESCRIPTION
I'm planning to add a new "Sponsors" page to the documentation and to the klipper3d.org website.  There are two main goals for doing this: it gives a location to inform users of how they can donate to Klipper, and it provides a place to list prominent sponsors of Klipper.

This PR adds the page with some existing donation links for Klipper and lists some common Free Software that is often used with Klipper.

I've received interest from some hardware manufacturers interested in sponsoring Klipper.  This page is where I would look to add those sponsorships in the future.

Along with adding the page, I've added links to it from the main Klipper splash page and in the page site index.

-Kevin