### PR TITLE
Printer config for Ender3 V2 with Sprite Extruder

### DIFF
--- a/config/printer-creality-ender3-v2-w-sprite-extruder-2022.cfg
+++ b/config/printer-creality-ender3-v2-w-sprite-extruder-2022.cfg
@@ -1,0 +1,105 @@
+# This file contains pin mappings for the stock 2020 Creality Ender 3
+# V2 with Sprite Extruder upgrade. To use this config, during
+# "make menuconfig" select the STM32F103 with a "28KiB bootloader"
+# and serial (on USART1 PA10/PA9) communication.
+
+# If you prefer a direct serial connection, in "make menuconfig"
+# select "Enable extra low-level configuration options" and select
+# serial (on USART3 PB11/PB10), which is broken out on the 10 pin IDC
+# cable used for the LCD module as follows:
+# 3: Tx, 4: Rx, 9: GND, 10: VCC
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning on the printer with the card inserted. The firmware
+# filename must end in ".bin" and must not match the last filename
+# that was flashed.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PC2
+dir_pin: PB9
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA5
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA6
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop  #enable to use bltouch
+# endstop_pin: ^PA7   #disable to use bltouch
+# position_endstop: 0.0  #disable to use bltouch
+position_max: 270
+position_min: -4
+homing_speed: 4
+second_homing_speed: 1
+homing_retract_dist: 2.0
+
+[extruder]
+step_pin: PB4
+dir_pin: PB3
+enable_pin: !PC3
+microsteps: 16
+gear_ratio: 42:12
+rotation_distance: 26.359
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC5
+#control: pid
+#pid_Kp: 23.561
+#pid_Ki: 1.208
+#pid_Kd: 114.859
+min_temp: 0
+max_temp: 260 # Set to 300 for S1 Pro
+
+[verify_heater extruder]
+check_gain_time: 200
+hysteresis: 5
+
+
+[heater_bed]
+heater_pin: PA2
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+control: pid
+# tuned for stock hardware with 50 degree Celsius target
+pid_Kp: 67.104
+pid_Ki: 0.544
+pid_Kd: 2068.466
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA0
+
+[mcu]
+serial: /dev/serial/by-id/usb_serial_1
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 5
+square_corner_velocity: 5.0
+max_z_accel: 100


### PR DESCRIPTION
There is a mix of config and BLtouch properties from Sprite Extruder.