### PR TITLE
Add a note about fixing underlying bugs in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,6 +62,10 @@ Common things a reviewer will look for:
 
    Submissions must pass all [regression test cases](Debugging.md).
 
+   When fixing a defect in the code, submitters should have a general
+   understanding of the root cause of that defect, and the fix should
+   target that root cause.
+
    Code submissions should not contain excessive debugging code,
    debugging options, nor run-time debug logging.
 


### PR DESCRIPTION
This adds a short blurb to the review guidelines to indicate that "bug fixes" should ideally identify the "root cause" of a bug and look to fix that root cause.  That is, we want to avoid "papering over bugs" and avoid "making random changes that seem to help".

-Kevin