### PR TITLE
Initial commit for TronXY X5SA-2E printer config.

### DIFF
--- a/printer-tronxy-x5sa-2e-2022.cfg
+++ b/printer-tronxy-x5sa-2e-2022.cfg
@@ -1,0 +1,215 @@
+# This is a Klipper configuration for TronXY X5SA-2E CoreXY Printer,
+# manufactured in May of 2022
+# 330x330x400 size with CXY-V6-191121 motherboard, 
+# with the stock Tronxy black self-levelling plate sensor
+# and stock Titan Extruder Clones.
+# 
+# Pinouts for your tronXY printer on this motherboard can be mined from
+# their GitHub project for the TronXY Marlin firmware.
+# 
+# The specific file, on GitHub: 
+# https://github.com/tronxy3d/F4xx-SIM480x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h
+# 
+# The File for some Single extrusion variants of the F446 boards:
+# https://github.com/tronxy3d/F4xx-SIM240x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h
+# The file for Legacy F103 Boards:
+# https://github.com/tronxy3d/STM32F103-PIC480x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h
+# 
+# Please refer to SuperSlicer for in depth configuration for your printer.
+# 
+# You MUST configure your slicer to use the T0 and T1 scripts for changing extruded filament.
+# 
+###########################################################
+# CAUTION: The Touchscreen cannot be used with Klipper!!! #
+# You will lose all the display functionalities!!!        #
+###########################################################
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[stepper_x]
+step_pin: PE5
+dir_pin: !PF1
+enable_pin: !PF0
+microsteps: 32
+rotation_distance: 40
+endstop_pin: !PC15
+position_endstop: -1
+position_min: -1
+position_max: 350 # for bed mesh
+homing_speed: 50
+homing_retract_dist: 10
+second_homing_speed: 10.0
+
+[stepper_y]
+step_pin: PF9
+dir_pin: !PF3
+enable_pin: !PF5
+microsteps: 32
+rotation_distance: 40
+endstop_pin: !PC14
+position_endstop: 0
+position_max: 330
+homing_retract_dist: 10
+homing_speed: 50.0
+second_homing_speed: 10.0
+
+[stepper_z]
+step_pin: PA6
+dir_pin: PF15
+enable_pin: !PA5
+microsteps: 32
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 400
+position_min: -2
+
+[stepper_z1]
+step_pin: PF6
+dir_pin: PF4
+enable_pin: !PF7
+microsteps: 32
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+
+[extruder]
+step_pin: PB1
+dir_pin: !PF13
+enable_pin: !PF14
+microsteps: 32
+rotation_distance: 22.478 # Titan Extruder Clone Rotation Distance
+gear_ratio: 66:22 # Titan Extruder Clone Gear Ratio
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PG7
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC3
+#control = pid
+#pid_kp = 22.685
+#pid_ki = 1.172
+#pid_kd = 109.740
+min_temp: 10
+max_temp: 275
+max_extrude_only_distance: 350
+
+[extruder_stepper fil2]
+extruder:
+step_pin: PD12
+dir_pin: !PG4
+enable_pin: !PG5
+microsteps: 32
+rotation_distance: 22.478 # Titan Extruder Clone Rotation Distance
+gear_ratio: 66:22 # Titan Extruder Clone Gear Ratio
+
+[heater_bed]
+heater_pin: PE2
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC2
+min_temp: 0
+max_temp: 110
+control: pid
+pid_kp = 73.323
+pid_ki = 0.871
+pid_kd = 1542.536
+
+[heater_fan hotend_fan]
+pin: PG9
+
+[fan]
+pin: PG0
+
+[controller_fan drivers_fan]
+pin: PD7
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: True
+runout_gcode:
+  M25
+switch_pin: !PE6
+
+[filament_switch_sensor filament_sensor1]
+pause_on_runout: True
+runout_gcode:
+  M25
+switch_pin: !PF12
+
+[output_pin beeper]
+pin: PA8
+
+[safe_z_home]
+home_xy_position: 165, 165
+speed: 50
+z_hop: 5
+z_hop_speed: 5
+
+[bed_screws]
+screw1: 5, 5
+screw2: 165, 5
+screw3: 325, 5
+screw4: 5, 325
+screw5: 165, 325
+screw6: 325, 325
+
+[bed_mesh]
+speed: 60
+probe_count: 4, 4
+horizontal_move_z: 5
+algorithm: bicubic
+mesh_min : 30, 30
+mesh_max : 300, 300
+mesh_pps: 0
+
+[probe]
+x_offset: -38.5
+y_offset: -10
+pin: !PE3
+speed: 30
+z_offset: 1
+
+####filament switching macros adapted from https://klipper.discourse.group/t/x-in-1-out-non-mixing-extruder-config/2387
+#### however, as the extruder is not "belted" the name was changed to fil2.
+
+[gcode_macro T0]
+gcode:
+  #Deactivate stepper in fil2
+  SYNC_EXTRUDER_MOTION EXTRUDER=fil2 MOTION_QUEUE=
+  #Activate stepper in extruder
+  SYNC_EXTRUDER_MOTION EXTRUDER=extruder MOTION_QUEUE=extruder
+
+[gcode_macro T1]
+gcode:
+  #Deactivate stepper in fil2
+  SYNC_EXTRUDER_MOTION EXTRUDER=extruder MOTION_QUEUE=
+  #Activate stepper in extruder
+  SYNC_EXTRUDER_MOTION EXTRUDER=fil2 MOTION_QUEUE=extruder
+
+[gcode_macro ACTIVATE_EXTRUDER]
+description: Replaces built-in macro for X-in, 1-out extruder configuration SuperSlicer fix
+rename_existing: ACTIVATE_EXTRUDER_BASE
+gcode:
+  {% if 'EXTRUDER' in params %}
+    {% set ext = params.EXTRUDER|default(EXTRUDER) %}
+     {% if ext == "extruder"%}
+       {action_respond_info("Switching to extruder.")}
+       T0
+     {% elif ext == "fil2" %}
+       {action_respond_info("Switching to fil2.")}
+       T1
+     {% else %}
+       {action_respond_info("EXTRUDER value being passed.")}
+       ACTIVATE_EXTRUDER_BASE EXTRUDER={ext}
+     {% endif %}
+  {% endif %}  
+
+[delayed_gcode activate_default_extruder]
+initial_duration: 1
+gcode:
+  ACTIVATE_EXTRUDER EXTRUDER=extruder


### PR DESCRIPTION
as the [shared_heater] tag is deprecated, it was avoided in favor the T0 and T1 macros that are already necessary. 

This config should be considered "initial" in that the user can rely on the pinouts, but needs to configure most of the other details themselves using the printer and SuperSlicer or some equivalent.

Pinouts for your tronXY printer on this motherboard can be mined from their GitHub project for the TronXY Marlin firmware.

This printer's pinouts were mined from
https://github.com/tronxy3d/F4xx-SIM480x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h

The File for some Single extrusion variants of the F446 boards: https://github.com/tronxy3d/F4xx-SIM240x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h The file for Legacy F103 Boards:
https://github.com/tronxy3d/STM32F103-PIC480x320/blob/firmware/Marlin/src/pins/stm32f4/pins_TRONXY_F446.h

Signed-off-by: Paul Gorman <pagorman@asu.edu>