### PR TITLE
bed_mesh: profile fixes

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -399,6 +399,26 @@ is not desirable the _default_ profile can be removed as follows:
 Any other saved profile can be removed in the same fashion, replacing
 _default_ with the named profile you wish to remove.
 
+
+#### Loading the default profile
+
+Previous versions of `bed_mesh` always loaded the profile named _default_
+on startup if it was present.  This behavior has been removed in favor of
+allowing the user to determine when a profile is loaded.  If a user wishes to
+load the `default` profile it is recommended to add
+`BED_MESH_PROFILE LOAD=default` to either their `START_PRINT` macro or their
+slicer's "Start G-Code" configuration, whichever is applicable.
+
+Alternatively the old behavior of loading a profile at startup can be
+restored with a `[delayed_gcode]`:
+
+```ini
+[delayed_gcode bed_mesh_init]
+initial_duration: .01
+gcode:
+  BED_MESH_PROFILE LOAD=default
+```
+
 ### Output
 
 `BED_MESH_OUTPUT PGP=[0 | 1]`

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230201:  The `[bed_mesh]` module no longer loads the `default` profile
+on startup.  It is recommended that users who use the `default` profile
+add `BED_MESH_PROFILE LOAD=default` to their `START_PRINT` macro (or
+to their slicer's "Start G-Code" configuration when applicable).
+
 20230103: It is now possible with the flash-sdcard.sh script to flash
 both variants of the Bigtreetech SKR-2, STM32F407 and STM32F429.
 This means that the original tag of btt-skr2 now has changed to either

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -129,7 +129,6 @@ class BedMesh:
     def handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
         self.bmc.print_generated_points(logging.info)
-        self.pmgr.initialize()
     def set_mesh(self, mesh):
         if mesh is not None and self.fade_end != self.FADE_DISABLE:
             self.log_fade_complete = True
@@ -1137,10 +1136,6 @@ class ProfileManager:
         self.gcode.register_command(
             'BED_MESH_PROFILE', self.cmd_BED_MESH_PROFILE,
             desc=self.cmd_BED_MESH_PROFILE_help)
-    def initialize(self):
-        self._check_incompatible_profiles()
-        if "default" in self.profiles:
-            self.load_profile("default")
     def get_profiles(self):
         return self.profiles
     def get_current_profile(self):


### PR DESCRIPTION
This makes a couple minor changes to the profile behavior for `bed_mesh`:

1) Require that a profile name be specified for the `PROFILE` parameter in `BED_MESH_CALIBRATE` and all parameters in `BED_MESH_PROFILE`.  This resolves #5875.

2) Introduce an `initial_profile` option.  This allows users to specify which profile is loaded at startup, or to bypass loading a profile at startup by specifying a profile name that doesn't exist (my preference is to set this to none).

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>