### PR TITLE
ci-install.sh: Add compatibility with ubuntu 22.04 LTS

### DIFF
--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -14,9 +14,17 @@ mkdir -p ${BUILD_DIR} ${CACHE_DIR}
 ######################################################################
 # Install system dependencies
 ######################################################################
+PYTHON_PKG="python2-dev"
+if test -f /etc/os-release; then
+    . /etc/os-release
+    ubuntu_year=$(echo $VERSION_ID | cut -f 1 -d '.')
+    if [ $ubuntu_year -le 18 ]; then
+        PYTHON_PKG="python-dev"
+    fi
+fi
 
 echo -e "\n\n=============== Install system dependencies\n\n"
-PKGS="virtualenv python-dev libffi-dev build-essential"
+PKGS="virtualenv $PYTHON_PKG libffi-dev build-essential"
 PKGS="${PKGS} gcc-avr avr-libc"
 PKGS="${PKGS} libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi"
 PKGS="${PKGS} pv libmpfr-dev libgmp-dev libmpc-dev texinfo bison flex"


### PR DESCRIPTION
The python package consumed here `python-dev` is available under ubuntu 18.04 as defined in the github workflows for this repo, but it is missing from any newer ubuntu release:

https://packages.ubuntu.com/search?keywords=python-dev&searchon=names&exact=1&suite=all&section=all

Instead, ubuntu now makes this available as `python2-dev`:

https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python2-dev&searchon=names