### PR TITLE
config: printer-artillery-sidewinder-x2-2022.cfg

### DIFF
--- a/config/printer-artillery-sidewinder-x2-2022.cfg
+++ b/config/printer-artillery-sidewinder-x2-2022.cfg
@@ -132,9 +132,9 @@ screw1_name: front left
 screw2: 223,63
 screw2_name: front right
 screw3: 223,263
-screw3_name: back left
+screw3_name: back right
 screw4: 23,263
-screw4_name: back right
+screw4_name: back left
 speed: 100.0
 screw_thread: CW-M5
 


### PR DESCRIPTION
Minor fix. The screw labels "back left" and "back right" where swapped in [screws_tilt_adjust] section.

Signed-off-by: Frank Roth <developer@freakydu.de>