### PR TITLE
Add Tenlog D3-Pro IDEX printer config

### DIFF
--- a/config/printer-tenlog-d3-pro.cfg
+++ b/config/printer-tenlog-d3-pro.cfg
@@ -1,0 +1,288 @@
+# This file contains a configuration snippet for a Tenlog TL-D3 Pro IDEX
+# printer. The same printer is sold under many names and can contain 2208
+# or 2209 drivers. The real printable size of the bed is 310mm x 310mm.
+# 
+# READ THIS WHOLE NOTE BEFORE USING THIS CONFIG!!!
+#
+# While flashing the printer you should DISCONNECT the printer from power
+# and connect only the USB cable.
+#
+# Note on hardware:
+#  Tenlog is known to sell slightly modified hardware without changing the name
+#  of the printer nor adding revision number. Thus, some settings here may not
+#  fit your printer. This config was created with the following hardware:
+#  - Area: 300x300x350 (advertised, real printable 310x310x359)
+#  - MB: "TENLOG 3D MB1 V2.3" + daughter board w/extruders connections
+#  - Driver: 7x TMC2209 (also works on TMC2208)
+#  - Motors: 42HD4027-01 (1.8°/s) on X1/X2/Y; others unknown
+#  - E-stops: optical (invert "endstop_pin" for older/mechanical ones)
+#  - Extruders: 2x Tenlog "regular" (has horizontal cutout and arrow cutout on
+#               the front, unlike Tenlog BMG or Tenlog Titan)
+#
+# Note on calibration:
+#  These printers are pretty inconsistent with temperature response. You need
+#  to calibrate PIDs on them by running these commands in order:
+#   PID_CALIBRATE HEATER=extruder TARGET=170
+#   PID_CALIBRATE HEATER=extruder1 TARGET=170
+#   PID_CALIBRATE HEATER=heater_bed TARGET=60
+#   SAVE_CONFIG
+#  Perform bed leveling as described here: https://www.klipper3d.org/Manual_Level.html
+
+# ===================== GENERAL PRINTER CONFIG =====================
+# The "TENLOG 3D MB1 V2.3" board is based on Atmel ATMEGA2560-16U
+# Tenlog's reference Marlin 1.x config uses Arduino pins definition, so to make
+# it easier to adapt to their changes Klipper config for D3P uses aliases here
+# See: https://github.com/tenlog/TL-D3/blob/master/Marlin/pins.h
+# Arduino aliases for atmega2560/1280 (Arduino mega) boards. These are 1:1 from
+# "config/sample-aliases.cfg"
+[board_pins arduino-mega]
+aliases:
+    ar0=PE0, ar1=PE1, ar2=PE4, ar3=PE5, ar4=PG5,
+    ar5=PE3, ar6=PH3, ar7=PH4, ar8=PH5, ar9=PH6,
+    ar10=PB4, ar11=PB5, ar12=PB6, ar13=PB7, ar14=PJ1,
+    ar15=PJ0, ar16=PH1, ar17=PH0, ar18=PD3, ar19=PD2,
+    ar20=PD1, ar21=PD0, ar22=PA0, ar23=PA1, ar24=PA2,
+    ar25=PA3, ar26=PA4, ar27=PA5, ar28=PA6, ar29=PA7,
+    ar30=PC7, ar31=PC6, ar32=PC5, ar33=PC4, ar34=PC3,
+    ar35=PC2, ar36=PC1, ar37=PC0, ar38=PD7, ar39=PG2,
+    ar40=PG1, ar41=PG0, ar42=PL7, ar43=PL6, ar44=PL5,
+    ar45=PL4, ar46=PL3, ar47=PL2, ar48=PL1, ar49=PL0,
+    ar50=PB3, ar51=PB2, ar52=PB1, ar53=PB0, ar54=PF0,
+    ar55=PF1, ar56=PF2, ar57=PF3, ar58=PF4, ar59=PF5,
+    ar60=PF6, ar61=PF7, ar62=PK0, ar63=PK1, ar64=PK2,
+    ar65=PK3, ar66=PK4, ar67=PK5, ar68=PK6, ar69=PK7,
+    analog0=PF0, analog1=PF1, analog2=PF2, analog3=PF3, analog4=PF4,
+    analog5=PF5, analog6=PF6, analog7=PF7, analog8=PK0, analog9=PK1,
+    analog10=PK2, analog11=PK3, analog12=PK4, analog13=PK5, analog14=PK6,
+    analog15=PK7,
+# Marlin adds these additional aliases
+    ml70=PG4, ml71=PG3, ml72=PJ2, ml73=PJ3, ml74=PJ7,
+    ml75=PJ4, ml76=PJ5, ml77=PJ6, ml78=PE2, ml79=PE6,
+    ml80=PE7, ml81=PD4, ml82=PD5, ml83=PD6, ml84=PH2,
+    ml85=PH7
+
+[mcu]
+baud: 250000
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 2900
+max_z_velocity: 20
+max_z_accel: 50
+
+
+# ===================== X-LEFT/E1 IDEX CARRIAGE & EXTRUDER ====================
+[stepper_x]
+step_pin: ar54
+dir_pin: ar55
+enable_pin: !ar38
+microsteps: 16
+rotation_distance: 40
+full_steps_per_rotation: 200
+endstop_pin: ^!ar3
+position_min: -47.7
+position_endstop: -47.7
+position_max: 306.3
+homing_speed: 50
+
+[extruder]
+step_pin: ar57
+dir_pin: !ar58
+enable_pin: !ar59
+microsteps: 16
+rotation_distance: 32.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+pressure_advance: 0.1
+heater_pin: ar11
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog15
+control: pid
+# DO NOT rely on these values! Calibrate your own printer (see top comment)
+pid_kp = 24.328
+pid_ki = 1.606
+pid_kd = 92.143
+min_temp: 10
+# Tenlog specifies max 300°C on the hotend but their firmware cuts off at 270°C
+max_temp: 270
+
+
+# ===================== X-RIGHT/E2 IDEX CARRIAGE & EXTRUDER ====================
+# X1 = [stepper_x]; X2 = [dual_carriage] with "axis: x"
+[dual_carriage]
+axis: x
+step_pin: ar36
+dir_pin: ar34
+enable_pin: !ar30
+microsteps: 16
+rotation_distance: 40
+full_steps_per_rotation: 200
+endstop_pin: ^!ar2
+position_endstop: 405.5
+position_max: 405.5
+homing_speed: 50
+
+[extruder1]
+step_pin: ar26
+dir_pin: ar28
+enable_pin: !ar24
+microsteps: 16
+rotation_distance: 32.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+pressure_advance: 0.1
+heater_pin: ar10
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog13
+# DO NOT rely on these values! Calibrate your own printer (see top comment)
+control: pid
+pid_kp = 23.813
+pid_ki = 1.470
+pid_kd = 96.444
+min_temp: 10
+# Tenlog specifies max 300°C on the hotend but their firmware cuts off at 270°C
+max_temp: 270
+
+
+# ===================== Y-AXIS CONFIG =====================
+[stepper_y]
+step_pin: ar60
+dir_pin: ar61
+enable_pin: !ar56
+microsteps: 16
+rotation_distance: 40
+full_steps_per_rotation: 200
+endstop_pin: ^!ar14
+position_endstop: 310
+# Configuration_tenlog.h "TL_SIZE_300" => "Y_MAX_POS" sets it to 320 but it
+# crashes on the frame at 313!
+position_max: 310
+homing_speed: 40
+
+
+# ===================== Z-AXIS CONFIG =====================
+# TL-D3 Pro contains a dual-screw driver for Z-axis (std. extruders are HEAVY)
+[stepper_z]
+step_pin: ar46
+dir_pin: ar48
+enable_pin: !ar62
+microsteps: 16
+#todo: this is yolo from matti - to validate
+rotation_distance: 4
+full_steps_per_rotation: 200
+endstop_pin: ^!ar18
+# Configuration_tenlog.h "TL_SIZE_300" => "Z_MAX_POS" sets 360 BUT this will crash into the frame!
+position_max: 359
+position_endstop = -0.035
+position_min: -1.0
+# Increasing this leads to missing steps
+homing_speed: 15
+
+[stepper_z1]
+step_pin: ar65
+dir_pin: ar66
+enable_pin: !ar64
+microsteps: 16
+rotation_distance: 4
+endstop_pin: ^!ar19
+
+
+# ===================== BED CONFIG =====================
+[heater_bed]
+heater_pin: ar8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: analog14
+min_temp: 10
+max_temp: 110
+# DO NOT rely on these values! Calibrate your own printer (see top comment)
+control: pid
+pid_kp = 73.517
+pid_ki = 1.175
+pid_kd = 1149.618
+
+# ===================== COOLING =====================
+# TL-D3 Pro has 4 fans in total: one for each extruder, one for
+# cooling the main board (MCU, X1/X2/Y/Z1/Z2 stepper drivers), one
+# cooling the back electronics compartment (E1/E2 stepper drivers,
+# and bed heater control).
+# TL-D3 Pro does NOT have individual extruder fan control, nor support
+# for individual control of electronics fans. Instead it has two
+# pins: one to control electronics (front & back) fans and one to
+# control both extruders fans.
+[controller_fan extruders]
+pin: ar9
+kick_start_time: 1.000
+off_below: 0.12
+heater: extruder,extruder1
+
+[controller_fan electronics]
+pin: ar5
+kick_start_time: 1.000
+off_below: 0.1
+stepper: extruder,extruder1,stepper_x,dual_carriage,stepper_y,stepper_z,stepper_z1
+heater: heater_bed
+
+
+# ===================== POWER SUPPLY =====================
+# TL-D3 Pro uses PSU with always-on standby power and an additional enable pin
+# for high-power stuff ("PS_ON_PIN" in Marlin)
+[output_pin ps_on]
+pin: ar40
+value: 0
+shutdown_value: 0
+
+# M80: Power On
+[gcode_macro m80]
+gcode:
+    SET_PIN PIN=ps_on VALUE=1
+
+# M81: Power Off
+[gcode_macro m81]
+gcode:
+    SET_PIN PIN=ps_on VALUE=0
+
+
+# ===================== OPTIONAL ACCESSORIES =====================
+# todo: TL-D3 Pro has two sensors; they're AND-ed
+[filament_switch_sensor e1_e2_sensor]
+switch_pin: ar15
+
+
+# ===================== MISC =====================
+# Helper scripts for homing dual-extruders (adapted from sample-idex.cfg)
+[gcode_macro PARK_extruder]
+gcode:
+    SAVE_GCODE_STATE NAME=park0
+    G90
+    G1 X-37.5
+    RESTORE_GCODE_STATE NAME=park0
+
+# Activate the primary extruder
+[gcode_macro T0]
+gcode:
+    PARK_{printer.toolhead.extruder}
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+    SET_DUAL_CARRIAGE CARRIAGE=0
+    SET_GCODE_OFFSET X=0 Y=0 Z=0.1
+
+[gcode_macro PARK_extruder1]
+gcode:
+    SAVE_GCODE_STATE NAME=park1
+    G90
+    G1 X346.5
+    RESTORE_GCODE_STATE NAME=park1
+
+[gcode_macro T1]
+gcode:
+    PARK_{printer.toolhead.extruder}
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+    SET_DUAL_CARRIAGE CARRIAGE=1
+    SET_GCODE_OFFSET X=48 Y=0 Z=0
+
+# ===================== DEBUG =====================
+# Options here are useful to be enabled while debugging this config. Do not
+# touch them unless you KNOW what you're doing.
+[force_move]
+enable_force_move: False


### PR DESCRIPTION
Caveat: the LCD config is missing as the printer's LCD isn't supported by anything but custom Tenlog code embedded in Marlin v1.