### PR TITLE
docs: Fix typo in mpu9250 documentation

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1640,7 +1640,7 @@ cs_pin:
 
 ### [mpu9250]
 
-Support for MPU-9250, MPU-9255, MPU-9255, MPU-6050, and MPU-6500
+Support for MPU-9250, MPU-9255, MPU-6515, MPU-6050, and MPU-6500
 accelerometers (one may define any number of sections with an
 "mpu9250" prefix).
 


### PR DESCRIPTION
Adding MPU-6515, replacing MPU-9255 duplicate