### PR TITLE
Do not write to console when variables are saved

### DIFF
--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -54,7 +54,6 @@ class SaveVariables:
             msg = "Unable to save variable"
             logging.exception(msg)
             raise gcmd.error(msg)
-        gcmd.respond_info("Variable Saved")
         self.loadVariables()
     def get_status(self, eventtime):
         return {'variables': self.allVariables}


### PR DESCRIPTION
Prevents `Variable Saved` from being written to the console every time SAVE_VARIABLE is called.