### PR TITLE
save_variables: Verify filename path is writeable at startup

### DIFF
--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -12,6 +12,8 @@ class SaveVariables:
         self.filename = os.path.expanduser(config.get('filename'))
         self.allVariables = {}
         try:
+            if not os.path.exists(self.filename):
+                open(self.filename, "w").close()
             self.loadVariables()
         except self.printer.command_error as e:
             raise config.error(str(e))


### PR DESCRIPTION
I've helped a number of people diagnose confusing `save_variable` errors because they copied the `filename` path in from a setup guide, but the copied path was actually invalid on their config. So, this just tries to create an empty file at `filename` if one is not already present. That way the user will get an error pointing to the bad path at startup, rather than a more confusing `'dict object' has no attribute` error sometime later while the printer is running.

Signed-off-by: Justin Schuh <code@justinschuh.com>