### PR TITLE
Set TRSYNC_TIMEOUT to 0.050 instead of 0.025

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -125,7 +125,7 @@ class MCU_trsync:
             s.note_homing_end()
         return params['trigger_reason']
 
-TRSYNC_TIMEOUT = 0.025
+TRSYNC_TIMEOUT = 0.050
 TRSYNC_SINGLE_MCU_TIMEOUT = 0.250
 
 class MCU_endstop:


### PR DESCRIPTION
This change is to support a slightly longer timeout for Multi-MCU setups, specifically in Can Bus scenarios where homing timeouts occur. Doesn't seem to cause any latency.