### PR TITLE
Add grouping for LEDs

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2829,7 +2829,18 @@ PCA9632 LED support. The PCA9632 is used on the FlashForge Dreamer.
 #initial_WHITE: 0.0
 #   See the "led" section for information on these parameters.
 ```
+### [led_group]
 
+Groups LEDs together into LED groups, which then can be used like any LED
+chain.
+```
+[led_group my_group]
+#leds:
+#   A list of LEDs to put in the group. Every chain in a new line with the chain
+#   name, optionally followed by the index range in brackets. Ranges can be
+#   combined by separating them with a comma. Example:
+#   neopixel:my_neopixel (2-4,6-7,10)
+```
 ## Additional servos, buttons, and other pins
 
 ### [servo]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2838,8 +2838,10 @@ chain.
 #leds:
 #   A list of LEDs to put in the group. Every chain in a new line with the chain
 #   name, optionally followed by the index range in brackets. Ranges can be
-#   combined by separating them with a comma. Example:
-#   neopixel:my_neopixel (2-4,6-7,10)
+#   combined by separating them with a comma. LEDs are indexed in the order they
+#   are configured. Example:
+#   my_neopixel (2-4,6-7,10)
+#   my_dotstar
 ```
 ## Additional servos, buttons, and other pins
 

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -78,6 +78,7 @@ class LEDHelper:
 # Main LED tracking code
 class PrinterLED:
     def __init__(self, config):
+        self.config = config
         self.printer = config.get_printer()
         self.led_helpers = {}
         self.active_templates = {}
@@ -94,8 +95,14 @@ class PrinterLED:
     def setup_helper(self, config, update_func, led_count=1):
         led_helper = LEDHelper(config, update_func, led_count)
         name = config.get_name().split()[-1]
+        if name in self.led_helpers:
+            raise self.config.error("LED name '%s' is not unique." % (name,))
         self.led_helpers[name] = led_helper
         return led_helper
+    def lookup_led_helper(self, name):
+        if name in self.led_helpers:
+            return self.led_helpers[name]
+        raise self.config.error("Unknown LED '%s'" % (name,))
     def _activate_timer(self):
         if self.render_timer is not None or not self.active_templates:
             return

--- a/klippy/extras/led_group.py
+++ b/klippy/extras/led_group.py
@@ -1,0 +1,58 @@
+# Support for PWM driven LEDs
+#
+# Copyright (C) 2022 Julian Schill <j.schill@web.de>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+class PrinterLEDGroup:
+    def __init__(self, config):
+        self.printer = printer = config.get_printer()
+        self.configLeds   = config.get('leds')
+        self.configChains = self.configLeds.split('\n')
+        self.leds=[]
+        self.ledChains=[]
+        for chain in self.configChains:
+            chain = chain.strip()
+            parms = [parameter.strip() for parameter in chain.split()
+                        if parameter.strip()]
+            if parms:
+                ledChain     = self.printer.lookup_object(parms[0]\
+                                                .replace(':',' '))
+                ledIndices   = ''.join(parms[1:]).strip('()').split(',')
+                for led in ledIndices:
+                    if led:
+                        if '-' in led:
+                            start, stop = map(int,led.split('-'))
+                            if stop == start:
+                                ledList = [start-1]
+                            elif stop > start:
+                                ledList = list(range(start-1, stop))
+                            else:
+                                ledList = list(reversed(range(stop-1, start)))
+                            for i in ledList:
+                                self.leds.append((ledChain, int(i)))
+                        else:
+                            for i in led.split(','):
+                                self.leds.append((ledChain, \
+                                                (int(i)-1)))
+                    else:
+                        for i in range(ledChain.led_helper.get_led_count()):
+                            self.leds.append((ledChain, int(i)))
+                if ledChain not in self.ledChains:
+                    self.ledChains.append(ledChain)
+        self.ledCount = len(self.leds)
+
+        pled = printer.load_object(config, "led")
+        self.led_helper = pled.setup_helper(config, self.update_leds,
+                                                self.ledCount)
+
+    def update_leds(self, led_state, print_time):
+        for i, (chain, index) in enumerate(self.leds):
+            chain.led_helper.set_color(index+1, led_state[i])
+        for chain in self.ledChains:
+            chain.led_helper.check_transmit(print_time)
+
+    def get_status(self, eventtime=None):
+        return self.led_helper.get_status(eventtime)
+
+def load_config_prefix(config):
+    return PrinterLEDGroup(config)

--- a/klippy/extras/led_group.py
+++ b/klippy/extras/led_group.py
@@ -7,15 +7,15 @@ class PrinterLEDGroup:
     def __init__(self, config):
         self.config = config
         self.printer = config.get_printer()
-        self.configLeds = config.get('leds')
-        self.configChains = self.configLeds.split('\n')
+        self.config_leds = config.get('leds')
+        self.config_chains = self.config_leds.split('\n')
         self.leds=[]
