### PR TITLE
Add Artillery Sidewinder X2 2022 stock printer.cfg

### DIFF
--- a/config/printer-artillery-sidewinder-x2-2022.cfg
+++ b/config/printer-artillery-sidewinder-x2-2022.cfg
@@ -1,0 +1,173 @@
+# This file contains stock 2021/2022 Artillery Sidewinder X2 configuration. 
+
+# To use this config, during "make menuconfig" select
+# the STM32F401 with a "No bootloader".
+# Flash this firmware by usb connection.
+# Set the physical bridge between +3.3V and Boot0 PIN on Artillery_Ruby mainboard. 
+# Then running the command:
+# make flash FLASH_DEVICE=/dev/serial/by-id/usb-Klipper_stm32f401xc_4F006F000351383532393535-if00
+
+# See more description here: https://blog.freakydu.de/posts/2022-10-01-klipper_with_artillery_sidewinderx2/
+# See docs/Config_Reference.md for a description of parameters.
+
+[mcu]
+serial: /dev/ttyACM0
+#serial: /dev/serial/by-id/usb-Klipper_stm32f401xc_4F006F000351383532393535-if00 
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 250
+max_accel: 1500
+max_z_velocity: 50  ## xy / 5 
+max_z_accel: 400 ## xy / 5
+square_corner_velocity: 5.0
+
+[stepper_x]
+step_pin: !PB14
+dir_pin: PB13
+enable_pin: !PB15
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA2
+position_endstop: 0
+position_max: 310
+homing_speed: 50
+homing_retract_dist: 5.0
+second_homing_speed: 10
+
+[stepper_y]
+step_pin: PB10
+dir_pin: PB2
+enable_pin: !PB12
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA1
+position_endstop: 0
+position_max: 310
+homing_speed: 50
+homing_retract_dist: 5.0
+second_homing_speed: 10
+
+[stepper_z]
+step_pin: PB0
+dir_pin: !PC5
+enable_pin: !PB1
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 400
+position_min: -2  # The Z carriage may need to travel below the Z=0. homing point if the bed has a significant tilt.
+homing_speed: 10 ## xy / 5 results in same stepper motor speed like x or y stepper
+homing_retract_dist: 5.0
+second_homing_speed: 2 ## xy / 5 results in same stepper motor speed like x or y stepper
+
+[extruder]
+step_pin: PA7
+dir_pin: PA6
+enable_pin: !PC4
+microsteps: 16
+gear_ratio: 3:1
+rotation_distance: 20.925 # with gear ration 3:1 configured
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+control = pid
+pid_kp = 20.860
+pid_ki = 1.131
+pid_kd = 96.218
+min_temp: 0
+max_temp: 250
+pressure_advance: 0.11375
+
+[bltouch]
+sensor_pin: PC2 
+control_pin: PC3 
+x_offset:27.25
+y_offset:-12.8
+z_offset = 2.0
+speed:5
+samples: 3
+samples_result: average
+samples_tolerance: 0.050
+samples_tolerance_retries: 3
+
+[heater_bed]
+heater_pin: PA8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC1
+control = pid
+pid_kp = 42.365
+pid_ki = 0.545
+pid_kd = 822.940
+min_temp: 0
+max_temp: 130
+
+[fan]
+# filament_cooling
+pin: PC8
+off_below: 0.1
+
+[heater_fan extruder]
+# fan on hotend/extruder
+pin: PC7
+heater: extruder
+heater_temp: 50.0
+off_below: 0.2
+
+[controller_fan case]
+# mainboard, artillery case
+pin: PC6
+off_below: 0.3
+idle_speed: 0.0
+
+[bed_mesh]
+speed: 100
+mesh_min: 27.25, 12.8
+mesh_max: 272.75, 287.2
+algorithm: bicubic
+probe_count: 5,5
+mesh_pps: 3
+fade_start: 1
+fade_end: 10
+
+[bed_screws]
+screw1: 23,63
+screw1_name: front left
+screw2: 223,63
+screw2_name: front right
+screw3: 223,263
+screw3_name: back right
+screw4: 23,263
+screw4_name: back left
+speed: 100.0
+
+[screws_tilt_adjust]
+screw1: 23,63
+screw1_name: front left
+screw2: 223,63
+screw2_name: front right
+screw3: 223,263
+screw3_name: back left
+screw4: 23,263
+screw4_name: back right
+speed: 100.0
+screw_thread: CW-M5	
+
+[safe_z_home]
+home_xy_position: 150,150
+z_hop: 15
+
+[neopixel extruder]
+pin: PB7
+initial_RED: 1.0
+initial_GREEN: 1.0
+initial_BLUE: 1.0
+
+[temperature_sensor mainboard]
+# stm32 temperature sensor
+sensor_type: temperature_mcu
+min_temp: 10
+max_temp: 60


### PR DESCRIPTION
Hey guys, 

after many hours of testing I like to add my Artillery Sidewinder X2 printer config, because there is no example in this repository. 
Its for the unmodified stock model, buyed in 2022. 


For the Mainsail stack the mainsail.cfg and pause/resume/cancel g-code macros must be configured in addition.
See also my klipper with sidewinder intro article [here](https://blog.freakydu.de/posts/2022-10-01-klipper_with_artillery_sidewinderx2/)


Anyway. Great work, great software. Thanks for Klipper (and friends ;-) ). Please keep up the good work.
freakyDude

Signed-off-by: Frank Roth <developer@freakydu.de>