### PR TITLE
spi_flash: add btt-octopus

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -70,6 +70,12 @@ BOARD_DEFS = {
         'mcu': "stm32f407xx",
         'spi_bus': "spi3a",
         "cs_pin": "PC9"
+    },
+    'btt-octopus': {
+        'mcu': "stm32f446xx",
+        "cs_pin": "PC11",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
     }
 }
 


### PR DESCRIPTION
Adds a board definition for BTT Octopus SPI/SD card flashing.

Was only able to get it working using `swspi` (software SPI), but is tested and (mostly) working on a real BTT Octopus v1.0. 

Only caveat is the the Octopus board doesn't seem to pick up the new firmware.bin after a soft-reset and I had to power-cycle it before it loaded the new firmware. Some details here: https://github.com/Klipper3d/klipper/pull/3792#issuecomment-1182706828