### PR TITLE
Fix software switching to DFU mode with stm32f429 MCU

### DIFF
--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -211,7 +211,22 @@ usb_hid_bootloader(void)
 static void
 usb_reboot_for_dfu_bootloader(void)
 {
-    irq_disable();
+    if (CONFIG_MACH_STM32F429) 
+    {
+        void (*SysMemBootJump)(void);
+        volatile uint32_t addr = 0x1FFF0000;
+
+        SysTick->CTRL = 0;
+        SysTick->LOAD = 0;
+        SysTick->VAL = 0;
+
+        SYSCFG->MEMRMP = 0x01;
+        SysMemBootJump = (void (*)(void)) (*((uint32_t *)(addr + 4)));
+
+        __set_MSP(*(uint32_t *)addr);
+
+        SysMemBootJump();
+    }    irq_disable();
     *(uint64_t*)USB_BOOT_FLAG_ADDR = USB_BOOT_FLAG;
     NVIC_SystemReset();
 }

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -211,20 +211,16 @@ usb_hid_bootloader(void)
 static void
 usb_reboot_for_dfu_bootloader(void)
 {
-    if (CONFIG_MACH_STM32F429) 
+    if (CONFIG_MACH_STM32F429)
     {
         void (*SysMemBootJump)(void);
         volatile uint32_t addr = 0x1FFF0000;
-
         SysTick->CTRL = 0;
         SysTick->LOAD = 0;
         SysTick->VAL = 0;
-
         SYSCFG->MEMRMP = 0x01;
         SysMemBootJump = (void (*)(void)) (*((uint32_t *)(addr + 4)));
-
         __set_MSP(*(uint32_t *)addr);
-
         SysMemBootJump();
     }
     irq_disable();

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -226,7 +226,8 @@ usb_reboot_for_dfu_bootloader(void)
         __set_MSP(*(uint32_t *)addr);
 
         SysMemBootJump();
-    }    irq_disable();
+    }
+    irq_disable();
     *(uint64_t*)USB_BOOT_FLAG_ADDR = USB_BOOT_FLAG;
     NVIC_SystemReset();
 }


### PR DESCRIPTION
stm32f4.c:
This fix make possible to go to DFU mode with STM32F429 and flash it using command:
make flash FLASH_DEVICE={FLASH_DEVICE_PATH}

Where FLASH_DEVICE_PATH could be found with:
ls /dev/serial/by-path/

Exmple:
make flash FLASH_DEVICE=/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.0

All flashes correctly but some errors are displayed after flash process finished. Just ignore them.
Same errors appears when you switch to DFU mode with jumper, it's a dfu-util errors, not klipper.

Signed-off-by: Ilya Vislotsky <i.vislotsky@gmail.com>