### PR TITLE
Added the possibility to get where the "cone shape" of the build volume starts from Macros

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -427,8 +427,8 @@ The following information is available in the `toolhead` object
 - `axis_minimum`, `axis_maximum`: The axis travel limits (mm) after
   homing.  It is possible to access the x, y, z components of this
   limit value (eg, `axis_minimum.x`, `axis_maximum.z`).
-- For Delta printers the `cone_start_z` is the max z height at 
-  maximum radius (`printer.toolhead.cone_start_z`)
+- For Delta printers the `cone_start_z` is the max z height at
+  maximum radius (`printer.toolhead.cone_start_z`).
 - `max_velocity`, `max_accel`, `max_accel_to_decel`,
   `square_corner_velocity`: The current printing limits that are in
   effect. This may differ from the config file settings if a

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -427,7 +427,8 @@ The following information is available in the `toolhead` object
 - `axis_minimum`, `axis_maximum`: The axis travel limits (mm) after
   homing.  It is possible to access the x, y, z components of this
   limit value (eg, `axis_minimum.x`, `axis_maximum.z`).
-- For Delta printers the `cone_start_z` is the max z height at maximum radius (`printer.toolhead.cone_start_z`)
+- For Delta printers the `cone_start_z` is the max z height at 
+  maximum radius (`printer.toolhead.cone_start_z`)
 - `max_velocity`, `max_accel`, `max_accel_to_decel`,
   `square_corner_velocity`: The current printing limits that are in
   effect. This may differ from the config file settings if a

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -427,6 +427,7 @@ The following information is available in the `toolhead` object
 - `axis_minimum`, `axis_maximum`: The axis travel limits (mm) after
   homing.  It is possible to access the x, y, z components of this
   limit value (eg, `axis_minimum.x`, `axis_maximum.z`).
+- For Delta printers the `cone_start_z` is the max z height at maximum radius (`printer.toolhead.cone_start_z`)
 - `max_velocity`, `max_accel`, `max_accel_to_decel`,
   `square_corner_velocity`: The current printing limits that are in
   effect. This may differ from the config file settings if a

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -150,6 +150,7 @@ class DeltaKinematics:
             'homed_axes': '' if self.need_home else 'xyz',
             'axis_minimum': self.axes_min,
             'axis_maximum': self.axes_max,
+            'limit_z': self.limit_z,
         }
     def get_calibration(self):
         endstops = [rail.get_homing_info().position_endstop

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -150,7 +150,7 @@ class DeltaKinematics:
             'homed_axes': '' if self.need_home else 'xyz',
             'axis_minimum': self.axes_min,
             'axis_maximum': self.axes_max,
-            'limit_z': self.limit_z,
+            'cone_start_z': self.limit_z,
         }
     def get_calibration(self):
         endstops = [rail.get_homing_info().position_endstop


### PR DESCRIPTION
Added the possibility to get where the "cone shape" of the build volume starts from Macros

Signed-off-by: Martin Malmqvist Volcomosq@gmx.com