### PR TITLE
Added precise location of [bed_screws] for Ender-3-s1 

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -131,7 +131,7 @@ runout_gcode: PAUSE
 recover_velocity: 25
 
 [bed_screws]
-# Ender s1
+# Ender-3-s1 bed
 screw1: 20, 29
 screw2: 195, 29
 screw3: 195, 198

--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -129,3 +129,10 @@ runout_gcode: PAUSE
 
 [pause_resume]
 recover_velocity: 25
+
+[bed_screws]
+# Ender s1
+screw1: 20, 29
+screw2: 195, 29
+screw3: 195, 198
+screw4: 20, 198

--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -131,7 +131,6 @@ runout_gcode: PAUSE
 recover_velocity: 25
 
 [bed_screws]
-# Ender-3-s1 bed
 screw1: 20, 29
 screw2: 195, 29
 screw3: 195, 198


### PR DESCRIPTION
Added precise location of [bed_screws] for Ender-3-s1 config for better manual bed leveling. 

[bed_screws] locations points the tip of the nozzel above the location of the manual bed leveling scews for optimal leveling.

Signed-off-by: Stas Yakobov <stas@3os.org>
