### PR TITLE
safe_z_home: Fix final z hop to use relative z coordinates

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20221114: Previously, with safe_z_home, it was possible that the
+z_hop after the g28 homing would go in the negative z direction.
+Now, a z_hop is performed after g28 only if it results in a positive
+hop, mirroring the behavior of the z_hop the occurs before
+the g28 homing.
+
 20220616: It was previously possible to flash an rp2040 in bootloader
 mode by running `make flash FLASH_DEVICE=first`. The equivalent
 command is now `make flash FLASH_DEVICE=2e8a:0003`.

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -80,8 +80,9 @@ class SafeZHoming:
             # Perform Z Hop again for pressure-based probes
             if self.z_hop:
                 pos = toolhead.get_position()
-                toolhead.manual_move([None, None, pos[2] + self.z_hop],
-                                     self.z_hop_speed)
+                if pos[2] < self.z_hop:
+                    toolhead.manual_move([None, None, self.z_hop],
+                                         self.z_hop_speed)
             # Move XY back to previous positions
             if self.move_to_previous:
                 toolhead.manual_move(prevpos[:2], self.speed)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -79,7 +79,9 @@ class SafeZHoming:
             self.prev_G28(g28_gcmd)
             # Perform Z Hop again for pressure-based probes
             if self.z_hop:
-                toolhead.manual_move([None, None, self.z_hop], self.z_hop_speed)
+                pos = toolhead.get_position()
+                toolhead.manual_move([None, None, pos[2] + self.z_hop],
+                                     self.z_hop_speed)
             # Move XY back to previous positions
             if self.move_to_previous:
                 toolhead.manual_move(prevpos[:2], self.speed)


### PR DESCRIPTION
After a G28 z-axis homing, there is a final z hop. It was hoping to height z_hop as an absolute z height rather than relative.

If the z-axis home leaves the head at a z height higher than z_hop, e.g. because you were using a probe to do z homing, this meant that it was z hopping in the negative z direction, which could result in crashing the toolhead.

Signed-off-by: Joshua Redstone <redstone@gmail.com>