### PR TITLE
scripts: update_mks_robin.py python env version

### DIFF
--- a/scripts/update_mks_robin.py
+++ b/scripts/update_mks_robin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Script to update firmware for MKS Robin bootloader
 #
 # Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>


### PR DESCRIPTION
The recent PR to change this to say `#!/usr/bin/env python` instead of `#!/usr/bin/env python2` can cause issues on non rpi based OS's where `python` is not mapped to `python3`.

`#!/usr/bin/env python3` should work in both situations.

Thanks
James

Signed-off-by: James Hartley <james@hartleyns.com>