### PR TITLE
add module for live-plotting data with plotjuggler

### DIFF
--- a/klippy/extras/plogjuggler.py
+++ b/klippy/extras/plogjuggler.py
@@ -1,0 +1,47 @@
+# Module for streaming data to plotjuggler
+#
+# Copyright (C) 2022  Konstantin Vogel <konstantin.vogel@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import json
+import websocket # pip install websocket-client
+import time
+import queue
+from threading import Thread
+
+class Plotjuggler:
+    def __init__(self, config):
+        self.host_adress = config.get('host_adress')
+        self.data_queue = queue.Queue()
+        self.reactor = config.get_reactor()
+        self.ws = None
+        self.reconnect_time = 0
+        self.reactor.register_event_handler("klippy:disconnect",
+            self.handle_disconnect)
+        Thread(target=self.run_server, args=[]).start()
+
+    def run_server(self):
+        while self.reactor._process:
+            data = json.dumps(self.data_queue.get())
+            try:
+                self.ws.send(data)
+            except:
+                now = time.time()
+                if now > self.reconnect_time:
+                    self.reconnect_time = now + 5
+                    self.ws = websocket.WebSocket(skip_utf8_validation=True)
+                    try:
+                        self.ws.connect("ws://" + self.host_adress)
+                    except:
+                        self.ws = None
+
+    def send_data(self, timestamp, name, data):
+        self.data_queue.put_nowait({'timestamp': timestamp, name: data})
+
+    def handle_disconnect(self):
+        self.data_queue.put_nowait({}) # Send dummy event to trigger the loop
+
+def load_config(config):
+    return Plotjuggler(config)


### PR DESCRIPTION
Plotjuggler is a more powerful and easy alternative to matplotlib. It is used by large companies in the robotics and self-driving space.
This PR serves as a minimal prototype and can be further integrated with motan, the heater controller etc. in the future. 
I encourage anyone to try it out.

### Limitations
* websocket server  is only supported with the Linux version of plotjuggler
* when passing non monotonic timestamps e.g. after a klipper restart plogjuggler has to be restarted as well due to a bug in plotjuggler


### How-to use
* run pip install websocket-client in the klippy virtual-environment
* add the following config section with your pc's ip
```
[plotjuggler]
host_adress: 192.168.178.100:9871
```
* open the plotjuggler software and select the websocket from the dropdown, click on start and enter the port as well as  'timestamp' in the respective fields.

* periodically run code sections like this to plot data

```python
plotjuggler = self.printer.lookup_object('plotjuggler', None)
if plotjuggler:
    plotjuggler.send_data(read_time, self.heater.name, {
        'temp': temp,
        'target_temp': target_temp})
```