### PR TITLE
Wrong uart_address assignment for Y and Z - BTT SKR CR6

### DIFF
--- a/config/generic-bigtreetech-skr-cr6-v1.0.cfg
+++ b/config/generic-bigtreetech-skr-cr6-v1.0.cfg
@@ -45,7 +45,7 @@ homing_speed: 50
 [tmc2209 stepper_y]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 2
+uart_address: 1
 run_current: 0.550
 stealthchop_threshold: 999999
 
@@ -63,7 +63,7 @@ position_max: 250
 [tmc2209 stepper_z]
 uart_pin: PC11
 tx_pin: PC10
-uart_address: 1
+uart_address: 2
 run_current: 0.550
 stealthchop_threshold: 999999
 


### PR DESCRIPTION
As found on discord by user David Carey.

uart_address for y and z are swapped. Discovered while setting up sensorless homing.

Signed off by: James Hartley <james@hartleyns.com>