### PR TITLE
Add SKR2, SKR3 and Creality 4.2.2/7 to spi_flash

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -87,6 +87,26 @@ BOARD_DEFS = {
         'spi_bus': 'spi3a',
         'cs_pin': 'PA15'
     },
+    'btt-skr-2': {
+        'mcu': "stm32f407xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+    },
+    'btt-skr-3': {
+        'mcu': 'stm32h743xx',
+        'spi_bus': 'spi3a',
+        'cs_pin': 'PA15',
+        'skip_verify': True
+    },
+    'creality-v4.2.2': {
+        'mcu': "stm32f103xe",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+    },
     'monster8': {
         'mcu': "stm32f407xx",
         'spi_bus': "spi3a",
@@ -123,7 +143,7 @@ BOARD_ALIASES = {
     'btt-skr-mini-mz': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],
-    'creality-v4.2.7': BOARD_DEFS['btt-skr-mini'],
+    'creality-v4.2.7': BOARD_DEFS['creality-v4.2.2'],
     'btt-octopus-f407-v1.0': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-octopus-f407-v1.1': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-octopus-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
@@ -139,7 +159,6 @@ BOARD_ALIASES = {
     'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v2': BOARD_DEFS['fysetc-spider'],
-    'monster8': BOARD_DEFS['monster8'],
     'robin_v3': BOARD_DEFS['monster8']
 }
 

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -87,13 +87,6 @@ BOARD_DEFS = {
         'spi_bus': 'spi3a',
         'cs_pin': 'PA15'
     },
-    'btt-skr-2': {
-        'mcu': "stm32f407xx",
-        'spi_bus': "swspi",
-        'spi_pins': "PC8,PD2,PC12",
-        'cs_pin': "PC11",
-        'skip_verify': True
-    },
     'btt-skr-3': {
         'mcu': 'stm32h743xx',
         'spi_bus': 'spi3a',
@@ -144,6 +137,7 @@ BOARD_ALIASES = {
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],
     'creality-v4.2.7': BOARD_DEFS['creality-v4.2.2'],
+    'btt-skr-2': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-octopus-f407-v1.0': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-octopus-f407-v1.1': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-octopus-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],


### PR DESCRIPTION
As discussed with Arksine, he has created new working settings for the Creality 4.2.x boards as the original 4.2.7 entry did not work, plus addition of SKR2 and SKR3. Tested on 4.2.2 and SKR2 and SKR3EZ.

These are using the new skip_verify functionality that was recently merged due to them using SDIO

Also removed a double definition for `monster8` it was in main definitions and aliased.

Signed-off-by: James Hartley <james@hartleyns.com>