### PR TITLE
Simplify and unify stm32h7_adc code

### DIFF
--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -43,6 +43,10 @@ lookup_clock_line(uint32_t periph_base)
                               .bit = 1 << pos};
 
     } else {
+        if (periph_base == ADC12_COMMON_BASE)
+            return (struct cline){.en = &RCC->AHB2ENR,
+                                  .rst = &RCC->AHB2RSTR,
+                                  .bit = RCC_AHB2ENR_ADC12EN};
         uint32_t pos = (periph_base - AHB2PERIPH_BASE) / 0x400;
         return (struct cline){.en = &RCC->AHB2ENR,
                               .rst = &RCC->AHB2RSTR,

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -40,6 +40,9 @@ lookup_clock_line(uint32_t periph_base)
         uint32_t bit = 1 << ((periph_base - D2_AHB2PERIPH_BASE) / 0x400);
         return (struct cline){.en=&RCC->AHB2ENR, .rst=&RCC->AHB2RSTR, .bit=bit};
     } else if (periph_base >= D2_AHB1PERIPH_BASE) {
+        if (periph_base == ADC12_COMMON_BASE)
+            return (struct cline){.en = &RCC->AHB1ENR, .rst = &RCC->AHB1RSTR,
+                                  .bit = RCC_AHB1ENR_ADC12EN};
         uint32_t bit = 1 << ((periph_base - D2_AHB1PERIPH_BASE) / 0x400);
         return (struct cline){.en=&RCC->AHB1ENR, .rst=&RCC->AHB1RSTR, .bit=bit};
     } else if (periph_base >= D2_APB2PERIPH_BASE) {

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -296,15 +296,9 @@ gpio_adc_setup(uint32_t pin)
                    | (aticks << 9)  | (aticks << 12) | (aticks << 15)
                    | (aticks << 18) | (aticks << 21) | (aticks << 24)
                    | (aticks << 27));
-        // Disable Continuous Mode
-        MODIFY_REG(adc->CFGR, ADC_CFGR_CONT_Msk, 0);
+
         // Set to 12 bit
-        if (is_stm32h723_adc3) {
-#ifdef ADC3_CFGR_RES
-            MODIFY_REG(adc->CFGR, ADC3_CFGR_RES_Msk, 0 << ADC3_CFGR_RES_Pos);
-            MODIFY_REG(adc->CFGR, ADC3_CFGR_ALIGN_Msk, 0<<ADC3_CFGR_ALIGN_Pos);
-#endif
-        } else {
+        if (!is_stm32h723_adc3) {
             MODIFY_REG(adc->CFGR, ADC_CFGR_RES_Msk, ADC_RES<<ADC_CFGR_RES_Pos);
         }
 #if CONFIG_MACH_STM32H7
@@ -321,8 +315,6 @@ gpio_adc_setup(uint32_t pin)
         }
         MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSS_Msk,
             OVERSAMPLES_EXPONENT << ADC_CFGR2_OVSS_Pos);
-#else // stm32l4
-        adc->CFGR |= ADC_CFGR_JQDIS | ADC_CFGR_OVRMOD;
 #endif
     }
 

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -14,7 +14,6 @@
 #include "sched.h" // sched_shutdown
 
 #if CONFIG_MACH_STM32H7
-  #define ADCIN_BANK_SIZE                     (20)
   #define RCC_AHBENR_ADC                      (RCC->AHB1ENR)
   #define RCC_AHBENR_ADCEN                    (RCC_AHB1ENR_ADC12EN)
   #define ADC_CKMODE                          (0b11)
@@ -24,14 +23,12 @@
     #define PCSEL                               PCSEL_RES0
   #endif
 #elif CONFIG_MACH_STM32L4
-  #define ADCIN_BANK_SIZE                     (19)
   #define RCC_AHBENR_ADC                      (RCC->AHB2ENR)
   #define RCC_AHBENR_ADCEN                    (RCC_AHB2ENR_ADCEN)
   #define ADC_CKMODE                          (0)
   #define ADC_ATICKS                          (0b100)
   #define ADC_TS                              (ADC12_COMMON)
 #elif CONFIG_MACH_STM32G4
