### PR TITLE
Add missing dependency for hid-flash to install script

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -20,7 +20,7 @@ install_packages()
     PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
     # ARM chip installation and building
     PKGLIST="${PKGLIST} stm32flash libnewlib-arm-none-eabi"
-    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0"
+    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 pkg-config"
 
     # Update system package info
     report_status "Running apt-get update..."


### PR DESCRIPTION
Module: INSTALL, added missing dependency

hid-flash requires pkg-config, this does not get installed by the install script. (and produces really misleading errors when missing)

I added it as a dependency which caused it to be installed by the install script and kiauh which allowed hid-flash to work right out of the box.

Signed-off-by: Adrian Joachim [adi.joachim12@gmail.com](mailto:adi.joachim12@gmail.com)