### PR TITLE
scripts: Support SDIO in flash-sdcard using split verification step and add BTT Octopus

### DIFF
--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -48,7 +48,7 @@ All options can be viewed by the help screen:
 ./scripts/flash-sdcard.sh -h
 SD Card upload utility for Klipper
 
-usage: flash_sdcard.sh [-h] [-l] [-b <baud>] [-f <firmware>]
+usage: flash_sdcard.sh [-h] [-l] [-c] [-b <baud>] [-f <firmware>]
                        <device> <board>
 
 positional arguments:
@@ -58,6 +58,7 @@ positional arguments:
 optional arguments:
   -h              show this message
   -l              list available boards
+  -c              run flash check/verify only (skip upload)
   -b <baud>       serial baud rate (default is 250000)
   -f <firmware>   path to klipper.bin
 ```
@@ -78,6 +79,14 @@ Note that when upgrading a MKS Robin E3 it is not necessary to manually run
 `update_mks_robin.py` and supply the resulting binary to `flash-sdcard.sh`.
 This procedure is automated during the upload process.
 
+The `-c` option is used to perform a check or verify-only operation
+to test if the board is running the specified firmware correctly.  This
+option is primarily intended for cases where a manual power-cycle is
+necessary to complete the flashing procedure, such as with bootloaders that
+use SDIO mode instead of SPI to access their SD Cards. (See Caveats below)
+But, it can also be used anytime to verify if the code flashed into the board
+matches the version in your build folder on any supported board.
+
 ## Caveats
 
 - As mentioned in the introduction, this method only works for upgrading
@@ -89,7 +98,16 @@ This procedure is automated during the upload process.
   the current version.
 - Only boards that use SPI for SD Card communication are supported.
   Boards that use SDIO, such as the Flymaker Flyboard and MKS Robin Nano
-  V1/V2, will not work.
+  V1/V2, will not work in SDIO mode.  However, it's usually possible to
+  flash such boards using Software SPI mode instead.  But if the board's
+  bootloader only uses SDIO mode to access the SD Card, a power-cycle of
+  the board and SD Card will be necessary so that the mode can switch from SPI
+  back to SDIO to complete reflashing.  Such boards should be defined with
+  `skip_verify` enabled to skip the verify step immediately after flashing.
+  Then after the manual power-cycle, you can rerun the exact same
+  `./scripts/flash-sdcard.sh` command, but add the `-c` option to complete
+  the check/verify operation.  See [Flashing Boards that use SDIO](#flashing-boards-that-use-sdio)
+  for examples.
 
 ## Board Definitions
 
@@ -118,17 +136,25 @@ The following fields may be specified:
   retreived from the board schematic.  This field is required.
 - `firmware_path`: The path on the SD Card where firmware should be
   transferred.  The default is `firmware.bin`.
-- `current_firmware_path`  The path on the SD Card where the renamed firmware
+- `current_firmware_path`: The path on the SD Card where the renamed firmware
   file is located after a successful flash.  The default is `firmware.cur`.
+- `skip_verify`: This defines a boolean value which tells the scripts to skip
+  the firmware verification step during the flashing process.  The default
+  is `False`.  It can be set to `True` for boards that require a manual
+  power-cycle to complete flashing.  To verify the firmware afterward, run
+  the script again with the `-c` option to perform the verification step.
+  [See caveats with SDIO cards](#caveats)
 
-If software SPI is required the `spi_bus` field should be set to `swspi`
+If software SPI is required, the `spi_bus` field should be set to `swspi`
 and the following additional field should be specified:
 - `spi_pins`:  This should be 3 comma separated pins that are connected to
   the SD Card in the format of `miso,mosi,sclk`.
 
 It should be exceedingly rare that Software SPI is necessary, typically only
-boards with design errors will require it. The `btt-skr-pro` board definition
-provides an example.
+boards with design errors or boards that normally only support SDIO mode for
+their SD Card will require it. The `btt-skr-pro` board definition provides an
+example of the former, and the `btt-octopus-f446-v1` board definition
+provides an example of the latter.
 
 Prior to creating a new board definition one should check to see if an
 existing board definition meets the criteria necessary for the new board.
@@ -145,3 +171,85 @@ BOARD_ALIASES = {
 If you need a new board definition and you are uncomfortable with the
 procedure outlined above it is recommended that you request one in
 the [Klipper Community Discord](Contact.md#discord).
+
+## Flashing Boards that use SDIO
+
+[As mentioned in the Caveats](#caveats), boards whose bootloader uses
+SDIO mode to access their SD Card require a power-cycle of the board,
+and specifically the SD Card itself, in order to switch from the SPI Mode
+used while writing the file to the SD Card back to SDIO mode for the
+bootloader to flash it into the board.  These board definitions will
+use the `skip_verify` flag, which tells the flashing tool to stop after
+writing the firmware to the SD Card so that the board can be manually
+power-cycled and the verification step deferred until that's complete.
+
+There are two scenarios -- one with the RPi Host running on a separate
+power supply and the other when the RPi Host is running on the same
+power supply as the main board being flashed.  The difference is whether
+or not it's necessary to also shutdown the RPi and then `ssh` again after
+the flashing is complete in order to do the verification step, or if the
+verification can be done immediately.  Here's examples of the two scenarios:
+
+### SDIO Programming with RPi on Separate Power Supply
+
+A typical session with the RPi on a Separate Power Supply looks like the
+following.  You will, of course, need to use your proper device path and
+board name:
+```
+sudo service klipper stop
+cd ~/klipper
+git pull
+make clean
+make menuconfig
+make
+./scripts/flash-sdcard.sh /dev/ttyACM0 btt-octopus-f446-v1
+[[[manually power-cycle the printer board here when instructed]]]
+./scripts/flash-sdcard.sh -c /dev/ttyACM0 btt-octopus-f446-v1
+sudo service klipper start
+```
+
+### SDIO Programming with RPi on the Same Power Supply
+
+A typical session with the RPi on the Same Power Supply looks like the
+following.  You will, of course, need to use your proper device path and
+board name:
+```
+sudo service klipper stop
+cd ~/klipper
+git pull
+make clean
+make menuconfig
+make
+./scripts/flash-sdcard.sh /dev/ttyACM0 btt-octopus-f446-v1
+sudo shutdown -h now
+[[[wait for the RPi to shutdown, then power-cycle and ssh again to the RPi when it restarts]]]
+sudo service klipper stop
+cd ~/klipper
+./scripts/flash-sdcard.sh -c /dev/ttyACM0 btt-octopus-f446-v1
+sudo service klipper start
+```
+
+In this case, since the RPi Host is being restarted, which will restart
+the `klipper` service, it's necessary to stop `klipper` again before doing
+the verification step and restart it after verification is complete.
+
+### SDIO to SPI Pin Mapping
+
+If your board's schematic uses SDIO for its SD Card, you can map the pins
+as described in the chart below to determine the compatible Software SPI
+pins to assign in the `board_defs.py` file:
+
+| SD Card Pin | Micro SD Card Pin  |  SDIO Pin Name   |   SPI Pin Name   |
+| :---------: | :----------------: | :--------------: | :--------------: |
+|      9      |         1          |       DATA2      |     None (PU)*   |
+|      1      |         2          |      CD/DATA3    |        CS        |
+|      2      |         3          |        CMD       |       MOSI       |
+|      4      |         4          |    +3.3V (VDD)   |    +3.3V (VDD)   |
+|      5      |         5          |        CLK       |       SCLK       |
+|      3      |         6          |     GND (VSS)    |     GND (VSS)    |
+|      7      |         7          |       DATA0      |       MISO       |
+|      8      |         8          |       DATA1      |     None (PU)*   |
+|     N/A     |         9          | Card Detect (CD) | Card Detect (CD) |
+|      6      |        10          |       GND        |        GND       |
+
+\* None (PU) indicates an unused pin with a pull-up resistor

--- a/scripts/flash-sdcard.sh
+++ b/scripts/flash-sdcard.sh
@@ -10,6 +10,7 @@ KLIPPER_BIN_DEFAULT=$KLIPPER_BIN
 KLIPPER_DICT_DEFAULT="${SRCDIR}/out/klipper.dict"
 SPI_FLASH="${SRCDIR}/scripts/spi_flash/spi_flash.py"
 BAUD_ARG=""
+CHECK_ARG=""
 # Force script to exit if an error occurs
 set -e
 
@@ -17,7 +18,7 @@ print_help_message()
 {
     echo "SD Card upload utility for Klipper"
     echo
-    echo "usage: flash_sdcard.sh [-h] [-l] [-b <baud>] [-f <firmware>] [-d <dictionary>]"
+    echo "usage: flash_sdcard.sh [-h] [-l] [-c] [-b <baud>] [-f <firmware>] [-d <dictionary>]"
     echo "                       <device> <board>"
     echo
     echo "positional arguments:"
@@ -27,13 +28,14 @@ print_help_message()
     echo "optional arguments:"
     echo "  -h                show this message"
     echo "  -l                list available boards"
+    echo "  -c                run flash check/verify only (skip upload)"
     echo "  -b <baud>         serial baud rate (default is 250000)"
     echo "  -f <firmware>     path to klipper.bin"
     echo "  -d <dictionary>   path to klipper.dict for firmware validation"
 }
 
 # Parse command line "optional args"
-while getopts "hlb:f:d:" arg; do
+while getopts "hlcb:f:d:" arg; do
     case $arg in
         h)
             print_help_message
@@ -43,6 +45,7 @@ while getopts "hlb:f:d:" arg; do
             ${KLIPPY_ENV} ${SPI_FLASH} -l
             exit 0
             ;;
+        c) CHECK_ARG="-c";;
         b) BAUD_ARG="-b ${OPTARG}";;
         f) KLIPPER_BIN=$OPTARG;;
         d) KLIPPER_DICT=$OPTARG;;
@@ -82,4 +85,4 @@ fi
 
 # Run Script
 echo "Flashing ${KLIPPER_BIN} to ${DEVICE}"
-${KLIPPY_ENV} ${SPI_FLASH} ${BAUD_ARG} ${KLIPPER_DICT} ${DEVICE} ${BOARD} ${KLIPPER_BIN}
+${KLIPPY_ENV} ${SPI_FLASH} ${CHECK_ARG} ${BAUD_ARG} ${KLIPPER_DICT} ${DEVICE} ${BOARD} ${KLIPPER_BIN}

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -44,6 +44,27 @@ BOARD_DEFS = {
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
+    'btt-octopus-f407-v1': {
+        'mcu': "stm32f407xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+    },
+    'btt-octopus-f429-v1': {
+        'mcu': "stm32f429xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+    },
+    'btt-octopus-f446-v1': {
+        'mcu': "stm32f446xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+    },
     'btt-skr-pro': {
         'mcu': "stm32f407xx",
         'spi_bus': "swspi",
@@ -103,6 +124,14 @@ BOARD_ALIASES = {
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],
     'creality-v4.2.7': BOARD_DEFS['btt-skr-mini'],
+    'btt-octopus-f407-v1.0': BOARD_DEFS['btt-octopus-f407-v1'],
+    'btt-octopus-f407-v1.1': BOARD_DEFS['btt-octopus-f407-v1'],
+    'btt-octopus-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-f429-v1.1': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-f446-v1.0': BOARD_DEFS['btt-octopus-f446-v1'],
+    'btt-octopus-f446-v1.1': BOARD_DEFS['btt-octopus-f446-v1'],
+    'btt-octopus-pro-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
+    'btt-octopus-pro-f446-v1.0': BOARD_DEFS['btt-octopus-f446-v1'],
     'btt-skr-pro-v1.1': BOARD_DEFS['btt-skr-pro'],
     'btt-skr-pro-v1.2': BOARD_DEFS['btt-skr-pro'],
     'btt-gtr-v1': BOARD_DEFS['btt-gtr'],

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -785,6 +785,13 @@ class SDCardSPI:
             if err_msgs:
                 raise OSError("\n".join(err_msgs))
 
+SDIO_WARNING = """
+This board requires a manual reboot to complete the flash process.
+If the board's bootloader uses SDIO mode for its SDCard, then a full
+power cycle is required.  Please perform the power cycle now and then
+rerun this utility with the 'check' option to verify flash.
+"""
+
 class MCUConnection:
     def __init__(self, k_reactor, device, baud, board_cfg):
         self.reactor = k_reactor
@@ -989,6 +996,9 @@ class MCUConnection:
         return sd_chksm
 
     def verify_flash(self, req_chksm, old_dictionary, req_dictionary):
+        if bool(self.board_config.get('skip_verify', False)):
+            output_line(SDIO_WARNING)
+            return
         output("Verifying Flash...")
         validation_passed = False
         msgparser = self._serial.get_msgparser()
@@ -1063,6 +1073,7 @@ class SPIFlash:
         self.firmware_checksum = None
         self.task_complete = False
         self.need_upload = True
+        self.need_verify = True
         self.old_dictionary = None
         self.new_dictionary = None
         if args['klipper_dict_path'] is not None:
@@ -1092,7 +1103,7 @@ class SPIFlash:
                 raise SPIFlashError("Unable to reconnect")
         output_line("Done")
 
-    def run_reset(self, eventtime):
+    def run_reset_upload(self, eventtime):
         # Reset MCU to default state if necessary
         self.mcu_conn.connect()
         if self.mcu_conn.check_need_restart():
@@ -1101,6 +1112,16 @@ class SPIFlash:
         else:
             self.need_upload = False
             self.run_sdcard_upload(eventtime)
+
+    def run_reset_verify(self, eventtime):
+        # Reset MCU to default state if necessary
+        self.mcu_conn.connect()
+        if self.mcu_conn.check_need_restart():
+            self.mcu_conn.reset()
+            self.task_complete = True
+        else:
+            self.need_verify = False
+            self.run_verify(eventtime)
 
     def run_sdcard_upload(self, eventtime):
         # Reconnect and upload
@@ -1121,7 +1142,8 @@ class SPIFlash:
 
     def run_verify(self, eventtime):
         # Reconnect and verify
-        self.mcu_conn.connect()
+        if not self.mcu_conn.connected:
+            self.mcu_conn.connect()
         self.mcu_conn.configure_mcu()
         self.mcu_conn.verify_flash(self.firmware_checksum, self.old_dictionary,
                                    self.new_dictionary)
@@ -1148,12 +1170,18 @@ class SPIFlash:
             self.mcu_conn = k_reactor = None
 
     def run(self):
-        self.run_reactor_task(self.run_reset)
-        self._wait_for_reconnect()
-        if self.need_upload:
-            self.run_reactor_task(self.run_sdcard_upload)
+        if not bool(self.board_config.get('verify_only', False)):
+            self.run_reactor_task(self.run_reset_upload)
             self._wait_for_reconnect()
-        self.run_reactor_task(self.run_verify)
+            if self.need_upload:
+                self.run_reactor_task(self.run_sdcard_upload)
+                self._wait_for_reconnect()
+            self.run_reactor_task(self.run_verify)
+        else:
+            self.run_reactor_task(self.run_reset_verify)
+            if self.need_verify:
+                self._wait_for_reconnect()
+                self.run_reactor_task(self.run_verify)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -1178,6 +1206,9 @@ def main():
         "-d", "--dict_path", metavar="<klipper.dict>", type=str,
         default=None, help="Klipper firmware dictionary")
     parser.add_argument(
+        "-c","--check", action="store_true",
+        help="Perform flash check/verify only")
+    parser.add_argument(
         "device", metavar="<device>", help="Device Serial Port")
     parser.add_argument(
         "board", metavar="<board>", help="Board Type")
@@ -1195,6 +1226,10 @@ def main():
     flash_args['baud'] = args.baud
     flash_args['klipper_bin_path'] = args.klipper_bin_path
     flash_args['klipper_dict_path'] = args.dict_path
+    flash_args['verify_only'] = args.check
+    if args.check:
+        # override board_defs setting when doing verify-only:
+        flash_args['skip_verify'] = False
     check_need_convert(args.board, flash_args)
     fatfs_lib.check_fatfs_build(output)
     try:


### PR DESCRIPTION
This PR replaces #5715 (I didn't realize you had to reopen a PR on GitHub **before** force pushing updates to the branch or it won't let you reopen it).

This changes the `flash-sdcard.sh`/`spi_flash.py` scripts to allow for a split flash/verification session as required to program boards that use SDIO for their SD Cards in order to perform a manual reboot/power-cycle.

It also adds support for the BigTreeTech Octopus boards, which use SDIO.  Here's what this new SDIO procedure looks like from a user-perspective, where I reflashed my Octopus board from `ga709ba43` to `g9e4994cb` while testing these changes:

First, I ran the verify step to confirm it worked independently and verify the device matched my existing `ga709ba43` build:

```
$ ./scripts/flash-sdcard.sh -c /dev/ttyACM0 btt-octopus-f446-v1.1
Flashing /home/pi/klipper/out/klipper.bin to /dev/ttyACM0
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
MCU needs restart: is_config=1, is_shutdown=0
Attempting MCU Reset...Done
Waiting for device to reconnect....Done
Connecting to MCU...Connected
Verifying Flash...Version matched...Done
Firmware Flash Successful
Current Firmware: v0.10.0-546-ga709ba43
Attempting MCU Reset...Done
SD Card Flash Complete

