### PR TITLE
Bugfix/sh1106 pixel

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3573,7 +3573,7 @@ Support for a display attached to the micro-controller.
 [display]
 lcd_type:
 #   The type of LCD chip in use. This may be "hd44780", "hd44780_spi",
-#   "st7920", "emulated_st7920", "uc1701", "ssd1306", or "sh1106".
+#   "st7920", "emulated_st7920", "uc1701", "ssd1306", "sh1106", or "sh1106a".
 #   See the display sections below for information on each type and
 #   additional parameters they provide. This parameter must be
 #   provided.
@@ -3777,7 +3777,7 @@ Information on configuring ssd1306 and sh1106 displays.
 ```
 [display]
 lcd_type:
-#   Set to either "ssd1306" or "sh1106" for the given display type.
+#   Set to either "ssd1306", "sh1106" or "sh1106a" for the given display type.
 #i2c_mcu:
 #i2c_bus:
 #i2c_speed:

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -17,7 +17,7 @@ LCD_chips = {
     'st7920': st7920.ST7920, 'emulated_st7920': st7920.EmulatedST7920,
     'hd44780': hd44780.HD44780, 'uc1701': uc1701.UC1701,
     'ssd1306': uc1701.SSD1306, 'sh1106': uc1701.SH1106,
-    'hd44780_spi': hd44780_spi.hd44780_spi
+    'hd44780_spi': hd44780_spi.hd44780_spi, 'sh1106a': uc1701.SH1106a
 }
 
 # Storage of [display_template my_template] config sections

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -239,7 +239,7 @@ class SH1106(SSD1306):
         x_offset = config.getint('x_offset', 0, minval=0, maxval=3)
         SSD1306.__init__(self, config, 132, x_offset=x_offset)
 
-# the SH1106 is SSD1306 compatible with up to 132 columns
+# the SH1106a is for 1.3inch OLED (Waveshare)
 class SH1106a(SSD1306):
     def __init__(self, config):
         x_offset = config.getint('x_offset', 0, minval=0, maxval=3) + 2

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -238,3 +238,9 @@ class SH1106(SSD1306):
     def __init__(self, config):
         x_offset = config.getint('x_offset', 0, minval=0, maxval=3)
         SSD1306.__init__(self, config, 132, x_offset=x_offset)
+
+# the SH1106 is SSD1306 compatible with up to 132 columns
+class SH1106a(SSD1306):
+    def __init__(self, config):
+        x_offset = config.getint('x_offset', 0, minval=0, maxval=3) + 2
+        SSD1306.__init__(self, config, 132, x_offset=x_offset)


### PR DESCRIPTION
I fixed 1.3 oled pixel issue.

waveshare 1.3 oled has sh1106 controller and 128px display it cannot work as 132px (cropped)

![20230211_082238](https://user-images.githubusercontent.com/22356766/218221358-9fc234ba-011e-4ca4-8749-6ec0f4a63d90.jpg)
![20230211_082257](https://user-images.githubusercontent.com/22356766/218221368-4583ab9a-a729-4780-8fe6-4ae98e723f52.jpg)



