### PR TITLE
homing: Support lazy homing in G28 command

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -8,7 +8,7 @@ commands that one may enter into the OctoPrint terminal tab.
 Klipper supports the following standard G-Code commands:
 - Move (G0 or G1): `G1 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>] [F<speed>]`
 - Dwell: `G4 P<milliseconds>`
-- Move to origin: `G28 [X] [Y] [Z]`
+- Move to origin: `G28 [O] [X] [Y] [Z]`
 - Turn off motors: `M18` or `M84`
 - Wait for current moves to finish: `M400`
 - Use absolute/relative distances for extrusion: `M82`, `M83`

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -30,13 +30,19 @@ class HomingOverride:
                 no_axis = False
                 break
 
+        lazy_axes = ''
+        if gcmd.get('O', None) is not None:
+            kin = self.printer.lookup_object('toolhead').get_kinematics()
+            curtime = self.printer.get_reactor().monotonic()
+            lazy_axes = kin.get_status(curtime)['homed_axes'].upper()
+
         if no_axis:
-            override = True
+            override = lazy_axes != 'XYZ'
         else:
             # check if we home an axis which needs the override
             override = False
             for axis in self.axes:
-                if gcmd.get(axis, None) is not None:
+                if gcmd.get(axis, None) is not None and axis not in lazy_axes:
                     override = True
 
         if not override:

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -53,18 +53,22 @@ class SafeZHoming:
         if not need_x and not need_y and not need_z:
             need_x = need_y = need_z = True
 
+        # Use lazy homing if requested
+        lazy_axes = ([] if gcmd.get('O', None) is None
+                     else kin_status['homed_axes'])
+
         # Home XY axes if necessary
         new_params = {}
-        if need_x:
+        if need_x and 'x' not in lazy_axes:
             new_params['X'] = '0'
-        if need_y:
+        if need_y and 'y' not in lazy_axes:
             new_params['Y'] = '0'
         if new_params:
             g28_gcmd = self.gcode.create_gcode_command("G28", "G28", new_params)
             self.prev_G28(g28_gcmd)
 
         # Home Z axis if necessary
-        if need_z:
+        if need_z and 'z' not in lazy_axes:
             # Throw an error if X or Y are not homed
             curtime = self.printer.get_reactor().monotonic()
             kin_status = toolhead.get_kinematics().get_status(curtime)


### PR DESCRIPTION
This adds the `O` optional/lazy homing parameter from Marlin, which skips rehoming for any axis that's already homed. This is very helpful in things like `START_PRINT`, `PARK`, and similar macros, where you want to ensure the axes are all homed but don't want to unnecessarily rehome.

This can already be done today by wrapping `G28` with macros, but the problem with such an approach is that `G28` is special cased for things like homing overrides. So, configs tend to get ugly pretty quickly when you take this route, which has become a growing problem with the increasing popularity of docking probes that require fairly involved homing overrides.