### PR TITLE
rp2040: Enabled hw pullups for the I2C pins

### DIFF
--- a/src/rp2040/i2c.c
+++ b/src/rp2040/i2c.c
@@ -75,8 +75,8 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
 
     const struct i2c_info *info = &i2c_bus[bus];
 
-    gpio_peripheral(info->sda_pin, 3, 0);
-    gpio_peripheral(info->scl_pin, 3, 0);
+    gpio_peripheral(info->sda_pin, 3, 1);
+    gpio_peripheral(info->scl_pin, 3, 1);
 
     if (!is_enabled_pclock(info->pclk)) {
         enable_pclock(info->pclk);


### PR DESCRIPTION
rp2040: Enables the hw pullups on the i2c pins to enable i2c communication without external pullups.

Tested on a custom rp2040 board with an i2c sensor on board and no external pullups with up to 800khz and with an external i2c sensor on a ~20cm cable with up to 400khz. Also works with external pullups to allow the external sensor to reach 1Mhz.

Signed-off-by: Adrian Joachim [adi.joachim12@gmail.com](mailto:adi.joachim12@gmail.com)