### PR TITLE
config: Make getlists return an empty list on empty string.

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -80,11 +80,15 @@ class ConfigWrapper:
     def getlists(self, option, default=sentinel, seps=(',',), count=None,
                  parser=str, note_valid=True):
         def lparser(value, pos):
+            if len(value.strip()) == 0:
+                # Return an empty list instead of [''] for empty string
+                parts = []
+            else:
+                parts = [p.strip() for p in value.split(seps[pos])]
             if pos:
                 # Nested list
-                parts = [p.strip() for p in value.split(seps[pos])]
                 return tuple([lparser(p, pos - 1) for p in parts if p])
-            res = [parser(p.strip()) for p in value.split(seps[pos])]
+            res = [parser(p) for p in parts]
             if count is not None and len(res) != count:
                 raise error("Option '%s' in section '%s' must have %d elements"
                             % (option, self.section, count))


### PR DESCRIPTION
The reason I needed this was for `[controller_fan]`'s `heater` option which defaults to `extruder`.
Unfortunately my machine does not have an extruder, or any heaters, causing a `Unknown heater 'extruder'` error.

Prior to this change, trying to specify an empty list of heaters causes a `Unknown heater ''` error because `getlists` returns a tuple of one empty string.

With this change I can now specify no heaters with:
`heater:`

Alternatively `controller_fan`'s default setting could be changed to handle the `extruder` heater not existing, but this seemed like a sensible change to deal with python's `''.split(',')` returning `['']`, which is silly.