### PR TITLE
config: added stock location of bed_screws for neptune2(s)(d)

### DIFF
--- a/config/printer-elegoo-neptune2-2021.cfg
+++ b/config/printer-elegoo-neptune2-2021.cfg
@@ -103,10 +103,16 @@ serial: /dev/ttyUSB0
 restart_method: command
 
 [bed_screws]
-screw1: 32.5, 32.5
-screw2: 32.5, 202.5
-screw3: 202.5, 32.5
-screw4: 202.5, 202.5
+screw1: 50, 50
+screw1_name: left_front
+screw2: 185, 50
+screw2_name: right_front
+screw3: 185, 185
+screw3_name: right_rear
+screw4: 50, 185
+screw4_name: left_rear
+screw5: 115, 115
+screw5_name: center
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
This config change adds stock config of the screw location. It can be found [here](https://github.com/NARUTOfzr/ZNP-Robin-Nano-V1.2-V1.3/blob/master/Configuration%20files/Neptune%202/elegoo.txt#L34).

