### PR TITLE
Add config file for the V4 version of the GT2560 boards

### DIFF
--- a/config/generic-gt2560-v4 .cfg
+++ b/config/generic-gt2560-v4 .cfg
@@ -15,7 +15,7 @@ max_z_velocity: 20
 max_z_accel: 500
 
 #[bltouch]
-#sensor_pin: ^PC7 #^PC7 default for z_min port,  ^PE7 for Z1-
+#sensor_pin: ^PC7              #^PC7 default for z_min port,  ^PE7 for Z1-
 #control_pin: PB5
 
 [stepper_x]
@@ -25,9 +25,8 @@ enable_pin: !PC2
 microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA2
-position_endstop: -10
-position_max: 220
-position_min: -10
+position_endstop: 0
+position_max: 200
 homing_speed: 30
 step_pulse_duration: .000002      # In the evenuatility that the stock GEEETECH drivers starts losing steps, changing this value to .000008 migth mitigate the issue
 
@@ -38,9 +37,8 @@ enable_pin: !PA7
 microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
-position_endstop: -5
-position_max: 213
-position_min: -5
+position_endstop: 0
+position_max: 200
 homing_speed: 30
 step_pulse_duration: .000002
 
@@ -50,9 +48,10 @@ dir_pin: PA1
 enable_pin: !PA5
 microsteps: 16
 rotation_distance: 8 
-endstop_pin: probe:z_virtual_endstop
-position_max: 220
-position_min: -2.5
+endstop_pin: ^PC7
+position_endstop: 0
+position_max: 200
+position_min: 0
 step_pulse_duration: .000002
 
 #[stepper_z1]
@@ -72,8 +71,9 @@ heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PK3
 min_temp: 5
-max_temp: 285
-min_extrude_temp: 170
+max_temp: 250
+control: pid
+
 
 #[extruder1]              
 #step_pin: PL0
@@ -86,12 +86,8 @@ min_extrude_temp: 170
 #sensor_type: ATC Semitec 104GT-2
 #sensor_pin: PK1
 #min_temp: 5
-#max_temp: 285
-#min_extrude_temp: 170
+#max_temp: 250
 #control: pid
-#pid_kp: 29.800
-#pid_ki: 1.774
-#pid_kd: 125.159
 
 [heater_bed]
 heater_pin: PG5
@@ -99,10 +95,7 @@ sensor_type: ATC Semitec 104GT-2
 sensor_pin: PK2
 min_temp: 0
 max_temp: 120
-#control: pid
-#pid_kp: 63.041
-#pid_ki: 2.898
-#pid_kd: 342.787
+control: pid
 
 [display]     # Pinout for the GEEETECH LCD2004 display with pulse encoder
 rs_pin: PD1

--- a/config/generic-gt2560-v4 .cfg
+++ b/config/generic-gt2560-v4 .cfg
@@ -14,9 +14,9 @@ max_accel: 1500
 max_z_velocity: 20
 max_z_accel: 500
 
-[bltouch]
-sensor_pin: ^PC7 #^PC7 default for z_min port,  ^PE7 for Z1-
-control_pin: PB5
+#[bltouch]
+#sensor_pin: ^PC7 #^PC7 default for z_min port,  ^PE7 for Z1-
+#control_pin: PB5
 
 [stepper_x]
 step_pin: PC0
@@ -29,7 +29,7 @@ position_endstop: -10
 position_max: 220
 position_min: -10
 homing_speed: 30
-step_pulse_duration: .000008
+step_pulse_duration: .000002      # In the evenuatility that the stock GEEETECH drivers starts losing steps, changing this value to .000008 migth mitigate the issue
 
 [stepper_y]
 step_pin: PC6
@@ -42,7 +42,7 @@ position_endstop: -5
 position_max: 213
 position_min: -5
 homing_speed: 30
-step_pulse_duration: .000008
+step_pulse_duration: .000002
 
 [stepper_z]
 step_pin: PA3
@@ -53,7 +53,7 @@ rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
 position_max: 220
 position_min: -2.5
-step_pulse_duration: .000008
+step_pulse_duration: .000002
 
 #[stepper_z1]
 #step_pin: PL6   # The Z1 driver is labeled E2 on the board
@@ -65,7 +65,7 @@ step_pin: PL3
 dir_pin: PL5         
 enable_pin: !PB6
 microsteps: 16
-rotation_distance: 7.501
+rotation_distance: 33.500
 nozzle_diameter: 0.4
 filament_diameter: 1.750
 heater_pin: PB4 
