### PR TITLE
fan: add power_pin option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2446,6 +2446,12 @@ pin:
 #   enough for fans below 10000 RPM at 2 PPR. This must be smaller than
 #   30/(tachometer_ppr*rpm), with some margin, where rpm is the
 #   maximum speed (in RPM) of the fan.
+#enable_pin:
+#   Optional pin to enable power to the fan. This can be useful for fans
+#   with dedicated PWM inputs. Some of these fans stay on even at 0% PWM
+#   input. In such a case, the PWM pin can be used normally, and e.g. a
+#   ground-switched FET(standard fan pin) can be used to control power to
+#   the fan.
 ```
 
 ### [heater_fan]
@@ -2467,6 +2473,7 @@ a shutdown_speed equal to max_power.
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
+#enable_pin:
 #   See the "fan" section for a description of the above parameters.
 #heater: extruder
 #   Name of the config section defining the heater that this fan is
@@ -2503,6 +2510,7 @@ watched component.
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
+#enable_pin:
 #   See the "fan" section for a description of the above parameters.
 #fan_speed: 1.0
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
@@ -2548,6 +2556,7 @@ information.
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
+#enable_pin:
 #   See the "fan" section for a description of the above parameters.
 #sensor_type:
 #sensor_pin:
@@ -2605,6 +2614,7 @@ with the SET_FAN_SPEED [gcode command](G-Codes.md#fan_generic).
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
+#enable_pin:
 #   See the "fan" section for a description of the above parameters.
 ```
 

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -30,6 +30,12 @@ class Fan:
         shutdown_power = max(0., min(self.max_power, shutdown_speed))
         self.mcu_fan.setup_start_value(0., shutdown_power)
 
+        self.enable_pin = None
+        enable_pin = config.get('enable_pin', None)
+        if enable_pin is not None:
+            self.enable_pin = ppins.setup_pin('digital_out', enable_pin)
+            self.enable_pin.setup_max_duration(0.)
+
         # Setup tachometer
         self.tachometer = FanTachometer(config)
 
@@ -46,6 +52,11 @@ class Fan:
         if value == self.last_fan_value:
             return
         print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
+        if self.enable_pin:
+            if value > 0 and self.last_fan_value == 0:
+                self.enable_pin.set_digital(print_time, 1)
+            elif value == 0 and self.last_fan_value > 0:
+                self.enable_pin.set_digital(print_time, 0)
         if (value and value < self.max_power and self.kick_start_time
             and (not self.last_fan_value or value - self.last_fan_value > .5)):
             # Run fan at full speed for specified kick_start_time


### PR DESCRIPTION
Hi,

This adds a `power_pin` option to fans. When the fan PWM target is set to a non-zero value, the `power_pin` will be pulled high.

The intended use case is for fans with dedicated PWM inputs. Some of these don't support going to 0% (off) but stay on at some low value. To be able to turn fans like these off, the fan ground can be switched normally(via a standard fan port ground-switching FET), while the `pin` can be connected directly to the fan PWM input. Using the dedicated PWM pin is preferable to ground switched PWM as the fan controller can provide much more accurate and linear control over the fan speed.

With the rising popularity of 4028s, this I believe this will soon(if not already) be useful to >100 printers. Many of the 4028s people are using are intended as server fans, where PWMing to zero is not generally desired.

Best regards,
Lasse