### PR TITLE
temperature_mcu: add reference_voltage

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2328,6 +2328,8 @@ monitor these temperatures.
 sensor_type: temperature_mcu
 #sensor_mcu: mcu
 #   The micro-controller to read from. The default is "mcu".
+#reference_voltage:
+#   The reference voltage for the ADC of the mcu. Default is 3.3
 #sensor_temperature1:
 #sensor_adc1:
 #   Specify the above two parameters (a temperature in Celsius and an

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -123,10 +123,10 @@ class PrinterTemperatureMCU:
         hot_temp = ((cal1 >> 12) & 0xff) + ((cal1 >> 20) & 0xf) / 10.
         room_1v = get1v((cal1 >> 24) & 0xff)
         hot_1v = get1v((cal2 >> 0) & 0xff)
-        room_adc = ((cal2 >> 8) & 0xfff)
-        * room_1v / (self.reference_voltage * 4095.)
-        hot_adc = ((cal2 >> 20) & 0xfff)
-        * hot_1v / (self.reference_voltage * 4095.)
+        room_adc = (
+            (cal2 >> 8) & 0xfff) * room_1v / (self.reference_voltage * 4095.)
+        hot_adc = (
+            (cal2 >> 20) & 0xfff) * hot_1v / (self.reference_voltage * 4095.)
         self.slope = (hot_temp - room_temp) / (hot_adc - room_adc)
         self.base_temperature = self.calc_base(room_temp, room_adc)
     def config_samd51(self):
