### PR TITLE
menu: Conditional display of common Control utils

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -24,6 +24,9 @@
 #       + Home All
 #       + Home Z
 #       + Home X/Y
+#       + Z Tilt
+#       + Quad Gantry Lvl
+#       + Bed Mesh
 #       + Steppers off
 #       + Fan: OFF
 #       + Fan speed: 000%
@@ -232,6 +235,24 @@ type: command
 enable: {not printer.idle_timeout.state == "Printing"}
 name: Home X/Y
 gcode: G28 X Y
+
+[menu __main __control __z_tilt]
+type: command
+enable: {not printer.idle_timeout.state == "Printing" and ('z_tilt' in printer)}
+name: Z Tilt
+gcode: Z_TILT_ADJUST
+
+[menu __main __control __quad_gantry_level]
+type: command
+enable: {not printer.idle_timeout.state == "Printing" and ('quad_gantry_level' in printer)}
+name: Quad Gantry Lvl
+gcode: QUAD_GANTRY_LEVEL
+
+[menu __main __control __bed_mesh]
+type: command
+enable: {not printer.idle_timeout.state == "Printing" and ('bed_mesh' in printer)}
+name: Bed Mesh
+gcode: BED_MESH_CALIBRATE
 
 [menu __main __control __disable]
 type: command
@@ -683,7 +704,7 @@ name: Calibration
 
 [menu __main __setup __calib __delta_calib_auto]
 type: command
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and ('delta_calibrate' in printer)}
 name: Delta cal. auto
 gcode:
     G28
@@ -691,12 +712,12 @@ gcode:
 
 [menu __main __setup __calib __delta_calib_man]
 type: list
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and ('delta_calibrate' in printer)}
 name: Delta cal. man
 
 [menu __main __setup __calib __bedprobe]
 type: command
-enable: {not printer.idle_timeout.state == "Printing"}
+enable: {(not printer.idle_timeout.state == "Printing") and ('probe' in printer)}
 name: Bed probe
 gcode: PROBE
 


### PR DESCRIPTION
This will hide features in the Klipper Display menu that isn't applicable for the machine, therefore we can add extra alignment tools in the Control menu as well.

Also conditionally displays Setup/Calibration options.

Signed-off-by: Nickolas Grigoriadis <nagrigoriadis@gmail.com>