### PR TITLE
config: Add basic config for ANET ET4+

### DIFF
--- a/config/printer-anet-et4plus-2020.cfg
+++ b/config/printer-anet-et4plus-2020.cfg
@@ -110,7 +110,7 @@ speed: 5
 
 [board_pins]
 aliases:
-# P1 header    
+# P1 header
     P1_1=PD7, P1_3=PB2, P1_5=PE4, P1_7=PB1, P1_9=<GND>,
     P1_2=PD5, P1_4=PE5, P1_6=PB0, P1_8=PD4, P1_10=<3V3>,
 # P2 header


### PR DESCRIPTION
Added a basic config for the ANET ET4+ (the one with the built in probe). The config is tested and working on my printer. 
Based on https://www.reddit.com/r/klippers/comments/vzh5lr/comment/iihgw4v and https://3dprint.wiki/reprap/anet/et4/setup-and-flash-klipper

Signed-off-by: Alexander Mahrt <mahrt95@gmail.com>