### PR TITLE
screws_tilt_adjust: adds `is_base` status property

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -390,6 +390,7 @@ object:
     and "MM" is the number of "minutes of a clock face" representing
     a partial screw turn. (E.g. "01:15" would mean to turn the screw
     one and a quarter revolutions.)
+  - `is_base`: Returns True if this is the base screw.
 
 ## servo
 

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -92,8 +92,9 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
-                self.results.append({'name': name + ' (base)', 'x': coord[0],
-                    'y': coord[1], 'z': z, 'sign': 'CW', 'adjust':'00:00'})
+                self.results.append({'name': name, 'x': coord[0],
+                    'y': coord[1], 'z': z, 'sign': 'CW', 'adjust':'00:00',
+                    'is_base': True})
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -116,7 +117,8 @@ class ScrewsTiltAdjust:
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
                 self.results.append({'name': name, 'x': coord[0], 'y': coord[1],
                     'z': z, 'sign': sign,
-                    'adjust':"%02d:%02d" % (full_turns, minutes)})
+                    'adjust':"%02d:%02d" % (full_turns, minutes),
+                    'is_base': False})
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
             self.max_diff_error = True
             raise self.gcode.error(


### PR DESCRIPTION
Following up on my comment [here](https://github.com/Klipper3d/klipper/pull/5921#issuecomment-1373749185), this PR removes the " (base)" suffix from the screw name and instead adds a new `is_base` boolean property to indicate which screw is the base one.

Here's a sample of the status object:

![image](https://user-images.githubusercontent.com/85504/211044348-cfb8697a-ff71-4520-b4e5-832245f5e2d5.png)


Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>