### PR TITLE
Added unregister_event_handler and unregister_chip

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -259,6 +259,11 @@ class Printer:
             (lambda e: self.invoke_shutdown(msg)))
     def register_event_handler(self, event, callback):
         self.event_handlers.setdefault(event, []).append(callback)
+    def unregister_event_handler(self, event, callbacks):
+        handlers = self.event_handlers.setdefault(event, [])
+        for callback in callbacks:
+            if callback in handlers:
+                handlers.remove(callback)
     def send_event(self, event, *params):
         return [cb(*params) for cb in self.event_handlers.get(event, [])]
     def request_exit(self, result):

--- a/klippy/pins.py
+++ b/klippy/pins.py
@@ -129,6 +129,11 @@ class PrinterPins:
             raise error("Duplicate chip name '%s'" % (chip_name,))
         self.chips[chip_name] = chip
         self.pin_resolvers[chip_name] = PinResolver()
+    def unregister_chip(self, chip_name):
+        chip_name = chip_name.strip()
+        if chip_name in self.chips:
+            del self.chips[chip_name]
+            del self.pin_resolvers[chip_name]
     def allow_multi_use_pin(self, pin_desc):
         pin_params = self.parse_pin(pin_desc)
         share_name = "%s:%s" % (pin_params['chip_name'], pin_params['pin'])


### PR DESCRIPTION
Added unregister_event_handler to klipper.py and unregister_chip to pins.py. I added these two methods to support the ability to have multiple probes. I'm currently working on a host module that supports multiple probes. For example, in my IDEX setup, I have a probe on each of the toolhead, I want to be able to activate one probe while deactivating others.In order to do so, I find that I need to unregister commands, event_handlers. and chips. Currently, only register_command supports unregistering a command by passing it a None as the second parameter. I needed the ability to unregister event_handlers and chips as well.