### PR TITLE
Update printer-sunlu-t3-2022.cfg

### DIFF
--- a/config/printer-sunlu-t3-2022.cfg
+++ b/config/printer-sunlu-t3-2022.cfg
@@ -20,7 +20,7 @@
 
 [mcu]
 #obtain your MCU id using ls /dev/serial/by-path/*
-serial: dev/serial/by-id/usb-Klipper_stm32f103xe_*
+serial: dev/serial/by-id/usb-Klipper_stm32f103xe_00000000000
 
 [printer]
 kinematics: cartesian

--- a/config/printer-sunlu-t3-2022.cfg
+++ b/config/printer-sunlu-t3-2022.cfg
@@ -20,7 +20,7 @@
 
 [mcu]
 #obtain your MCU id using ls /dev/serial/by-path/*
-serial: dev/serial/by-id/usb-Klipper_stm32f103xe_833E31383534300530343833-if00
+serial: dev/serial/by-id/usb-Klipper_stm32f103xe_*
 
 [printer]
 kinematics: cartesian
@@ -37,7 +37,7 @@ sensor_pin: PC14
 control_pin: PA1
 x_offset: -28.45
 y_offset: 4
-z_offset: 1.915  #recheck you own
+z_offset: 1.915
 pin_up_touch_mode_reports_triggered: FALSE #needed bc of the bltouch clone used by sunlu
 
 [safe_z_home]
@@ -70,20 +70,10 @@ screw4_name: Rear Left
 ##The act of loading and unloading filament will trigger a paused state##
 [filament_motion_sensor Filament_Sensor]
 detection_length: 7.0
-#   The minimum length of filament pulled through the sensor to trigger
-#   a state change on the switch_pin
-#   Default is 7 mm.
 extruder: extruder
-#   The name of the extruder section this sensor is associated with.
-#   This parameter must be provided.
 switch_pin: !PC15
 pause_on_runout: FALSE
 runout_gcode: PAUSE
-#insert_gcode:
-#event_delay:
-#pause_delay:
-#   See the "filament_switch_sensor" section for a description of the
-#   above parameters.
 
 #########################################################
 # Motion Axis
@@ -129,14 +119,14 @@ step_pin: PB3
 dir_pin: !PB4
 enable_pin: !PD2
 microsteps: 16
-rotation_distance: 23.18840579710145  #verify your own
+rotation_distance: 23.18840579710145
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PC8
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PA0
 control: pid
-pid_Kp: 19.479 #calibrate your own PID
+pid_Kp: 19.479
 pid_Ki: 1.073
 pid_Kd: 88.385
 min_temp: 0
@@ -147,7 +137,7 @@ heater_pin: PC9
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC3
 control: pid
-pid_Kp: 62.673 #calibrate your own PID
+pid_Kp: 62.673
 pid_Ki: 1.530
 pid_Kd: 641.619
 min_temp: 0

--- a/config/printer-sunlu-t3-2022.cfg
+++ b/config/printer-sunlu-t3-2022.cfg
@@ -66,7 +66,7 @@ screw3_name: Rear Right
 screw4: 31,204 #X,Y Position
 screw4_name: Rear Left
 
-##IMPORTANT. Add if using the filament sensor add CLEAR_PAUSE to your slicer's start gcode or to your print start macro.##
+##IMPORTANT. If using the filament sensor add CLEAR_PAUSE to your slicer's start gcode or to your print start macro.##
 ##The act of loading and unloading filament will trigger a paused state##
 [filament_motion_sensor Filament_Sensor]
 detection_length: 7.0

--- a/config/printer-sunlu-t3-2022.cfg
+++ b/config/printer-sunlu-t3-2022.cfg
@@ -66,13 +66,24 @@ screw3_name: Rear Right
 screw4: 31,204 #X,Y Position
 screw4_name: Rear Left
 
-[filament_switch_sensor Filament_Runout]
-pause_on_runout: True
-#runout_gcode:
+##IMPORTANT. Add if using the filament sensor add CLEAR_PAUSE to your slicer's start gcode or to your print start macro.##
+##The act of loading and unloading filament will trigger a paused state##
+[filament_motion_sensor Filament_Sensor]
+detection_length: 7.0
+#   The minimum length of filament pulled through the sensor to trigger
+#   a state change on the switch_pin
+#   Default is 7 mm.
+extruder: extruder
+#   The name of the extruder section this sensor is associated with.
+#   This parameter must be provided.
+switch_pin: !PC15
+pause_on_runout: FALSE
+runout_gcode: PAUSE
 #insert_gcode:
-event_delay: 3.0
-pause_delay: 5
-switch_pin: !PC15 #if reads runout when loaded remove !
+#event_delay:
+#pause_delay:
+#   See the "filament_switch_sensor" section for a description of the
+#   above parameters.
 
 #########################################################
 # Motion Axis
@@ -128,8 +139,6 @@ control: pid
 pid_Kp: 19.479 #calibrate your own PID
 pid_Ki: 1.073
 pid_Kd: 88.385
-min_extrude_temp: 175
-max_extrude_only_distance: 400
 min_temp: 0
 max_temp: 250
 


### PR DESCRIPTION
Fix filament sensor and remove unneeded config changes in extruder

The filament sensor on the printer used for initial testing had been removed prior to flashing klipper to it. Only a basic test to see it if triggered or not was preformed. It was discovered by someone else doing some testing on another printer that it would frequently pause. This was a simple oversight, assuming it was a runout switch.

Removed section of config related to filament runout switch and replaced with basic config for filament motion so they printer will simply pause when no more motion is detected. Also notated to add CLEAR_PAUSE to start gcode if using this sensor as it will trigger a paused state when loading or unloading filament. If printer is in a paused state at the start of the print, the attempt to pause will cause the printer to rapidly pause and unpause itself.

Removed min_extruder_temp and max_extrude_only_distance from the extruder section, as they were there only for macros on a test system that is not put into this sample config

signed-off-by: Zachary Welvaert zwelvaert@gmail.com