### PR TITLE
linux process: add 'GPIOI' for linux process

### DIFF
--- a/src/linux/gpio.c
+++ b/src/linux/gpio.c
@@ -27,6 +27,7 @@ DECL_ENUMERATION_RANGE("pin", "gpiochip4/gpio0", GPIO(4, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip5/gpio0", GPIO(5, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip6/gpio0", GPIO(6, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip7/gpio0", GPIO(7, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip8/gpio0", GPIO(8, 0), MAX_GPIO_LINES);
 
 struct gpio_line {
     int chipid;
@@ -34,8 +35,8 @@ struct gpio_line {
     int fd;
     int state;
 };
-static struct gpio_line gpio_lines[8 * MAX_GPIO_LINES];
-static int gpio_chip_fd[8] = { -1, -1, -1, -1, -1, -1, -1, -1 };
+static struct gpio_line gpio_lines[9 * MAX_GPIO_LINES];
+static int gpio_chip_fd[9] = { -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
 static int
 get_chip_fd(uint8_t chipId)

--- a/src/linux/internal.h
+++ b/src/linux/internal.h
@@ -6,7 +6,7 @@
 #include <stdint.h> // uint32_t
 #include "autoconf.h" // CONFIG_CLOCK_FREQ
 
-#define MAX_GPIO_LINES    256
+#define MAX_GPIO_LINES    288
 #define GPIO(PORT, NUM) ((PORT) * MAX_GPIO_LINES + (NUM))
 #define GPIO2PORT(PIN) ((PIN) / MAX_GPIO_LINES)
 #define GPIO2PIN(PIN) ((PIN) % MAX_GPIO_LINES)


### PR DESCRIPTION
Add the Klipper control of `GPIOI` port for BTT CB1 (H616). Theoretically, it will not have a negative impact on other SoC.