### PR TITLE
My AZSMZ Mini + AZSMZ Display config

### DIFF
--- a/config/generic-azsmz-mini.cfg
+++ b/config/generic-azsmz-mini.cfg
@@ -1,0 +1,131 @@
+# This file contains common pin mappings for AZSMZ Mini and the fitting display. To use
+# this config, the firmware should be compiled for the LPC1769.
+
+# See docs/Config_Reference.md for a description of parameters.
+[include mainsail.cfg] 
+
+[stepper_x]
+step_pin: !P2.0
+dir_pin: !P0.5
+enable_pin: !P0.4
+microsteps: 16
+rotation_distance: 40 # 20T pulleys
+endstop_pin: !P1.24 
+position_endstop: 0
+position_max: 185
+homing_speed: 50
+
+[stepper_y]
+step_pin: !P2.1
+dir_pin: !P0.11
+enable_pin: !P0.10
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^P1.26
+position_endstop: 0
+position_max: 180
+homing_speed: 50
+
+[stepper_z]
+step_pin: P2.2
+dir_pin: P0.20
+enable_pin: !P0.19
+microsteps: 16
+rotation_distance: 4
+endstop_pin: probe:z_virtual_endstop # when using a probe on the endstop pin 
+position_min: -2 # The Z carriage may need to travel below the Z=0
+                 # homing point if the bed has a significant tilt.
+#endstop_pin: !P1.28 # -> When not using a probe
+#position_endstop: 1.5
+position_max: 180
+
+[extruder]
+step_pin: P2.3
+dir_pin: !P0.22
+enable_pin: !P0.21
+microsteps: 16
+rotation_distance: 7.711 # standard number for bmg-style extruder. But i have severe overextrusion issues with that. For now i'm using 0.8 extrusion factor in the slicer.
+#gear_ratio: "50:17" # bmg-style gear ratio. It's not really 3:1.
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.4 #D10 heater pin
+sensor_type: PT1000 # I use a directly connected pt1000. Works fine.
+sensor_pin: P0.23
+control: pid
+max_power: 0.6
+pid_kp = 10.491
+pid_ki = 0.416
+pid_kd = 66.093
+min_temp: 0
+max_temp: 300
+min_extrude_temp: 160
+max_extrude_only_distance: 301
+
+[probe]
+pin: !P1.28 #This is the Z Endstop pin. I use a 12-36v inductive probe with an lm1117-3.3 voltage-regulator board on the output. -> Brown to 12/24V, Blue to Ground. Black to LM1117 V-In, Ground from somewhere to LM1117 LM1117 Gnd In. LM1117 Outputs to Z-Endstop Sig and Gnd.
+x_offset: 25
+#   The distance (in mm) between the probe and the nozzle along the
+#   x-axis. The default is 0.
+y_offset: -7.5
+#   The distance (in mm) between the probe and the nozzle along the
+#   y-axis. The default is 0.
+z_offset: 2.4
+#   The distance (in mm) between the bed and the nozzle when the probe
+#   triggers. This parameter must be provided.
+samples_tolerance: 0.050
+samples_tolerance_retries: 0
+#   The number of times to retry if a sample is found that exceeds
+#   samples_tolerance. On a retry, all current samples are discarded
+#   and the probe attempt is restarted. If a valid set of samples are
+#   not obtained in the given number of retries then an error is
+#   reported. The default is zero which causes an error to be reported
+#   on the first sample that exceeds samples_tolerance.
+
+[safe_z_home]
+home_xy_position: 0, 0
+speed: 50
+z_hop: 5
+z_hop_speed: 7
+
+[bed_mesh]
+mesh_min: 25, 10
+mesh_max: 185, 175
+probe_count: 5, 5
+
+[heater_bed]
+heater_pin: P2.5 #D8 Heater pin
+sensor_type: Generic 3950
+sensor_pin: P0.25
+min_temp: 0
+max_temp: 150
+control = pid
+pid_kp = 48.791
+pid_ki = 2.243
+pid_kd = 265.301
+
+[fan]
+pin: P0.26 #The fan control pin regulates the ground, so you need to connect Black to FAN, Red to VCC! The unregulated fan is between Gnd and VCC.
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_lpc1769_0B50000803A43DAE70C4BB53C42000F5-if00
+[static_digital_output leds]
+pins: P1.18, P1.19, P1.20, P1.21
+
+# AZSMZ Mini Display
+[display]
+lcd_type: uc1701
+cs_pin: P1.22
+a0_pin: P2.6
+spi_software_sclk_pin: P0.15
+spi_software_mosi_pin: P0.18
+spi_software_miso_pin: P0.17
+encoder_pins: ^P4.28, ^P1.27
+click_pin: ^!P3.26
+contrast: 60
+
+[printer]
+kinematics: corexy # Hypercube CoreXY printer
+max_velocity: 300
+max_accel: 2000
+max_z_velocity: 5
+max_z_accel: 100


### PR DESCRIPTION
Hi, 

in the last years i changed every single part of my corexy project, so i decided to reuse the leftovers in the "Trashcube". 

Part of this was configuring Klipper for this chinese Smoothieboard clone with the fitting display:
[AZSMZ Mini](https://de.aliexpress.com/item/32835645667.html) and [AZSMZ 12864 LCD](https://de.aliexpress.com/item/32837222770.html)

It's not directly supported by Smoothieware, so the last FW-Version was from 2017 and a pain to use. I'd never have reused it again without Klipper, love your work! Maybe someone also has that hacky abomination laying around, so i'd like to contribute this.



