### PR TITLE
linux_mcu:  use correct gpio bias flags

### DIFF
--- a/src/linux/gpio.c
+++ b/src/linux/gpio.c
@@ -147,11 +147,11 @@ gpio_in_reset(struct gpio_in g, int8_t pull_up)
     memset(&req, 0, sizeof(req));
     req.lines = 1;
     req.flags = GPIOHANDLE_REQUEST_INPUT;
-#if defined(GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP)
+#if defined(GPIOHANDLE_REQUEST_BIAS_PULL_UP)
     if (pull_up > 0) {
-        req.flags |= GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP;
+        req.flags |= GPIOHANDLE_REQUEST_BIAS_PULL_UP;
     } else if (pull_up < 0) {
-        req.flags |= GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_DOWN;
+        req.flags |= GPIOHANDLE_REQUEST_BIAS_PULL_DOWN;
     }
 #endif
     req.lineoffsets[0] = g.line->offset;


### PR DESCRIPTION
This replaces stale gpiod bias flags introduced in the original pull request, #2787.   According to [this comment](https://github.com/Klipper3d/klipper/pull/2787#issuecomment-623004661) the decision was made to remove the libgpiod dependency and use ioctl's directly, however the bias flags were not updated.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>