### PR TITLE
Add get_status() method to screws_tilt_adjust

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -375,21 +375,21 @@ The following information is available in the `screws_tilt_adjust`
 object:
 - `error`: Returns True if the most recent `SCREWS_TILT_CALCULATE`
   command included the `MAX_DEVIATION` parameter and any of the probed
-  screw points exceeded the specified `MAX_DEVIATION`. 
+  screw points exceeded the specified `MAX_DEVIATION`.
 - `results`: A list of the probed screw locations. Each entry in
   the list will be a dictionary containing the following keys:
   - `name`: The name of the screw as specified in the config file.
   - `x`: The X coordinate of the screw as specified in the config file.
   - `y`: The Y coordinate of the screw as specified in the config file.
   - `z`: The measured Z height of the screw location.
-  - `sign`: A string specifying the direction to turn to screw for the 
+  - `sign`: A string specifying the direction to turn to screw for the
     necessary adjustment. Either "CW" for clockwise or "CCW" for
     counterclockwise. The base screw will not have a `sign` key.
   - `adjust`: The number of screw turns to adjust the screw, given in
     the format "HH:MM," where "HH" is the number of full screw turns
     and "MM" is the number of "minutes of a clock face" representing
     a partial screw turn. (E.g. "01:15" would mean to turn the screw
-    one and a quarter revolutions.) 
+    one and a quarter revolutions.)
 
 ## servo
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -369,6 +369,28 @@ The following information is available in the `query_endstops` object
   the QUERY_ENDSTOP command must be run prior to the macro containing
   this reference.
 
+## screws_tilt_adjust
+
+The following information is available in the `screws_tilt_adjust`
+object:
+- `error`: Returns True if the most recent `SCREWS_TILT_CALCULATE`
+  command included the `MAX_DEVIATION` parameter and any of the probed
+  screw points exceeded the specified `MAX_DEVIATION`. 
+- `results`: A list of the probed screw locations. Each entry in
+  the list will be a dictionary containing the following keys:
+  - `name`: The name of the screw as specified in the config file.
+  - `x`: The X coordinate of the screw as specified in the config file.
+  - `y`: The Y coordinate of the screw as specified in the config file.
+  - `z`: The measured Z height of the screw location.
+  - `sign`: A string specifying the direction to turn to screw for the 
+    necessary adjustment. Either "CW" for clockwise or "CCW" for
+    counterclockwise. The base screw will not have a `sign` key.
+  - `adjust`: The number of screw turns to adjust the screw, given in
+    the format "HH:MM," where "HH" is the number of full screw turns
+    and "MM" is the number of "minutes of a clock face" representing
+    a partial screw turn. (E.g. "01:15" would mean to turn the screw
+    one and a quarter revolutions.) 
+
 ## servo
 
 The following information is available in

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -93,7 +93,7 @@ class ScrewsTiltAdjust:
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
                 self.results.append({'name': name + ' (base)', 'x': coord[0],
-                    'y': coord[1], 'z': z})
+                    'y': coord[1], 'z': z, 'sign': 'CW', 'adjust':'00:00'})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -12,7 +12,9 @@ class ScrewsTiltAdjust:
         self.config = config
         self.printer = config.get_printer()
         self.screws = []
+        self.results = []
         self.max_diff = None
+        self.max_diff_error = False
         # Read config
         for i in range(99):
             prefix = "screw%d" % (i + 1,)
@@ -57,7 +59,13 @@ class ScrewsTiltAdjust:
         self.direction = direction
         self.probe_helper.start_probe(gcmd)
 
+    def get_status(self, eventtime):
+        return {'error': self.max_diff_error,
+            'results': self.results}
+
     def probe_finalize(self, offsets, positions):
+        self.results = []
+        self.max_diff_error = False
         # Factors used for CW-M3, CCW-M3, CW-M4, CCW-M4, CW-M5 and CCW-M5
         threads_factor = {0: 0.5, 1: 0.5, 2: 0.7, 3: 0.7, 4: 0.8, 5: 0.8}
         is_clockwise_thread = (self.thread & 1) == 0
@@ -84,6 +92,8 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
+                self.results.append({'name':name + ' (base)', 'x':coord[0],
+                    'y':coord[1], 'z':z})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -104,7 +114,11 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
+                self.results.append({'name':name, 'x':coord[0], 'y':coord[1],
+                    'z':z, 'sign':sign,
+                    'adjust':"%02d:%02d" % (full_turns, minutes)})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
+            self.max_diff_error = True
             raise self.gcode.error(
                 "bed level exceeds configured limits ({}mm)! " \
                 "Adjust screws and restart print.".format(self.max_diff))

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -92,8 +92,8 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
-                self.results.append({'name':name + ' (base)', 'x':coord[0],
-                    'y':coord[1], 'z':z})
+                self.results.append({'name': name + ' (base)', 'x': coord[0],
+                    'y': coord[1], 'z': z})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -114,8 +114,8 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
-                self.results.append({'name':name, 'x':coord[0], 'y':coord[1],
-                    'z':z, 'sign':sign,
+                self.results.append({'name': name, 'x': coord[0], 'y': coord[1],
+                    'z': z, 'sign': sign,
                     'adjust':"%02d:%02d" % (full_turns, minutes)})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
             self.max_diff_error = True


### PR DESCRIPTION
_This is a resubmission of my earlier [PR #4634](https://github.com/Klipper3d/klipper/pull/4634) with additional work to fix the previously identified whitespace issues and to add the required documentation. Here's the explanation from the original PR:_

This adds a get_status() method to the screws_tilt_adjust.py module so that gcode macros and menu elements can read the results from the `screws_tilt_calculate` command. This creates a new `printer.screws_tilt_adjust` object with two properties:

`error`: False by default, but True if the `screws_tilt_calculate` command triggered the "bed level exceeds configured limits" error.
`results`: Until the `screws_tilt_calculate` command is run, this is an empty python list. But once `screws_tilt_calculate` has completed successfully, this is a list containing a python dictionary for each configured bed screw. Each of those dictionaries contains the following keys:

- **name**: Value is the name of the screw from the config file
- **x**: Value is the configured X coordinate of the screw
- **y**: Value is the configured Y coordinate of the screw
- **z**: Value is the measured Z probe height above the screw
- **sign**:* Value is either "CW" for clockwise or "CCW" for counter-clockwise 
- **adjust**:* Value is the amount the screw must be adjusted, expressed in the same "time" format as is output in the console. (e.g. `01:15` for one full turn plus a quarter turn)

*_The dictionary for the "base" screw does not have the **sign** or **adjust** keys because the calculation assumes the base screw will not be adjusted._

I have successfully used this new get_status() method together with a handful of macros, custom menus, display groups, and even a couple of custom glyphs to enable Z-probe bed tramming directly from the printer LCD, with a rudimentary GUI and everything.