### PR TITLE
bed_screws: report status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -28,6 +28,17 @@ The following information is available in the
 - `profiles`: The set of currently defined profiles as setup
    using BED_MESH_PROFILE.
 
+## bed_screws
+
+The following information is available in the
+`Config_Reference.md#bed_screws` object:
+- `is_active`: Returns True if the bed screws adjustment tool is currently
+active.
+- `state`: The bed screws adjustment tool state. It is one of
+the following strings: "adjust", "fine".
+- `current_screw`: The index for the current screw being adjusted.
+- `accepted_screws`: The number of accepted screws.
+
 ## configfile
 
 The following information is available in the `configfile` object

--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -7,9 +7,7 @@
 class BedScrews:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.state = None
-        self.current_screw = 0
-        self.accepted_screws = 0
+        self.reset()
         self.number_of_screws = 0
         # Read config
         screws = []
@@ -39,6 +37,10 @@ class BedScrews:
         self.gcode.register_command("BED_SCREWS_ADJUST",
                                     self.cmd_BED_SCREWS_ADJUST,
                                     desc=self.cmd_BED_SCREWS_ADJUST_help)
+    def reset(self):
+        self.state = None
+        self.current_screw = 0
+        self.accepted_screws = 0
     def move(self, coord, speed):
         self.printer.lookup_object('toolhead').manual_move(coord, speed)
     def move_to_screw(self, state, screw):
@@ -64,6 +66,13 @@ class BedScrews:
         self.gcode.register_command('ACCEPT', None)
         self.gcode.register_command('ADJUSTED', None)
         self.gcode.register_command('ABORT', None)
+    def get_status(self, eventtime):
+        return {
+            'is_active': self.state is not None,
+            'state': self.state,
+            'current_screw': self.current_screw,
+            'accepted_screws': self.accepted_screws
+        }
     cmd_BED_SCREWS_ADJUST_help = "Tool to help adjust bed leveling screws"
     def cmd_BED_SCREWS_ADJUST(self, gcmd):
         if self.state is not None:
@@ -92,7 +101,7 @@ class BedScrews:
             self.move_to_screw('fine', 0)
             return
         # Done
-        self.state = None
+        self.reset()
         self.move((None, None, self.horizontal_move_z), self.lift_speed)
         gcmd.respond_info("Bed screws tool completed successfully")
     cmd_ADJUSTED_help = "Accept bed screw position after notable adjustment"
@@ -103,7 +112,7 @@ class BedScrews:
     cmd_ABORT_help = "Abort bed screws tool"
     def cmd_ABORT(self, gcmd):
         self.unregister_commands()
-        self.state = None
+        self.reset()
 
 def load_config(config):
     return BedScrews(config)


### PR DESCRIPTION
Exposes the current status of `BED_SCREWS_ADJUST` under `bed_screws`:

When not running, status is:

```python
{
  'is_active': False,
  'state': None,
  'current_screw': 0,
  'accepted_screws': 0
}
```

When a `BED_SCREWS_ADJUST` command is initiated, it will set active to True and the remaining values will update accordingly.

I've decided not to expose the "calculated" screws data inside bed_screws.py as we can get that directly from the config.

This will allow frontends like Fluidd and Mainsail to show an "assistant/wizard" type interface to help with the `BED_SCREWS_ADJUST` command!

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>