### PR TITLE
stepper_enable: report status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -395,6 +395,12 @@ The following information is available in
 - `printer["servo <config_name>"].value`: The last setting of the PWM
   pin (a value between 0.0 and 1.0) associated with the servo.
 
+## stepper_enable
+
+The following information is available in the `stepper_enable` object (this
+object is available if any stepper is defined):
+- `steppers["<stepper>"]`: Returns True if the given stepper is enabled.
+
 ## system_stats
 
 The following information is available in the `system_stats` object

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -108,6 +108,10 @@ class PrinterStepperEnable:
             el.motor_disable(print_time)
             logging.info("%s has been manually disabled", stepper)
         toolhead.dwell(DISABLE_STALL_TIME)
+    def get_status(self, eventtime):
+        steppers = { name: et.is_motor_enabled()
+                           for (name, et) in self.enable_lines.items() }
+        return {'steppers': steppers}
     def _handle_request_restart(self, print_time):
         self.motor_off()
     def cmd_M18(self, gcmd):


### PR DESCRIPTION
Adds status report to the `stepper_enable` module, so one can know what steppers are currently enabled and use that information in interfaces (Fluidd, Mainsail, ... ) or macros.

![image](https://user-images.githubusercontent.com/85504/217040831-d7196365-332f-4795-84b8-ee6de169400f.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>