### PR TITLE
RPi_microcontroller.md: add service start command

### DIFF
--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -46,6 +46,7 @@ To build and install the new micro-controller code, run:
 sudo service klipper stop
 make flash
 sudo service klipper start
+sudo systemctl start klipper-mcu.service
 ```
 
 If klippy.log reports a "Permission denied" error when attempting to


### PR DESCRIPTION
Added service start command, as either this or a reboot is needed to actually start the service. Neither is specified.

Thanks
James

Signed-off-by: James Hartley <james@hartleyns.com>