### PR TITLE
adxl345: Apply correct scaling for X,Y and Z axes

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -24,7 +24,8 @@ ADXL345_DEV_ID = 0xe5
 SET_FIFO_CTL = 0x90
 
 FREEFALL_ACCEL = 9.80665 * 1000.
-SCALE = 0.0039 * FREEFALL_ACCEL # 3.9mg/LSB * Earth gravity in mm/s**2
+SCALE_XY = 0.003774 * FREEFALL_ACCEL # 1 / 265 (at 3.3V) mg/LSB
+SCALE_Z  = 0.003906 * FREEFALL_ACCEL # 1 / 256 (at 3.3V) mg/LSB
 
 Accel_Measurement = collections.namedtuple(
     'Accel_Measurement', ('time', 'accel_x', 'accel_y', 'accel_z'))
@@ -231,8 +232,8 @@ class ADXL345:
         self.printer = config.get_printer()
         AccelCommandHelper(config, self)
         self.query_rate = 0
-        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
-              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
+        am = {'x': (0, SCALE_XY), 'y': (1, SCALE_XY), 'z': (2, SCALE_Z),
+              '-x': (0, -SCALE_XY), '-y': (1, -SCALE_XY), '-z': (2, -SCALE_Z)}
         axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
         if any([a not in am for a in axes_map]):
             raise config.error("Invalid adxl345 axes_map parameter")


### PR DESCRIPTION
According to ADXL345/ADXL343 datasheets, at 3.3V supply voltage, which is most frequent in the various boards, the sensitivity of X and Y axes changes to 265 LSB/g from 256 LSB/g at 2.5V.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>