### PR TITLE
module: Printer-creality-ender3-s1plus-2022, Added [bed_screws] block…

### DIFF
--- a/config/printer-creality-ender3-s1plus-2022.cfg
+++ b/config/printer-creality-ender3-s1plus-2022.cfg
@@ -129,3 +129,9 @@ runout_gcode: PAUSE
 
 [pause_resume]
 recover_velocity: 25
+
+[bed_screws]
+screw1: 27, 27
+screw2: 267, 27
+screw3: 267, 267
+screw4: 27, 267


### PR DESCRIPTION
… with appropriate positions of the screws for the Ender 3 S1 Plus.

In order to ease the manual leveling process I've added the [bed_screws] coordinates to the Ender 3 S1 Plus example configuration. Using the precision of the stepper motors allows you to level the bed more easily but also more accurately.

Signed-off-by: Fabio Bier githubklipper@proxymail.nl