### PR TITLE
config: Ender 3 s1 pro Fixed possible interference between y axis roller and belt tensioner.

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -38,7 +38,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
 position_endstop: -8
-position_max: 238
+position_max: 238 # Set to 233 for S1 Pro
 position_min: -13
 homing_speed: 50
 
@@ -111,7 +111,7 @@ stow_on_each_sample: false
 [bed_mesh]
 speed: 120
 mesh_min: 20, 20
-mesh_max: 200, 197
+mesh_max: 200, 197 # Set to 200, 192 for S1 Pro
 probe_count: 4,4
 algorithm: bicubic
 


### PR DESCRIPTION
I've noticed that the y axis roller crashes into the belt tensioner housing during the bed probe routine on the S1 pro. Therefore i've added comments about limiting the y axis max position and adjusting the bed mesh section for this machine.