-        self.ledChains=[]
+        self.led_chains=[]
         self.printer.register_event_handler('klippy:connect',
                                                 self._handle_connect)
 
     def _handle_connect(self):
-        for chain in self.configChains:
+        for chain in self.config_chains:
             chain = chain.strip()
             parms = [parameter.strip() for parameter in chain.split()
                         if parameter.strip()]
@@ -24,39 +24,39 @@ class PrinterLEDGroup:
                     raise self.config.error(
                         "Error in '%s': LED group of LED groups is not allowed"
                             % (self.config.get_name(),))
-                ledChain = self.printer.lookup_object(parms[0]\
+                led_chain = self.printer.lookup_object(parms[0]\
                                                 .replace(':',' '))
-                chainLen = ledChain.led_helper.get_led_count()
-                ledIndices = ''.join(parms[1:]).strip('()').split(',')
-                for led in ledIndices:
+                chain_len = led_chain.led_helper.get_led_count()
+                led_indices = ''.join(parms[1:]).strip('()').split(',')
+                for led in led_indices:
                     if led:
                         if '-' in led:
                             start, stop = map(int,led.split('-'))
-                            if start > chainLen or stop > chainLen or \
+                            if start > chain_len or stop > chain_len or \
                                 start < 1 or stop < 1:
                                 raise self.config.error(
                                     "LED index out of range for '%s' in '%s'"
                                         % (parms[0],self.config.get_name(),))
                             if stop == start:
-                                ledList = [start-1]
+                                led_list = [start-1]
                             elif stop > start:
-                                ledList = list(range(start-1, stop))
+                                led_list = list(range(start-1, stop))
                             else:
-                                ledList = list(reversed(range(stop-1, start)))
-                            for i in ledList:
-                                self.leds.append((ledChain, int(i)))
+                                led_list = list(reversed(range(stop-1, start)))
+                            for i in led_list:
+                                self.leds.append((led_chain, int(i)))
                         else:
                             i = int(led)
-                            if i > chainLen or i < 1:
+                            if i > chain_len or i < 1:
                                 raise self.config.error(
                                     "LED index out of range for '%s' in '%s'"
                                         % (parms[0],self.config.get_name(),))
-                            self.leds.append((ledChain, (int(i)-1)))
+                            self.leds.append((led_chain, (int(i)-1)))
                     else:
-                        for i in range(chainLen):
-                            self.leds.append((ledChain, int(i)))
-                if ledChain not in self.ledChains:
-                    self.ledChains.append(ledChain)
+                        for i in range(chain_len):
+                            self.leds.append((led_chain, int(i)))
+                if led_chain not in self.led_chains:
+                    self.led_chains.append(led_chain)
         self.ledCount = len(self.leds)
 
         pled = self.printer.load_object(self.config, "led")
@@ -66,7 +66,7 @@ class PrinterLEDGroup:
     def update_leds(self, led_state, print_time):
         for i, (chain, index) in enumerate(self.leds):
             chain.led_helper.set_color(index+1, led_state[i])
-        for chain in self.ledChains:
+        for chain in self.led_chains:
             chain.led_helper.check_transmit(print_time)
 
     def get_status(self, eventtime=None):

--- a/klippy/extras/led_group.py
+++ b/klippy/extras/led_group.py
@@ -1,15 +1,19 @@
-# Support for PWM driven LEDs
+# Support for LED groups
 #
 # Copyright (C) 2022 Julian Schill <j.schill@web.de>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 class PrinterLEDGroup:
     def __init__(self, config):
-        self.printer = printer = config.get_printer()
-        self.configLeds   = config.get('leds')
+        self.config = config
+        self.printer = config.get_printer()
+        self.configLeds = config.get('leds')
         self.configChains = self.configLeds.split('\n')
         self.leds=[]
         self.ledChains=[]
+        self.printer.register_event_handler('klippy:ready', self._handle_ready)
+
+    def _handle_ready(self):
         for chain in self.configChains:
             chain = chain.strip()
             parms = [parameter.strip() for parameter in chain.split()
@@ -41,8 +45,8 @@ class PrinterLEDGroup:
                     self.ledChains.append(ledChain)
         self.ledCount = len(self.leds)
 
-        pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds,
+        pled = self.printer.load_object(self.config, "led")
+        self.led_helper = pled.setup_helper(self.config, self.update_leds,
                                                 self.ledCount)
 
     def update_leds(self, led_state, print_time):


### PR DESCRIPTION
This adds the functionality to create groups of LEDs to either separate a chain or combine multiple chains to one big LED chain.

Configuration is like this:
```
[led_group mygroup]
leds:
  neopixel:grbw (2-4,6-7,10)
  neopixel:grb
  dotstar:my_dotstar (32-35)
  ```

The indexing is then done in the order of the group definition. 
The code was partly taken out from the LED effect module, created by Paul McGowan and maintained by me.

Signed-off-by: Julian Schill <j.schill@web.de>