### PR TITLE
Update Contacts.md with improved github issue tracker description

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Directions
+  - name: Contact Directions
     url: https://www.klipper3d.org/Contact.html
     about: Have a question? Need help? Start here.
   - name: Klipper Forum

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,6 +1,0 @@
----
-name: Create a Klipper github issue
-about: Working on improving Klipper? Provide an update on your work here.
----
-<!-- Directions have recently changed. Do not open this ticket without
- following the directions at: https://www.klipper3d.org/Contact.html -->

--- a/docs/Contact.md
+++ b/docs/Contact.md
@@ -7,8 +7,9 @@ This document provides contact information for Klipper.
 3. [I have a question about Klipper](#i-have-a-question-about-klipper)
 4. [I have a feature request](#i-have-a-feature-request)
 5. [Help! It doesn't work!](#help-it-doesnt-work)
-6. [I have diagnosed a defect in the Klipper software](#i-have-diagnosed-a-defect-in-the-klipper-software)
+6. [I found a bug in the Klipper software](#i-found-a-bug-in-the-klipper-software)
 7. [I am making changes that I'd like to include in Klipper](#i-am-making-changes-that-id-like-to-include-in-klipper)
+8. [Klipper github](#klipper-github)
 
 ## Community Forum
 
@@ -46,8 +47,6 @@ experiencing general printing problems, then you will likely get a
 better response by asking in a general 3d-printing forum or a forum
 dedicated to your printer hardware.
 
-Do not open a Klipper github issue to ask a question.
-
 ## I have a feature request
 
 All new features require someone interested and able to implement that
@@ -56,8 +55,6 @@ feature, you can search for ongoing developments in the
 [Klipper Community Forum](#community-forum). There is also
 [Klipper Discord Chat](#discord-chat) for discussions between
 collaborators.
-
-Do not open a Klipper github issue to request a feature.
 
 ## Help! It doesn't work!
 
@@ -88,35 +85,27 @@ other Klipper users then you can join the
 [Klipper Discord Chat](#discord-chat). Both are communities where
 Klipper users can discuss Klipper with other users.
 
-Do not open a Klipper github issue to request help.
-
-## I have diagnosed a defect in the Klipper software
+## I found a bug in the Klipper software
 
 Klipper is an open-source project and we appreciate when collaborators
 diagnose errors in the software.
 
+Problems should be reported in the
+[Klipper Community Forum](#community-forum).
+
 There is important information that will be needed in order to fix a
 bug. Please follow these steps:
-1. Be sure the bug is in the Klipper software. If you are thinking
-   "there is a problem, I can't figure out why, and therefore it is a
-   Klipper bug", then **do not** open a github issue. In that case,
-   someone interested and able will need to first research and
-   diagnose the root cause of the problem. If you would like to share
-   the results of your research or check if other users are
-   experiencing similar issues then you can search the
-   [Klipper Community Forum](#community-forum).
-2. Make sure you are running unmodified code from
+1. Make sure you are running unmodified code from
    [https://github.com/Klipper3d/klipper](https://github.com/Klipper3d/klipper).
    If the code has been modified or is obtained from another source,
-   then you will need to reproduce the problem on the unmodified code
-   from
+   then you should reproduce the problem on the unmodified code from
    [https://github.com/Klipper3d/klipper](https://github.com/Klipper3d/klipper)
-   prior to reporting an issue.
-3. If possible, run an `M112` command in the OctoPrint terminal window
-   immediately after the undesirable event occurs. This causes Klipper
-   to go into a "shutdown state" and it will cause additional
-   debugging information to be written to the log file.
-4. Obtain the Klipper log file from the event. The log file has been
+   prior to reporting.
+2. If possible, run an `M112` command immediately after the
+   undesirable event occurs. This causes Klipper to go into a
+   "shutdown state" and it will cause additional debugging information
+   to be written to the log file.
+3. Obtain the Klipper log file from the event. The log file has been
    engineered to answer common questions the Klipper developers have
    about the software and its environment (software version, hardware
    type, configuration, event timing, and hundreds of other
@@ -136,16 +125,12 @@ bug. Please follow these steps:
    4. Do not modify the log file in any way; do not provide a snippet
       of the log. Only the full unmodified log file provides the
       necessary information.
-   5. If the log file is very large (eg, greater than 2MB) then one
-      may need to compress the log with zip or gzip.
-5. Open a new github issue at
-   [https://github.com/Klipper3d/klipper/issues](https://github.com/Klipper3d/klipper/issues)
-   and provide a clear description of the problem. The Klipper
-   developers need to understand what steps were taken, what the
-   desired outcome was, and what outcome actually occurred. The
-   Klipper log file **must be attached** to that ticket:
-
-   ![attach-issue](img/attach-issue.png)
+   5. It is a good idea to compress the log file with zip or gzip.
+5. Open a new topic on the [Klipper Community Forum](#community-forum)
+   and provide a clear description of the problem. Other Klipper
+   contributors will need to understand what steps were taken, what
+   the desired outcome was, and what outcome actually occurred. The
+   compressed Klipper log file should be attached to that topic.
 
 ## I am making changes that I'd like to include in Klipper
 
@@ -159,7 +144,14 @@ There are several
 [documents for developers](Overview.md#developer-documentation). If
 you have questions on the code then you can also ask in the
 [Klipper Community Forum](#community-forum) or on the
-[Klipper Community Discord](#discord-chat). If you would like to
-provide an update on your current progress then you can open a Github
-issue with the location of your code, an overview of the changes, and
-a description of its current status.
+[Klipper Community Discord](#discord-chat).
+
+## Klipper github
+
+Klipper github may be used by contributors to share the status of
+their work to improve Klipper. It is expected that the person opening
+a github ticket is actively working on the given task and will be the
+one performing all the work necessary to accomplish it. The Klipper
+github is not used for requests, nor to report bugs, nor to ask
+questions. Use the [Klipper Community Forum](#community-forum) or the
+[Klipper Community Discord](#discord-chat) instead.


### PR DESCRIPTION
The Klipper github issue tracker isn't really used for anything at this point.  The Klipper discourse tool (along with Klipper discord) seem to be much better tools in general for tracking topics.  This PR updates the Contact.md document to be a little more clear on that.

Comments?
-Kevin