### PR TITLE
Add a BME280 report time config option to reduce mcu load

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2162,6 +2162,9 @@ sensor_type: BME280
 #i2c_speed:
 #   See the "common I2C settings" section for a description of the
 #   above parameters.
+#bme280_report_time:
+#   Interval in seconds between readings. Default is 0.8, with minimum
+#   0.8.
 ```
 
 ### HTU21D sensor

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -89,7 +89,7 @@ class BME280:
         self.i2c = bus.MCU_I2C_from_config(
             config, default_addr=BME280_CHIP_ADDR, default_speed=100000)
         self.mcu = self.i2c.get_mcu()
-        self.report_time = config.getfloat('bme280_report_time', 
+        self.report_time = config.getfloat('bme280_report_time',
                                            BME280_MIN_REPORT_TIME,
                                            minval=BME280_MIN_REPORT_TIME)
         self.iir_filter = config.getint('bme280_iir_filter', 1)

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -89,7 +89,8 @@ class BME280:
         self.i2c = bus.MCU_I2C_from_config(
             config, default_addr=BME280_CHIP_ADDR, default_speed=100000)
         self.mcu = self.i2c.get_mcu()
-        self.report_time = config.getfloat('bme280_report_time', BME280_MIN_REPORT_TIME,
+        self.report_time = config.getfloat('bme280_report_time', 
+                                           BME280_MIN_REPORT_TIME,
                                            minval=BME280_MIN_REPORT_TIME)
         self.iir_filter = config.getint('bme280_iir_filter', 1)
         self.os_temp = config.getint('bme280_oversample_temp', 2)


### PR DESCRIPTION
module: BME280, add bme280_report_time option

Having hooked up 2 BME280 chips on two i2c busses of the same RPI, I see a high "MCU RPI Load" utilization
Looking at the code it reported every .8 seconds.
I do not need the sensors to be this precise and tested reporting every 30 seconds instead which brings down the MCU load significantly but with a burst every 30 seconds

This PR is to add an option to specify a custom report time similar to the one in the LM75 temperature sensor
The previous REPORT_TIME if the BME280 was used as a default/minimum value.
This change reads the report time value from a bme280_report_time option in the config files

Signed-off-by: Sylvain Dansereau brutus_dansereau@hotmail.com
