### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -4,7 +4,7 @@
 #   pip install -r klippy-requirements.txt
 cffi==1.14.6
 pyserial==3.4
-greenlet==1.1.2
+greenlet==2.0.1
 Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1


### PR DESCRIPTION
No breaking changes are identified in the greenlet changelog (besides requiring C++11) at https://greenlet.readthedocs.io/en/latest/changes.html, and in my testing, this works fine.

Without this change, there's a bunch of errors like the following when doing `pip install`:

```
arm-linux-gnueabihf-gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/opt/klipper/include -I/usr/include/python3.11 -c src/greenlet/greenlet.c -o build/temp.linux-armv7l-cpython-311/src/greenlet/greenlet.o
      In file included from src/greenlet/greenlet.c:11:
      src/greenlet/greenlet.h:42:5: error: unknown type name ‘CFrame’
         42 |     CFrame* cframe;
            |     ^~~~~~
      src/greenlet/greenlet.c: In function ‘green_clear_exc’:
      src/greenlet/greenlet.c:173:17: error: ‘_PyErr_StackItem’ {aka ‘struct _err_stackitem’} has no member named ‘exc_type’
        173 |     g->exc_state.exc_type = NULL;
            |                 ^
      src/greenlet/greenlet.c:175:17: error: ‘_PyErr_StackItem’ {aka ‘struct _err_stackitem’} has no member named ‘exc_traceback’
        175 |     g->exc_state.exc_traceback = NULL;
            |                 ^
      src/greenlet/greenlet.c: In function ‘g_switchstack’:
      src/greenlet/greenlet.c:528:44: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘recursion_depth’; did you mean ‘recursion_limit’?
        528 |         current->recursion_depth = tstate->recursion_depth;
            |                                            ^~~~~~~~~~~~~~~
            |                                            recursion_limit
      src/greenlet/greenlet.c:529:38: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘frame’; did you mean ‘cframe’?
        529 |         current->top_frame = tstate->frame;
            |                                      ^~~~~
            |                                      cframe
      src/greenlet/greenlet.c:552:25: warning: assignment to ‘int *’ from incompatible pointer type ‘_PyCFrame *’ [-Wincompatible-pointer-types]
        552 |         current->cframe = tstate->cframe;
            |                         ^
      src/greenlet/greenlet.c:577:17: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘recursion_depth’; did you mean ‘recursion_limit’?
        577 |         tstate->recursion_depth = target->recursion_depth;
            |                 ^~~~~~~~~~~~~~~
            |                 recursion_limit
      src/greenlet/greenlet.c:578:17: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘frame’; did you mean ‘cframe’?
        578 |         tstate->frame = target->top_frame;
            |                 ^~~~~
            |                 cframe
      src/greenlet/greenlet.c:601:24: warning: assignment to ‘_PyCFrame *’ from incompatible pointer type ‘int *’ [-Wincompatible-pointer-types]
        601 |         tstate->cframe = target->cframe;
            |                        ^
      src/greenlet/greenlet.c: In function ‘g_initialstub’:
      src/greenlet/greenlet.c:813:5: error: unknown type name ‘CFrame’
        813 |     CFrame trace_info;
            |     ^~~~~~
      src/greenlet/greenlet.c:857:18: error: incompatible types when assigning to type ‘int’ from type ‘_PyCFrame’
        857 |     trace_info = *PyThreadState_GET()->cframe;
            |                  ^
      src/greenlet/greenlet.c:864:17: error: request for member ‘previous’ in something not a structure or union
        864 |     self->cframe->previous = &PyThreadState_GET()->root_cframe;
            |                 ^~
      src/greenlet/greenlet.c:878:50: error: ‘PyThreadState’ {aka ‘struct _ts’} has no member named ‘recursion_depth’; did you mean ‘recursion_limit’?
        878 |     self->recursion_depth = PyThreadState_GET()->recursion_depth;
            |                                                  ^~~~~~~~~~~~~~~
            |                                                  recursion_limit
```