### PR TITLE
Support requesting bootloader when using UART

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -44,6 +44,8 @@ source "src/simulator/Kconfig"
 # Generic configuration options for serial ports
 config SERIAL
     bool
+config SERIAL_BOOTLOADER_SIDECHANNEL
+    bool
 config SERIAL_BAUD
     depends on SERIAL
     int "Baud rate for serial port" if LOW_LEVEL_OPTIONS

--- a/src/generic/serial_irq.c
+++ b/src/generic/serial_irq.c
@@ -79,6 +79,9 @@ console_task(void)
     if (ret > 0)
         command_dispatch(receive_buf, pop_count);
     if (ret) {
+        if (CONFIG_SERIAL_BOOTLOADER_SIDECHANNEL && ret < 0 && pop_count == 32
+            && !memcmp(receive_buf, " \x1c Request Serial Bootloader!! ~", 32))
+            bootloader_request();
         console_pop_input(pop_count);
         if (ret > 0)
             command_send_ack();

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -14,6 +14,7 @@ config LPC_SELECT
     select HAVE_CHIPID
     select HAVE_GPIO_HARD_PWM
     select HAVE_STEPPER_BOTH_EDGE
+    select SERIAL_BOOTLOADER_SIDECHANNEL
 
 config BOARD_DIRECTORY
     string

--- a/src/lpc176x/internal.h
+++ b/src/lpc176x/internal.h
@@ -23,5 +23,6 @@ int is_enabled_pclock(uint32_t pclk);
 void enable_pclock(uint32_t pclk);
 uint32_t get_pclock_frequency(uint32_t pclk);
 void gpio_peripheral(uint32_t gpio, int func, int pullup);
+void usb_disconnect(void);
 
 #endif // internal.h

--- a/src/lpc176x/usbserial.c
+++ b/src/lpc176x/usbserial.c
@@ -8,8 +8,6 @@
 #include "autoconf.h" // CONFIG_SMOOTHIEWARE_BOOTLOADER
 #include "board/armcm_boot.h" // armcm_enable_irq
 #include "board/armcm_timer.h" // udelay
-#include "board/armcm_reset.h" // try_request_canboot
-#include "board/irq.h" // irq_disable
 #include "board/misc.h" // timer_read_time
 #include "byteorder.h" // cpu_to_le32
 #include "command.h" // DECL_CONSTANT_STR
@@ -246,20 +244,12 @@ usb_set_configure(void)
     usb_irq_enable();
 }
 
+// Force a USB disconnect (used during reboot into bootloader)
 void
-bootloader_request(void)
+usb_disconnect(void)
 {
-    if (!CONFIG_SMOOTHIEWARE_BOOTLOADER)
-        return;
-    try_request_canboot();
-    // Disable USB and pause for 5ms so host recognizes a disconnect
-    irq_disable();
     sie_cmd_write(SIE_CMD_SET_DEVICE_STATUS, 0);
     udelay(5000);
-    // The "LPC17xx-DFU-Bootloader" will enter the bootloader if the
-    // watchdog timeout flag is set.
-    LPC_WDT->WDMOD = 0x07;
-    NVIC_SystemReset();
 }
 
 

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -14,6 +14,7 @@ config STM32_SELECT
     select HAVE_STRICT_TIMING
     select HAVE_CHIPID
     select HAVE_STEPPER_BOTH_EDGE
+    select SERIAL_BOOTLOADER_SIDECHANNEL
 
 config BOARD_DIRECTORY
     string


### PR DESCRIPTION
This PR adds a "side-channel" mechanism for entering the bootloader when using serial communication. This makes it easier to automate flashing scripts. USB and canbus have similar side-channel mechanisms - this PR extends the concept to UART.

The mechanism to enter the bootloader over serial is to send a special string on the serial port. For example:
`echo -e '~~~ \x1c Request Serial Bootloader!!!~~~' > /dev/ttyAMA0`
The string is specially crafted so that the Klipper message parser will not fragment it.

I have enabled this support on lpc176x and stm32 (as there is UART CanBoot support for these boards).

@Arksine - thoughts?

-Kevin
