### PR TITLE
Update instructions for generic-th3d-ezboard-lite-v2.0.cfg

### DIFF
--- a/config/generic-th3d-ezboard-lite-v2.0.cfg
+++ b/config/generic-th3d-ezboard-lite-v2.0.cfg
@@ -1,11 +1,15 @@
 # This file contains common pin mappings for the TH3D EZBoard Lite v2.
-# To use this config, the firmware should be compiled for the
-# STM32F405 with 12mhz Crystal, 48KiB Bootloader, and USB communication.
+# To use this config, check "Enable extra low-level configuration options"
+# and compile the firmware for the STM32F405 with 12mhz Crystal, 
+# 48KiB Bootloader, and USB communication.
+
+# After the firmware in compiled, change directory to out/ and
+# execute the following command
+# arm-none-eabi-objcopy -O srec klipper.elf firmware.bin
 
 # The "make flash" command does not work on this board. Instead,
-# after running "make", copy the generated "out/klipper.bin" file to a
-# file named "firmware.bin" on an SD card and then restart the board
-# with that SD card.
+# after running "make", copy the generated "out/firmware.bin" file to
+# an SD card and then restart the board with that SD card.
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
Corrected the build instructions for the TH3D EZBoard V2 to include the command to convert Klipper.elf to a SREC bin format named firmware.bin. The SREC format is required for the bootloader installed on the board.