### PR TITLE
Update Creality Ender S1 Config

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -25,9 +25,9 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA5
-position_endstop: -10
-position_max: 235
-position_min: -15
+position_endstop: -11
+position_max: 240
+position_min: -11
 homing_speed: 50
 
 [stepper_y]
@@ -37,9 +37,9 @@ enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
-position_endstop: -10
-position_max: 241
-position_min: -15
+position_endstop: -8
+position_max: 224
+position_min: -8
 homing_speed: 50
 
 [stepper_z]
@@ -109,18 +109,23 @@ probe_with_touch_mode: true
 stow_on_each_sample: false
 
 [bed_mesh]
-speed: 120
+speed: 100
 mesh_min: 20, 20
-mesh_max: 200, 200
-probe_count: 4,4
+mesh_max: 200, 183
+probe_count: 5,5
 algorithm: bicubic
+
+[bed_screws]
+screw1: 20, 25
+screw2: 195, 25
+screw3: 195, 195
+screw4: 20, 195
 
 [safe_z_home]
 home_xy_position: 147, 154
 speed: 75
-z_hop: 5
+z_hop: 10
 z_hop_speed: 5
-move_to_previous: true
 
 [filament_switch_sensor e0_sensor]
 switch_pin: !PC15


### PR DESCRIPTION
I found that the provided configuration for the stock `Ender 3 S1` is moving the bed outside of the physical limits of the printer.

The result is that the bed is crashing heavily even during a bed mesh calibration.

These changes update the end-stop positions, axis limits and bed mesh points.

The new end-stop positions and limits are targeting the official printing area of 220*220mm

I also added a section for the bed screws position.