### PR TITLE
extruder: store currently sync'ed motion queue name

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -126,6 +126,9 @@ The following information is available for extruder_stepper objects (as well as
 [extruder](Config_Reference.md#extruder) objects):
 - `pressure_advance`: The current [pressure advance](Pressure_Advance.md) value.
 - `smooth_time`: The current pressure advance smooth time.
+- `motion_queue`: The name of the extruder that this extruder stepper is
+  currently synchronized to.  This is reported as `None` if the extruder stepper
+  is not currently associated with an extruder.
 
 ## fan
 


### PR DESCRIPTION
Adds a new `motion_queue` property to `ExtruderStepper` so we can store the current motion queue name and return on `get_status()`.

![image](https://user-images.githubusercontent.com/85504/216775901-4a22a39a-64d3-43c9-a99f-236d8160c77f.png)

When no motion queue is set, this returns null:

![image](https://user-images.githubusercontent.com/85504/216776058-049741e5-f71e-4f49-b97b-d65388779243.png)

This will allow frontends (Fluidd, Mainsail, ...) to show the current motion queue in sync on each extruder stepper, and for easy changes!

Follows up on [this Discourse topic](https://klipper.discourse.group/t/storing-the-current-extruder-from-sync-extruder-motion/6413)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>