### PR TITLE
Richardjm/probe discard first

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1817,6 +1817,10 @@ z_offset:
 #   samples. If this tolerance is exceeded then either an error is
 #   reported or the attempt is restarted (see
 #   samples_tolerance_retries). The default is 0.100mm.
+#samples_discard_first: 0
+#   The number of samples to discard when starting to probe. This can
+#   be used if the first probe is often less accurate. The default is
+#   zero.
 #samples_tolerance_retries: 0
 #   The number of times to retry if a sample is found that exceeds
 #   samples_tolerance. On a retry, all current samples are discarded

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -922,7 +922,7 @@ setting in the [probe config section](Config_Reference.md#probe).
 "open").
 
 #### PROBE_ACCURACY
-`PROBE_ACCURACY [PROBE_SPEED=<mm/s>] [SAMPLES=<count>]
+`PROBE_ACCURACY [PROBE_SPEED=<mm/s>] [LIFT_SPEED=<mm/s>] [SAMPLES=<count>]
 [SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_DISCARD_FIRST=<count>]`: Calculate the
 maximum, minimum, average, median, and standard deviation of multiple probe
 samples. By default,10 SAMPLES are taken. Otherwise the optional parameters

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -911,7 +911,8 @@ see the [probe calibrate guide](Probe_Calibrate.md)).
 #### PROBE
 `PROBE [PROBE_SPEED=<mm/s>] [LIFT_SPEED=<mm/s>] [SAMPLES=<count>]
 [SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_TOLERANCE=<mm>]
-[SAMPLES_TOLERANCE_RETRIES=<count>] [SAMPLES_RESULT=median|average]`:
+[SAMPLES_TOLERANCE_RETRIES=<count>] [SAMPLES_RESULT=median|average]
+[SAMPLES_DISCARD_FIRST=<count>]`:
 Move the nozzle downwards until the probe triggers. If any of the
 optional parameters are provided they override their equivalent
 setting in the [probe config section](Config_Reference.md#probe).
@@ -922,10 +923,10 @@ setting in the [probe config section](Config_Reference.md#probe).
 
 #### PROBE_ACCURACY
 `PROBE_ACCURACY [PROBE_SPEED=<mm/s>] [SAMPLES=<count>]
-[SAMPLE_RETRACT_DIST=<mm>]`: Calculate the maximum, minimum, average,
-median, and standard deviation of multiple probe samples. By default,
-10 SAMPLES are taken. Otherwise the optional parameters default to
-their equivalent setting in the probe config section.
+[SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_DISCARD_FIRST=<count>]`: Calculate the
+maximum, minimum, average, median, and standard deviation of multiple probe
+samples. By default,10 SAMPLES are taken. Otherwise the optional parameters
+default to their equivalent setting in the probe config section.
 
 #### PROBE_CALIBRATE
 `PROBE_CALIBRATE [SPEED=<speed>] [<probe_parameter>=<value>]`: Run a

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -173,16 +173,16 @@ class PrinterProbe:
             if discards <= samples_discard_first:
                 gcmd.respond_info("Probe sample discarded")
                 discards += 1
-                continue
-            positions.append(pos)
-            # Check samples tolerance
-            z_positions = [p[2] for p in positions]
-            if max(z_positions) - min(z_positions) > samples_tolerance:
-                if retries >= samples_retries:
-                    raise gcmd.error("Probe samples exceed samples_tolerance")
-                gcmd.respond_info("Probe samples exceed tolerance. Retrying...")
-                retries += 1
-                positions = []
+            else:
+              positions.append(pos)
+              # Check samples tolerance
+              z_positions = [p[2] for p in positions]
+              if max(z_positions) - min(z_positions) > samples_tolerance:
+                  if retries >= samples_retries:
+                      raise gcmd.error("Probe samples exceed samples_tolerance")
+                  gcmd.respond_info("Probe samples exceed tolerance. Retrying...")
+                  retries += 1
+                  positions = []
             # Retract
             if len(positions) < sample_count:
                 self._move(probexy + [pos[2] + sample_retract_dist], lift_speed)
@@ -235,8 +235,8 @@ class PrinterProbe:
             if discards <= samples_discard_first:
                 gcmd.respond_info("Probe sample discarded")
                 discards += 1
-                continue
-            positions.append(pos)
+            else:
+              positions.append(pos)
             # Retract
             liftpos = [None, None, pos[2] + sample_retract_dist]
             self._move(liftpos, lift_speed)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -49,7 +49,7 @@ class PrinterProbe:
         self.samples_retries = config.getint('samples_tolerance_retries', 0,
                                              minval=0)
         self.samples_discard = config.getint('samples_discard_first', 0,
-                                             above=-1)
+                                             minval=0)
         # Register z_virtual_endstop pin
         self.printer.lookup_object('pins').register_chip('probe', self)
         # Register homing event handlers
@@ -157,7 +157,7 @@ class PrinterProbe:
         samples_retries = gcmd.get_int("SAMPLES_TOLERANCE_RETRIES",
                                        self.samples_retries, minval=0)
         samples_discard_first = gcmd.get_int("SAMPLES_DISCARD_FIRST",
-                                             self.samples_discard, above=-1)
+                                             self.samples_discard, minval=0)
         samples_result = gcmd.get("SAMPLES_RESULT", self.samples_result)
         must_notify_multi_probe = not self.multi_probe_pending
         if must_notify_multi_probe:
@@ -215,7 +215,7 @@ class PrinterProbe:
         sample_retract_dist = gcmd.get_float("SAMPLE_RETRACT_DIST",
                                              self.sample_retract_dist, above=0.)
         samples_discard_first = gcmd.get_int("SAMPLES_DISCARD_FIRST",
-                                             self.samples_discard, above=-1)
+                                             self.samples_discard, minval=0)
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
         gcmd.respond_info("PROBE_ACCURACY at X:%.3f Y:%.3f Z:%.3f"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -170,7 +170,7 @@ class PrinterProbe:
             # Probe position
             pos = self._probe(speed)
             # Discard the first readings (probably at most one)
-            if discards <= samples_discard_first:
+            if discards < samples_discard_first:
                 gcmd.respond_info("Probe sample discarded")
                 discards += 1
             else:
@@ -179,10 +179,13 @@ class PrinterProbe:
               z_positions = [p[2] for p in positions]
               if max(z_positions) - min(z_positions) > samples_tolerance:
                   if retries >= samples_retries:
-                      raise gcmd.error("Probe samples exceed samples_tolerance")
-                  gcmd.respond_info("Probe samples exceed tolerance. Retrying...")
+                      raise gcmd.error(
+                                "Probe samples exceed samples_tolerance")
+                  gcmd.respond_info(
+                      "Probe samples exceed tolerance. Retrying...")
                   retries += 1
                   positions = []
+                  # Do not reset discards as they are done once per probe
             # Retract
             if len(positions) < sample_count:
                 self._move(probexy + [pos[2] + sample_retract_dist], lift_speed)
@@ -232,7 +235,7 @@ class PrinterProbe:
             # Probe position
             pos = self._probe(speed)
             # Discard the first readings (probably at most one)
-            if discards <= samples_discard_first:
+            if discards < samples_discard_first:
                 gcmd.respond_info("Probe sample discarded")
                 discards += 1
             else:


### PR DESCRIPTION
Supports the ability to discard the first n probes. Allowing a faster first probe before accurate subsequent measurements.

There are many users implementing this mechanism via manually replacing the probe.py file with a version that supports discarding the first probe.