### PR TITLE
controller_fan: Add min_speed configuration

### DIFF
--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -23,6 +23,8 @@ class ControllerFan:
         self.idle_speed = config.getfloat(
             'idle_speed', default=self.fan_speed, minval=0., maxval=1.)
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
+        self.min_speed = config.getfloat(
+            'min_speed', default=0., minval=0., maxval=1.)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
         self.last_speed = 0.
@@ -46,7 +48,7 @@ class ControllerFan:
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)
     def callback(self, eventtime):
-        speed = 0.
+        speed = self.min_speed
         active = False
         for name in self.stepper_names:
             active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()


### PR DESCRIPTION
Adds a min_speed configuration value that allows the user to override the minimum speed. The min_speed value is used on startup and after the idle_speed timeout.

This allows a single fan in a combined electronics enclosure to always run at a defined speed to keep air flowing even when the configured steppers and
heaters are not active.

Signed-off-by: Charles Willis (5862883+trippwill@users.noreply.github.com)