### PR TITLE
improvement: detect filament precence on hall_filament_width_sensor without RunoutHelper class

### DIFF
--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -129,7 +129,7 @@ class HallFilamentWidthSensor:
         self.runout_helper.note_filament_present(
             self.fast_dia > self.runout_dia)
         # Does filament exists
-        if self.diameter > 0.5:
+        if self.fast_dia > self.runout_dia:
             if len(self.filament_array) > 0:
                 # Get first position in filament array
                 pending_position = self.filament_array[0][0]
@@ -162,7 +162,7 @@ class HallFilamentWidthSensor:
 
     def cmd_M407(self, gcmd):
         response = ""
-        if self.diameter > 0:
+        if self.diameter > self.runout_dia:
             response += ("Filament dia (measured mm): "
                          + str(self.diameter))
         else:

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -213,7 +213,8 @@ class HallFilamentWidthSensor:
         return {'Diameter': self.diameter,
                 'Raw':(self.lastFilamentWidthReading+
                  self.lastFilamentWidthReading2),
-                'is_active':self.is_active}
+                'is_active':self.is_active,
+                'filament_detected': (self.fast_dia > self.runout_dia)}
     def cmd_log_enable(self, gcmd):
         self.is_log = True
         gcmd.respond_info("Filament width logging Turned On")

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -29,6 +29,7 @@ class HallFilamentWidthSensor:
         self.min_diameter = (self.nominal_filament_dia
                              - self.measurement_max_difference)
         self.diameter =self.nominal_filament_dia
+        self.fast_dia =self.nominal_filament_dia
         self.is_active =config.getboolean('enable', False)
         self.runout_dia=config.getfloat('min_diameter', 1.0)
         self.is_log =config.getboolean('logging', False)
@@ -95,6 +96,7 @@ class HallFilamentWidthSensor:
           ((self.lastFilamentWidthReading+self.lastFilamentWidthReading2)
            -self.rawdia1)+self.dia1,2)
         self.diameter=(5.0 * self.diameter + diameter_new)/6
+        self.fast_dia=diameter_new
 
     def update_filament_array(self, last_epos):
         # Fill array
@@ -125,7 +127,7 @@ class HallFilamentWidthSensor:
         self.update_filament_array(last_epos)
         # Check runout
         self.runout_helper.note_filament_present(
-            self.diameter > self.runout_dia)
+            self.fast_dia > self.runout_dia)
         # Does filament exists
         if self.diameter > 0.5:
             if len(self.filament_array) > 0:


### PR DESCRIPTION
improvement: added the ability to use detect the presence of a filament in the same way as in filament_switch_sensor, without using the RunoutHelper class (this is necessary for example to use as a toolhead_sensor in the ERCF MMU script set)