### PR TITLE
config: Add basic config for ANET ET4+

### DIFF
--- a/config/printer-anet-et4plus-2020.cfg
+++ b/config/printer-anet-et4plus-2020.cfg
@@ -1,0 +1,136 @@
+# This file contains common pin mappings for the ANET ET4+ printer for klipper.
+# Important: It only works for the printer model with a Z axis probe. (ET4+)
+# Based on https://www.reddit.com/r/klippers/comments/vzh5lr/comment/iihgw4v and https://3dprint.wiki/reprap/anet/et4/setup-and-flash-klipper
+# Firmware must be flashed for STM32F407
+
+[stepper_x]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PB7
+rotation_distance: 40
+microsteps: 16
+endstop_pin: ^!PC13
+position_min: -3
+position_endstop: -3
+position_max: 205
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB3
+dir_pin: PD6
+enable_pin: !PB4
+rotation_distance: 40
+microsteps: 16
+endstop_pin: ^!PE12
+position_min: -8
+position_endstop: -8
+position_max: 205
+homing_speed: 50
+
+[stepper_z]
+step_pin: PA12
+dir_pin: !PA11
+enable_pin: !PA15
+rotation_distance: 8
+microsteps: 16
+endstop_pin: probe:z_virtual_endstop
+position_max: 250
+position_min: -10
+homing_speed: 12
+second_homing_speed: 6
+
+# Home at 100, 100 (to imitate the default firmware behaviour)
+[safe_z_home]
+home_xy_position: 100, 100
+speed: 50
+
+# Bed Mesh with the correct positions for ET4X
+[bed_mesh]
+mesh_min: 30, 30
+mesh_max: 205, 205
+probe_count: 5
+speed: 120
+
+[extruder]
+step_pin: PB9
+dir_pin: PB8
+enable_pin: !PE0
+rotation_distance: 33.0064
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA0 # END_CONTROL
+sensor_pin: PA1 # TEMP_EXB1
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_kp: 21.896
+pid_ki: 1.206
+pid_kd: 99.352
+min_temp: 5
+max_temp: 250
+
+[heater_bed]
+heater_pin: PE2 # BED_CONTROL
+sensor_pin: PA4 # TEMP_BED
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_kp: 68.403
+pid_ki: 1.677
+pid_kd: 697.707
+min_temp: 5
+max_temp: 100
+
+# Cold End Fan
+[fan]
+pin: PE3 # LAY_FAN
+
+[heater_fan fan1]
+pin: PE1 # END_FAN
+
+
+[mcu]
+baud: 115200
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 4000
+max_z_velocity: 12
+max_z_accel: 50
+
+[filament_switch_sensor filament_sensor]
+switch_pin: PA2 # MAT_DET
+pause_on_runout: True
+
+[probe]
+pin: !PC3 # LV_DET
+speed: 5
+
+[board_pins]
+aliases:
+# P1 header
+    P1_1=PD7, P1_3=PB2, P1_5=PE4, P1_7=PB1, P1_9=<GND>,
+    P1_2=PD5, P1_4=PE5, P1_6=PB0, P1_8=PD4, P1_10=<3V3>,
+# P2 header
+    P2_1= PE6, P2_3=PD15, P2_5=PD1, P2_7=PE8, P2_9=PE10,
+    P2_2=PD13, P2_4=PD14, P2_6=PD0, P2_8=PE7, P2_10=PE9
+
+[virtual_sdcard]
+path: /home/pi/gcode_files
+
+[display_status]
+
+[screws_tilt_adjust]
+screw1: 25, 20
+screw1_name: front left screw
+screw2: 25, 200
+screw2_name: rear left screw
+screw3: 198, 220
+screw3_name: rear right screw
+screw4: 198, 20
+screw4_name: front right screw
+horizontal_move_z: 10
+speed: 50
+screw_thread: CW-M3


### PR DESCRIPTION
Added a basic config for the ANET ET4+ (the one with the built in probe). The config is tested and working on my printer. 
Based on https://www.reddit.com/r/klippers/comments/vzh5lr/comment/iihgw4v and https://3dprint.wiki/reprap/anet/et4/setup-and-flash-klipper

Signed-off-by: Alexander Mahrt <mahrt95@gmail.com>