### PR TITLE
homing: add event to signal homed status to extras.

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -266,6 +266,9 @@ class PrinterHoming:
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         try:
             kin.home(homing_state)
+            axes_str = "".join([a for (a, i) in zip("xyz", [0, 1, 2])
+                                if i in axes])
+            self.printer.send_event("homing:homed", axes_str)
         except self.printer.command_error:
             if self.printer.is_shutdown():
                 raise self.printer.command_error(


### PR DESCRIPTION
Signed-off-by: Matt Baker <baker.matt.j@gmail.com>

This commit adds a homed event that extras can act on.

Its initial use is to enable a displacement sensor based homing routine using the Beacon eddy current sensor. In the routine, the machine is first homed through standard procedures, the event indicates completion, and then a native displacement is measured at stationary z and applied to the machines position. This allows fast dive speeds for closing the gap, followed by high precision measurement at fixed z afterwards.

There are presently around 70 units of the new sensor in private circles and many more being shipped out around the end of the year. Klipper is the only supported firmware, so it will surpass the 100 threshold readily.

This is the only required change outside of a modularized extras module to support the sensor. Adding the signal will allow the module to be easily managed externally until the implementation is stable enough for mainline integration.