### PR TITLE
temperature_sensors: add ATC Semitec 104NT-4-R025H43G thermistor

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -712,9 +712,10 @@ heater_pin:
 #   periods) to the heater. The default is 1.0.
 sensor_type:
 #   Type of sensor - common thermistors are "EPCOS 100K B57560G104F",
-#   "ATC Semitec 104GT-2", "ATC Semitec 104NT-4-R025H42G", "Generic
-#   3950","Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
-#   "SliceEngineering 450", and "TDK NTCG104LH104JT1". See the
+#   "ATC Semitec 104NT-4-R025H42G", "ATC Semitec 104GT-2",
+#   "ATC Semitec 104NT-4-R025H43G", "Generic 3950",
+#   "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
+#   "SliceEngineering 450", or "TDK NTCG104LH104JT1". See the
 #   "Temperature sensors" section for other sensors. This parameter
 #   must be provided.
 sensor_pin:
@@ -2156,6 +2157,7 @@ sections that use one of these sensors.
 sensor_type:
 #   One of "EPCOS 100K B57560G104F", "ATC Semitec 104GT-2",
 #   "ATC Semitec 104NT-4-R025H42G", "Generic 3950",
+#   "ATC Semitec 104NT-4-R025H43G",
 #   "Honeywell 100K 135-104LAG-J01", "NTC 100K MGB18-104F39050L32",
 #   "SliceEngineering 450", or "TDK NTCG104LH104JT1"
 sensor_pin:

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -53,6 +53,15 @@ resistance2: 1074
 temperature3: 300
 resistance3: 82.78
 
+# Definition from (20220728): https://atcsemitec.co.uk/wp-content/uploads/2019/01/Semitec-NT-4-Glass-NTC-Thermistor.pdf
+[thermistor ATC Semitec 104NT-4-R025H43G]
+temperature1: 25
+resistance1: 100000
+temperature2: 160
+resistance2: 941.4
+temperature3: 300
+resistance3: 67.72
+
 # Definition from (20211101): https://www.tdk-electronics.tdk.com/inf/50/db/ntc_09/Glass_enc_Sensors__B57560__G560__G1560.pdf
 # (B57560G104 is same definition as B57560G1104)
 [thermistor EPCOS 100K B57560G104F]


### PR DESCRIPTION
I believe this has been substituted into "E3D V6 all-metal hotends"
based on measurements with a thermocouple and practical experiments.

The beta is significantly different from the -42G resulting in a
10-15C offset at printing temperatures.

Signed-off-by: Ben Jackson <ben@ben.com>