@@ -75,12 +75,12 @@ min_temp: 5
 max_temp: 285
 min_extrude_temp: 170
 
-#[extruder1]
+#[extruder1]              
 #step_pin: PL0
 #dir_pin: PL2
 #enable_pin: !PL1
 #microsteps: 16
-#rotation_distance: 7.501
+#rotation_distance: 33.500
 #nozzle_diameter: 0.4
 #filament_diameter: 1.750
 #sensor_type: ATC Semitec 104GT-2
@@ -104,8 +104,7 @@ max_temp: 120
 #pid_ki: 2.898
 #pid_kd: 342.787
 
-[display]
-lcd_type: hd44780
+[display]     # Pinout for the GEEETECH LCD2004 display with pulse encoder
 rs_pin: PD1
 e_pin: PH0
 d4_pin: PH1

--- a/config/generic-gt2560V4 .cfg
+++ b/config/generic-gt2560V4 .cfg
@@ -1,0 +1,130 @@
+#This file contains common pin mappings for the Geeetech GT2560 V4.0
+# board. GT2560 board uses a firmware compiled for the AVR
+# atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[mcu]
+serial: /dev/ttyUSB0
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 1500
+max_z_velocity: 20
+max_z_accel: 500
+
+[bltouch]
+sensor_pin: ^PC7 #^PC7 default for z_min port,  ^PE7 for Z1-
+control_pin: PB5
+
+[stepper_x]
+step_pin: PC0
+dir_pin: !PG2
+enable_pin: !PC2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA2
+position_endstop: -10
+position_max: 220
+position_min: -10
+homing_speed: 30
+step_pulse_duration: .000008
+
+[stepper_y]
+step_pin: PC6
+dir_pin: !PC4
+enable_pin: !PA7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PA6
+position_endstop: -5
+position_max: 213
+position_min: -5
+homing_speed: 30
+step_pulse_duration: .000008
+
+[stepper_z]
+step_pin: PA3
+dir_pin: PA1
+enable_pin: !PA5
+microsteps: 16
+rotation_distance: 8 
+endstop_pin: probe:z_virtual_endstop
+position_max: 220
+position_min: -2.5
+step_pulse_duration: .000008
+
+#[stepper_z1]
+#step_pin: PL6   # The Z1 driver is labeled E2 on the board
+#dir_pin: PL4     
+#enable_pin: !PG0
+
+[extruder]
+step_pin: PL3
+dir_pin: PL5         
+enable_pin: !PB6
+microsteps: 16
+rotation_distance: 7.501
+nozzle_diameter: 0.4
+filament_diameter: 1.750
+heater_pin: PB4 
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK3
+min_temp: 5
+max_temp: 285
+min_extrude_temp: 170
+
+#[extruder1]
+#step_pin: PL0
+#dir_pin: PL2
+#enable_pin: !PL1
+#microsteps: 16
+#rotation_distance: 7.501
+#nozzle_diameter: 0.4
+#filament_diameter: 1.750
+#sensor_type: ATC Semitec 104GT-2
+#sensor_pin: PK1
+#min_temp: 5
+#max_temp: 285
+#min_extrude_temp: 170
+#control: pid
+#pid_kp: 29.800
+#pid_ki: 1.774
+#pid_kd: 125.159
+
+[heater_bed]
+heater_pin: PG5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK2
+min_temp: 0
+max_temp: 120
+#control: pid
+#pid_kp: 63.041
+#pid_ki: 2.898
+#pid_kd: 342.787
+
+[display]
+lcd_type: hd44780
+rs_pin: PD1
+e_pin: PH0
+d4_pin: PH1
+d5_pin: PD0
+d6_pin: PE3
+d7_pin: PC1
+encoder_pins: ^PL7, ^PG1
+click_pin: ^!PD2
+
+[controller_fan chassis_fan]
+pin: PH4
+
+[fan]
+pin: PH6
+
+[heater_fan nozzle_fan]            
+pin: PH5
+heater: extruder
+heater_temp: 50.0
+
+#[output_pin beeper]
+#pin: PD3


### PR DESCRIPTION
The current generic-gt2560.cfg file is based on revision 3.0 of the board in question, which ceased production long ago. V4.0 is among the newest version to be packed in Geeetech products. V4.1 is theoretically also compatible, although I haven't been able to test it. 
Signed-off-by: Matteo Parenti, matteoparenti02@gmail.com