### PR TITLE
Dual Loop PID

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -794,6 +794,13 @@ sensor_type:
 sensor_pin:
 #   Analog input pin connected to the sensor. This parameter must be
 #   provided.
+#secondary_sensor_name:
+#   The temperature_sensor name of a second sensor to use for temperature
+#   control. This sensor will limit the heater power to not allow the
+#   temperature to exceed the 'secondary_max_temp_target' value.
+#   This sensor will work alongside the dual_loop_pid control algorithm.
+#secondary_max_temp_target:
+#   The maximum temperature target that the secondary sensor will allow.
 #pullup_resistor: 4700
 #   The resistance (in ohms) of the pullup attached to the thermistor.
 #   This parameter is only valid when the sensor is a thermistor. The
@@ -803,8 +810,8 @@ sensor_pin:
 #   be smoothed to reduce the impact of measurement noise. The default
 #   is 1 seconds.
 control:
-#   Control algorithm (either pid or watermark). This parameter must
-#   be provided.
+#   Control algorithm (either pid, dual_loop_pid or watermark). This
+#   parameter must be provided.
 pid_Kp:
 pid_Ki:
 pid_Kd:
@@ -817,6 +824,23 @@ pid_Kd:
 #   off and 1.0 being full on. Consider using the PID_CALIBRATE
 #   command to obtain these parameters. The pid_Kp, pid_Ki, and pid_Kd
 #   parameters must be provided for PID heaters.
+#primary_pid_kp:
+#primary_pid_ki:
+#primary_pid_kd:
+#secondary_pid_kp:
+#secondary_pid_ki:
+#secondary_pid_kd:
+#   On 'dual_loop_pid' control use two PID loops to control the
+#   temperature. The primary PID loop controls the temperature
+#   directly. The secondary PID loop controls the power to the primary
+#   PID loop. This allows the primary PID loop to be tuned for
+#   temperature control, while the secondary PID loop can be tuned for
+#   power control, not exceeding the temperature limit set on
+#   'secondary_max_temp_target'.
+#   The primary sensor is positioned close where the temperature
+#   measurament should be more accurate (e.g. on the bed surface). The
+#   secondary sensor is positioned where the temperature measurament
+#   should not exceed a limit (e.g. on the silicone heater).
 #max_delta: 2.0
 #   On 'watermark' controlled heaters this is the number of degrees in
 #   Celsius above the target temperature before disabling the heater

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -13,6 +13,36 @@ class PIDCalibrate:
         gcode.register_command('PID_CALIBRATE', self.cmd_PID_CALIBRATE,
                                desc=self.cmd_PID_CALIBRATE_help)
     cmd_PID_CALIBRATE_help = "Run PID calibration test"
+
+    def _calibrate(self, pheaters, heater, target, fname, gcmd,
+                   calibrate_secondary):
+        if isinstance(heater.control, heaters.ControlDualLoopPID) and \
+                calibrate_secondary:
+            sec_target = heater.control.sec_max_temp_target
+            calibrate = ControlAutoTune(heater, sec_target, heater.control,
+                                        calibrate_secondary=calibrate_secondary)
+        elif isinstance(heater.control, heaters.ControlDualLoopPID) and \
+                not calibrate_secondary:
+            calibrate = ControlAutoTune(heater, target, heater.control,
+                                        calibrate_secondary=calibrate_secondary)
+        else:
+            calibrate = ControlAutoTune(heater, target)
+        old_control = heater.set_control(calibrate)
+        try:
+            pheaters.set_temperature(heater, target, True)
+        except self.printer.command_error as e:
+            heater.set_control(old_control)
+            raise
+        heater.set_control(old_control)
+        if fname is not None:
+            calibrate.write_file(fname)
+        if calibrate.check_busy(0., 0., 0.):
+            raise gcmd.error("pid_calibrate interrupted")
+        # Log and report results
+        kp, ki, kd = calibrate.calc_final_pid()
+
+        return kp, ki, kd
+
     def cmd_PID_CALIBRATE(self, gcmd):
         heater_name = gcmd.get('HEATER')
         target = gcmd.get_float('TARGET')
@@ -23,36 +53,62 @@ class PIDCalibrate:
         except self.printer.config_error as e:
             raise gcmd.error(str(e))
         self.printer.lookup_object('toolhead').get_last_move_time()
