### PR TITLE
Multiple steppers per axis on CoreXZ

### DIFF
--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -9,13 +9,12 @@ import stepper
 class CoreXZKinematics:
     def __init__(self, toolhead, config):
         # Setup axis rails
-        self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
-                       stepper.PrinterRail(config.getsection('stepper_y')),
-                       stepper.PrinterRail(config.getsection('stepper_z')) ]
-        self.rails[0].get_endstops()[0][0].add_stepper(
-            self.rails[2].get_steppers()[0])
-        self.rails[2].get_endstops()[0][0].add_stepper(
-            self.rails[0].get_steppers()[0])
+        self.rails = [stepper.LookupMultiRail(config.getsection('stepper_' + n))
+                      for n in 'xyz']
+        for s in self.rails[0].get_steppers():
+            self.rails[2].get_endstops()[0][0].add_stepper(s)
+        for s in self.rails[2].get_steppers():
+            self.rails[0].get_endstops()[0][0].add_stepper(s)
         self.rails[0].setup_itersolve('corexz_stepper_alloc', b'+')
         self.rails[1].setup_itersolve('cartesian_stepper_alloc', b'y')
         self.rails[2].setup_itersolve('corexz_stepper_alloc', b'-')


### PR DESCRIPTION
Changes and sample configuration to make it possible to use multiple steppers on +/- axis on a CoreXZ.
Using a stepper in each corner shortens the slack of the belt in a CoreXZ. This is especially useful in larger setups.
It similar to [PR #4886](https://github.com/Klipper3d/klipper/pull/4886)
