### PR TITLE
Update update_mks_robin.py

### DIFF
--- a/scripts/update_mks_robin.py
+++ b/scripts/update_mks_robin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script to update firmware for MKS Robin bootloader
 #
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>


### PR DESCRIPTION
We are no longer using Python2.
Using the script as is, gives an error.
Removing the 2 from the script header solves the issue.

Signed-off-by: Márcio Pereira <3dprintpt@gmail.com>