### PR TITLE
manual_probe: report status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -244,6 +244,17 @@ The following information is available for each `[led led_name]`,
   chain could be accessed at
   `printer["neopixel <config_name>"].color_data[1][2]`.
 
+## manual_probe
+
+The following information is available in the
+`manual_probe` object:
+- `is_active`: Returns True if a manual probing helper script is currently
+active.
+- `z_position`: The current height of the nozzle (as the printer currently
+understands it).
+- `z_position_lower`: Last probe attempt just lower than the current height.
+- `z_position_upper`: Last probe attempt just greater than the current height.
+
 ## mcu
 
 The following information is available in


### PR DESCRIPTION
Exposes a `ManualProbe` status, that will be set by `ManualProbeHelper`.

When not running, status is:

```python
{
  'is_active': False,
  'z_position': None,
  'z_position_lower': None,
  'z_position_upper': None
}
```

When a manual probe is initiated, `ManualProbeHelper` will set `active` to `True` and the remaining values will update accordingly.

This will allow frontends like Fluidd and Mainsail to show an "assistant/wizard" type interface to help with these commands!

This PR is a follow up on this Discourse topic: https://klipper.discourse.group/t/exposing-calibration-testz-accept-abort-state/3511

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>