### PR TITLE
stm32 i2c speed

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -337,6 +337,14 @@ config STM32F0_TRIM
         Default is 16 (use factory default). Each increment increases
         the clock rate by ~240KHz.
 
+choice
+    prompt "I2C Clock Speed" if LOW_LEVEL_OPTIONS
+    config STM32_I2C_CLOCK_100kHz
+        bool "100 kHz"
+    config STM32_I2C_Clock_400kHz
+        bool "400 kHz"
+endchoice
+
 
 ######################################################################
 # Communication inteface

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -341,7 +341,7 @@ choice
     prompt "I2C Clock Speed" if LOW_LEVEL_OPTIONS
     config STM32_I2C_CLOCK_100kHz
         bool "100 kHz"
-    config STM32_I2C_Clock_400kHz
+    config STM32_I2C_CLOCK_400kHz
         bool "400 kHz"
 endchoice
 

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -82,12 +82,12 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         // Set 100Khz frequency and enable
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
         i2c->CR2 = pclk / 1000000;
-         
-	if ( CONFIG_STM32_I2C_CLOCK_400kHz)
-	   i2c->CCR = pclk / 400000 / 2;
-	else
-	  i2c->CCR = pclk / 100000 / 2;
-	
+
+        if ( CONFIG_STM32_I2C_CLOCK_400kHz)
+          i2c->CCR = pclk / 400000 / 2;
+        else
+          i2c->CCR = pclk / 100000 / 2;
+
         i2c->TRISE = (pclk / 1000000) + 1;
         i2c->CR1 = I2C_CR1_PE;
     }

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -82,8 +82,8 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         // Set 100Khz frequency and enable
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
         i2c->CR2 = pclk / 1000000;
-
-	if ( CONFIG_STM32_I2C_CLOCK_100kHz)
+         
+	if ( CONFIG_STM32_I2C_CLOCK_400kHz)
 	   i2c->CCR = pclk / 400000 / 2;
 	else
 	  i2c->CCR = pclk / 100000 / 2;

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -82,7 +82,12 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         // Set 100Khz frequency and enable
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
         i2c->CR2 = pclk / 1000000;
-        i2c->CCR = pclk / 100000 / 2;
+
+	if ( CONFIG_STM32_I2C_CLOCK_100kHz)
+	   i2c->CCR = pclk / 400000 / 2;
+	else
+	  i2c->CCR = pclk / 100000 / 2;
+	
         i2c->TRISE = (pclk / 1000000) + 1;
         i2c->CR1 = I2C_CR1_PE;
     }


### PR DESCRIPTION
Added the option to choose between 100 kHz and 400 kHz for STM32
in lowlevel Kconfig.
 
I plan to use an mpu6050 with a STM32F1 (Blue-Pill).

Signed-off-by: Jan Schunke <findus4fun@gmail.com>