### PR TITLE
Add SET_DIGIPOT command to mcp4018 implementation

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -746,6 +746,54 @@ scheduled to run after the stepper move completes, however if a manual
 stepper move uses SYNC=0 then future G-Code movement commands may run
 in parallel with the stepper movement.
 
+### [mcp4018]
+
+The following command is available when a
+[mcp4018 config section](Config_Reference.md#mcp4018) is
+enabled.
+
+#### SET_DIGIPOT
+`SET_DIGIPOT DIGIPOT=config_name WIPER=<value>`: This command will
+change the current value of the digipot.  This value should typically
+be between 0.0 and 1.0, unless a 'scale' is defined in the config.
+When 'scale' is defined, then this value should be  between 0.0 and
+'scale'.
+
+If needed, this can be used in a macro to recreate `G130` used in 
+older Makerbot printers to lower the stepper current during heating 
+(to prevent power supply brown outs)
+
+```
+[gcode_macro G130]
+gcode:
+  M400
+  {% if ('X' in params) and ('mcp4018 x_axis_pot' in printer.configfile.config) %}
+    {% set x_value = params['X']|float %}
+    {% set x_axis_pot_scale = printer.configfile.config["mcp4018 x_axis_pot"].scale|float %}
+    SET_DIGIPOT DIGIPOT=x_axis_pot WIPER={ x_axis_pot_scale * (x_value / 127.0)}
+  {% endif %}
+  {% if ('Y' in params) and ('mcp4018 y_axis_pot' in printer.configfile.config) %}
+    {% set y_value = params['Y']|float %}
+    {% set y_axis_pot_scale = printer.configfile.config["mcp4018 y_axis_pot"].scale|float %}
+    SET_DIGIPOT DIGIPOT=y_axis_pot WIPER={ y_axis_pot_scale * (y_value / 127.0)}
+  {% endif %}
+  {% if ('Z' in params) and ('mcp4018 z_axis_pot' in printer.configfile.config) %}
+    {% set z_value = params['Z']|float %}
+    {% set z_axis_pot_scale = printer.configfile.config["mcp4018 z_axis_pot"].scale|float %}
+    SET_DIGIPOT DIGIPOT=z_axis_pot WIPER={ z_axis_pot_scale * (z_value / 127.0)}
+  {% endif %}
+  {% if ('A' in params) and ('mcp4018 a_axis_pot' in printer.configfile.config) %}
+    {% set a_value = params['A']|float %}
+    {% set a_axis_pot_scale = printer.configfile.config["mcp4018 a_axis_pot"].scale|float %}
+    SET_DIGIPOT DIGIPOT=a_axis_pot WIPER={ a_axis_pot_scale * (a_value / 127.0)}
+  {% endif %}
+  {% if ('B' in params) and ('mcp4018 b_axis_pot' in printer.configfile.config) %}
+    {% set b_value = params['B']|float %}
+    {% set b_axis_pot_scale = printer.configfile.config["mcp4018 b_axis_pot"].scale|float %}
+    SET_DIGIPOT DIGIPOT=b_axis_pot WIPER={ b_axis_pot_scale * (b_value / 127.0)}
+  {% endif %}
+```
+
 ### [led]
 
 The following command is available when any of the

--- a/klippy/extras/mcp4018.py
+++ b/klippy/extras/mcp4018.py
@@ -68,17 +68,33 @@ class SoftwareI2C:
 
 class mcp4018:
     def __init__(self, config):
+        self.printer = config.get_printer()
         self.i2c = SoftwareI2C(config, 0x2f)
         self.scale = config.getfloat('scale', 1., above=0.)
         self.start_value = config.getfloat('wiper',
                                            minval=0., maxval=self.scale)
         config.get_printer().register_event_handler("klippy:connect",
                                                     self.handle_connect)
+        # Register commands
+        self.name = config.get_name().split()[1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("SET_DIGIPOT", "DIGIPOT", self.name,
+                                   self.cmd_SET_DIGIPOT,
+                                   desc=self.cmd_SET_DIGIPOT_help)
     def handle_connect(self):
         self.set_dac(self.start_value)
     def set_dac(self, value):
         val = int(value * 127. / self.scale + .5)
         self.i2c.i2c_write([val])
+    cmd_SET_DIGIPOT_help = "Set digipot value"
+    def cmd_SET_DIGIPOT(self, gcmd):                
+        wiper = gcmd.get_float('WIPER', None)
+        if (wiper is not None):
+            if (wiper >= 0.0) and (wiper <= self.scale):                
+                self.set_dac(wiper)
+                gcmd.respond_info("New value for DIGIPOT = %s, wiper = %.2f" % (self.name, wiper))
+            else:
+                gcmd.respond_info("Value outside of scale for DIGIPOT = %s, wiper = %.2f" % (self.name, wiper))
 
 def load_config_prefix(config):
     return mcp4018(config)


### PR DESCRIPTION
Added a `SET_DIGIPOT` command to the mcp4018 implementation.

Previously the mcp4018 was read only, and set at the time of configuration.  This allows you to change the value during a print, which is needed for some older printers that need to lower the stepper current during preheating. (smaller power supplies needed all the power to heat the bed, so the steppers are lowered to just enough to hold position while the bed comes up to temp, and then raised for printing.)

By way of testing, I printed an entire Voron 2.4 on a heavily modified Makerbot Replicator 2X with a Mightyboard Rev G that uses the mcp4018 to control stepper current.

Documentation updates are included, along with instructions on how to implement a `G130` macro, for compatibility with the start g-code that is commonly used with vintage printers that use mcp4018 to adjust their vRef voltages.

Thanks for your consideration.