### PR TITLE
Add pinout diagram for UART/serial connection for Ender3-S1

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -7,13 +7,25 @@
 # For a direct serial connection, in "make menuconfig" select
 # "Enable extra low-level configuration options" and  Serial
 # (on USART2 PA3/PA2), which is on the 10 pin IDC cable used
-# for the LCD module as follows: 3: Tx, 4: Rx, 9: GND, 10: VCC
+# for the LCD module as follows: 3: Tx, 4: Rx, 9: GND
+#
+# Pinout of port on MCU:
+#
+# | 2: NC	| 4: DIN	| 6: ENT	| 8: B	| 10: GND |
+# | 1: NC	| 3: DOUT	| 5: BEEP	| 7: A	| 9: 5V   |
+#                   | KEY		  |
+#
+# Pinout of port on display end of the cable:
+#
+#                   | KEY		  |
+# | 2: NC	| 4: DIN	| 6: ENT	| 8: B	| 10: GND |
+# | 1: NC	| 3: DOUT	| 5: BEEP	| 7: A	| 9: 5V   |
 
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The filename
 # must be changed to "firmware.bin"
 
-# With STM32F401, you might need to put "firmware.bin" in a
+# With STM32F401, you will need to put "firmware.bin" in a
 # folder on the SD card called "STM32F4_UPDATE" in order to flash.
 
 # See docs/Config_Reference.md for a description of parameters.


### PR DESCRIPTION
It wasn't super clear to me so hopefully this helps someone in the future. I also removed VCC since it shouldn't be connected when utilizing UART (correct me if I'm wrong).

Also for posterity I used the following instructions: https://github.com/FYSETC/FYSETC-SPIDER/blob/main/firmware/Klipper/Connect%20RPI%20uart.md

and modified my `[mcu]` entry in my `printer.cfg`:

```
[mcu]
serial: /dev/ttyAMA0
restart_method: command
```