### PR TITLE
adc: Account for jitter when rescheduling samples

### DIFF
--- a/src/stm32/stm32f0_adc.c
+++ b/src/stm32/stm32f0_adc.c
@@ -119,7 +119,20 @@ gpio_adc_sample(struct gpio_adc g)
             return 0;
         goto need_delay;
     }
+#if CONFIG_MACH_STM32G0
+    // Acknowledge EOC flag, clear Channel Config Ready before updating CHSELR
+    adc->ISR = ADC_ISR_EOC | ADC_ISR_CCRDY;
+    adc->ISR;
+#endif
+
     adc->CHSELR = g.chan;
+
+#if CONFIG_MACH_STM32G0
+    // Wait for Channel Config Ready
+    while (!(adc->ISR & ADC_ISR_CCRDY))
+        ;
+#endif
+
     adc->CR = CR_FLAGS | ADC_CR_ADSTART;
 
 need_delay:


### PR DESCRIPTION
Recompute the waketime for the ADC sample timer relative to the current time instead of the previous waketime when the hardware is busy. If `gpio_adc_sample` repeatedly asks for a delay, scheduling jitter will eventually cause us to compute a waketime in the past and trip the scheduler safety checks.

I ran into this issue when setting up Klipper on a new BTT SKR Mini E3 v3.0 board (STM32G0-based). Without this patch, the board would crash with "Rescheduled timer in the past" -- randomly, but typically within an hour after power-on/reset. After this patch, I haven't seen any more problems and have been able to complete several prints.

During initial debugging, I noticed in the crash log receive queue dump that the repeated `analog_in_state` messages for one of the channels went missing shortly before the crash; that's what led me down this path. [My sample crash log](https://gist.github.com/Fraxul/d6d72d8dcb3ad1226c3fe8d8a0f4ff57)

I also noted the same pattern in crash logs found when searching for other user reports of this issue. In all cases, there were missing `analog_in_state` reports immediately prior to the crash.
[Sample 1](https://klipper.discourse.group/t/mcu-mcu-shutdown-rescheduled-timer-in-the-past/3293) 
[Sample 2](https://klipper.discourse.group/t/skr-e3-mini-v3-mcu-mcu-shutdown-rescheduled-timer-in-the-past/3456)
[Sample 3](https://klipper.discourse.group/t/random-mcu-rescheduled-timer-errors/2812)
[Sample 4](https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/issues/667)

