### PR TITLE
Make installation paths and some variables configurable

### DIFF
--- a/scripts/flash-sdcard.sh
+++ b/scripts/flash-sdcard.sh
@@ -3,7 +3,7 @@
 #  unattended firmware updates on boards with "SD Card" bootloaders
 
 # Non-standard installations may need to change this location
-KLIPPY_ENV="${HOME}/klippy-env/bin/python"
+KLIPPY_ENV="${KLIPPER_VENV:-${HOME}/klippy-env/bin/python}"
 SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 KLIPPER_BIN="${SRCDIR}/out/klipper.bin"
 KLIPPER_BIN_DEFAULT=$KLIPPER_BIN

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This script installs Klipper on an Arch Linux system
 
-PYTHONDIR="${HOME}/klippy-env"
+PYTHONDIR="${KLIPPER_VENV:-${HOME}/klippy-env}"
 SYSTEMDDIR="/etc/systemd/system"
-AURCLIENT="pamac"
-KLIPPER_USER=$USER
-KLIPPER_GROUP=$KLIPPER_USER
+AURCLIENT="${AURCLIENT:-pamac build}"
+KLIPPER_USER="${KLIPPER_USER:-$USER}"
+KLIPPER_GROUP="${KLIPPER_GROUP:-$KLIPPER_USER}"
 
 # Step 1: Install system packages
 install_packages()
@@ -26,7 +26,7 @@ install_packages()
     # Install desired packages
      report_status "Installing packages..."
      sudo pacman -S ${PKGLIST}
-     $AURCLIENT build ${AURLIST}
+     $AURCLIENT ${AURLIST}
 }
 
 # Step 2: Create python virtual environment

--- a/scripts/install-centos.sh
+++ b/scripts/install-centos.sh
@@ -2,7 +2,7 @@
 # This script installs Klipper on an x86_64 machine running the
 # CentOS 7 distribution.
 
-PYTHONDIR="${HOME}/klippy-env"
+PYTHONDIR="${KLIPPER_VENV:-${HOME}/klippy-env}"
 SYSTEMDDIR="/etc/systemd/system"
 
 # Step 1: Install system packages

--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -2,10 +2,10 @@
 # This script installs Klipper on an debian
 #
 
-PYTHONDIR="${HOME}/klippy-env"
+PYTHONDIR="${KLIPPER_VENV:-${HOME}/klippy-env}"
 SYSTEMDDIR="/etc/systemd/system"
-KLIPPER_USER=$USER
-KLIPPER_GROUP=$KLIPPER_USER
+KLIPPER_USER="${KLIPPER_USER:-$USER}"
+KLIPPER_GROUP="${KLIPPER_GROUP:-$KLIPPER_USER}"
 
 # Step 1: Install system packages
 install_packages()

--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -2,7 +2,7 @@
 # This script installs Klipper on a Raspberry Pi machine running the
 # OctoPi distribution.
 
-PYTHONDIR="${HOME}/klippy-env"
+PYTHONDIR="${KLIPPER_VENV:-${HOME}/klippy-env}"
 
 # Step 1: Install system packages
 install_packages()

--- a/scripts/install-ubuntu-18.04.sh
+++ b/scripts/install-ubuntu-18.04.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # This script installs Klipper on an Ubuntu 18.04 machine with Octoprint
 
-PYTHONDIR="${HOME}/klippy-env"
+PYTHONDIR="${KLIPPER_VENV:-${HOME}/klippy-env}"
 SYSTEMDDIR="/etc/systemd/system"
-KLIPPER_USER=$USER
-KLIPPER_GROUP=$KLIPPER_USER
+KLIPPER_USER="${KLIPPER_USER:-$USER}"
+KLIPPER_GROUP="${KLIPPER_GROUP:-$KLIPPER_USER}"
 
 # Step 1: Install system packages
 install_packages()


### PR DESCRIPTION
```sh
KLIPPER_VENV=$HOME/.venvs/klipper ./scripts/install-debian.sh
AURCLIENT='yay -S' ./scripts/install-arch.sh
```

I have been using a relocated virtualenv like this for a while now,
 and relocated all my virtualenvs to a single ~/venvs folder for
 organizations-sake. Personally, I set KLIPPER_VENV in my .profile
 and everything just works.

If you would like, I can update documentation to explain these
 options.

Signed-off-by: Franklyn Tackitt <git@frank.af>