### PR TITLE
rp2040: Added canboot bootloader support for rp2040.

### DIFF
--- a/src/atsam/Kconfig
+++ b/src/atsam/Kconfig
@@ -70,6 +70,10 @@ config FLASH_START
     default 0x400000 if MACH_SAM4 || MACH_SAME70
     default 0x80000
 
+config BOOTLOADER_START
+   hex
+   default 0x0
+
 config FLASH_SIZE
     hex
     default 0x80000

--- a/src/atsamd/Kconfig
+++ b/src/atsamd/Kconfig
@@ -154,6 +154,10 @@ config FLASH_START
     default 0x2000 if FLASH_START_2000
     default 0x0000
 
+config BOOTLOADER_START
+   hex
+   default 0x0
+
 choice
     prompt "Communication interface"
     config ATSAMD_USB

--- a/src/generic/armcm_reset.c
+++ b/src/generic/armcm_reset.c
@@ -20,7 +20,7 @@ canboot_reset(uint64_t req_signature)
     if (!(CONFIG_FLASH_START & 0x00FFFFFF))
         // No bootloader
         return;
-    uint32_t *bl_vectors = (uint32_t *)(CONFIG_FLASH_START & 0xFF000000);
+    uint32_t *bl_vectors = (uint32_t *)(CONFIG_BOOTLOADER_START);
     uint64_t *boot_sig = (uint64_t *)(bl_vectors[1] - 9);
     uint64_t *req_sig = (uint64_t *)bl_vectors[0];
     if (boot_sig == (void *)ALIGN((size_t)boot_sig, 8) &&

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -63,6 +63,10 @@ config FLASH_START
     default 0x4000 if SMOOTHIEWARE_BOOTLOADER
     default 0x0000
 
+config BOOTLOADER_START
+   hex
+   default 0x0
+
 choice
     prompt "Communication interface"
     config LPC_USB

--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -27,8 +27,12 @@ config CLOCK_FREQ
     int
     default 12000000
 
+config USE_BOOTLOADER
+   bool "Use CanBoot bootloader"
+
 config FLASH_SIZE
     hex
+    default 0x1FC000 if USE_BOOTLOADER
     default 0x200000
 
 config RAM_START
@@ -45,8 +49,12 @@ config STACK_SIZE
 
 config FLASH_START
     hex
+    default 0x10004000 if USE_BOOTLOADER
     default 0x10000000
 
+config BOOTLOADER_START
+    hex
+    default 0x10000100
 
 ######################################################################
 # Bootloader options

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -10,7 +10,6 @@ CFLAGS += -Ilib/rp2040 -Ilib/rp2040/cmsis_include -Ilib/fast-hash -Ilib/can2040
 
 CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
 CFLAGS_klipper.elf += -T $(OUT)src/rp2040/rp2040_link.ld
-$(OUT)klipper.elf: $(OUT)stage2.o $(OUT)src/rp2040/rp2040_link.ld
 
 # Add source files
 src-y += rp2040/main.c rp2040/gpio.c rp2040/adc.c generic/crc16_ccitt.c
@@ -28,7 +27,14 @@ src-$(CONFIG_USBCANBUS) += ../lib/fast-hash/fasthash.c rp2040/usbserial.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += rp2040/hard_pwm.c
 src-$(CONFIG_HAVE_GPIO_SPI) += rp2040/spi.c
 src-$(CONFIG_HAVE_GPIO_I2C) += rp2040/i2c.c
-
+ifeq ($(CONFIG_USE_BOOTLOADER), y)
+$(OUT)klipper.elf: $(OUT)src/rp2040/rp2040_link.ld
+target-y += $(OUT)klipper.bin
+$(OUT)klipper.bin: $(OUT)klipper.elf
+	@echo "  Creating hex file $@"
+	$(Q)$(OBJCOPY) -O binary $< $@
+else
+$(OUT)klipper.elf: $(OUT)stage2.o $(OUT)src/rp2040/rp2040_link.ld
 # rp2040 stage2 building
 STAGE2_FILE := $(shell echo $(CONFIG_RP2040_STAGE2_FILE))
 $(OUT)stage2.o: lib/rp2040/boot_stage2/$(STAGE2_FILE) $(OUT)autoconf.h
@@ -59,3 +65,4 @@ lib/rp2040_flash/rp2040_flash:
 flash: $(OUT)klipper.uf2 lib/rp2040_flash/rp2040_flash
 	@echo "  Flashing $< to $(FLASH_DEVICE)"
 	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(if $(NOSUDO),--no-sudo) $(OUT)klipper.uf2
+endif

--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h> // uint32_t
 #include "board/misc.h" // bootloader_request
+#include "generic/armcm_reset.h"
 #include "hardware/structs/clocks.h" // clock_hw_t
 #include "hardware/structs/pll.h" // pll_hw_t
 #include "hardware/structs/resets.h" // sio_hw
@@ -45,6 +46,7 @@ DECL_INIT(watchdog_init);
 void
 bootloader_request(void)
 {
+    try_request_canboot();
     // Use the bootrom-provided code to reset into BOOTSEL mode
     reset_to_usb_boot(0, 0);
 }

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -250,6 +250,10 @@ config FLASH_START
     default 0x8020200 if STM32_FLASH_START_20200
     default 0x8000000
 
+config BOOTLOADER_START
+   hex
+   default 0x8000000
+
 config ARMCM_RAM_VECTORTABLE
     bool
     default y if MACH_STM32F0 && FLASH_START != 0x8000000


### PR DESCRIPTION
This PR add support for the canboot bootloader on rp2040 mcu. The corresponding canboot pr is here https://github.com/Arksine/CanBoot/pull/45
The most changes are trivial.
The makefile was modified to produce binary instead of uf2  if bootloader is used.. 
boot2 generation is skipped if bootloader is used. 
Option was added to the KConfig.
The nontrivial part of the PR - bootloader offset. On RP2040 first 256 bytes of the flash are used for boot2, so user bootloader is placed at the strange offset.

Signed-off-by: Alex Malishev <malishev@gmail.com>