-        calibrate = ControlAutoTune(heater, target)
-        old_control = heater.set_control(calibrate)
-        try:
-            pheaters.set_temperature(heater, target, True)
-        except self.printer.command_error as e:
-            heater.set_control(old_control)
-            raise
-        heater.set_control(old_control)
-        if write_file:
-            calibrate.write_file('/tmp/heattest.txt')
-        if calibrate.check_busy(0., 0., 0.):
-            raise gcmd.error("pid_calibrate interrupted")
-        # Log and report results
-        Kp, Ki, Kd = calibrate.calc_final_pid()
-        logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
-        gcmd.respond_info(
-            "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
-            "The SAVE_CONFIG command will update the printer config file\n"
-            "with these parameters and restart the printer." % (Kp, Ki, Kd))
-        # Store results for SAVE_CONFIG
-        configfile = self.printer.lookup_object('configfile')
-        configfile.set(heater_name, 'control', 'pid')
-        configfile.set(heater_name, 'pid_Kp', "%.3f" % (Kp,))
-        configfile.set(heater_name, 'pid_Ki', "%.3f" % (Ki,))
-        configfile.set(heater_name, 'pid_Kd', "%.3f" % (Kd,))
+
+        if isinstance(heater.control, heaters.ControlDualLoopPID):
+            fname = '/tmp/heattest_secondary.txt' if write_file else None
+            kp_s, ki_s, kd_s = self._calibrate(pheaters, heater, target,
+                                               fname, gcmd,
+                                               calibrate_secondary=True)
+            old_kp = heater.control.secondary_pid.Kp
+            old_ki = heater.control.secondary_pid.Ki
+            old_kd = heater.control.secondary_pid.Kd
+            heater.control.secondary_pid.kp = kp_s
+            heater.control.secondary_pid.ki = ki_s
+            heater.control.secondary_pid.kd = kd_s
+            fname = '/tmp/heattest_primary.txt' if write_file else None
+            kp_p, ki_p, kd_p = self._calibrate(pheaters, heater, target,
+                                               fname, gcmd,
+                                               calibrate_secondary=False)
+            heater.control.secondary_pid.kp = old_kp
+            heater.control.secondary_pid.ki = old_ki
+            heater.control.secondary_pid.kd = old_kd
+            gcmd.respond_info(
+                "PID parameters: primary_pid_Kp=%.3f primary_pid_Ki=%.3f"
+                "primary_pid_Kd=%.3f\n"
+                "secondary_pid_Kp=%.3f secondary_pid_Ki=%.3f"
+                "secondary_pid_Kd=%.3f\n"
+                "The SAVE_CONFIG command will update the printer config file\n"
+                "with these parameters and restart the printer."
+                % (kp_p, ki_p, kd_p, kp_s, ki_s, kd_s))
+            # Store results for SAVE_CONFIG
+            configfile = self.printer.lookup_object('configfile')
+            configfile.set(heater_name, 'control', 'dual_loop_pid')
+            configfile.set(heater_name, 'primary_pid_Kp', "%.3f" % (kp_p,))
+            configfile.set(heater_name, 'primary_pid_Ki', "%.3f" % (ki_p,))
+            configfile.set(heater_name, 'primary_pid_Kd', "%.3f" % (kd_p,))
+            configfile.set(heater_name, 'secondary_pid_Kp', "%.3f" % (kp_s,))
+            configfile.set(heater_name, 'secondary_pid_Ki', "%.3f" % (ki_s,))
+            configfile.set(heater_name, 'secondary_pid_Kd', "%.3f" % (kd_s,))
+        else:
+            fname = '/tmp/heattest.txt' if write_file else None
+            Kp, Ki, Kd = self._calibrate(pheaters, heater, target, fname, gcmd,
+                                         calibrate_secondary=False)
+            logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
+            gcmd.respond_info(
+                "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
+                "The SAVE_CONFIG command will update the printer config file\n"
+                "with these parameters and restart the printer." % (Kp, Ki, Kd))
+            # Store results for SAVE_CONFIG
+            configfile = self.printer.lookup_object('configfile')
+            configfile.set(heater_name, 'control', 'pid')
+            configfile.set(heater_name, 'pid_Kp', "%.3f" % (Kp,))
+            configfile.set(heater_name, 'pid_Ki', "%.3f" % (Ki,))
+            configfile.set(heater_name, 'pid_Kd', "%.3f" % (Kd,))
 
 TUNE_PID_DELTA = 5.0
 
 class ControlAutoTune:
