### PR TITLE
Docs: make pico/mpu example cfg match example wiring

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -195,7 +195,7 @@ serial: /dev/serial/by-id/<your PICO's serial ID>
 
 [mpu9250]
 i2c_mcu: pico
-i2c_bus: i2c1a
+i2c_bus: i2c0a
 
 [resonance_tester]
 accel_chip: mpu9250
@@ -203,7 +203,7 @@ probe_points:
     100, 100, 20  # an example
 
 [static_digital_output pico_3V3pwm] # Improve power stability
-pin: pico:gpio23
+pins: pico:gpio23
 ```
 
 Restart Klipper via the `RESTART` command.


### PR DESCRIPTION
The [wiring diagram example](https://github.com/Klipper3d/klipper/blob/228259da1e74f0a24788d1cead23a8dabaf9cb38/docs/Measuring_Resonances.md) for pico+mpu shows i2c0a, but config example shows i2c1a and will cause timeout.

Additionally, pin -> pins in [current config reference](https://www.klipper3d.org/Config_Reference.html#static_digital_output).