### PR TITLE
Support for load cell homing/probing + hx711 adc

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1250,6 +1250,9 @@ This enables the use of a load cell for homing and probing (e.g. mesh leveling).
 A QUERY_LOAD_CELL_PROBE command can be used to print out measurements.
 This can be useful for setting the initial values for the gain, threshold, and 'invert'.
 Afterwards a QUERY_LOAD_CELL_PROBE_END command stops the sampling.
+All probing or homing moves should be issued with low acceleration and low square-corner-velocity
+to prevent false triggers. Use a command like this 
+"SET_VELOCITY_LIMIT ACCEL=100 SQUARE_CORNER_VELOCITY=0.1"
 
 To use the load cell as a z endstop set the following config option in the stepper_z section
 ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1244,6 +1244,53 @@ See also: [extended g-code commands](G-Codes.md#z_thermal_adjust).
 #   parameter.
 ```
 
+## Load cell probe
+
+This enables the use of a load cell for homing and probing (e.g. mesh leveling).
+A QUERY_LOAD_CELL_PROBE command can be used to print out measurements.
+This can be useful for setting the initial values for the gain, threshold, and 'invert'.
+Afterwards a QUERY_LOAD_CELL_PROBE_END command stops the sampling.
+
+To use the load cell as a z endstop set the following config option in the stepper_z section
+```
+endstop_pin: load_cell_probe:z_virtual_endstop
+```
+
+```
+[load_cell_probe]
+adc: my_load_cell:None
+#   Specify a load cell ADC. This uses the usual syntax of mcu:pin
+#   for the 'mcu' specify a configured load cell adc.
+force_threshold: 70000
+#   The force limit sets the force at which the axis stops moving.
+#   During initial setup, a manual force can be applied to find a reasonable value for this.
+#   Use a QUERY_LOAD_CELL_PROBE command to print out measured values.
+#   If there are false triggers/retries this should be increased,
+#   some deformation is expected and does not impact the accuracy.
+#invert: False
+#   Invert the 'direction' of the load cell if needed.
+#   The values should increase with the applied force.
+#   Negative baseline values are ok.
+#z_offset: 0.05
+#   A fixed Z offset. This is often not needed.
+```
+
+## HX711
+
+The HX711 chip is a popular load cell adc, unless this came with your printer you may have to
+solder a harware jumper to enable the 80sps mode. Otherwise it will only output 20 samples per second
+which won't work well.
+
+```
+[hx711 my_load_cell]
+dout_pin: mcu2:PE1
+sck_pin: mcu2:PE0
+gain: 128
+#   Gain can be 32, 64, 128.
+#   Reduce this if the measurements are reaching their limits.
+#   when reducing the gain, the force_threshold in load_cell_probe should be reduced as well.
+```
+
 ## Customized homing
 
 ### [safe_z_home]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1248,13 +1248,16 @@ See also: [extended g-code commands](G-Codes.md#z_thermal_adjust).
 
 This enables the use of a load cell for homing and probing (e.g. mesh leveling).
 A QUERY_LOAD_CELL_PROBE command can be used to print out measurements.
-This can be useful for setting the initial values for the gain, threshold, and 'invert'.
+This can be useful for setting the initial values for the gain, threshold
+and 'invert'.
 Afterwards a QUERY_LOAD_CELL_PROBE_END command stops the sampling.
-All probing or homing moves should be issued with low acceleration and low square-corner-velocity
-to prevent false triggers. Use a command like this 
+
+All probing or homing moves should be issued with low acceleration and low
+square-corner-velocity to prevent false triggers. Use a command like this
 "SET_VELOCITY_LIMIT ACCEL=100 SQUARE_CORNER_VELOCITY=0.1"
 
-To use the load cell as a z endstop set the following config option in the stepper_z section
+To use the load cell as a z endstop set the following config option in the
+stepper_z section
 ```
 endstop_pin: load_cell_probe:z_virtual_endstop
 ```
@@ -1266,7 +1269,8 @@ adc: my_load_cell:None
 #   for the 'mcu' specify a configured load cell adc.
 force_threshold: 70000
 #   The force limit sets the force at which the axis stops moving.
-#   During initial setup, a manual force can be applied to find a reasonable value for this.
+#   During initial setup, a manual force can be applied to find a reasonable
+#   value for this.
 #   Use a QUERY_LOAD_CELL_PROBE command to print out measured values.
 #   If there are false triggers/retries this should be increased,
 #   some deformation is expected and does not impact the accuracy.
@@ -1280,9 +1284,9 @@ force_threshold: 70000
 
 ## HX711
 
-The HX711 chip is a popular load cell adc, unless this came with your printer you may have to
-solder a harware jumper to enable the 80sps mode. Otherwise it will only output 20 samples per second
-which won't work well.
+The HX711 chip is a popular load cell adc, unless this came with your printer,
+you may have to solder a hardware jumper to enable the 80sps mode.
+Otherwise it will only output 20 samples per seconds which won't work well.
 
 ```
 [hx711 my_load_cell]
@@ -1291,7 +1295,8 @@ sck_pin: mcu2:PE0
 gain: 128
 #   Gain can be 32, 64, 128.
 #   Reduce this if the measurements are reaching their limits.
-#   when reducing the gain, the force_threshold in load_cell_probe should be reduced as well.
+#   when reducing the gain, the force_threshold in load_cell_probe should be
+#   reduced as well.
 ```
 
 ## Customized homing

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -5,7 +5,6 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
-import numpy as np
 from . import probe, load_cell_probe
 
 PROFILE_VERSION = 1
@@ -852,10 +851,6 @@ class ZMesh:
                            (self.mesh_x_count - 1)
         self.mesh_y_dist = (self.mesh_y_max - self.mesh_y_min) / \
                            (self.mesh_y_count - 1)
-        self.probe_x_dist = (self.mesh_x_max - self.mesh_x_min) / \
-                            (params['x_count'] - 1)
-        self.probe_y_dist = (self.mesh_y_max - self.mesh_y_min) / \
-                            (params['y_count'] - 1)
     def get_mesh_matrix(self):
         if self.mesh_matrix is not None:
             return [[round(z, 6) for z in line]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -5,7 +5,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
-from . import probe
+import numpy as np
+from . import probe, load_cell_probe
 
 PROFILE_VERSION = 1
 PROFILE_OPTIONS = {
@@ -297,10 +298,26 @@ class BedMeshCalibrate:
         self._generate_points(config.error)
         self._profile_name = None
         self.orig_points = self.points
-        self.probe_helper = probe.ProbePointsHelper(
+        self.screws = []
+        self.linear_model = None
+        if config.has_section('load_cell_probe'):
+            _probe = load_cell_probe
+        else:
+            _probe = probe
+        self.probe_helper = _probe.ProbePointsHelper(
             config, self.probe_finalize, self._get_adjusted_points())
         self.probe_helper.minimum_points(3)
         self.probe_helper.use_xy_offsets(True)
+        for i in range(99):
+            prefix = f"screw{i+1}"
+            if config.get(prefix, None) is None:
+                break
+            self.screws.append(config.getfloatlist(prefix, count=2))
+        self.screw_pitch = config.getchoice('screw_thread', {'M3': 0.5, 'M4': 0.7, 'M5': 0.8}, default='M3')
+        if config.getboolean('invert_direction', False):
+            self.screw_pitch *= -1
+        if 0 < len(self.screws) < 3:
+            raise config.error("bed_screws: Must have at least three screws")
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'BED_MESH_CALIBRATE', self.cmd_BED_MESH_CALIBRATE,
@@ -724,6 +741,38 @@ class BedMeshCalibrate:
         self.bedmesh.set_mesh(z_mesh)
         self.gcode.respond_info("Mesh Bed Leveling Complete")
         self.bedmesh.save_profile(self._profile_name)
+        self.calculate_screw_rotations(z_mesh)
+    def calculate_screw_rotations(self, z_mesh):
+        if not self.screws:
+            return
+        mesh_values = np.array(z_mesh.get_probed_matrix())
+        mesh_points = []
+        for y, Y in enumerate(mesh_values):
+            for x, X in enumerate(Y):
+                mesh_points.append(
+                    [1,
+                    z_mesh.mesh_x_min + x*z_mesh.probe_x_dist,
+                    z_mesh.mesh_y_min + y*z_mesh.probe_y_dist])
+        mesh_values = mesh_values.flatten()
+        mesh_points = np.array(mesh_points)
+        self.linear_model, r, rank, s = np.linalg.lstsq(mesh_points, mesh_values, rcond=-1)
+        logging.info(f"run lstsq with {mesh_points} {mesh_values} got n {self.linear_model}")
+        offset = self.calc_z(*self.screws[0])
+        res = []
+        for i, screw in enumerate(self.screws[1:]):
+            d = self.calc_z(*screw) - offset
+            res.append([screw, -d/self.screw_pitch])
+            logging.info(f"Rotate screw{i+1} {res[i][0]} {abs(res[i][1]):.2}x {'CW' if res[i][1] >= 0 else 'CCW'}")
+    def calc_z(self, x, y):
+        return self.linear_model[0] + self.linear_model[1]*x + self.linear_model[2]*y
+    def apply_screw_rotations(self):
+        values = self.bedmesh.z_mesh.probed_matrix
+        for y, Y in enumerate(values):
+            for x, X in enumerate(Y):
+                values[y][x] -= self.calc_z(
+                    self.bedmesh.z_mesh.mesh_x_min + x*self.bedmesh.z_mesh.probe_x_dist,
+                    self.bedmesh.z_mesh.mesh_y_min + y*self.bedmesh.z_mesh.probe_y_dist)
+        self.bedmesh.z_mesh.build_mesh(values)
     def _dump_points(self, probed_pts, corrected_pts, offsets):
         # logs generated points with offset applied, points received
         # from the finalize callback, and the list of corrected points
@@ -847,6 +896,10 @@ class ZMesh:
                            (self.mesh_x_count - 1)
         self.mesh_y_dist = (self.mesh_y_max - self.mesh_y_min) / \
                            (self.mesh_y_count - 1)
+        self.probe_x_dist = (self.mesh_x_max - self.mesh_x_min) / \
+                            (params['x_count'] - 1)
+        self.probe_y_dist = (self.mesh_y_max - self.mesh_y_min) / \
+                            (params['y_count'] - 1)
     def get_mesh_matrix(self):
         if self.mesh_matrix is not None:
             return [[round(z, 6) for z in line]

--- a/klippy/extras/hx711.py
+++ b/klippy/extras/hx711.py
@@ -1,0 +1,57 @@
+# Support for HX711 ADC chip
+#
+# Copyright (C) 2023  Konstantin Vogel <konstantin.vogel@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+
+
+class MCU_hx711:
+
+    def __init__(self, main):
+        self._main = main
+        self.printer = main.printer
+        self.reactor = self.printer.get_reactor()
+        self.mcu = main.mcu
+        self._last_value = 0.
+        self._last_clock = 0
+        self._callbacks = []
+        self.oid = self.mcu.create_oid()
+        self.mcu.register_config_callback(self._build_config)
+    def _build_config(self):
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.mcu._serial.register_response(self._handle_adc_state, "hx711_in_state", self.oid)
+        self.mcu.add_config_cmd(f"config_hx711 oid={self.oid} dout_pin={self._main.dout_pin} sck_pin={self._main.sck_pin} gain={self._main.gain}")
+        self.query_adc_cmd = self.mcu.lookup_command("query_hx711 oid=%c enable=%u endstop_oid=%i", cq=cmd_queue)
+    def setup_adc_callback(self, report_time, callback):
+        self._callbacks.append(callback)
+    def _handle_adc_state(self, params):
+        params['value'] *= self._main.direction
+        self._last_value = params['value']
+        self._last_clock = params['clock']
+        for cb in self._callbacks:
+            cb(self._last_clock, self._last_value)
+
+class PrinterHx711:
+
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.config = config
+        self.name = config.get_name().split()[1]
+        ppins = self.printer.lookup_object('pins')
+        dout_pin_params = ppins.lookup_pin(config.get('dout_pin'))
+        sck_pin_params = ppins.lookup_pin(config.get('sck_pin'))
+        self.dout_pin = dout_pin_params['pin']
+        self.sck_pin = sck_pin_params['pin']
+        self.mcu = dout_pin_params['chip']
+        self.gain = config.getchoice('gain', {32: 2, 64: 3, 128: 1}, default=64)
+        self.direction = -1 if config.getboolean('invert', False) else 1
+        ppins.register_chip(self.name, self)
+
+    def setup_pin(self, pin_type, pin_params):
+        self.sensor = MCU_hx711(self)
+        return self.sensor
+
+def load_config_prefix(config):
+    return PrinterHx711(config)

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -19,7 +19,6 @@ class LoadCellProbe:
         pin_name = config.get('adc')
         ppins = self.printer.lookup_object('pins')
         ppins.register_chip('load_cell_probe', self)
-
         self._adc = ppins.setup_pin('adc', pin_name)
         self._mcu = self._adc.mcu
         self._oid = self._mcu.create_oid()
@@ -239,16 +238,6 @@ class ProbePointsHelper:
         self.lcp.baseline = []
         self.retries = 0
         self.results = []
-        spacing = [None, None]
-        i = 0
-        while spacing[0] is None or spacing[1] is None:
-            sx = abs(self.probe_points[i][0] - self.probe_points[i+1][0])
-            sy = abs(self.probe_points[i][1] - self.probe_points[i+1][1])
-            if sx > 0.0001 and not spacing[0]:
-                spacing[0] = sx
-            if sy > 0.0001 and not spacing[1]:
-                spacing[1] = sy
-            i+=1
         while 1:
             done = self._move_next()
             if done:

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -1,0 +1,340 @@
+# Load cell probes
+#
+# Copyright (C) 2023 Konstantin Vogel <konstantin.vogel@gmx.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from collections import deque
+from math import sqrt
+import logging
+import numpy as np
+
+PROBING_START_DELAY = 0.010
+
+class LoadCellProbe:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+
+        pin_name = config.get('adc')
+        ppins = self.printer.lookup_object('pins')
+        ppins.register_chip('load_cell_probe', self)
+
+        self._adc = ppins.setup_pin('adc', pin_name)
+        self._mcu = self._adc.mcu
+        self._oid = self._mcu.create_oid()
+        self._data_completion = None
+        self._trigger_completion = None
+        self._overshoot_sample_time = 0.03 # How long to keep measuring after halting the stepper
+        self._need_data_to = 0
+        self.values = deque(maxlen=300)
+        self.baseline = []
+        self.steppers = []
+        self.manual_query = False
+
+        self.position_endstop    = config.getfloat('z_offset', 0)
+        self.force_threshold     = config.getfloat('force_threshold', above=0.)
+        self.noise_limit         = config.getfloat('noise_limit', self.force_threshold*0.15)
+        self.stiffness_max       = config.getfloat('stiffness_max', self.force_threshold)
+        self.stiffness_min       = config.getfloat('stiffness_min', 0)
+        self.linear_noise_limit2 = config.getfloat('linear_noise_limit', self.force_threshold*0.2)**2
+
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.printer.register_event_handler('klippy:mcu_identify', self._handle_mcu_identify)
+        self._mcu.register_config_callback(self._build_config)
+        self.gcode.register_command('QUERY_LOAD_CELL', self.cmd_QUERY_LOAD_CELL)
+        self.gcode.register_command('QUERY_LOAD_CELL_END', self.cmd_QUERY_LOAD_CELL_END)
+
+    def _build_config(self):
+        cmd_queue = self._mcu.alloc_command_queue()
+        s = [-1, -1, -1]
+        for i, st in enumerate(self.steppers):
+            s[i] = st._oid
+        self._mcu.add_config_cmd(f"config_load_cell_probe oid={self._oid} stepper1={s[0]} stepper2={s[1]} stepper3={s[2]}")
+        self._mcu._serial.register_response(self.trigger, 'load_cell_probe_triggered', self._oid)
+        self.enable_load_cell_trigger_cmd = self._mcu.lookup_command("enable_load_cell_trigger oid=%c enable=%i limit=%i", cq=cmd_queue)
+
+    def setup_pin(self, pin_type, pin_params):
+        return self
+
+    def _handle_ready(self):
+        self._adc.setup_adc_callback(None, self._adc_callback)
+        self.toolhead = self.printer.lookup_object('toolhead')
+        self.bed_mesh = self.printer.lookup_object('bed_mesh')
+
+    def calculate_baseline(self, stop_clock):
+        full_data = np.array(self.values)
+        # logging.info(full_data)
+        data = full_data[:,1]
+        # remove samples after stop, because the load cell will be under constant tension until retracting
+        data = data[full_data[:,0] < stop_clock]
+        dev = np.abs(data - np.median(data))
+        mdev = np.median(dev)
+        s = dev/mdev if mdev else 0.
+        no_outliers = data[s<4]
+        new_baseline = np.median(no_outliers)
+        noise = np.std(no_outliers)
+        if noise > self.noise_limit:
+            logging.info(f"Noise limit for baseline measurement exceeded {noise} > {self.noise_limit}")
+            return None
+        logging.info(f"got new baseline of {new_baseline} rejected {100*(len(data)-len(no_outliers))/len(data):.0f}% of samples")
+        self.baseline.append(new_baseline)
+        if len(self.baseline) > 10:
+            self.baseline = self.baseline[5:]
+        normal = 0
+        weight = 5
+        avg = 0
+        for b in reversed(self.baseline):
+            normal += weight
+            avg += weight*b
+            weight -= 1
+            if weight == 0:
+                break
+        return avg/normal
+
+    def calculate_t0(self, stop_clock64):
+        c1 = stop_clock64 + self._overshoot_sample_time
+        if c1 > self.values[-1][1]:
+            self._need_data_to = c1
+            self._data_completion = self.reactor.completion()
+            self._data_completion.wait()
+        baseline = self.calculate_baseline(stop_clock64)
+        if baseline is None:
+            return None
+        values = list(self.values)
+        A = []
+        y = []
+        last_residual = np.inf
+        skipped_samples = 0
+        for i, v in enumerate(reversed(values)):
+            if v[0] > c1:
+                skipped_samples += 1
+                continue
+            self.reactor.pause(self.reactor.NOW) # let other stuff run
+            A.append([self._mcu.clock_to_print_time(v[0]), 1])
+            y.append(v[1])
+            if len(y) > 50:
+                return None
+            if len(y) > 5:
+                mxn, residual, rank, s = np.linalg.lstsq(np.array(A), y, rcond=-1)
+                logging.info(f"lin fit with {A} and {y} residual {residual}")
+                peakness = (v[1] - baseline)/(values[-(skipped_samples+1)][1] - baseline) # 1 if sample is peak, 0 if sample is baseline
+                if not len(residual):
+                    logging.info(f"Numeric error, rank is {rank}")
+                    return None
+                added_residual = residual[0] - last_residual
+                if added_residual >= (0.8 + 0.7*peakness)*last_residual/(len(y)-1):
+                    break
+                last_residual = residual[0]
+                last_mxn = mxn
+        noise = last_residual/len(y)
+        if noise > self.linear_noise_limit2:
+            logging.info(f"Noise limit for linear approximation exceeded {sqrt(noise)} > {sqrt(self.linear_noise_limit2)}")
+            return None
+        t0 = (baseline - last_mxn[1]) / last_mxn[0]
+        logging.info(f"sample_count {i-skipped_samples} t0 {t0} t_stop {self._mcu.clock_to_print_time(stop_clock64)} t1 {self._mcu.clock_to_print_time(c1)} residual {last_residual}")
+        return t0
+
+    def _adc_callback(self, clock32, value):
+        clock64 = self._mcu.clock32_to_clock64(clock32)
+        self.values.append((clock64, value))
+        if self._data_completion and clock64 >= self._need_data_to:
+            self._data_completion.complete(None)
+        if self.manual_query:
+            self.gcode.respond_info(f"Load Cell Value is {value}")
+
+    def get_offsets(self):
+        return 0, 0, 0
+
+    def trigger(self, params):
+        logging.info(f"triggered with {params}")
+        if self._trigger_completion:
+            self._trigger_completion.complete(self._mcu.clock32_to_clock64(params['clock']))
+
+    def _handle_mcu_identify(self):
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        for stepper in kin.get_steppers():
+            if stepper.is_active_axis('z'):
+                self.steppers.append(stepper)
+
+    def cmd_QUERY_LOAD_CELL(self, gcmd):
+        self.manual_query = True
+        self._adc.query_adc_cmd.send([self._adc.oid, 1, self._oid])
+
+    def cmd_QUERY_LOAD_CELL_END(self, gcmd):
+        self.manual_query = False
+        self._adc.query_adc_cmd.send([self._adc.oid, 0, -1])
+
+   ######################################################################
+   # Endstop interface
+   ######################################################################
+
+    def add_stepper(self, stepper):
+        pass
+
+    def get_position_endstop(self):
+        return 0
+
+    def get_steppers(self):
+        return self.steppers
+
+    def home_start(self, print_time, sample_time=None, sample_count=None, rest_time=None, triggered=True, homing=True):
+        if homing:
+            self.baseline = []
+        self._adc.query_adc_cmd.send([self._adc.oid, 1, self._oid])
+        self.reactor.pause(self.reactor.monotonic() + 1)
+        self.enable_load_cell_trigger_cmd.send([self._oid, 1, int(self.force_threshold)])
+        self._trigger_completion = self.reactor.completion()
+        return self._trigger_completion
+
+    def home_wait(self, home_end_time, homing=True):
+        self.reactor.register_callback(lambda e: self._trigger_completion.complete(0), home_end_time)
+        stop_clock64 = self._trigger_completion.wait()
+        if stop_clock64 != 0:
+            t0 = self.calculate_t0(stop_clock64)
+        if homing:
+            for s in self.steppers:
+                s.note_homing_end()
+        self._adc.query_adc_cmd.send([self._adc.oid, 0, -1])
+        if stop_clock64 == 0:
+            return 0, True
+        if t0 is None:
+            logging.info("linear fit failed")
+            return self._mcu.clock_to_print_time(stop_clock64), True
+        return t0, False
+
+    def query_endstop(self, print_time):
+        return False
+
+    def get_position_endstop(self):
+        return self.position_endstop
+
+class ProbePointsHelper:
+    def __init__(self, config, finalize_callback, default_points=None):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.lcp = self.printer.lookup_object('load_cell_probe')
+
+        self.results = None
+        self.retries = 0
+        self.finalize_callback = finalize_callback
+        self.probe_points = default_points
+
+        self.horizontal_move_z = config.getfloat('horizontal_move_z', 6.) # needs to be different from current pos
+        self.retract_dist      = config.getfloat('sample_retract_dist', 2., above=0.)
+        self.probe_speed       = config.getfloat('probe_speed', 3, above=0.)
+        self.retract_speed     = config.getfloat('retract_speed', 10, above=0.)
+        self.speed             = config.getfloat('speed', 100., above=0.)
+        if default_points is None or config.get('points', None) is not None:
+            self.probe_points = config.getlists('points', seps=(',', '\n'), parser=float, count=2)
+
+    def minimum_points(self, n):
+        pass
+
+    def use_xy_offsets(self, use_offsets):
+        pass
+
+    def start_probe(self, gcmd):
+        self.lcp.baseline = []
+        self.retries = 0
+        self.results = []
+        spacing = [None, None]
+        i = 0
+        while spacing[0] is None or spacing[1] is None:
+            sx = abs(self.probe_points[i][0] - self.probe_points[i+1][0])
+            sy = abs(self.probe_points[i][1] - self.probe_points[i+1][1])
+            if sx > 0.0001 and not spacing[0]:
+                spacing[0] = sx
+            if sy > 0.0001 and not spacing[1]:
+                spacing[1] = sy
+            i+=1
+        while 1:
+            done = self._move_next()
+            if done:
+                break
+            pos = self.probing_move()
+            self.results.append(pos)
+
+    def update_probe_points(self, points, min_points):
+        self.probe_points = points
+
+    def retry_probing_move(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        self.retries += 1
+        if self.retries > 5:
+            raise self.printer.command_error("Load Cell Probing failed after 5 Retries")
+        # Lift toolhead
+        toolhead.manual_move([None, None, self.retract_dist], self.retract_speed)
+        return self.probing_move()
+
+    def probing_move(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        kin = toolhead.get_kinematics()
+        gcode_move = self.printer.lookup_object('gcode_move')
+        movepos = self._fill_coord([None, None, -2, None])
+        toolhead.flush_step_generation()
+        # Start endstop checking
+        print_time = toolhead.get_last_move_time()
+        completion = self.lcp.home_start(print_time, homing=False)
+        toolhead.dwell(PROBING_START_DELAY)
+        # Issue move
+        error = None
+        try:
+            toolhead.drip_move(movepos, self.probe_speed, completion)
+        except self.printer.command_error as e:
+            error = "Error during probing move: " + str(e)
+        # Wait for endstops to trigger
+        move_end_print_time = toolhead.get_last_move_time()
+        trigger_time, retry = self.lcp.home_wait(move_end_print_time, homing=False)
+        if trigger_time == 0:
+            logging.info("Probe not triggered after timeout")
+        # Determine stepper halt positions
+        toolhead.flush_step_generation()
+        trig_kin_pos = {s.get_name(): s.get_commanded_position() for s in kin.get_steppers()}
+        for s in self.lcp.steppers:
+            s.note_load_cell_probing_end()
+            trig_kin_pos[s.get_name()] = s.mcu_to_commanded_position(s.get_past_mcu_position(trigger_time))
+        trig_pos = self.probe_points[len(self.results)] + (kin.calc_position(trig_kin_pos)[2],)
+        kin_pos = {s.get_name(): s.get_commanded_position() for s in kin.get_steppers()}
+        position = list(kin.calc_position(kin_pos))[:3] + toolhead.get_position()[3:]
+        toolhead.set_position(position)
+        logging.info(f"trig_pos {trig_pos} trig_kin_pos {trig_kin_pos} trigger_time {trigger_time} move_end_print_time {move_end_print_time} kin_pos {kin_pos} therefore setting position {position}")
+        gcode_move.reset_last_position()
+        if error is not None:
+            raise self.printer.command_error(error)
+        if retry:
+            return self.retry_probing_move()
+        return trig_pos
+
+    def _move_next(self):
+        self.reactor.pause(self.reactor.monotonic() + 0.01)
+        toolhead = self.printer.lookup_object('toolhead')
+        # Lift toolhead
+        toolhead.manual_move([None, None, self.horizontal_move_z], self.retract_speed)
+        # Check if done probing
+        if len(self.results) >= len(self.probe_points):
+            toolhead.get_last_move_time()
+            res = self.finalize_callback((0, 0, 0), self.results)
+            if res != "retry":
+                return True
+            self.results = []
+        # Move to next XY probe point
+        nextpos = list(self.probe_points[len(self.results)])
+        toolhead.manual_move(nextpos, self.speed)
+        toolhead.wait_moves()
+        toolhead.get_last_move_time()
+        self.reactor.pause(self.reactor.monotonic() + 0.3)
+        return False
+
+    def _fill_coord(self, coord):
+        toolhead = self.printer.lookup_object('toolhead')
+        # Fill in any None entries in 'coord' with current toolhead position
+        thcoord = list(toolhead.get_position())
+        for i in range(len(coord)):
+            if coord[i] is not None:
+                thcoord[i] = coord[i]
+        return thcoord
+
+def load_config(config):
+    return LoadCellProbe(config)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -219,7 +219,7 @@ class MCU_endstop:
             return home_end_time
         params = self._query_cmd.send([self._oid])
         next_clock = self._mcu.clock32_to_clock64(params['next_clock'])
-        return self._mcu.clock_to_print_time(next_clock - self._rest_ticks)
+        return self._mcu.clock_to_print_time(next_clock - self._rest_ticks), False
     def query_endstop(self, print_time):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._mcu.is_fileoutput():

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 src-y += sched.c command.c basecmd.c debugcmds.c
 src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c \
     trsync.c
-src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c
+src-$(CONFIG_HAVE_GPIO_ADC) += adccmds.c hx711.c load_cell_probe.c
 src-$(CONFIG_HAVE_GPIO_SPI) += spicmds.c thermocouple.c
 src-$(CONFIG_HAVE_GPIO_I2C) += i2ccmds.c
 src-$(CONFIG_HAVE_GPIO_HARD_PWM) += pwmcmds.c

--- a/src/hx711.c
+++ b/src/hx711.c
@@ -1,0 +1,116 @@
+// Communication with HX711 ADC
+//
+// Copyright (C) 2023 Konstantin Vogel <konstantin.vogel@gmx.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_*
+#include "board/misc.h" // timer_read_time
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_TASK
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h"
+#include "load_cell_probe.h"
+
+#define SAMPLE_INTERVAL (CONFIG_CLOCK_FREQ/80)
+#define COMM_DELAY (40*(CONFIG_CLOCK_FREQ/1000000))
+
+
+struct hx711 {
+    uint32_t oid;
+    int32_t sample;
+    uint32_t sample_idx;
+    uint32_t gain;
+    struct timer timer;
+    struct gpio_in dout;
+    struct gpio_out sck;
+    int32_t endstop_oid;
+    uint32_t last_sample_time;
+    int32_t result;
+};
+
+
+struct hx711 *hx711_1;
+static struct task_wake hx711_wake;
+
+static uint_fast8_t hx711_event(struct timer *timer)
+{
+    struct hx711 *h = hx711_1;
+    uint32_t out = 0;
+    uint32_t delay = 0;
+
+    if (h->sample_idx == 0 && gpio_in_read(h->dout)) {
+    }
+    else if (h->sample_idx % 2) {
+        if (h->sample_idx < 48)
+            h->sample |= gpio_in_read(h->dout) << (31 - (h->sample_idx)/2);
+        h->sample_idx++;
+    }
+    else {
+        out = 1;
+        h->sample_idx++;
+    }
+    if (h->sample_idx >= (48 + 2*h->gain)){
+        out = 0;
+        h->result = h->sample;
+        sched_wake_task(&hx711_wake);
+        delay = 1;
+        h->sample_idx = 0;
+        h->sample = 0;
+    }
+    gpio_out_write(h->sck, out);
+    if (delay){
+        h->last_sample_time = timer_read_time() + SAMPLE_INTERVAL;
+        h->timer.waketime = h->last_sample_time;}
+    else
+        h->timer.waketime = timer_read_time() + COMM_DELAY;
+
+    return SF_RESCHEDULE;
+}
+
+
+void hx711_task(void)
+{
+    if (!sched_check_wake(&hx711_wake))
+        return;
+    struct hx711 *h = hx711_1;
+    h->result >>= 8;
+    if (h->endstop_oid >= 0)
+        check_load_cell_probe(h->endstop_oid, h->result, h->timer.waketime);
+    sendf("hx711_in_state oid=%c clock=%u value=%i", h->oid, h->timer.waketime, h->result);
+
+}
+DECL_TASK(hx711_task);
+
+
+void command_config_hx711(uint32_t *args)
+{
+    struct hx711 *h = oid_alloc(args[0], command_config_hx711, sizeof(*h));
+    h->dout = gpio_in_setup(args[1], -1); // enable pulldown
+    h->sck = gpio_out_setup(args[2], 0); // initialize as low
+    h->gain = args[3];
+    h->sample_idx = 0;
+    h->sample = 0;
+    h->oid = args[0];
+    h->timer.func = hx711_event;
+    h->last_sample_time = timer_read_time() + SAMPLE_INTERVAL;
+    h->timer.waketime = h->last_sample_time;
+    hx711_1 = h;
+}
+DECL_COMMAND(command_config_hx711, "config_hx711 oid=%c dout_pin=%u sck_pin=%u gain=%u");
+
+
+void command_query_hx711(uint32_t *args)
+{
+    struct hx711 *h = oid_lookup(args[0], command_config_hx711);
+    h->endstop_oid = args[2];
+    h->sample_idx = 0;
+    h->sample = 0;
+    sched_del_timer(&h->timer);
+
+    if (args[1]){
+        h->last_sample_time = timer_read_time() + SAMPLE_INTERVAL;
+        h->timer.waketime = h->last_sample_time;
+        sched_add_timer(&h->timer);}
+}
+DECL_COMMAND(command_query_hx711, "query_hx711 oid=%c enable=%u endstop_oid=%i");

--- a/src/load_cell_probe.c
+++ b/src/load_cell_probe.c
@@ -1,0 +1,53 @@
+// Load cell probing and homing
+//
+// Copyright (C) 2023 Konstantin Vogel <konstantin.vogel@gmx.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "command.h" // DECL_COMMAND
+#include "basecmd.h" // oid_alloc
+#include "board/irq.h" // irq_disable
+#include "stepper.h"
+
+struct load_cell_probe {
+    uint32_t oid;
+    int32_t limit;
+    int32_t stepper_oid[3];
+    int32_t triggering_active;
+};
+
+void command_config_load_cell_probe(uint32_t *args)
+{
+    struct load_cell_probe *lcp = oid_alloc(args[0], command_config_load_cell_probe, sizeof(*lcp));
+    lcp->oid = args[0];
+    lcp->limit = 0;
+    lcp->stepper_oid[0] = args[1];
+    lcp->stepper_oid[1] = args[2];
+    lcp->stepper_oid[2] = args[3];
+    lcp->triggering_active = 0;
+}
+DECL_COMMAND(command_config_load_cell_probe, "config_load_cell_probe oid=%c stepper1=%i stepper2=%i stepper3=%i");
+
+void check_load_cell_probe(uint32_t oid, int32_t value, uint32_t time)
+{
+    struct load_cell_probe *lcp = oid_lookup(oid, command_config_load_cell_probe);
+    if (value > lcp->limit && lcp->triggering_active)
+    {   
+        irq_disable();
+        lcp->triggering_active = 0;
+        for (int i=0; i<3; i++){
+            if (lcp->stepper_oid[i] >= 0)
+                stepper_manual_stop(lcp->stepper_oid[i]);
+        }
+        irq_enable();
+        sendf("load_cell_probe_triggered oid=%u clock=%u", oid, time);
+    } 
+}
+
+void command_enable_load_cell_trigger(uint32_t *args)
+{
+    struct load_cell_probe *lcp = oid_lookup(args[0], command_config_load_cell_probe);
+    lcp->triggering_active = args[1];
+    lcp->limit = args[2];
+}
+DECL_COMMAND(command_enable_load_cell_trigger, "enable_load_cell_trigger oid=%c enable=%i limit=%i");

--- a/src/load_cell_probe.h
+++ b/src/load_cell_probe.h
@@ -1,0 +1,9 @@
+
+#ifndef __LOAD_CELL_PROBE_H
+#define __LOAD_CELL_PROBE_H
+
+#include <stdint.h> // uint32_t
+
+void check_load_cell_probe(uint32_t oid, int32_t value, uint32_t time);
+
+#endif // load_cell_probe.h

--- a/src/stepper.h
+++ b/src/stepper.h
@@ -2,7 +2,9 @@
 #define __STEPPER_H
 
 #include <stdint.h> // uint8_t
+#include "sched.h" // struct timer
 
 uint_fast8_t stepper_event(struct timer *t);
+void stepper_manual_stop(uint32_t oid);
 
 #endif // stepper.h


### PR DESCRIPTION
Just wanted to share my current implementation of load cell probing as there seems to be a lot of interest in the feature.
I know there is already a PR regarding this (#5623) however my implementation is different in that it uses one continuous approach instead of moving in small steps. This is quicker and also enables homing with just the load cell.

In its current state the implementation works well on my printer, however it hasn't been broadly tested, and my setup uses a very nonstandard version of klipper. So it's possible i have overlooked something when creating the PR.

**Before merging**

This is not ready to be merged yet, I'm not really sure how the adc interface should be implemented,
also there are probably some shortcuts that will need to be adressed. Some feedback on this would be great.
Also I will fix the python2 compatibility, the formatting, and split this into separate commits. I just didn't bother with this yet as there will probably be some other changes as well.

**Limitations**
* needs numpy (I think this makes these things a lot more readable, maybe it can be installed manually for now)
* doesn't support multi-mcu homing (not sure how easy this is to implement or if it is needed, fundamentally there is less room for overshoot/latency as the printhead is already under tension at the end of a homing move) 
* delta printers probably don't work


**How to test this**
* you need a printer with a hx711 load cell adc
* you need to install numpy
* you need to to use python3 (for now)
* use a different retract distance for probing/homing (i think there is a bug with manual_move when commanding a move to the current position)
* tune the direction, force_threshold, and homing/probing speeds. (my printer uses 3 load cells in parallel, so the 70000 threshold is probably wrong for other printers)

**How it works**

Generally the code acts as a probe and as an endstop. So for probing or homing a move is issued until a fixed force threshold is reached which stops the stepper (like an endstop). Then the time of contact is determined by fitting a linear function to the force and calculating the intersection with a baseline value. 
Large disturbances during probing, or e.g. a filament blob on the nozzle can affect the result. To mitigate this an automatic retry algorithm is implemented. This has some additional (undocumented) config parameters.
This pr also includes a function to calculate screw rotations from a mesh_bed calibration. Not sure if this is useful as there is a separate module for this already.


<img width="1055" alt="Screenshot 2023-01-27 031648" src="https://user-images.githubusercontent.com/42315676/215485815-a6d44c27-92b6-45f4-badc-d02346456562.png">
