### PR TITLE
scripts: Python3 compatability

### DIFF
--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -14,7 +14,7 @@ klippy/chelper/__init__.py`.
 ## Compiling python code
 
 Many distributions have a policy of compiling all python code before packaging
-to improve startup time. You can do this by running `python2 -m compileall
+to improve startup time. You can do this by running `python3 -m compileall
 klippy`.
 
 ## Versioning
@@ -22,7 +22,7 @@ klippy`.
 If you are building a package of Klipper from git, it is usual practice not to
 ship a .git directory, so the versioning must be handled without git.  To do
 this, use the script shipped in `scripts/make_version.py` which should be run as
-follows: `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`.
+follows: `python3 scripts/make_version.py YOURDISTRONAME > klippy/.version` or `python2 scripts/make_version.py YOURDISTRONAME > klippy/.version`
 
 ## Sample packaging script
 

--- a/scripts/avrsim.py
+++ b/scripts/avrsim.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Script to interact with simulavr by simulating a serial port.
 #
-# Copyright (C) 2015-2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2015-2018 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, optparse, time, os, pty, fcntl, termios, errno

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # Script to handle build time requests embedded in C code.
 #
-# Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2021 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, subprocess, optparse, logging, shlex, socket, time, traceback

--- a/scripts/calibrate_shaper.py
+++ b/scripts/calibrate_shaper.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Shaper auto-calibration script
 #
-# Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020 Dmitry Butyugin <dmbutyugin@google.com>
+# Copyright (C) 2020 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from __future__ import print_function

--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Tool to query CAN bus uuids
 #
-# Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2021 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, optparse, time

--- a/scripts/check_whitespace.py
+++ b/scripts/check_whitespace.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Check files for whitespace problems
 #
-# Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os.path, unicodedata

--- a/scripts/checkstack.py
+++ b/scripts/checkstack.py
@@ -1,16 +1,14 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script that tries to find how much stack space each function in an
 # object is using.
 #
-# Copyright (C) 2015  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2015 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 # Usage:
 #   avr-objdump -d out/klipper.elf | scripts/checkstack.py
-
-import sys
-import re
+import sys, re
 
 # Functions that change stacks
 STACKHOP = []
@@ -187,7 +185,7 @@ def main():
 
     # Update for known indirect functions
     funcsbyname = {}
-    for info in funcs.values():
+    for info in list(funcs.values()):
         funcnameroot = info.funcname.split('.')[0]
         funcsbyname[funcnameroot] = info
     cmdfunc = funcsbyname.get('sched_main')
@@ -208,16 +206,16 @@ def main():
             stackusage = cmdfunc.basic_stack_usage + 2 + numparams * 4
             cmdfunc.noteCall(0, calladdr, stackusage)
     eventfunc = funcsbyname.get('__vector_13', funcsbyname.get('__vector_17'))
-    for funcnameroot, info in funcsbyname.items():
+    for funcnameroot, info in list(funcsbyname.items()):
         if funcnameroot.endswith('_event') and eventfunc is not None:
             eventfunc.noteCall(0, info.funcaddr, eventfunc.basic_stack_usage+2)
 
     # Calculate maxstackusage
-    for info in funcs.values():
+    for info in list(funcs.values()):
         calcmaxstack(info, funcs)
 
     # Sort functions for output
-    funcinfos = orderfuncs(funcs.keys(), funcs.copy())
+    funcinfos = orderfuncs(list(funcs.keys()), funcs.copy())
 
     # Show all functions
     print(OUTPUTDESC)

--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Tool to enter a USB bootloader and flash Klipper
 #
-# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, re, subprocess, optparse, time, fcntl, termios, struct

--- a/scripts/graph_accelerometer.py
+++ b/scripts/graph_accelerometer.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Generate adxl345 accelerometer graphs
 #
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
-# Copyright (C) 2020  Dmitry Butyugin <dmbutyugin@google.com>
+# Copyright (C) 2020 Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020 Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import importlib, optparse, os, sys

--- a/scripts/graph_temp_sensor.py
+++ b/scripts/graph_temp_sensor.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Tool to graph temperature sensor ADC resolution
 #
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, optparse
 import matplotlib
-
 
 ######################################################################
 # Dummy config / printer / etc. class emulation
@@ -44,7 +43,6 @@ class DummyConfig:
     # Emulate mcu_adc class
     def setup_adc_callback(self, time, callback):
         pass
-
 
 ######################################################################
 # Plotting
@@ -97,7 +95,6 @@ def plot_resistance(config, sensors):
     ax.grid(True)
     fig.tight_layout()
     return fig
-
 
 ######################################################################
 # Startup

--- a/scripts/logextract.py
+++ b/scripts/logextract.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script to extract config and shutdown information file a klippy.log file
 #
-# Copyright (C) 2017  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2017 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, re, collections, ast
 
 def format_comment(line_num, line):
     return "# %6d: %s" % (line_num, line)
-
 
 ######################################################################
 # Config file extraction
@@ -43,7 +42,6 @@ class GatherConfig:
         f = open(self.filename, 'wb')
         f.write('\n'.join(self.comments + self.config_lines).strip() + '\n')
         f.close()
-
 
 ######################################################################
 # TMC UART message parsing
@@ -142,7 +140,6 @@ class TMCUartHelper:
         elif len(data) == 0:
             return ""
         return "(length?)"
-
 
 ######################################################################
 # Shutdown extraction
@@ -440,7 +437,7 @@ class StatsStream:
             keyparts[mcu + name] = val
         min_ts = 0
         max_ts = 999999999999
-        for mcu_name, mcu in self.mcus.items():
+        for mcu_name, mcu in list(self.mcus.items()):
             sname = '%s:send_seq' % (mcu_name,)
             rname = '%s:receive_seq' % (mcu_name,)
             if sname not in keyparts:
@@ -489,9 +486,9 @@ class StatsStream:
     def get_lines(self):
         # Ignore old stats
         all_ts = []
-        for mcu_name, mcu in self.mcus.items():
-            all_ts.extend(mcu.sent_seq_to_time.values())
-            all_ts.extend(mcu.receive_seq_to_time.values())
+        for mcu_name, mcu in list(self.mcus.items()):
+            all_ts.list.extend(mcu.sent_seq_to_time.values())
+            all_ts.list.extend(mcu.receive_seq_to_time.values())
         if not all_ts:
             return []
         min_stream_ts = min(all_ts)
@@ -517,7 +514,7 @@ class GatherShutdown:
         self.filename = "%s.shutdown%05d" % (logname, line_num)
         self.comments = []
         if configs:
-            configs_by_id = {c.config_num: c for c in configs.values()}
+            configs_by_id = {c.config_num: c for c in list(configs.values())}
             config = configs_by_id[max(configs_by_id.keys())]
             config.add_comment(format_comment(line_num, recent_lines[-1][1]))
             self.comments.append("# config %s" % (config.filename,))
@@ -565,7 +562,6 @@ class GatherShutdown:
         f.write('\n'.join(self.comments + out))
         f.close()
 
-
 ######################################################################
 # Startup
 ######################################################################
@@ -603,7 +599,7 @@ def main():
     if handler is not None:
         handler.finalize()
     # Write found config files
-    for cfg in configs.values():
+    for cfg in list(configs.values()):
         cfg.write_file()
 
 if __name__ == '__main__':

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -1,20 +1,12 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Get the version number for klippy
 #
-# Copyright (C) 2018  Lucas Fink <software@lfcode.ca>
+# Copyright (C) 2018 Lucas Fink <software@lfcode.ca>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
-from __future__ import print_function
-
-import argparse
-import os
-import sys
+import argparse,os,sys,util
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../klippy'))
-
-import util
-
 
 def main(argv):
     p = argparse.ArgumentParser()
@@ -25,7 +17,6 @@ def main(argv):
     args = p.parse_args()
     print(util.get_git_version(from_file=False),
           args.distroname.replace(' ', ''), sep='-')
-
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Module supporting uploads Klipper firmware to an SD Card via SPI
 #
 # Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com>
@@ -85,7 +85,6 @@ def check_need_convert(board_name, config):
         os.system(cmd)
         output_line("Done")
         config['klipper_bin_path'] = robin_bin
-
 
 ###########################################################
 #
@@ -266,7 +265,7 @@ class FatFS:
         if ret == 0:
             self.sdcard.print_card_info(print_func)
             dinfo = self.get_disk_info()
-            for key, val in sorted(dinfo.items(), key=lambda x: x[0]):
+            for key, val in sorted(list(dinfo.items()), key=lambda x: x[0]):
                 print_func("%s: %s" % (key, val))
         else:
             raise OSError("flash_sdcard: failed to mount SD Card, returned %s"
@@ -672,7 +671,7 @@ class SDCardSPI:
         print_func("SDHC/SDXC: %s" % (self.high_capacity))
         print_func("Write Protected: %s" % (self.write_protected))
         print_func("Sectors: %d" % (self.total_sectors,))
-        for name, val in self.card_info.items():
+        for name, val in list(self.card_info.items()):
             print_func("%s: %s" % (name, val))
 
     def read_sector(self, sector):
@@ -1240,7 +1239,6 @@ def main():
         traceback.print_exc(file=sys.stdout)
         sys.exit(-1)
     output_line("SD Card Flash Complete")
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/stepstats.py
+++ b/scripts/stepstats.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script to calculate stats for each stepper from a log of messages
 #
-# Copyright (C) 2016  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import optparse
@@ -32,9 +32,9 @@ def main():
             so = steppers[args['oid']]
             so[2] += 1
             so[{'0': 3, '1': 4}[so[1]]] += int(args['count'])
-    for oid, so in sorted([(int(i[0]), i[1]) for i in steppers.items()]):
-        print "oid:%3d dir_cmds:%6d queue_cmds:%7d (%8d -%8d = %8d)" % (
-            oid, so[0], so[2], so[4], so[3], so[4]-so[3])
+    for oid, so in sorted([(int(i[0]), i[1]) for i in list(steppers.items())]):
+        print("oid:%3d dir_cmds:%6d queue_cmds:%7d (%8d -%8d = %8d)" % (
+            oid, so[0], so[2], so[4], so[3], so[4]-so[3]))
 
 if __name__ == '__main__':
     main()

--- a/scripts/update_chitu.py
+++ b/scripts/update_chitu.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Encodes STM32 firmwares to be flashable from SD card by Chitu motherboards.
 # Relocate firmware to 0x08008800!
 
 # Copied from Marlin and modified.
 # Licensed under GPL-3.0
 
-import os
-import struct
-import uuid
-import sys
-import hashlib
+import os, struct, uuid, sys, hashlib
 
 def calculate_crc(contents, seed):
     accumulating_xor_value = seed;
@@ -62,7 +58,6 @@ def xor_block(r0, r1, block_number, block_size, file_key):
 
         #increment the loop_counter
         loop_counter = loop_counter + 1
-
 
 def encode_file(input, output_file, file_length):
     input_file = bytearray(input.read())

--- a/scripts/update_mks_robin.py
+++ b/scripts/update_mks_robin.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script to update firmware for MKS Robin bootloader
 #
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import optparse

--- a/scripts/whconsole.py
+++ b/scripts/whconsole.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # Test console for webhooks interface
 #
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020 Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, optparse, socket, fcntl, select, json, errno, time


### PR DESCRIPTION
Here's my third attempt. I excluded `whconsole.py` and `buildcommands.py` as those two scripts would take a little more time / work to get migrated over. Also it was suggested in the last PR that setting the she bang to just python (Which most likely be symlinked to python3) so I did just that and left the scripts alone that explicitly required python2 for compatibility sake.

Signed-off-by: John Unland [unlandj2012@gmail.com](mailto:unlandj2012@gmail.com)