### PR TITLE
scripts: Support BigTreeTech Octopus boards in flash-sdcard

### DIFF
--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -89,7 +89,8 @@ This procedure is automated during the upload process.
   the current version.
 - Only boards that use SPI for SD Card communication are supported.
   Boards that use SDIO, such as the Flymaker Flyboard and MKS Robin Nano
-  V1/V2, will not work.
+  V1/V2, will not work in SDIO mode.  However, it's usually possible to
+  flash such boards using Software SPI mode instead.
 
 ## Board Definitions
 
@@ -127,8 +128,9 @@ and the following additional field should be specified:
   the SD Card in the format of `miso,mosi,sclk`.
 
 It should be exceedingly rare that Software SPI is necessary, typically only
-boards with design errors will require it. The `btt-skr-pro` board definition
-provides an example.
+boards with design errors or boards that normally only support SDIO mode for
+their SD Card will require it. The `btt-skr-pro` board definition provides an
+example.
 
 Prior to creating a new board definition one should check to see if an
 existing board definition meets the criteria necessary for the new board.

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -44,6 +44,24 @@ BOARD_DEFS = {
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
+    'btt-octopus-f407-v1': {
+        'mcu': "stm32f407xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        "cs_pin": "PC11"
+    },
+    'btt-octopus-f429-v1': {
+        'mcu': "stm32f429xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        "cs_pin": "PC11"
+    },
+    'btt-octopus-f446-v1': {
+        'mcu': "stm32f446xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        "cs_pin": "PC11"
+    },
     'btt-skr-pro': {
         'mcu': "stm32f407xx",
         'spi_bus': "swspi",
@@ -103,6 +121,14 @@ BOARD_ALIASES = {
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],
     'creality-v4.2.7': BOARD_DEFS['btt-skr-mini'],
+    'btt-octopus-f407-v1.0': BOARD_DEFS['btt-octopus-f407-v1'],
+    'btt-octopus-f407-v1.1': BOARD_DEFS['btt-octopus-f407-v1'],
+    'btt-octopus-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-f429-v1.1': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-f446-v1.0': BOARD_DEFS['btt-octopus-f446-v1'],
+    'btt-octopus-f446-v1.1': BOARD_DEFS['btt-octopus-f446-v1'],
+    'btt-octopus-pro-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-pro-f446-v1.0': BOARD_DEFS['btt-octopus-f446-v1'],
     'btt-skr-pro-v1.1': BOARD_DEFS['btt-skr-pro'],
     'btt-skr-pro-v1.2': BOARD_DEFS['btt-skr-pro'],
     'btt-gtr-v1': BOARD_DEFS['btt-gtr'],


### PR DESCRIPTION
Since SDIO is effectively a superset of SPI, with respect to SD Cards, it's possible to use SPI Flash to still flash boards that normally use SDIO.

Unfortunately, the hardware SPI peripheral pin assignments don't usually line up to allow hardware SPI on these (such as is the case with the STM32F407, STM32F429, and STM32F446 MCUs on the BTT Octopus boards), but Software SPI is still an option.

I have personally tried this on my Octopus v1.1 board with the STM32F446 MCU and it worked with no issues.  According to BTT schematics, documentation, and information available, all of the current Octopus and Octopus Pro variants with the F407, F429, and F446 MCUs use the same SDIO pinout configuration.

Therefore, this PR defines the pins for the Octopus with those three MCUs and aliases the names for the various board configurations available for purchase on the BIQU website.