-    def __init__(self, heater, target):
+    def __init__(self, heater, target, control=None, calibrate_secondary=False):
         self.heater = heater
         self.heater_max_power = heater.get_max_power()
         self.calibrate_temp = target
@@ -66,6 +122,9 @@ class ControlAutoTune:
         self.last_pwm = 0.
         self.pwm_samples = []
         self.temp_samples = []
+        # Control for Dual loop pid
+        self._control = control
+        self._calibrate_secondary = calibrate_secondary
     # Heater control
     def set_pwm(self, read_time, value):
         if value != self.last_pwm:
@@ -73,28 +132,42 @@ class ControlAutoTune:
                 (read_time + self.heater.get_pwm_delay(), value))
             self.last_pwm = value
         self.heater.set_pwm(read_time, value)
-    def temperature_update(self, read_time, temp, target_temp):
-        self.temp_samples.append((read_time, temp))
+    def temperature_update(self, read_time, primary_temp, target_temp,
+                           secondary_temp=None):
+
+        if self._calibrate_secondary:
+            ref_temp = secondary_temp
+        else:
+            ref_temp = primary_temp
+
+        self.temp_samples.append((read_time, ref_temp))
         # Check if the temperature has crossed the target and
         # enable/disable the heater if so.
-        if self.heating and temp >= target_temp:
+        if self.heating and ref_temp >= target_temp:
             self.heating = False
             self.check_peaks()
             self.heater.alter_target(self.calibrate_temp - TUNE_PID_DELTA)
-        elif not self.heating and temp <= target_temp:
+        elif not self.heating and ref_temp <= target_temp:
             self.heating = True
             self.check_peaks()
             self.heater.alter_target(self.calibrate_temp)
         # Check if this temperature is a peak and record it if so
         if self.heating:
-            self.set_pwm(read_time, self.heater_max_power)
-            if temp < self.peak:
-                self.peak = temp
+            if self._control is not None and not self._calibrate_secondary:
+                pid = self._control.secondary_pid
+                sec_target = self._control.sec_max_temp_target
+                _, bounded_co = pid.calculate_output(read_time, secondary_temp,
+                                                     sec_target)
+                self.set_pwm(read_time, bounded_co)
+            else:
+                self.set_pwm(read_time, self.heater_max_power)
+            if ref_temp < self.peak:
+                self.peak = ref_temp
                 self.peak_time = read_time
         else:
             self.set_pwm(read_time, 0.)
-            if temp > self.peak:
-                self.peak = temp
+            if ref_temp > self.peak:
+                self.peak = ref_temp
                 self.peak_time = read_time
     def check_busy(self, eventtime, smoothed_temp, target_temp):
         if self.heating or len(self.peaks) < 12:


### PR DESCRIPTION
The idea behind the following PR is to have a more accurate bed surface temperature

Usually users who have big and thick beds have an offset between the bed surface and the thermistor temperature located on the heater, also they usually need to wait some time for the bed surface to reach the thermal equilibrium with the heater.

This PR allow the user set a new control algo that uses two sensors, one for the bed surface and one for the heater.

This new algorithm uses two PID loops, one for controlling the heater and one for controlling the bed surface, it works using the minimum control values beetwen the both PID loops.
The main target for the heater will be always the bed surface, the maximum heater temperature is set on the heater section.

Here we can see a more detailed simulation:
![image](https://user-images.githubusercontent.com/8016520/210602894-7b46de66-232a-46f7-9092-ece7895230dd.png)
 
The temperature on the heater (orange curve) was set to not exceed 100ºC while the bed surface target was on 60ºC

And here we can see a practical situation on my printer, which have a bed size 350mmx350mmx8mm. In this situation the same parameters was set as in the simulation

![curva_dualpid](https://user-images.githubusercontent.com/8016520/210603312-886870d3-d8e4-467a-a085-ffb5107e226f.png)
![curva_dualpid2](https://user-images.githubusercontent.com/8016520/210603770-66df2f42-e569-4733-92e1-dc3d890819c6.png)
![image](https://user-images.githubusercontent.com/8016520/210603894-e06de353-0e38-4772-9da9-5fd004683f7c.png)

Here is how I setup the sensors in my bed:
![image](https://user-images.githubusercontent.com/8016520/210604491-f759b54c-3d27-4708-8051-d1663e356f7a.png)

and here how my configuration looks like now:
![image](https://user-images.githubusercontent.com/8016520/210604697-07ef86d0-91f3-4f9e-ae80-5b70f69a4f3e.png)





