### PR TITLE
config: Add config for Fysetc S6 v2 with BTT TMC2226

### DIFF
--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -100,7 +100,7 @@ max_z_accel: 100
 
 
 ########################################
-# TMC UART configuration
+# TMC2208 UART configuration
 ########################################
 
 #[tmc2208 stepper_x]
@@ -130,6 +130,42 @@ max_z_accel: 100
 
 #[tmc2208 extruder2]
 #uart_pin: PE0
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+####################################################
+# TMC2226 from BigTreeTech UART configuration
+####################################################
+# Basically needs one jumper to close JP1 for UART mode. 
+# Additional one  needs for JP6-3 & JP6-11 in case TMC2226 v1.0 from BTT
+
+#[tmc2209 stepper_x]
+#uart_pin: PE7
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+#[tmc2209 stepper_y]
+#uart_pin: PE7
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+#[tmc2209 stepper_z]
+#uart_pin: PD10
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+#[tmc2209 extruder]
+#uart_pin: PD7
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+#[tmc2209 extruder1]
+#uart_pin: PC14
+#run_current: 0.8
+#stealthchop_threshold: 999999
+
+#[tmc2209 extruder2]
+#uart_pin: PC15
 #run_current: 0.8
 #stealthchop_threshold: 999999
 

--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -136,8 +136,8 @@ max_z_accel: 100
 ####################################################
 # TMC2226 from BigTreeTech UART configuration
 ####################################################
-# Basically needs one jumper to close JP1 for UART mode. 
-# Additional one  needs for JP6-3 & JP6-11 in case TMC2226 v1.0 from BTT
+# Basically needs one jumper to close JP1 for UART mode.
+# Additional one needs for JP6-3 & JP6-11 in case TMC2226 v1.0 from BTT.
 
 #[tmc2209 stepper_x]
 #uart_pin: PE7


### PR DESCRIPTION
Basically we needs one `JP1` jumper to close  for UART mode([Fysetc guide](https://github.com/FYSETC/FYSETC-S6/blob/main/README.md#uart-mode-config)).
But it works only for Fysetc drivers, not for BigTreeTech drivers because they have a little different [pinout](https://cln.sh/LdphTWg6).

So I found out, additional one jumper we needs for `JP6-3` & `JP6-11` ([photo](https://cln.sh/rhgv72KF)) in case TMC2226 v1.0 from BTT.

Actual UART pins([screenshot](https://cln.sh/3XP8wBKQ)), which different from TMC2208, I took from [Fysetc repo](https://github.com/FYSETC/FYSETC-S6/blob/main/hardware/V2.0/S6%20V2.0%20SCH%20.pdf).

And maybe we don't need to solder `PDN` jumper in case TMC2209 BTT ([Fysetc guide](https://raw.githubusercontent.com/FYSETC/FYSETC-S6/main/images/TMC2209.JPG) bottom right corner), can't test myself.