### PR TITLE
spi_flash: Fix definition for btt-skr-mini-e3-v3

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -28,7 +28,8 @@ BOARD_DEFS = {
     },
     'btt-skr-mini-v3': {
         'mcu': "stm32g0b1xx",
-        'spi_bus': "spi1",
+        'spi_bus': "swspi",
+        'spi_pins': "PA6,PA7,PA5",
         "cs_pin": "PA4"
     },
     'flyboard-mini': {


### PR DESCRIPTION
The original config gets an error: "SPIFlashError: Failed to Initialize SD Card." when flashing skr-mini-e3-v3 through UART.
Same result with several sd cards with different brands and capacity.
![Screenshot 2022-10-17 010749](https://user-images.githubusercontent.com/14959712/196049546-7505bf91-d50b-4d49-b8b4-6c7ed18a224d.png)

Changing spi_bus to swspi 	made it work.
![Screenshot 2022-10-17 010425](https://user-images.githubusercontent.com/14959712/196049686-70c4a8b2-4e4a-4941-ba8f-5257038d13f5.png)

Signed-off-by:  Nathan Chiu <nhchiu2009@gmail.com>