### PR TITLE
Add bootloader 64Kib for Lerdge Board

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -235,6 +235,8 @@ choice
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F4x5
     config STM32_FLASH_START_10000
         bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446 || MACH_STM32F401
+    config STM32_FLASH_START_10000
+        bool "64KiB bootloader (Lerdge Board)" if MACH_STM32F4
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103


### PR DESCRIPTION
I tested the Lerdge X board. The main functionality works. Currently there is no screen and touchscreen support.
Links for instructions and files:

https://www.lerdge.com/document/detail/Klipper-tutorial1
https://www.lerdge.com/public/upload/file/Klipper%20Firmware%20for%20Lerdge%20&%20Klipper%20printer%20config.zip