### PR TITLE
tmc: Configurable microstep lookup table

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3073,6 +3073,23 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#driver_MSLUT0: 2863314260
+#driver_MSLUT1: 1251300522
+#driver_MSLUT2: 608774441
+#driver_MSLUT3: 269500962
+#driver_MSLUT4: 4227858431
+#driver_MSLUT5: 3048961917
+#driver_MSLUT6: 1227445590
+#driver_MSLUT7: 4211234
+#driver_MSLUTSEL: 4294934614
+#driver_MSLUTSTART: 16187392
+#   These fields control the Microstep Table registers directly. The optimal
+#   wave table is specific to each motor and might vary with current. An
+#   optimal configuration will have minimal print artifacts caused by
+#   non-linear stepper movement. The values specified above are the default
+#   values used by the driver. The value must be specified as a decimal integer
+#   (hex form is not supported). In order to compute the wave table fields,
+#   see the tmc2130 "Calculation Sheet" from the Trinamic website.
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 0
 #driver_TBL: 1
@@ -3328,6 +3345,23 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#driver_MSLUT0: 2863314260
+#driver_MSLUT1: 1251300522
+#driver_MSLUT2: 608774441
+#driver_MSLUT3: 269500962
+#driver_MSLUT4: 4227858431
+#driver_MSLUT5: 3048961917
+#driver_MSLUT6: 1227445590
+#driver_MSLUT7: 4211234
+#driver_MSLUTSEL: 4294934614
+#driver_MSLUTSTART: 16187392
+#   These fields control the Microstep Table registers directly. The optimal
+#   wave table is specific to each motor and might vary with current. An
+#   optimal configuration will have minimal print artifacts caused by
+#   non-linear stepper movement. The values specified above are the default
+#   values used by the driver. The value must be specified as a decimal integer
+#   (hex form is not supported). In order to compute the wave table fields,
+#   see the tmc2130 "Calculation Sheet" from the Trinamic website.
 #driver_IHOLDDELAY: 6
 #driver_TPOWERDOWN: 10
 #driver_TBL: 2

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3081,8 +3081,15 @@ run_current:
 #driver_MSLUT5: 3048961917
 #driver_MSLUT6: 1227445590
 #driver_MSLUT7: 4211234
-#driver_MSLUTSEL: 4294934614
-#driver_MSLUTSTART: 16187392
+#driver_W0: 2
+#driver_W1: 1
+#driver_W2: 1
+#driver_W3: 1
+#driver_X1: 128
+#driver_X2: 255
+#driver_X3: 255
+#driver_START_SIN: 0
+#driver_START_SIN90: 247
 #   These fields control the Microstep Table registers directly. The optimal
 #   wave table is specific to each motor and might vary with current. An
 #   optimal configuration will have minimal print artifacts caused by
@@ -3353,8 +3360,15 @@ run_current:
 #driver_MSLUT5: 3048961917
 #driver_MSLUT6: 1227445590
 #driver_MSLUT7: 4211234
-#driver_MSLUTSEL: 4294934614
-#driver_MSLUTSTART: 16187392
+#driver_W0: 2
+#driver_W1: 1
+#driver_W2: 1
+#driver_W3: 1
+#driver_X1: 128
+#driver_X2: 255
+#driver_X3: 255
+#driver_START_SIN: 0
+#driver_START_SIN90: 247
 #   These fields control the Microstep Table registers directly. The optimal
 #   wave table is specific to each motor and might vary with current. An
 #   optimal configuration will have minimal print artifacts caused by

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -501,6 +501,20 @@ class TMCVirtualPinHelper:
 # Config reading helpers
 ######################################################################
 
+# Helper to initialize the wave table from config or defaults
+def TMCWaveTableHelper(config, mcu_tmc):
+    set_config_field = mcu_tmc.get_fields().set_config_field
+    set_config_field(config, "mslut0", 0xAAAAB554)
+    set_config_field(config, "mslut1", 0x4A9554AA)
+    set_config_field(config, "mslut2", 0x24492929)
+    set_config_field(config, "mslut3", 0x10104222)
+    set_config_field(config, "mslut4", 0xFBFFFFFF)
+    set_config_field(config, "mslut5", 0xB5BB777D)
+    set_config_field(config, "mslut6", 0x49295556)
+    set_config_field(config, "mslut7", 0x00404222)
+    set_config_field(config, "mslutsel", 0xFFFF8056)
+    set_config_field(config, "mslutstart", 0x00F70000)
+
 # Helper to configure and query the microstep settings
 def TMCMicrostepHelper(config, mcu_tmc):
     fields = mcu_tmc.get_fields()

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -512,8 +512,15 @@ def TMCWaveTableHelper(config, mcu_tmc):
     set_config_field(config, "mslut5", 0xB5BB777D)
     set_config_field(config, "mslut6", 0x49295556)
     set_config_field(config, "mslut7", 0x00404222)
