### PR TITLE
z_thermal_adjust: hotfix for M105 internal error

### DIFF
--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -145,6 +145,12 @@ class ZThermalAdjuster:
             self.measured_min = min(self.measured_min, self.smoothed_temp)
             self.measured_max = max(self.measured_max, self.smoothed_temp)
 
+    def get_temp(self, eventtime):
+        return self.smoothed_temp, 0.
+
+    def stats(self, eventtime):
+        return False, '%s: temp=%.1f' % ("z_thermal_adjust", self.smoothed_temp)
+
     def cmd_SET_Z_THERMAL_ADJUST(self, gcmd):
         enable = gcmd.get_int('ENABLE', None, minval=0, maxval=1)
         coeff = gcmd.get_float('TEMP_COEFF', None, minval=-1, maxval=1)


### PR DESCRIPTION
M105 expects a get_temp method for all sensors with a gcode_id defined. z_thermal_adjust crashes when the gcode_id parameter is set and M105 is called. 

Port get_temp and stats (for good measure?) methods from temperature_sensor.

Signed-off-by: Robert Pazdzior <robertp@norbital.com>