### PR TITLE
workflows: Update various actions versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ci_cache
         key: ${{ runner.os }}-build-${{ hashFiles('scripts/ci-install.sh') }}
@@ -21,7 +21,7 @@ jobs:
       run: ./scripts/ci-build.sh 2>&1
 
     - name: Upload micro-controller data dictionaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: data-dict
         path: ci_build/dict

--- a/.github/workflows/klipper3d-deploy.yaml
+++ b/.github/workflows/klipper3d-deploy.yaml
@@ -12,12 +12,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/_klipper3d/mkdocs-requirements.txt') }}

--- a/.github/workflows/klipper3d-deploy.yaml
+++ b/.github/workflows/klipper3d-deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Build MkDocs Pages
         run: docs/_klipper3d/build-translations.sh
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: site # The folder the action should deploy.

--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'Klipper3d/klipper'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v6
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: |


### PR DESCRIPTION
PR bumps the versions of a couple of workflows actions. `build-test.yml` ran just fine, see [this ](https://github.com/junland/klipper/actions/runs/3707390702/jobs/6283738263)for reference. Also `stale-issue-bot.yml` had an update for `actions/stale`  from v3 to v6.

Signed-off-by: John Unland [unlandj2012@gmail.com](mailto:unlandj2012@gmail.com)