### PR TITLE
2.9x speedup for stm32h7 by enabling cpu cache

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -248,6 +248,26 @@ results were obtained by running an STM32F407 binary on an STM32F446
 | 1 stepper            | 46    |
 | 3 stepper            | 205   |
 
+### STM32H7 step rate benchmark
+
+The following configuration sequence is used on a STM32H743VIT6:
+```
+allocate_oids count=3
+config_stepper oid=0 step_pin=PD4 dir_pin=PD3 invert_step=-1 step_pulse_ticks=0
+config_stepper oid=1 step_pin=PA15 dir_pin=PA8 invert_step=-1 step_pulse_ticks=0
+config_stepper oid=2 step_pin=PE2 dir_pin=PE3 invert_step=-1 step_pulse_ticks=0
+finalize_config crc=0
+```
+
+The test was last run on commit `577746f2` with gcc version
+`arm-none-eabi-gcc (15:8-2019-q3-1+b1) 8.3.1 20190703 (release)
+[gcc-8-branch revision 273027]`.
+
+| stm32h7              | ticks |
+| -------------------- | ----- |
+| 1 stepper            | 44    |
+| 3 stepper            | 198   |
+
 ### STM32G0B1 step rate benchmark
 
 The following configuration sequence is used on the STM32G0B1:

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -166,7 +166,7 @@ config FLASH_SIZE
 
 config RAM_START
     hex
-    default 0x24000000 if MACH_STM32H743
+    default 0x24000000 if MACH_STM32H750 || MACH_STM32H743
     default 0x20000000
 
 config RAM_SIZE
@@ -181,8 +181,7 @@ config RAM_SIZE
     default 0x10000 if MACH_STM32F401
     default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x24000 if MACH_STM32G0B1
-    default 0x20000 if MACH_STM32H750
-    default 0x80000 if MACH_STM32H743
+    default 0x80000 if MACH_STM32H750 || MACH_STM32H743
 
 config STACK_SIZE
     int

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -148,6 +148,9 @@ clock_setup(void)
             ;
     }
 
+    SCB_EnableICache();
+    SCB_EnableDCache();
+
     // Set flash latency according to clock frequency (pg.159)
     uint32_t flash_acr_latency = (CONFIG_CLOCK_FREQ > 450000000) ?
         FLASH_ACR_LATENCY_4WS : FLASH_ACR_LATENCY_2WS;


### PR DESCRIPTION
As @KevinOConnor mentioned, someone ran the step rate benchmark on a stm32h743 mcu and only achieved a step rate of 570 ticks with the 3 stepper benchmark. This is much slower than the 204 ticks taken by the stm32f4 mcu.

I could roughly reproduce this result. And indeed it seems to be due to the cpu cache not being enabled. With this change the step time went down to 194 ticks!

The pr also changes the stm32h750 to use a larger ram area (like the stm32h743 did already).