### PR TITLE
Fixed pressure advance formula, it was based on mm instead of layers

### DIFF
--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -60,8 +60,8 @@ height.
 ![tune_pa](img/tune_pa.jpg)
 
 The pressure_advance value can then be calculated as `pressure_advance
-= <start> + <measured_height> * <factor>`. (For example, `0 + 12.90 *
-.020` would be `.258`.)
+= <start> + ( <measured_height> / <layer_height> ) * <factor>`. (For example, `0 + ( 12.90 / 0.3) *
+.020` would be `.86`.)
 
 It is possible to choose custom settings for START and FACTOR if that
 helps identify the best pressure advance setting. When doing this, be


### PR DESCRIPTION
The description clearly says: The above TUNING_TOWER command instructs Klipper to alter the pressure_advance setting on each layer of the print.

The formula then proceeds to calculate pressure advance based on Z-height in mm instead of layer count. 

I have confirmed the value changing indeed on every layer, so the logical conclusion would be that the formula is missing the conversion from layer-count to mm., or in other words the relation between Z-movement height and measured height. 

