### PR TITLE
screws_tilt_adjust: status result as dictionary

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230202: The format of the `printer.screws_tilt_adjust` status
+information has changed. The information is now stored as a dictionary of
+screws with the resulting measurements. See the
+[status reference](Status_Reference.md#screws_tilt_adjust) for details.
+
 20230201:  The `[bed_mesh]` module no longer loads the `default` profile
 on startup.  It is recommended that users who use the `default` profile
 add `BED_MESH_PROFILE LOAD=default` to their `START_PRINT` macro (or

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -376,20 +376,17 @@ object:
 - `error`: Returns True if the most recent `SCREWS_TILT_CALCULATE`
   command included the `MAX_DEVIATION` parameter and any of the probed
   screw points exceeded the specified `MAX_DEVIATION`.
-- `results`: A list of the probed screw locations. Each entry in
-  the list will be a dictionary containing the following keys:
-  - `name`: The name of the screw as specified in the config file.
-  - `x`: The X coordinate of the screw as specified in the config file.
-  - `y`: The Y coordinate of the screw as specified in the config file.
+- `results["<screw>"]`: A dictionary containing the following keys:
   - `z`: The measured Z height of the screw location.
   - `sign`: A string specifying the direction to turn to screw for the
     necessary adjustment. Either "CW" for clockwise or "CCW" for
-    counterclockwise. The base screw will not have a `sign` key.
+    counterclockwise.
   - `adjust`: The number of screw turns to adjust the screw, given in
     the format "HH:MM," where "HH" is the number of full screw turns
     and "MM" is the number of "minutes of a clock face" representing
     a partial screw turn. (E.g. "01:15" would mean to turn the screw
     one and a quarter revolutions.)
+  - `is_base`: Returns True if this is the base screw.
 
 ## servo
 

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -64,7 +64,7 @@ class ScrewsTiltAdjust:
             'results': self.results}
 
     def probe_finalize(self, offsets, positions):
-        self.results = []
+        self.results = {}
         self.max_diff_error = False
         # Factors used for CW-M3, CCW-M3, CW-M4, CCW-M4, CW-M5 and CCW-M5
         threads_factor = {0: 0.5, 1: 0.5, 2: 0.7, 3: 0.7, 4: 0.8, 5: 0.8}
@@ -92,8 +92,9 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f" %
                     (name + ' (base)', coord[0], coord[1], z))
-                self.results.append({'name': name + ' (base)', 'x': coord[0],
-                    'y': coord[1], 'z': z, 'sign': 'CW', 'adjust':'00:00'})
+                sign = "CW" if is_clockwise_thread else "CCW"
+                self.results["screw%d" % (i + 1,)] = {'z': z, 'sign': sign,
+                    'adjust': '00:00', 'is_base': True}
             else:
                 # Calculate how knob must be adjusted for other positions
                 diff = z_base - z
@@ -114,9 +115,9 @@ class ScrewsTiltAdjust:
                 self.gcode.respond_info(
                     "%s : x=%.1f, y=%.1f, z=%.5f : adjust %s %02d:%02d" %
                     (name, coord[0], coord[1], z, sign, full_turns, minutes))
-                self.results.append({'name': name, 'x': coord[0], 'y': coord[1],
-                    'z': z, 'sign': sign,
-                    'adjust':"%02d:%02d" % (full_turns, minutes)})
+                self.results["screw%d" % (i + 1,)] = {'z': z, 'sign': sign,
+                    'adjust':"%02d:%02d" % (full_turns, minutes),
+                    'is_base': False}
         if self.max_diff and any((d > self.max_diff) for d in screw_diff):
             self.max_diff_error = True
             raise self.gcode.error(


### PR DESCRIPTION
Changes the format of the `printer.screws_tilt_adjust` status to a dictionary of screws with the resulting measurements.

![image](https://user-images.githubusercontent.com/85504/215054773-f2d6f447-6e74-40c2-8bdb-45ca7b8f6b74.png)

Remaining values can easily be retrieved from active printer configuration.

This follows up on https://github.com/Klipper3d/klipper/pull/5921#issuecomment-1373749185 and replaces the PR #5974

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>