### PR TITLE
virtual_sdcard: read new lines as-is

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, logging
+import os, logging, io
 
 VALID_GCODE_EXTS = ['gcode', 'g', 'gco']
 
@@ -177,7 +177,7 @@ class VirtualSD:
             if fname not in flist:
                 fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
-            f = open(fname, 'r')
+            f = io.open(fname, 'r', newline='')
             f.seek(0, os.SEEK_END)
             fsize = f.tell()
             f.seek(0)


### PR DESCRIPTION
The existing code works perfectly under python2: the internal `open` function will open the file and allow reading of the data with unaltered line-endings (meaning that lines will be CRLF or LF ended)

But python3 has changed the behavior of the `open` function to be an alias of `io.open`. And that brings in the Universal Line Endings as default, meaning that any CRLF will be read as LF.

Context [here](https://docs.python.org/3/howto/pyporting.html):

> You should also use io.open() for opening files instead of the built-in open() function as the io module is consistent from Python 2 to 3 while the built-in open() function is not (in Python 3 it’s actually io.open()).

This changes the behavior by ensuring we read line-endings as-is (by using `io.open` and passing in `newline=''`)

From my tests, this change will work fine with python2 and python3.

Fixes #5755 

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>