### PR TITLE
bed_mesh: relative_reference_index range check

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -295,8 +295,9 @@ class BedMeshCalibrate:
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
         self._generate_points(config.error)
-        if self.relative_reference_index >= len(self.points):
-            raise config.error("Invalid relative_reference_index")
+        if self.relative_reference_index != None:
+            if self.relative_reference_index >= len(self.points):
+                raise config.error("Invalid relative_reference_index")
         self._profile_name = None
         self.orig_points = self.points
         self.probe_helper = probe.ProbePointsHelper(

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -295,7 +295,7 @@ class BedMeshCalibrate:
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
         self._generate_points(config.error)
-        if self.relative_reference_index >= len(self.points):    
+        if self.relative_reference_index >= len(self.points):
             raise config.error("Invalid relative_reference_index")
         self._profile_name = None
         self.orig_points = self.points

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -295,6 +295,8 @@ class BedMeshCalibrate:
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
         self._generate_points(config.error)
+        if self.relative_reference_index >= len(self.points):    
+            raise config.error("Invalid relative_reference_index")
         self._profile_name = None
         self.orig_points = self.points
         self.probe_helper = probe.ProbePointsHelper(


### PR DESCRIPTION
Added a simple range check to the relative_reference_index,
so that having it set too large leads to a reasonable error
instead of a confusing index out of range message.

Signed-off-by: Ben Eastep <shifting@shifting.ca>