### PR TITLE
stm32h7_adc: Fix potential race condition with ADC values

### DIFF
--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -280,7 +280,7 @@ gpio_adc_sample(struct gpio_adc g)
     if (adc->ISR & ADC_ISR_EOC && adc->SQR1 == (g.chan << ADC_SQR1_SQ1_Pos))
         return 0;
     // Conversion started but not ready or wrong channel
-    if (adc->CR & ADC_CR_ADSTART)
+    if (adc->CR & ADC_CR_ADSTART || adc->ISR & ADC_ISR_EOC)
         return timer_from_us(10);
     // Start sample
     adc->SQR1 = (g.chan << ADC_SQR1_SQ1_Pos);


### PR DESCRIPTION
When playing around with some adc setups i found that if the timer checking the adc values is set to a time significantly after the conversion is ready, the values between different adc pins could get mixed up. With the stock klipper code this was extremely unlikely to happen as the adc request would have to arrive within a window of <1us.

This was already forshadowed by the comment 
 // ADSTART is not as long true as SR_STRT on stm32f4
