### PR TITLE
Fix the STM32H743 mcu temp on SKR-3

### DIFF
--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -190,7 +190,7 @@ gpio_adc_setup(uint32_t pin)
     }
 
     if (pin == ADC_TEMPERATURE_PIN) {
-        ADC3_COMMON->CCR = ADC_CCR_TSEN;
+        ADC3_COMMON->CCR |= ADC_CCR_TSEN;
     } else {
         gpio_peripheral(pin, GPIO_ANALOG, 0);
     }


### PR DESCRIPTION
module: stm32h7 ADC
Fix mcu temperature on SKR-3

Signed-off-by: Aaron DeLyser [bluwolf@gmail.com](mailto:bluwolf@gmail.com)