### PR TITLE
Update printer-creality-ender3-s1-2021.cfg

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -2,19 +2,25 @@
 # S1 (and S1 pro). To use this config, check the STM32 Chip on the
 # V2.4S1 Board then during "make menuconfig" select either the
 # STM32F103 with a "28KiB bootloader" or select the STM32F401 with a
-# "64KiB bootloader" and serial (on USART1 PA10/PA9) communication for
-# both depending on the STM32 chip installed on your printer's
-# motherboard.
+# "64KiB bootloader" for both depending on the STM32 chip installed on 
+# your printer's motherboard.
+
+# For USB connection, you must select SERIAL (on USART1 PA10/PA9) communication
+# in "make menuconfig". DO NOT SELECT USB or else it will not work.
 
 # If you prefer a direct serial connection, in "make menuconfig"
 # select "Enable extra low-level configuration options" and select
-# Serial (on USART2 PA3/PA2), which is broken out on the 10 pin IDC
-# cable used for the LCD module as follows:
-# 3: Tx, 4: Rx, 9: GND, 10: VCC
+# Serial (on USART2 PA3/PA2), which is broken out on the 10 pin (2x5) IDC
+# socket used for the non-touch LCD module as follows:
+# 3: Tx, 4: Rx, 9: GND, 10: VCC. Pin 1 is top right with key notch at the top.
 
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware
-# filename must changed to "firmware.bin"
+# filename must changed to "firmware.bin".
+
+# FOR STM32F401 CHIPS: the .bin file must be inside a folder named "STM32F4_UPDATE"
+# and it MUST be a different filename than the previous flash.
+# You can simply add sequential numbers after "klipper"
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -48,6 +54,9 @@ dir_pin: !PB5
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 8
+# If using physical Z switch instead of probe, uncomment line 59 and comment line 60,
+# as well as comment all lines in [bltouch] section.
+# endstop_pin: !PA7
 endstop_pin: probe:z_virtual_endstop
 position_max: 270
 position_min: -4


### PR DESCRIPTION
Clarified firmware build instructions for this printer to avoid 'no mcu communication' issue after flash due to confusing wording, added important detail for F401 variant, added option for physical Z endstop switch.