### PR TITLE
scripts: support CanBoot on RP2040 in `make flash`

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -193,6 +193,7 @@ def call_picoboot(bus, addr, binfile, sudo):
 
 # Flash via Klipper modified "picoboot"
 def flash_picoboot(device, binfile, sudo):
+    ttyname, serbypath = translate_serial_to_tty(device)
     buspath, devpath = translate_serial_to_usb_path(device)
     # We need one level up to get access to busnum/devnum files
     usbdir = os.path.dirname(devpath)
@@ -202,7 +203,10 @@ def flash_picoboot(device, binfile, sudo):
         bus = f.read().strip()
     with open(usbdir + "/devnum") as f:
         addr = f.read().strip()
-    call_picoboot(bus, addr, binfile, sudo)
+    if detect_canboot(devpath):
+        call_flashcan(serbypath, binfile)
+    else:
+        call_picoboot(bus, addr, binfile, sudo)
 
 
 ######################################################################

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -45,7 +45,7 @@ $(OUT)klipper.uf2: $(OUT)klipper.elf $(OUT)lib/rp2040/elf2uf2/elf2uf2
 	@echo "  Creating uf2 file $@"
 	$(Q)$(OUT)lib/rp2040/elf2uf2/elf2uf2 $< $@
 
-target-$(CONFIG_RP2040_HAVE_STAGE2) += $(OUT)klipper.uf2
+rptarget-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)klipper.uf2
 rplink-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)src/rp2040/rp2040_link.ld
 stage2-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)stage2.o
 
@@ -54,10 +54,11 @@ $(OUT)klipper.bin: $(OUT)klipper.elf
 	@echo "  Creating bin file $@"
 	$(Q)$(OBJCOPY) -O binary $< $@
 
-target-$(CONFIG_RP2040_HAVE_BOOTLOADER) += $(OUT)klipper.bin
+rptarget-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)klipper.bin
 rplink-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)src/generic/armcm_link.ld
 
 # Set klipper.elf linker rules
+target-y += $(rptarget-y)
 CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs -T $(rplink-y)
 OBJS_klipper.elf += $(stage2-y)
 $(OUT)klipper.elf: $(stage2-y) $(rplink-y)
@@ -67,6 +68,6 @@ lib/rp2040_flash/rp2040_flash:
 	@echo "  Building rp2040_flash"
 	$(Q)make -C lib/rp2040_flash rp2040_flash
 
-flash: $(OUT)klipper.uf2 lib/rp2040_flash/rp2040_flash
+flash: $(rptarget-y) lib/rp2040_flash/rp2040_flash
 	@echo "  Flashing $< to $(FLASH_DEVICE)"
-	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(if $(NOSUDO),--no-sudo) $(OUT)klipper.uf2
+	$(Q)$(PYTHON) ./scripts/flash_usb.py -t $(CONFIG_MCU) -d "$(FLASH_DEVICE)" $(if $(NOSUDO),--no-sudo) $(rptarget-y)


### PR DESCRIPTION
Allows `make flash` to work successfully with an RP2040 running CanBoot instead of the stock bootloader.