### PR TITLE
add feedrate information to all movements (menu.cfg)

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,9 @@ All dates in this document are approximate.
 
 ## Changes
 
+20220821: The movement entries in the "menu.cfg" for 10/1/0.1 mm are
+expanded with the feedrate. For X and Y F6000. For Z F1500.
+
 20220616: It was previously possible to flash an rp2040 in bootloader
 mode by running `make flash FLASH_DEVICE=first`. The equivalent
 command is now `make flash FLASH_DEVICE=2e8a:0003`.

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -300,7 +300,7 @@ input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 X{menu.input}
+    G1 X{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_10mm __axis_y]
@@ -313,7 +313,7 @@ input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Y{menu.input}
+    G1 Y{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_10mm __axis_z]
@@ -327,7 +327,7 @@ input_step: 10.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Z{menu.input}
+    G1 Z{menu.input} F1500
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_10mm __axis_e]
@@ -360,7 +360,7 @@ input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 X{menu.input}
+    G1 X{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_1mm __axis_y]
@@ -373,7 +373,7 @@ input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Y{menu.input}
+    G1 Y{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_1mm __axis_z]
@@ -387,7 +387,7 @@ input_step: 1.0
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Z{menu.input}
+    G1 Z{menu.input} F1500
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_1mm __axis_e]
@@ -420,7 +420,7 @@ input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 X{menu.input}
+    G1 X{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_01mm __axis_y]
@@ -433,7 +433,7 @@ input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Y{menu.input}
+    G1 Y{menu.input} F6000
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_01mm __axis_z]
@@ -447,7 +447,7 @@ input_step: 0.1
 gcode:
     SAVE_GCODE_STATE NAME=__move__axis
     G90
-    G1 Z{menu.input}
+    G1 Z{menu.input} F1500
     RESTORE_GCODE_STATE NAME=__move__axis
 
 [menu __main __control __move_01mm __axis_e]


### PR DESCRIPTION
For moves (10,1,0.1) the feedrate information was missing.
This commit updates the X and Y moves to F6000
Z to F1500

Signed-off-by: Christian Schnellrieder <schnellrieder.cs@gmail.com>