### PR TITLE
virtual_pins: initial implementation of virtual pins

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1562,6 +1562,13 @@ Marlin/RepRapFirmware compatible M486 G-Code macro.
 [exclude_object]
 ```
 
+### [virtual_pins]
+
+Enables support for virtual pins, unseful for testing purposes.
+
+See the [command reference](G-Codes.md#virtual_pins) for additional
+information.
+
 ## Resonance compensation
 
 ### [input_shaper]

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -278,3 +278,15 @@ using gtkwave with:
 ```
 gtkwave avrsim.vcd
 ```
+
+### Using virtual-pins
+
+The AVR atmega644p has a total of 40 pins, but only 30 of those can actually be
+used in Klipper (with 8 ADC capable).
+
+If you need more pins, you can use add a
+[virtual_pins config section](Config_Reference.md#virtual_pins) and start using
+`virtual_pin:<name>` as the pin name.
+
+The virtual pins can be modified at run-time using the
+[SET_VIRTUAL_PIN command](G-Codes.md#set_virtual_pin).

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1270,6 +1270,16 @@ three possible combinations of options:
   You can simply count bands or read tuning tower labels to determine
   the optimum value.
 
+### [virtual_pins]
+
+The following command is available when a
+[virtual_pins config section](Config_Reference.md#virtual_pins) is
+enabled.
+
+#### SET_VIRTUAL_PIN
+`SET_VIRTUAL_PIN PIN=<virtual_pin_name> VALUE=<value>`: This will
+alter the value of the specified virtual pin.
+
 ### [virtual_sdcard]
 
 Klipper supports the following standard G-Code commands if the

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -468,6 +468,13 @@ on a hybrid_corexy or hybrid_corexz robot
 - `active_carriage`: The current active carriage.
 Possible values are: "CARRIAGE_0", "CARRIAGE_1"
 
+## virtual_pins
+
+The following information is available in the
+[virtual_pins](Config_Reference.md#virtual_pins) object:
+- `pins`: Returns a dictionary containing the pin name and the value.
+  Additional fields may be available depending on the type of pin.
+
 ## virtual_sdcard
 
 The following information is available in the

--- a/klippy/extras/virtual_pins.py
+++ b/klippy/extras/virtual_pins.py
@@ -1,0 +1,221 @@
+# Virtual Pins support
+#
+# Copyright (C) 2022  Pedro Lamas <pedrolamas@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class VirtualPins:
+    def __init__(self, config):
+        self._printer = config.get_printer()
+        ppins = self._printer.lookup_object('pins')
+        ppins.register_chip('virtual_pin', self)
+        self._pins = {}
+        self._oid_count = 0
+        self._config_callbacks = []
+        self._printer.register_event_handler("klippy:connect",
+                                             self.handle_connect)
+
+    def handle_connect(self):
+        for cb in self._config_callbacks:
+            cb()
+
+    def setup_pin(self, pin_type, pin_params):
+        ppins = self._printer.lookup_object('pins')
+        name = pin_params['pin']
+        if name in self._pins:
+            return self._pins[name]
+        if pin_type == 'digital_out':
+            pin = DigitalOutVirtualPin(self, pin_params)
+        elif pin_type == 'pwm':
+            pin = PwmVirtualPin(self, pin_params)
+        elif pin_type == 'adc':
+            pin = AdcVirtualPin(self, pin_params)
+        elif pin_type == 'endstop':
+            pin = EndstopVirtualPin(self, pin_params)
+        else:
+            raise ppins.error("unable to create virtual pin of type %s" % (
+                pin_type,))
+        self._pins[name] = pin
+        return pin
+
+    def create_oid(self):
+        self._oid_count += 1
+        return self._oid_count - 1
+
+    def register_config_callback(self, cb):
+        self._config_callbacks.append(cb)
+
+    def seconds_to_clock(self, time):
+        return 0
+
+    def add_config_cmd(self, cmd, is_init=False, on_restart=False):
+        pass
+
+    def alloc_command_queue(self):
+        pass
+
+    def lookup_command(self, msgformat, cq=None):
+        return VirtualCommand()
+
+    def lookup_query_command(self, msgformat, respformat, oid=None,
+                             cq=None, is_async=False):
+        return VirtualCommandQuery(respformat, oid)
+
+    def get_printer(self):
+        return self._printer
+
+    def get_status(self, eventtime):
+        return {
+            'pins': {
+                name : pin.get_status(eventtime)
+                    for name, pin in self._pins.items()
+            }
+        }
+
+class VirtualCommand:
+    def send(self, data=(), minclock=0, reqclock=0):
+        pass
+
+class VirtualCommandQuery:
+    def __init__(self, respformat, oid):
+        entries = respformat.split()
+        self._response = {}
+        for entry in entries[1:]:
+            key, _ = entry.split('=')
+            self._response[key] = oid if key == 'oid' else 1
+
+    def send(self, data=(), minclock=0, reqclock=0):
+        return self._response
+
+    def send_with_preface(self, preface_cmd, preface_data=(), data=(),
+                          minclock=0, reqclock=0):
+        return self._response
+
+class VirtualPin:
+    def __init__(self, mcu, pin_params):
+        self._mcu = mcu
+        self._name = pin_params['pin']
+        self._pullup = pin_params['pullup']
+        self._invert = pin_params['invert']
+        self._value = self._pullup
+        printer = self._mcu.get_printer()
+        self._real_mcu = printer.lookup_object('mcu')
+        gcode = printer.lookup_object('gcode')
+        gcode.register_mux_command("SET_VIRTUAL_PIN", "PIN", self._name,
+                                   self.cmd_SET_VIRTUAL_PIN,
+                                   desc=self.cmd_SET_VIRTUAL_PIN_help)
+
+    cmd_SET_VIRTUAL_PIN_help = "Set the value of an output pin"
+    def cmd_SET_VIRTUAL_PIN(self, gcmd):
+        self._value = gcmd.get_float('VALUE', minval=0., maxval=1.)
+
+    def get_mcu(self):
+        return self._real_mcu
+
+class DigitalOutVirtualPin(VirtualPin):
+    def __init__(self, mcu, pin_params):
+        VirtualPin.__init__(self, mcu, pin_params)
+
+    def setup_max_duration(self, max_duration):
+        pass
+
+    def setup_start_value(self, start_value, shutdown_value):
+        self._value = start_value
+
+    def set_digital(self, print_time, value):
+        self._value = value
+
+    def get_status(self, eventtime):
+        return {
+            'value': self._value,
+            'type': 'digital_out'
+        }
+
+class PwmVirtualPin(VirtualPin):
+    def __init__(self, mcu, pin_params):
+        VirtualPin.__init__(self, mcu, pin_params)
+
+    def setup_max_duration(self, max_duration):
+        pass
+
+    def setup_start_value(self, start_value, shutdown_value):
+        self._value = start_value
+
+    def setup_cycle_time(self, cycle_time, hardware_pwm=False):
+        pass
+
+    def set_pwm(self, print_time, value, cycle_time=None):
+        self._value = value
+
+    def get_status(self, eventtime):
+        return {
+            'value': self._value,
+            'type': 'pwm'
+        }
+
+class AdcVirtualPin(VirtualPin):
+    def __init__(self, mcu, pin_params):
+        VirtualPin.__init__(self, mcu, pin_params)
+        self._callback = None
+        self._min_sample = 0.
+        self._max_sample = 0.
+        printer = self._mcu.get_printer()
+        printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+
+    def handle_connect(self):
+        reactor = self._mcu.get_printer().get_reactor()
+        reactor.register_timer(self._raise_callback, reactor.monotonic() + 2.)
+
+    def setup_adc_callback(self, report_time, callback):
+        self._callback = callback
+
+    def setup_minmax(self, sample_time, sample_count,
+                     minval=0., maxval=1., range_check_count=0):
+
+        self._min_sample = minval
+        self._max_sample = maxval
+
+    def _raise_callback(self, eventtime):
+        range = self._max_sample - self._min_sample
+        sample_value = (self._value * range) + self._min_sample
+        self._callback(eventtime, sample_value)
+
+    def get_status(self, eventtime):
+        return {
+            'value': self._value,
+            'type': 'adc'
+        }
+
+class EndstopVirtualPin(VirtualPin):
+    def __init__(self, mcu, pin_params):
+        VirtualPin.__init__(self, mcu, pin_params)
+        self._steppers = []
+
+    def add_stepper(self, stepper):
+        self._steppers.append(stepper)
+
+    def query_endstop(self, print_time):
+        return self._value
+
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        reactor = self._mcu.get_printer().get_reactor()
+        completion = reactor.completion()
+        completion.complete(True)
+        return completion
+
+    def home_wait(self, home_end_time):
+        return 1
+
+    def get_steppers(self):
+        return list(self._steppers)
+
+    def get_status(self, eventtime):
+        return {
+            'value': self._value,
+            'type': 'endstop'
+        }
+
+def load_config(config):
+    return VirtualPins(config)


### PR DESCRIPTION
This is a follow up on https://klipper.discourse.group/t/new-virtual-pins-module-for-testing-purposes/4727/6

As the AVR atmega644p only has 30 usable pins, that can be quite low when one wants to test features while developing for Fluidd or Mainsail.

This is where virtual-pins comes in!

On the “printer.cfg”, add a `[virtual_pins]` section, and from that point on, try setting a few pins to `virtual_pin:<pin-name>`.

That will add a new SET_VIRTUAL_PIN gcode command that allow to set a virtual pin value (pass `PIN=<pin-name>` and `VALUE=<value>`)

The global or individual pins state can be retrieved from the status of `printer.virtual_pins`.

Note: I understand that this might not be of usefulness in Klipper mainline (this is mostly a debug helper feature!), but in the end, its impact is only seen when the section is added, so I am sending a PR so that this can be properly evaluated.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>