### PR TITLE
Add support for thermal protection without temperature delta

### DIFF
--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -31,7 +31,8 @@ class HeaterCheck:
         self.last_target = self.goal_temp = self.error = 0.
         self.goal_systime = self.printer.get_reactor().NEVER
         self.check_timer = None
-        self.use_temperature_delta = config.getboolean('use_temperature_delta', True)
+        self.use_temperature_delta = config.getboolean('use_temperature_delta',
+                                                        True)
     def handle_connect(self):
         if self.printer.get_start_args().get('debugoutput') is not None:
             # Disable verify_heater if outputting to a debug file
@@ -60,7 +61,8 @@ class HeaterCheck:
         if ( self.use_temperature_delta ):
             self.error += (target - self.hysteresis) - temp
         if not self.approaching_target:
-            if not self.use_temperature_delta and temp < (target - self.hysteresis):
+            delta = target - self.hysteresis
+            if not self.use_temperature_delta and temp < delta:
                 self.error += 1.
                 logging.info("Heater %s not heating as expected. cumulative errors: %.3f - max_errors: %.3f", self.heater_name, self.error, self.max_error)
             if target != self.last_target:

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -65,7 +65,7 @@ class HeaterCheck:
             if not self.use_temperature_delta and temp < delta:
                 self.error += 1.
                 logging.info("Heater %s not heating as expected. \
-                                errors: %.3f - max_errors: %.3f", 
+                                errors: %.3f - max_errors: %.3f",
                                 self.heater_name, self.error, self.max_error)
             if target != self.last_target:
                 # Target changed - reset checks

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -64,7 +64,9 @@ class HeaterCheck:
             delta = target - self.hysteresis
             if not self.use_temperature_delta and temp < delta:
                 self.error += 1.
-                logging.info("Heater %s not heating as expected. cumulative errors: %.3f - max_errors: %.3f", self.heater_name, self.error, self.max_error)
+                logging.info("Heater %s not heating as expected. \
+                                errors: %.3f - max_errors: %.3f", 
+                                self.heater_name, self.error, self.max_error)
             if target != self.last_target:
                 # Target changed - reset checks
                 logging.info("Heater %s approaching new target of %.3f",

--- a/klippy/extras/verify_heater.py
+++ b/klippy/extras/verify_heater.py
@@ -31,6 +31,7 @@ class HeaterCheck:
         self.last_target = self.goal_temp = self.error = 0.
         self.goal_systime = self.printer.get_reactor().NEVER
         self.check_timer = None
+        self.use_temperature_delta = config.getboolean('use_temperature_delta', True)
     def handle_connect(self):
         if self.printer.get_start_args().get('debugoutput') is not None:
             # Disable verify_heater if outputting to a debug file
@@ -56,8 +57,12 @@ class HeaterCheck:
                 self.error = 0.
             self.last_target = target
             return eventtime + 1.
-        self.error += (target - self.hysteresis) - temp
+        if ( self.use_temperature_delta ):
+            self.error += (target - self.hysteresis) - temp
         if not self.approaching_target:
+            if not self.use_temperature_delta and temp < (target - self.hysteresis):
+                self.error += 1.
+                logging.info("Heater %s not heating as expected. cumulative errors: %.3f - max_errors: %.3f", self.heater_name, self.error, self.max_error)
             if target != self.last_target:
                 # Target changed - reset checks
                 logging.info("Heater %s approaching new target of %.3f",


### PR DESCRIPTION
Sometimes using the temperature delta (target temp - current temp) as increment for the error counter, trigger the thermal protection too fast, particurally with low-power heater or a not perfectly aligned fan duct.

This PR add a setting `use_temperature_delta` that disable the use of delta, thermal protection is then triggered when the temperature is lower than `target - hysteresis` for at least `max_errors` seconds. This is similiar to Marlin's thermal runaway protection.

Tested properly with
```
[verify_heater extruder]
  hysteresis: 10
  max_error: 40
```

unplugging the thermistor cable starts the counter and after 40 seconds the heater is killed.