### PR TITLE
Bed Mesh: using z axis lift speed instead general speed

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1012,6 +1012,9 @@ information.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#probe_speed: 5
+#   The speed (in mm/s) when moving from a horizontal_move_z position
+#   to a probe_height position. The default is 5.
 ```
 
 ### [bed_screws]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -94,7 +94,6 @@ class BedMesh:
         self.bmc = BedMeshCalibrate(config, self)
         self.z_mesh = None
         self.toolhead = None
-        self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.fade_start = config.getfloat('fade_start', 1.)
         self.fade_end = config.getfloat('fade_end', 0.)
         self.fade_dist = self.fade_end - self.fade_start
@@ -251,7 +250,7 @@ class BedMesh:
             gcmd.respond_info("Bed has not been probed")
         else:
             self.z_mesh.print_probed_matrix(gcmd.respond_info)
-            self.z_mesh.print_mesh(gcmd.respond_raw, self.horizontal_move_z)
+            self.z_mesh.print_mesh(gcmd.respond_raw, self.bmc.probe_helper.horizontal_move_z)
     cmd_BED_MESH_MAP_help = "Serialize mesh and output to terminal"
     def cmd_BED_MESH_MAP(self, gcmd):
         if self.z_mesh is not None:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -366,7 +366,7 @@ class ProbePointsHelper:
         self.speed = config.getfloat('speed', 50., above=0.)
         self.use_offsets = False
         # Internal probing state
-        self.lift_speed = self.speed
+        self.lift_speed = config.getfloat('probe_speed', 5.)
         self.probe_offsets = (0., 0., 0.)
         self.results = []
     def minimum_points(self,n):
@@ -383,11 +383,7 @@ class ProbePointsHelper:
     def _move_next(self):
         toolhead = self.printer.lookup_object('toolhead')
         # Lift toolhead
-        speed = self.lift_speed
-        if not self.results:
-            # Use full speed to first probe position
-            speed = self.speed
-        toolhead.manual_move([None, None, self.horizontal_move_z], speed)
+        toolhead.manual_move([None, None, self.horizontal_move_z], self.lift_speed)
         # Check if done probing
         if len(self.results) >= len(self.probe_points):
             toolhead.get_last_move_time()


### PR DESCRIPTION
Using lift speed for z axis, because for the large printers we need quick toolhead move with slow bed move