### PR TITLE
Update generic-bigtreetech-octopus.cfg for f429 and h723 chips

### DIFF
--- a/config/generic-bigtreetech-octopus.cfg
+++ b/config/generic-bigtreetech-octopus.cfg
@@ -1,6 +1,12 @@
-# This file contains common pin mappings for the BigTreeTech Octopus.
-# To use this config, the firmware should be compiled for the
-# STM32F446 with a "32KiB bootloader" and a "12MHz crystal" clock reference.
+# This file contains common pin mappings for the BigTreeTech Octopus
+# and Octopus Pro boards. To use this config, start by identifying the
+# micro-controller on the board - it may be an STM32F446, STM32F429,
+# or an STM32H723.  Select the appropriate micro-controller in "make
+# menuconfig" and select "Enable low-level configuration options". For
+# STM32F446 boards the firmware should be compiled with a "32KiB
+# bootloader" and a "12MHz crystal" clock reference. For STM32F429
+# boards use a "32KiB bootloader" and an "8MHz crystal". For STM32H723
+# boards use a "128KiB bootloader" and a "25Mhz crystal".
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
This adds information on some additional variants of the Octopus (and Octopus Pro) boards.  In particular, the crystal speeds are different on the various boards.

@bigtreetech - fyi.

-Kevin