### PR TITLE
Note that "TEST_MACRO25; comment" fails with "Malformed command"

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -11,6 +11,10 @@ lower case. If any numbers are used in the macro name then they must
 all be at the end of the name (eg, TEST_MACRO25 is valid, but
 MACRO25_TEST3 is not).
 
+Also note that macros with names similar to TEST_MACRO25 will fail to
+be parsed if they are followed by comments (e.g. `TEST_MACRO25; GCODE comment`),
+with a `Malformed command` error.
+
 ## Formatting of G-Code in the config
 
 Indentation is important when defining a macro in the config file. To

--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -11,9 +11,9 @@ lower case. If any numbers are used in the macro name then they must
 all be at the end of the name (eg, TEST_MACRO25 is valid, but
 MACRO25_TEST3 is not).
 
-Also note that macros with names similar to TEST_MACRO25 will fail to
-be parsed if they are followed by comments (e.g. `TEST_MACRO25; GCODE comment`),
-with a `Malformed command` error.
+Also note that macros with names not similar to "T0" will fail to
+be parsed if they are followed by comments (e.g. "MACRONAME; a comment"),
+and will raise a malformed command error.
 
 ## Formatting of G-Code in the config
 


### PR DESCRIPTION
Note an undocumented issue with comments in macro names.

To reproduce, create a macro named "TEST_MACRO25" with any content. Run it bare, and then with any comment. The commented version will fail.

Signed off by Nico