### PR TITLE
Motion queue flush fixes

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -332,7 +332,7 @@ class ToolHead:
         if self.special_queuing_state:
             self._update_drip_move_time(next_move_time)
         self._update_move_time(next_move_time)
-        self.last_kin_move_time = next_move_time
+        self.last_kin_move_time = max(self.last_kin_move_time, next_move_time)
     def flush_step_generation(self):
         # Transition from "Flushed"/"Priming"/main state to "Flushed" state
         self.move_queue.flush()

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -341,8 +341,14 @@ class ToolHead:
         self.reactor.update_timer(self.flush_timer, self.reactor.NEVER)
         self.move_queue.set_flush_time(self.buffer_time_high)
         self.idle_flush_print_time = 0.
-        flush_time = self.last_kin_move_time + self.kin_flush_delay
-        flush_time = max(flush_time, self.print_time - self.kin_flush_delay)
+        # Determine actual last "itersolve" flush time
+        lastf = self.print_time - self.kin_flush_delay
+        # Calculate flush time that includes kinematic scan windows
+        flush_time = max(lastf, self.last_kin_move_time + self.kin_flush_delay)
+        if flush_time > self.print_time:
+            # Flush in small time chunks
+            self._update_move_time(flush_time)
+        # Flush kinematic scan windows and step buffers
         self.force_flush_time = max(self.force_flush_time, flush_time)
         self._update_move_time(max(self.print_time, self.force_flush_time))
     def _flush_lookahead(self):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -240,7 +240,7 @@ class ToolHead:
         # Kinematic step generation scan window time tracking
         self.kin_flush_delay = SDS_CHECK_TIME
         self.kin_flush_times = []
-        self.last_kin_flush_time = self.last_kin_move_time = 0.
+        self.force_flush_time = self.last_kin_move_time = 0.
         # Setup iterative solver
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
@@ -279,16 +279,16 @@ class ToolHead:
     def _update_move_time(self, next_print_time):
         batch_time = MOVE_BATCH_TIME
         kin_flush_delay = self.kin_flush_delay
-        lkft = self.last_kin_flush_time
+        fft = self.force_flush_time
         while 1:
             self.print_time = min(self.print_time + batch_time, next_print_time)
-            sg_flush_time = max(lkft, self.print_time - kin_flush_delay)
+            sg_flush_time = max(fft, self.print_time - kin_flush_delay)
             for sg in self.step_generators:
                 sg(sg_flush_time)
-            free_time = max(lkft, sg_flush_time - kin_flush_delay)
+            free_time = max(fft, sg_flush_time - kin_flush_delay)
             self.trapq_finalize_moves(self.trapq, free_time)
             self.extruder.update_move_time(free_time)
-            mcu_flush_time = max(lkft, sg_flush_time - self.move_flush_time)
+            mcu_flush_time = max(fft, sg_flush_time - self.move_flush_time)
             for m in self.all_mcus:
                 m.flush_moves(mcu_flush_time)
             if self.print_time >= next_print_time:
@@ -296,7 +296,7 @@ class ToolHead:
     def _calc_print_time(self):
         curtime = self.reactor.monotonic()
         est_print_time = self.mcu.estimated_print_time(curtime)
-        kin_time = max(est_print_time + MIN_KIN_TIME, self.last_kin_flush_time)
+        kin_time = max(est_print_time + MIN_KIN_TIME, self.force_flush_time)
         kin_time += self.kin_flush_delay
         min_print_time = max(est_print_time + self.buffer_time_start, kin_time)
         if min_print_time > self.print_time:
@@ -343,8 +343,8 @@ class ToolHead:
         self.idle_flush_print_time = 0.
         flush_time = self.last_kin_move_time + self.kin_flush_delay
         flush_time = max(flush_time, self.print_time - self.kin_flush_delay)
-        self.last_kin_flush_time = max(self.last_kin_flush_time, flush_time)
-        self._update_move_time(max(self.print_time, self.last_kin_flush_time))
+        self.force_flush_time = max(self.force_flush_time, flush_time)
+        self._update_move_time(max(self.print_time, self.force_flush_time))
     def _flush_lookahead(self):
         if self.special_queuing_state:
             return self.flush_step_generation()


### PR DESCRIPTION
The `note_kinematic_activity()` call had a subtle flaw that could result in the steps generated by manual_stepper not being properly flushed out (on a SYNC=0 move).  Not properly flushing out the step generation could result in "timer too close" errors.

-Kevin
