### PR TITLE
Avoid overriding existing KCONFIG_CONFIG env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 OUT=out/
 
 # Kconfig includes
-export KCONFIG_CONFIG     := $(CURDIR)/.config
+export KCONFIG_CONFIG     ?:= $(CURDIR)/.config
 -include $(KCONFIG_CONFIG)
 
 # Common command definitions


### PR DESCRIPTION
Change assignment from := to ?:= to retain any existing KCONFIG_CONFIG variable set to make managing multiple configs easier.