-    set_config_field(config, "mslutsel", 0xFFFF8056)
-    set_config_field(config, "mslutstart", 0x00F70000)
+    set_config_field(config, "w0", 2)
+    set_config_field(config, "w1", 1)
+    set_config_field(config, "w2", 1)
+    set_config_field(config, "w3", 1)
+    set_config_field(config, "x1", 128)
+    set_config_field(config, "x2", 255)
+    set_config_field(config, "x3", 255)
+    set_config_field(config, "start_sin", 0)
+    set_config_field(config, "start_sin90", 247)
 
 # Helper to configure and query the microstep settings
 def TMCMicrostepHelper(config, mcu_tmc):

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -55,8 +55,19 @@ Fields["MSLUT4"] = { "mslut4": 0xffffffff }
 Fields["MSLUT5"] = { "mslut5": 0xffffffff }
 Fields["MSLUT6"] = { "mslut6": 0xffffffff }
 Fields["MSLUT7"] = { "mslut7": 0xffffffff }
-Fields["MSLUTSEL"] = { "mslutsel": 0xffffffff }
-Fields["MSLUTSTART"] = { "mslutstart": 0xffffffff }
+Fields["MSLUTSEL"] = {
+    "x3":                       0xFF << 24,
+    "x2":                       0xFF << 16,
+    "x1":                       0xFF << 8,
+    "w3":                       0x03 << 6,
+    "w2":                       0x03 << 4,
+    "w1":                       0x03 << 2,
+    "w0":                       0x03 << 0,
+}
+Fields["MSLUTSTART"] = {
+    "start_sin":                0xFF << 0,
+    "start_sin90":              0xFF << 16,
+}
 Fields["MSCNT"] = { "mscnt": 0x3ff }
 Fields["MSCURACT"] = { "cur_a": 0x1ff, "cur_b": 0x1ff << 16 }
 Fields["CHOPCONF"] = {

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -11,10 +11,12 @@ TMC_FREQUENCY=13200000.
 Registers = {
     "GCONF": 0x00, "GSTAT": 0x01, "IOIN": 0x04, "IHOLD_IRUN": 0x10,
     "TPOWERDOWN": 0x11, "TSTEP": 0x12, "TPWMTHRS": 0x13, "TCOOLTHRS": 0x14,
-    "THIGH": 0x15, "XDIRECT": 0x2d, "MSLUT0": 0x60, "MSLUTSEL": 0x68,
-    "MSLUTSTART": 0x69, "MSCNT": 0x6a, "MSCURACT": 0x6b, "CHOPCONF": 0x6c,
-    "COOLCONF": 0x6d, "DCCTRL": 0x6e, "DRV_STATUS": 0x6f, "PWMCONF": 0x70,
-    "PWM_SCALE": 0x71, "ENCM_CTRL": 0x72, "LOST_STEPS": 0x73,
+    "THIGH": 0x15, "XDIRECT": 0x2d, "MSLUT0": 0x60, "MSLUT1": 0x61,
+    "MSLUT2": 0x62, "MSLUT3": 0x63, "MSLUT4": 0x64, "MSLUT5": 0x65,
+    "MSLUT6": 0x66, "MSLUT7": 0x67, "MSLUTSEL": 0x68, "MSLUTSTART": 0x69,
+    "MSCNT": 0x6a, "MSCURACT": 0x6b, "CHOPCONF": 0x6c, "COOLCONF": 0x6d,
+    "DCCTRL": 0x6e, "DRV_STATUS": 0x6f, "PWMCONF": 0x70, "PWM_SCALE": 0x71,
+    "ENCM_CTRL": 0x72, "LOST_STEPS": 0x73,
 }
 
 ReadRegisters = [
@@ -45,6 +47,16 @@ Fields["TSTEP"] = { "tstep": 0xfffff }
 Fields["TPWMTHRS"] = { "tpwmthrs": 0xfffff }
 Fields["TCOOLTHRS"] = { "tcoolthrs": 0xfffff }
 Fields["THIGH"] = { "thigh": 0xfffff }
+Fields["MSLUT0"] = { "mslut0": 0xffffffff }
+Fields["MSLUT1"] = { "mslut1": 0xffffffff }
+Fields["MSLUT2"] = { "mslut2": 0xffffffff }
+Fields["MSLUT3"] = { "mslut3": 0xffffffff }
+Fields["MSLUT4"] = { "mslut4": 0xffffffff }
+Fields["MSLUT5"] = { "mslut5": 0xffffffff }
+Fields["MSLUT6"] = { "mslut6": 0xffffffff }
+Fields["MSLUT7"] = { "mslut7": 0xffffffff }
+Fields["MSLUTSEL"] = { "mslutsel": 0xffffffff }
+Fields["MSLUTSTART"] = { "mslutstart": 0xffffffff }
 Fields["MSCNT"] = { "mscnt": 0x3ff }
 Fields["MSCURACT"] = { "cur_a": 0x1ff, "cur_b": 0x1ff << 16 }
 Fields["CHOPCONF"] = {
@@ -268,6 +280,7 @@ class TMC2130:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
+        tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -171,6 +171,16 @@ Fields["IOIN"] = {
 Fields["LOST_STEPS"] = {
     "lost_steps":               0xfffff << 0
 }
+Fields["MSLUT0"] = { "mslut0": 0xffffffff }
+Fields["MSLUT1"] = { "mslut1": 0xffffffff }
+Fields["MSLUT2"] = { "mslut2": 0xffffffff }
+Fields["MSLUT3"] = { "mslut3": 0xffffffff }
+Fields["MSLUT4"] = { "mslut4": 0xffffffff }
+Fields["MSLUT5"] = { "mslut5": 0xffffffff }
+Fields["MSLUT6"] = { "mslut6": 0xffffffff }
+Fields["MSLUT7"] = { "mslut7": 0xffffffff }
+Fields["MSLUTSEL"] = { "mslutsel": 0xffffffff }
+Fields["MSLUTSTART"] = { "mslutstart": 0xffffffff }
 Fields["MSCNT"] = {
     "mscnt":                    0x3ff << 0
 }
@@ -299,6 +309,7 @@ class TMC5160:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
+        tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         #   CHOPCONF
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -179,8 +179,19 @@ Fields["MSLUT4"] = { "mslut4": 0xffffffff }
 Fields["MSLUT5"] = { "mslut5": 0xffffffff }
 Fields["MSLUT6"] = { "mslut6": 0xffffffff }
 Fields["MSLUT7"] = { "mslut7": 0xffffffff }
-Fields["MSLUTSEL"] = { "mslutsel": 0xffffffff }
-Fields["MSLUTSTART"] = { "mslutstart": 0xffffffff }
+Fields["MSLUTSEL"] = {
+    "x3":                       0xFF << 24,
+    "x2":                       0xFF << 16,
+    "x1":                       0xFF << 8,
+    "w3":                       0x03 << 6,
+    "w2":                       0x03 << 4,
+    "w1":                       0x03 << 2,
+    "w0":                       0x03 << 0,
+}
+Fields["MSLUTSTART"] = {
+    "start_sin":                0xFF << 0,
+    "start_sin90":              0xFF << 16,
+}
 Fields["MSCNT"] = {
     "mscnt":                    0x3ff << 0
 }


### PR DESCRIPTION
Make all the tmc microstep lookup table registers configurable via the config file. It also loads the default values on startup if the parameters are not provided. TMC220x and TMC2660 do not support this feature (only TMC2130 and TMC5160 for now).
Without this PR these registers can't be configured at all (no fields defined, just the register address, so not even SET_TMC_FIELD works). Without this PR the default values are also not loaded, so it is possible to use an incorrect value in these registers if you switch from a firmware that uses them (eg, Prusa-Firmware for the MK3) and don't power cycle the printer.

And here is a request for this feature on the klipper forum: https://klipper.discourse.group/t/access-to-tmc-microstep-lookup-table-registers/2903?u=leptun. There are more, but this was the only direct request for this feature.

Todo: update docs after everything else is accepted