### PR TITLE
docs: Clarify homing_override gcode: requirement

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1176,8 +1176,8 @@ gcode:
 #   found in the normal g-code input. See docs/Command_Templates.md
 #   for G-Code format. If a G28 is contained in this list of commands
 #   then it will invoke the normal homing procedure for the printer.
-#   The commands listed here must home all axes. This parameter must
-#   be provided.
+#   The commands listed here must be able to home each axis configured
+#   under axes: below. This parameter must be provided.
 #axes: xyz
 #   The axes to override. For example, if this is set to "z" then the
 #   override script will only be run when the z axis is homed (eg, via


### PR DESCRIPTION
The previous wording made it seem like you could not implement a G-Code macro that handled single-axis homing, and instead had to home ALL axes every time. Hopefully the updated text is less misleading, as single-axis homing works fine if your G-Code macro is smart enough to do so.