### PR TITLE
Update printer-creality-ender3-s1-2021.cfg

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -18,6 +18,9 @@
 
 # See docs/Config_Reference.md for a description of parameters.
 
+#Data pulled from Ender 3 S1 "Pro" firmware on Github (https://github.com/mriscoc/Ender3V2S1) for bed max and min positions. Optimal config for stock printer that works very well. 
+#Added homing positive false, as the printer homes towards zero.
+
 [stepper_x]
 step_pin: PC2
 dir_pin: PB9
@@ -26,9 +29,10 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA5
 position_endstop: -10
-position_max: 235
+position_max: 230
 position_min: -15
 homing_speed: 50
+homing_positive_dir: false
 
 [stepper_y]
 step_pin: PB8
@@ -38,9 +42,10 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
 position_endstop: -8
-position_max: 238
+position_max: 220
 position_min: -13
 homing_speed: 50
+homing_positive_dir: false
 
 [stepper_z]
 step_pin: PB6


### PR DESCRIPTION
#Data pulled from Ender 3 S1 "Pro" firmware on Github (https://github.com/mriscoc/Ender3V2S1) for bed max and min positions. Optimal config for stock printer that works very well.  #Added homing positive false, as the printer homes towards zero.

Stock position values caused belt skipping and binding on the bed.