-  #define ADCIN_BANK_SIZE                     (19)
   #define RCC_AHBENR_ADC                      (RCC->AHB2ENR)
   #define RCC_AHBENR_ADCEN                    (RCC_AHB2ENR_ADC12EN)
   #define ADC_CKMODE                          (0b11)
@@ -44,6 +41,8 @@
 DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
 
 DECL_CONSTANT("ADC_MAX", 4095);
+
+#define ADCIN_BANK_SIZE 20
 
 // GPIOs like A0_C are not covered!
 // This always gives the pin connected to the positive channel
@@ -137,6 +136,7 @@ static const uint8_t adc_pins[] = {
     ADC_TEMPERATURE_PIN,    // [16] vtemp
     0,                      // [17] vbat/3
     0,                      // [18] vref
+    0,
     0,                      // [0] vssa       ADC 2
     GPIO('A', 0),           // [1]
     GPIO('A', 1),           // [2]

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -156,11 +156,12 @@ static const uint8_t adc_pins[] = {
 
 // ADC timing
 #define ADC_CKMODE 0b11
-#define ADC_ATICKS (CONFIG_MACH_STM32H7 ? 0b101 : 0b100)
-// stm32h7: clock=25Mhz, Tsamp=64.5, Tconv=71, total=2.84us
-// stm32h723 adc3: clock=50Mhz, Tsamp=92.5, Tconv=105, total=2.1us
-// stm32l4: clock=20Mhz, Tsamp=47.5, Tconv=60, total=3.0us
-// stm32g4: clock=37.5Mhz, Tsamp=47.5, Tconv=60, total=1.6us
+#define ADC_ATICKS 0b110
+#define ADC_ATICKS_H723_ADC3 0b111
+// stm32h7: clock=25Mhz, Tsamp=387.5, Tconv=394, total=15.76us
+// stm32h723 adc3: clock=50Mhz, Tsamp=640.5, Tconv=653, total=13.06us
+// stm32l4: clock=20Mhz, Tsamp=247.5, Tconv=260, total=13.0us
+// stm32g4: clock=37.5Mhz, Tsamp=247.5, Tconv=260, total=6.933us
 
 // Handle register name differences between chips
 #if CONFIG_MACH_STM32H723
@@ -217,8 +218,11 @@ gpio_adc_setup(uint32_t pin)
             ;
 
         // Setup chip specific flags
+        uint32_t aticks = ADC_ATICKS;
 #if CONFIG_MACH_STM32H7
-        if (!(CONFIG_MACH_STM32H723 && adc == ADC3)) {
+        if (CONFIG_MACH_STM32H723 && adc == ADC3) {
+            aticks = ADC_ATICKS_H723_ADC3;
+        } else {
             // Use linear calibration on stm32h7
             cr |= ADC_CR_ADCALLIN;
             // Set boost mode on stm32h7 (adc clock is at 25Mhz)
@@ -241,7 +245,6 @@ gpio_adc_setup(uint32_t pin)
            ;
 
         // Set ADC clock cycles sample time for every channel
-        uint32_t aticks = ADC_ATICKS;
         uint32_t av = (aticks           | (aticks << 3)  | (aticks << 6)
                        | (aticks << 9)  | (aticks << 12) | (aticks << 15)
                        | (aticks << 18) | (aticks << 21) | (aticks << 24)

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -237,11 +237,10 @@ gpio_adc_setup(uint32_t pin)
             ;
 
         // Enable ADC
-        // "Clear the ADRDY bit in the ADC_ISR register by writing ‘1’"
-        adc->ISR |= ADC_ISR_ADRDY;
+        adc->ISR = ADC_ISR_ADRDY;
         adc->ISR; // Dummy read to make sure write is flushed
         adc->CR |= ADC_CR_ADEN;
-        while(!(adc->ISR & ADC_ISR_ADRDY))
+        while (!(adc->ISR & ADC_ISR_ADRDY))
            ;
 
         // Set ADC clock cycles sample time for every channel

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -24,11 +24,6 @@
   #if CONFIG_MACH_STM32H723
     #define PCSEL                               PCSEL_RES0
   #endif
-
-  // Number of samples is 2^OVERSAMPLES_EXPONENT (exponent can be 0-10)
-  #define OVERSAMPLES_EXPONENT 3
-  #define OVERSAMPLES (1 << OVERSAMPLES_EXPONENT)
-
 #elif CONFIG_MACH_STM32L4
   #define ADCIN_BANK_SIZE                     (19)
   #define RCC_AHBENR_ADC                      (RCC->AHB2ENR)
@@ -37,9 +32,6 @@
   #define ADC_ATICKS                          (0b100)
   #define ADC_RES                             (0b00)
   #define ADC_TS                              (ADC12_COMMON)
-
-  #define OVERSAMPLES                         (0)
-
 #elif CONFIG_MACH_STM32G4
   #define ADCIN_BANK_SIZE                     (19)
   #define RCC_AHBENR_ADC                      (RCC->AHB2ENR)
@@ -49,8 +41,6 @@
   #define ADC_RES                             (0b00)
   #define ADC_TS                              (ADC12_COMMON)
   #define ADC_CCR_TSEN                        (ADC_CCR_VSENSESEL)
-
-  #define OVERSAMPLES                         (0)
 #endif
 
 #define ADC_TEMPERATURE_PIN 0xfe
@@ -301,21 +291,6 @@ gpio_adc_setup(uint32_t pin)
         if (!is_stm32h723_adc3) {
             MODIFY_REG(adc->CFGR, ADC_CFGR_RES_Msk, ADC_RES<<ADC_CFGR_RES_Pos);
         }
-#if CONFIG_MACH_STM32H7
-        // Set hardware oversampling
-        MODIFY_REG(adc->CFGR2, ADC_CFGR2_ROVSE_Msk, ADC_CFGR2_ROVSE);
-        if (is_stm32h723_adc3) {
-#ifdef ADC3_CFGR2_OVSR
-            MODIFY_REG(adc->CFGR2, ADC3_CFGR2_OVSR_Msk,
-                       (OVERSAMPLES_EXPONENT - 1) << ADC3_CFGR2_OVSR_Pos);
-#endif
-        } else {
-            MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSR_Msk,
-                       (OVERSAMPLES - 1) << ADC_CFGR2_OVSR_Pos);
-        }
-        MODIFY_REG(adc->CFGR2, ADC_CFGR2_OVSS_Msk,
-            OVERSAMPLES_EXPONENT << ADC_CFGR2_OVSS_Pos);
-#endif
     }
 
     if (pin == ADC_TEMPERATURE_PIN) {

--- a/src/stm32/stm32l4.c
+++ b/src/stm32/stm32l4.c
@@ -42,7 +42,7 @@ lookup_clock_line(uint32_t periph_base)
                               .rst = &RCC->AHB1RSTR,
                               .bit = 1 << pos};
 
-    } else if (periph_base == ADC1_BASE) {
+    } else if (periph_base == ADC12_COMMON_BASE) {
         return (struct cline){.en = &RCC->AHB2ENR,
                               .rst = &RCC->AHB2RSTR,
                               .bit = RCC_AHB2ENR_ADCEN};


### PR DESCRIPTION
The stm32h7_adc.c code is used on a number of chips now - stm32g431, stm32l412, stm32h723, stm32h743, and stm32h750.  The adc code had a lot of ifdefs and slightly different behavior between chips.  Most of these differences were unnecessary.  This PR reworks the code to use less ifdefs.

I found and (hopefully) fixed a few bugs while doing this:
1. The stm32l412 should not use CKMODE=0.
2. On stm32h7 the adc actually runs at 25Mhz so the code should use BOOST=0b10.
3. The ISR clear of ADRDY should use explicit writes instead of read-modify-write.

I have also reworked the code to use explicit register writes where practical (instead of read-modify-write).

I have tested this on stm32h723.  I don't have stm32l4, stm32g4, stm32h743, nor stm32h750 chips to test.

@D4SK , @adelyser, @mattthebaker, @bigtreetech - FYI.

-Kevin