### PR TITLE
STM32 G0 and G4 fix SWD debug

### DIFF
--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -183,8 +183,11 @@ armcm_main(void)
 
     check_usb_dfu_bootloader();
 
-    // Set flash latency
-    FLASH->ACR = (2<<FLASH_ACR_LATENCY_Pos) | FLASH_ACR_ICEN | FLASH_ACR_PRFTEN;
+    // Set flash latency, cache and prefetch; use reset value as base
+    uint32_t acr = 0x00040600;
+    acr = (acr & ~FLASH_ACR_LATENCY) | (2<<FLASH_ACR_LATENCY_Pos);
+    acr |= FLASH_ACR_ICEN | FLASH_ACR_PRFTEN;
+    FLASH->ACR = acr;
 
     // Configure main clock
     clock_setup();

--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -130,7 +130,7 @@ clock_setup(void)
                        ((CONFIG_CLOCK_FREQ>30000000) ? FLASH_ACR_LATENCY_1WS :
                                                     FLASH_ACR_LATENCY_0WS)))));
     FLASH->ACR = (latency | FLASH_ACR_ICEN | FLASH_ACR_DCEN
-                  | FLASH_ACR_PRFTEN);
+                  | FLASH_ACR_PRFTEN | FLASH_ACR_DBG_SWEN);
 
     enable_pclock(PWR_BASE);
     PWR->CR3 |= PWR_CR3_APC; // allow gpio pullup/down


### PR DESCRIPTION
Do not clear the DBG_SWEN bit for the MCU families that have it. This bit is by default set to 1 on reset, but the flash latency initialization code would overwrite that bit with 0, disabling the SWD interface.
The G4 can just use a simple mask for the bit, but on the G0 family it's a bit more complicated since not all MCUs have that bit present. In this particular case, the G0x1 family has this bit, but on the G0x0 family it is defined as "reserved". Unfortunately, even though it is reserved, it still might exist there and function correctly (as was the case with my board), so it might be better to follow the instructions from the datasheet in this case and keep reserved bits to the reset value.

@mattthebaker ping as requested by Kevin.