@@ -151,10 +151,10 @@ class PrinterTemperatureMCU:
         cal_adc_30 = self.read16(0x1FFFF7B8) / 4095.
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32g0(self):
-        cal_adc_30 = self.read16(0x1FFF75A8)
-        * 3.0 / (self.reference_voltage * 4095.)
-        cal_adc_130 = self.read16(0x1FFF75CA)
-        * 3.0 / (self.reference_voltage * 4095.)
+        cal_adc_30 = self.read16(
+            0x1FFF75A8) * 3.0 / (self.reference_voltage * 4095.)
+        cal_adc_130 = self.read16(
+            0x1FFF75CA) * 3.0 / (self.reference_voltage * 4095.)
         self.slope = (130. - 30.) / (cal_adc_130 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32h7(self):

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -16,10 +16,12 @@ class PrinterTemperatureMCU:
         self.printer = config.get_printer()
         self.base_temperature = self.slope = None
         self.temp1 = self.adc1 = self.temp2 = self.adc2 = None
+        self.reference_voltage = None
         self.min_temp = self.max_temp = 0.
         self.debug_read_cmd = None
         # Read config
         mcu_name = config.get('sensor_mcu', 'mcu')
+        self.reference_voltage = config.getfloat('reference_voltage', default=3.3)
         self.temp1 = config.getfloat('sensor_temperature1', None)
         if self.temp1 is not None:
             self.adc1 = config.getfloat('sensor_adc1', minval=0., maxval=1.)
@@ -94,17 +96,17 @@ class PrinterTemperatureMCU:
         raise self.printer.config_error("MCU temperature not supported on %s"
                                         % (self.mcu_type,))
     def config_rp2040(self):
-        self.slope = 3.3 / -0.001721
-        self.base_temperature = self.calc_base(27., 0.706 / 3.3)
+        self.slope = self.reference_voltage / -0.001721
+        self.base_temperature = self.calc_base(27., 0.706 / self.reference_voltage)
     def config_sam3(self):
-        self.slope = 3.3 / .002650
-        self.base_temperature = self.calc_base(27., 0.8 / 3.3)
+        self.slope = self.reference_voltage / .002650
+        self.base_temperature = self.calc_base(27., 0.8 / self.reference_voltage)
     def config_sam4(self):
-        self.slope = 3.3 / .004700
-        self.base_temperature = self.calc_base(27., 1.44 / 3.3)
+        self.slope = self.reference_voltage / .004700
+        self.base_temperature = self.calc_base(27., 1.44 / self.reference_voltage)
     def config_same70(self):
-        self.slope = 3.3 / .002330
-        self.base_temperature = self.calc_base(25., 0.72 / 3.3)
+        self.slope = self.reference_voltage / .002330
+        self.base_temperature = self.calc_base(25., 0.72 / self.reference_voltage)
     def config_samd21(self, addr=0x00806030):
         def get1v(val):
             if val & 0x80:
@@ -116,18 +118,18 @@ class PrinterTemperatureMCU:
         hot_temp = ((cal1 >> 12) & 0xff) + ((cal1 >> 20) & 0xf) / 10.
         room_1v = get1v((cal1 >> 24) & 0xff)
         hot_1v = get1v((cal2 >> 0) & 0xff)
-        room_adc = ((cal2 >> 8) & 0xfff) * room_1v / (3.3 * 4095.)
-        hot_adc = ((cal2 >> 20) & 0xfff) * hot_1v / (3.3 * 4095.)
+        room_adc = ((cal2 >> 8) & 0xfff) * room_1v / (self.reference_voltage * 4095.)
+        hot_adc = ((cal2 >> 20) & 0xfff) * hot_1v / (self.reference_voltage * 4095.)
         self.slope = (hot_temp - room_temp) / (hot_adc - room_adc)
         self.base_temperature = self.calc_base(room_temp, room_adc)
     def config_samd51(self):
         self.config_samd21(addr=0x00800100)
     def config_stm32f1(self):
-        self.slope = 3.3 / -.004300
-        self.base_temperature = self.calc_base(25., 1.43 / 3.3)
+        self.slope = self.reference_voltage / -.004300
+        self.base_temperature = self.calc_base(25., 1.43 / self.reference_voltage)
     def config_stm32f2(self):
-        self.slope = 3.3 / .002500
-        self.base_temperature = self.calc_base(25., .76 / 3.3)
+        self.slope = self.reference_voltage / .002500
+        self.base_temperature = self.calc_base(25., .76 / self.reference_voltage)
     def config_stm32f4(self, addr1=0x1FFF7A2C, addr2=0x1FFF7A2E):
         cal_adc_30 = self.read16(addr1) / 4095.
         cal_adc_110 = self.read16(addr2) / 4095.
@@ -136,12 +138,12 @@ class PrinterTemperatureMCU:
     def config_stm32f0x2(self):
         self.config_stm32f4(addr1=0x1FFFF7B8, addr2=0x1FFFF7C2)
     def config_stm32f070(self):
-        self.slope = 3.3 / -.004300
+        self.slope = self.reference_voltage / -.004300
         cal_adc_30 = self.read16(0x1FFFF7B8) / 4095.
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32g0(self):
-        cal_adc_30 = self.read16(0x1FFF75A8) * 3.0 / (3.3 * 4095.)
-        cal_adc_130 = self.read16(0x1FFF75CA) * 3.0 / (3.3 * 4095.)
+        cal_adc_30 = self.read16(0x1FFF75A8) * 3.0 / (self.reference_voltage * 4095.)
+        cal_adc_130 = self.read16(0x1FFF75CA) * 3.0 / (self.reference_voltage * 4095.)
         self.slope = (130. - 30.) / (cal_adc_130 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32h7(self):

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -151,8 +151,10 @@ class PrinterTemperatureMCU:
         cal_adc_30 = self.read16(0x1FFFF7B8) / 4095.
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32g0(self):
-        cal_adc_30 = self.read16(0x1FFF75A8) * 3.0 / (self.reference_voltage * 4095.)
-        cal_adc_130 = self.read16(0x1FFF75CA) * 3.0 / (self.reference_voltage * 4095.)
+        cal_adc_30 = self.read16(0x1FFF75A8)
+            * 3.0 / (self.reference_voltage * 4095.)
+        cal_adc_130 = self.read16(0x1FFF75CA)
+            * 3.0 / (self.reference_voltage * 4095.)
         self.slope = (130. - 30.) / (cal_adc_130 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32h7(self):

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -21,7 +21,8 @@ class PrinterTemperatureMCU:
         self.debug_read_cmd = None
         # Read config
         mcu_name = config.get('sensor_mcu', 'mcu')
-        self.reference_voltage = config.getfloat('reference_voltage', default=3.3)
+        self.reference_voltage = config.getfloat(
+            'reference_voltage', default=3.3)
         self.temp1 = config.getfloat('sensor_temperature1', None)
         if self.temp1 is not None:
             self.adc1 = config.getfloat('sensor_adc1', minval=0., maxval=1.)
@@ -97,16 +98,20 @@ class PrinterTemperatureMCU:
                                         % (self.mcu_type,))
     def config_rp2040(self):
         self.slope = self.reference_voltage / -0.001721
-        self.base_temperature = self.calc_base(27., 0.706 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            27., 0.706 / self.reference_voltage)
     def config_sam3(self):
         self.slope = self.reference_voltage / .002650
-        self.base_temperature = self.calc_base(27., 0.8 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            27., 0.8 / self.reference_voltage)
     def config_sam4(self):
         self.slope = self.reference_voltage / .004700
-        self.base_temperature = self.calc_base(27., 1.44 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            27., 1.44 / self.reference_voltage)
     def config_same70(self):
         self.slope = self.reference_voltage / .002330
-        self.base_temperature = self.calc_base(25., 0.72 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            25., 0.72 / self.reference_voltage)
     def config_samd21(self, addr=0x00806030):
         def get1v(val):
             if val & 0x80:
@@ -118,18 +123,22 @@ class PrinterTemperatureMCU:
         hot_temp = ((cal1 >> 12) & 0xff) + ((cal1 >> 20) & 0xf) / 10.
         room_1v = get1v((cal1 >> 24) & 0xff)
         hot_1v = get1v((cal2 >> 0) & 0xff)
-        room_adc = ((cal2 >> 8) & 0xfff) * room_1v / (self.reference_voltage * 4095.)
-        hot_adc = ((cal2 >> 20) & 0xfff) * hot_1v / (self.reference_voltage * 4095.)
+        room_adc = ((cal2 >> 8) & 0xfff)
+            * room_1v / (self.reference_voltage * 4095.)
+        hot_adc = ((cal2 >> 20) & 0xfff)
+            * hot_1v / (self.reference_voltage * 4095.)
         self.slope = (hot_temp - room_temp) / (hot_adc - room_adc)
         self.base_temperature = self.calc_base(room_temp, room_adc)
     def config_samd51(self):
         self.config_samd21(addr=0x00800100)
     def config_stm32f1(self):
         self.slope = self.reference_voltage / -.004300
-        self.base_temperature = self.calc_base(25., 1.43 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            25., 1.43 / self.reference_voltage)
     def config_stm32f2(self):
         self.slope = self.reference_voltage / .002500
-        self.base_temperature = self.calc_base(25., .76 / self.reference_voltage)
+        self.base_temperature = self.calc_base(
+            25., .76 / self.reference_voltage)
     def config_stm32f4(self, addr1=0x1FFF7A2C, addr2=0x1FFF7A2E):
         cal_adc_30 = self.read16(addr1) / 4095.
         cal_adc_110 = self.read16(addr2) / 4095.

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -124,9 +124,9 @@ class PrinterTemperatureMCU:
         room_1v = get1v((cal1 >> 24) & 0xff)
         hot_1v = get1v((cal2 >> 0) & 0xff)
         room_adc = ((cal2 >> 8) & 0xfff)
-            * room_1v / (self.reference_voltage * 4095.)
+        * room_1v / (self.reference_voltage * 4095.)
         hot_adc = ((cal2 >> 20) & 0xfff)
-            * hot_1v / (self.reference_voltage * 4095.)
+        * hot_1v / (self.reference_voltage * 4095.)
         self.slope = (hot_temp - room_temp) / (hot_adc - room_adc)
         self.base_temperature = self.calc_base(room_temp, room_adc)
     def config_samd51(self):
@@ -152,9 +152,9 @@ class PrinterTemperatureMCU:
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32g0(self):
         cal_adc_30 = self.read16(0x1FFF75A8)
-            * 3.0 / (self.reference_voltage * 4095.)
+        * 3.0 / (self.reference_voltage * 4095.)
         cal_adc_130 = self.read16(0x1FFF75CA)
-            * 3.0 / (self.reference_voltage * 4095.)
+        * 3.0 / (self.reference_voltage * 4095.)
         self.slope = (130. - 30.) / (cal_adc_130 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
     def config_stm32h7(self):


### PR DESCRIPTION
This allows for boards that don't run their ADC with 3.3V to output accurate MCU temperature readings.

Signed-off-by: Peter Stehrer <peter.stehrer@cloudflight.io>