```

I then updated and reflashed it:

```
$ make clean
$ git pull
$ make
$ ./scripts/flash-sdcard.sh /dev/ttyACM0 btt-octopus-f446-v1.1
Flashing /home/pi/klipper/out/klipper.bin to /dev/ttyACM0
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
MCU needs restart: is_config=1, is_shutdown=0
Attempting MCU Reset...Done
Waiting for device to reconnect....Done
Connecting to MCU...Connected
Initializing SD Card and Mounting file system...

SD Card Information:
Version: 2.0
SDHC/SDXC: True
Write Protected: False
Sectors: 31116288
manufacturer_id: 3
oem_id: SD
product_name: SL16G
product_revision: 8.128
serial_number: 5A650D40
manufacturing_date: 11/2015
capacity: 14.8 GiB
fs_type: FAT32
volume_label: b''
volume_serial: 808739888
Uploading Klipper Firmware to SD Card...Done
Validating Upload...Done
Firmware Upload Complete: firmware.bin, Size: 26548, Checksum (SHA1): 224A11A4B6492EA0B867F8C9F8448FB47362FF73
Attempting MCU Reset...Done
Waiting for device to reconnect.....Done
Connecting to MCU...Connected
This board requires a manual reboot to complete the flash process.
If the board's bootloader uses SDIO mode for its SDCard, then a full
power cycle is required.  Please perform the power cycle now and then
rerun this utility with the 'check' option to verify flash.
Attempting MCU Reset...Done
SD Card Flash Complete
```

Then after I power-cycled my board and RPi and resumed with the verification step:

```
$ ./scripts/flash-sdcard.sh -c /dev/ttyACM0 btt-octopus-f446-v1.1
Flashing /home/pi/klipper/out/klipper.bin to /dev/ttyACM0
Checking FatFS CFFI Build...
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
MCU needs restart: is_config=1, is_shutdown=0
Attempting MCU Reset...Done
Waiting for device to reconnect.....Done
Connecting to MCU...Connected
Verifying Flash...Version matched...Done
Firmware Flash Successful
Current Firmware: v0.10.0-554-g9e4994cb
Attempting MCU Reset...Done
SD Card Flash Complete
```

Note, as illustrated here during my testing, the new check/verify operation can also be used to verify if the device matches the build folder.  That can be used on all boards, not just those that require the split or that use SDIO.

I used `c` and `check` for the new command-line option instead of `v` and `verify` to avoid a conflict with `verbose` that was already defined.
