### PR TITLE
Allow either one of I, J, K to be default-zero on G2/G3

### DIFF
--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -84,7 +84,7 @@ class ArcSupport:
             asPlanar = [ gcmd.get_float(a, 0.) for i,a in enumerate('JK') ]
             axes = (Y_AXIS, Z_AXIS, X_AXIS)
 
-        if not asPlanar[0] or not asPlanar[1]:
+        if not (asPlanar[0] or asPlanar[1]):
             raise gcmd.error("G2/G3 requires IJ, IK or JK parameters")
 
         asE = gcmd.get_float("E", None)

--- a/test/klippy/gcode_arcs.test
+++ b/test/klippy/gcode_arcs.test
@@ -11,6 +11,12 @@ G2 X125 Y32 Z20 E1 I10.5 J10.5
 # XY+Z arc move
 G2 X20 Y20 Z10 E1 I10.5 J10.5
 
+# allowable commands
+G2 X20 Y20 I0 J10
+G2 X20 Y20 J10
+G2 X20 Y20 I10 J0
+G2 X20 Y20 I10
+
 # Home and move in XZ arc
 G28
 G90
@@ -21,6 +27,12 @@ G2 X125 Y20 Z32 E1 I10.5 K10.5
 # XZ+Y arc move
 G2 X20 Y10 Z20 E1 I10.5 K10.5
 
+# allowable commands
+G2 X20 Y20 I0 K10
+G2 X20 Y20 K10
+G2 X20 Y20 I10 K0
+G2 X20 Y20 I10
+
 # Home and move in YZ arc
 G28
 G90
@@ -30,3 +42,9 @@ G2 X20 Y125 Z32 E1 J10.5 K10.5
 
 # YZ+X arc move
 G2 X10 Y20 Z20 E1 J10.5 K10.5
+
+# allowable commands
+G2 X20 Y20 J0 K10
+G2 X20 Y20 K10
+G2 X20 Y20 J10 K0
+G2 X20 Y20 J10


### PR DESCRIPTION
Implemented the suggested comments from @KevinOConnor and @ajmirsky in #5937 which I accidentally closed with a wrong force-push.

Signed-off-by: Wijnand Modderman-Lenstra <maze@pyth0n.org>