### PR TITLE
Add spi_flash board definition for Mellow FLY Gemini V2

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -70,6 +70,11 @@ BOARD_DEFS = {
         'mcu': "stm32f407xx",
         'spi_bus': "spi3a",
         "cs_pin": "PC9"
+    },
+    'fly-gemini-v2': {
+        'mcu': "stm32f405xx",
+        'spi_bus': "spi1",
+        "cs_pin": "PA4"
     }
 }
 


### PR DESCRIPTION
Just a board configuration for Mellow FLY Gemini V2 to be able to flash via sd card.