### PR TITLE
Use consistent memory position/size on stm32h743

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -166,7 +166,6 @@ config FLASH_SIZE
 
 config RAM_START
     hex
-    default 0x24000000 if MACH_STM32H743
     default 0x20000000
 
 config RAM_SIZE
@@ -181,8 +180,7 @@ config RAM_SIZE
     default 0x10000 if MACH_STM32F401
     default 0x20000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x24000 if MACH_STM32G0B1
-    default 0x20000 if MACH_STM32H750
-    default 0x80000 if MACH_STM32H743
+    default 0x20000 if MACH_STM32H7
 
 config STACK_SIZE
     int


### PR DESCRIPTION
Since Klipper never uses more than about 16KiB of ram, there isn't a gain to using a different memory map on the stm32h743 chip.  Make that chip the same as stm32h750 and other stm32 chips.

@D4SK  @adelyser - fyi.

-Kevin