### PR TITLE
Bed Mesh: using z axis lift speed instead general speed + additional fix to bed screws

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1012,6 +1012,9 @@ information.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#probe_speed: 5
+#   The speed (in mm/s) when moving from a horizontal_move_z position
+#   to a probe_height position. The default is 5.
 ```
 
 ### [bed_screws]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -94,7 +94,6 @@ class BedMesh:
         self.bmc = BedMeshCalibrate(config, self)
         self.z_mesh = None
         self.toolhead = None
-        self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
         self.fade_start = config.getfloat('fade_start', 1.)
         self.fade_end = config.getfloat('fade_end', 0.)
         self.fade_dist = self.fade_end - self.fade_start
@@ -251,7 +250,8 @@ class BedMesh:
             gcmd.respond_info("Bed has not been probed")
         else:
             self.z_mesh.print_probed_matrix(gcmd.respond_info)
-            self.z_mesh.print_mesh(gcmd.respond_raw, self.horizontal_move_z)
+            self.z_mesh.print_mesh(gcmd.respond_raw,
+                                   self.bmc.probe_helper.horizontal_move_z)
     cmd_BED_MESH_MAP_help = "Serialize mesh and output to terminal"
     def cmd_BED_MESH_MAP(self, gcmd):
         if self.z_mesh is not None:

--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -47,8 +47,8 @@ class BedScrews:
         # Move up, over, and then down
         self.move((None, None, self.horizontal_move_z), self.lift_speed)
         coord, name = self.states[state][screw]
-        self.move((coord[0], coord[1], self.horizontal_move_z), self.speed)
-        self.move((coord[0], coord[1], self.probe_z), self.lift_speed)
+        self.move((coord[0], coord[1], None), self.speed)
+        self.move((None, None, self.probe_z), self.lift_speed)
         # Update state
         self.state = state
         self.current_screw = screw
@@ -79,7 +79,7 @@ class BedScrews:
             raise gcmd.error("Already in bed_screws helper; use ABORT to exit")
         # reset accepted screws
         self.accepted_screws = 0
-        self.move((None, None, self.horizontal_move_z), self.speed)
+        self.move((None, None, self.horizontal_move_z), self.lift_speed)
         self.move_to_screw('adjust', 0)
     cmd_ACCEPT_help = "Accept bed screw position"
     def cmd_ACCEPT(self, gcmd):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -407,12 +407,10 @@ class ProbePointsHelper:
         self.results = []
         if probe is None or method != 'automatic':
             # Manual probe
-            self.lift_speed = self.speed
             self.probe_offsets = (0., 0., 0.)
             self._manual_probe_start()
             return
         # Perform automatic probing
-        self.lift_speed = probe.get_lift_speed(gcmd)
         self.probe_offsets = probe.get_offsets()
         if self.horizontal_move_z < self.probe_offsets[2]:
             raise gcmd.error("horizontal_move_z can't be less than"

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -366,7 +366,7 @@ class ProbePointsHelper:
         self.speed = config.getfloat('speed', 50., above=0.)
         self.use_offsets = False
         # Internal probing state
-        self.lift_speed = self.speed
+        self.lift_speed = config.getfloat('probe_speed', 5.)
         self.probe_offsets = (0., 0., 0.)
         self.results = []
     def minimum_points(self,n):
@@ -383,11 +383,8 @@ class ProbePointsHelper:
     def _move_next(self):
         toolhead = self.printer.lookup_object('toolhead')
         # Lift toolhead
-        speed = self.lift_speed
-        if not self.results:
-            # Use full speed to first probe position
-            speed = self.speed
-        toolhead.manual_move([None, None, self.horizontal_move_z], speed)
+        toolhead.manual_move([None, None, self.horizontal_move_z],
+                             self.lift_speed)
         # Check if done probing
         if len(self.results) >= len(self.probe_points):
             toolhead.get_last_move_time()


### PR DESCRIPTION
Using lift speed for z axis, because for the large printers we need quick toolhead move with slow bed move