### PR TITLE
Anycubic 4 max pro 2.0 fixed problem with underextrusion after unretract.

### DIFF
--- a/config/printer-anycubic-4maxpro-2.0-2021.cfg
+++ b/config/printer-anycubic-4maxpro-2.0-2021.cfg
@@ -70,7 +70,9 @@ rotation_distance: 7.488
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 instantaneous_corner_velocity: 1.5
-max_extrude_only_distance: 500
+max_extrude_only_distance: 100
+max_extrude_only_velocity: 50
+max_extrude_only_accel: 1500
 heater_pin: PB4
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: PK5

--- a/config/printer-anycubic-4maxpro-2.0-2021.cfg
+++ b/config/printer-anycubic-4maxpro-2.0-2021.cfg
@@ -140,6 +140,16 @@ screw4: 265, 5
 [filament_switch_sensor filament_sensor]
 switch_pin: ^!PC4
 
+[output_pin buzz]
+pin: PC6
+pwm: True
+
+[output_pin AUTO_POWEROFF]
+pin: PD0
+pwm: True
+cycle_time: 0.02
+value: 1
+
 
 # This macro (M300) uses internal integrated beeper
 # Just use it in your G-code for making sounds. Example: M300 S1000 P500

--- a/config/printer-anycubic-4maxpro-2.0-2021.cfg
+++ b/config/printer-anycubic-4maxpro-2.0-2021.cfg
@@ -11,7 +11,7 @@
 
 # For Anycubic 4Max Pro (not 2.0) owners:
 #       Be careful when using this config! This config tested only on Anycubic
-#       4Max Pro 2.0 with klipper v0.9.1-667-g31761500! At first, you should
+#       4Max Pro 2.0! At first, you should
 #       set homing_speed on 5, and run homing and click on the endstops with
 #       your fingers. It is necessary to make sure that all the motors are
 #       spinning in the right direction, all the temperature sensors show the
@@ -139,3 +139,40 @@ screw4: 265, 5
 
 [filament_switch_sensor filament_sensor]
 switch_pin: ^!PC4
+
+
+# This macro (M300) uses internal integrated beeper
+# Just use it in your G-code for making sounds. Example: M300 S1000 P500
+[gcode_macro M300]
+gcode:
+    {% set S = params.S|default(800)|float %}
+    {% set P = params.P|default(100)|int %}
+    SET_PIN PIN=buzz VALUE=0.5 CYCLE_TIME={ 1.0 / S | float }
+    G4 P{P}
+    SET_PIN PIN=buzz VALUE=0
+
+# This macro (M81) uses internal integrated PSU control-relay.
+# Just use M81 in your end_gcode if you want to poweroff your printer after print.
+# Note: as in original Marlin firmware, before powerdown, printer will be cool hotend
+# until temperature will be below 45°С / 113°F.
+
+[gcode_macro M81]
+gcode:
+    {% set required_extruder_temp = params.T|default(45)|int %}
+    {% if printer.extruder.temperature > required_extruder_temp|default(45)|int %}
+            M300
+            M300
+            M300
+            M117 COOLING DOWN BEFORE POWER OFF
+            M109 S{required_extruder_temp}
+            SET_PIN PIN=AUTO_POWEROFF VALUE=0.5
+            G4 P60
+            SET_PIN PIN=AUTO_POWEROFF VALUE=1
+    {% else %}
+            M300
+            M117 POWER OFF SOON
+            G4 P10000
+            SET_PIN PIN=AUTO_POWEROFF VALUE=0.5
+            G4 P60
+            SET_PIN PIN=AUTO_POWEROFF VALUE=1
+    {% endif %}


### PR DESCRIPTION
Soorry Guys, but in spent about two years for searching this problem.  I tried every possible calibrations, and they doesn't help. When I could avoid that problem, I did not belive it.

When extruder do unretract, acceleration is too high by default. The acceleration is so great that the plastic simply does not have time to melt, and at the same time, kinematics starts moving. In result I get under extrusion after unretraction. See pictures below.

I have been trying for a long time to figure out how this parameter is calculated by default, and what it was equal to. I don't know. 

```
#max_extrude_only_velocity:
#max_extrude_only_accel:
#   Maximum velocity (in mm/s) and acceleration (in mm/s^2) of the
#   extruder motor for retractions and extrude-only moves. These
#   settings do not have any impact on normal printing moves. If not
#   specified then they are calculated to match the limit an XY
#   printing move with a cross section of 4.0*nozzle_diameter^2 would
#   have.
```

Parts printed with default (empty) `max_extrude_only_accel`:

![photo_2023-02-16_11-51-44](https://user-images.githubusercontent.com/42711898/219333864-ded63a7c-dad9-43c2-bd5c-a84fe74fcaf5.jpg)
![photo_2023-02-16_11-52-00](https://user-images.githubusercontent.com/42711898/219333917-55d2dbe8-5fae-492f-a1fb-a4c65b453c88.jpg)

Let's see, that would be if I set  `max_extrude_only_accel: 1500` (truncated model from previous foto):

![photo_2023-02-16_13-18-20](https://user-images.githubusercontent.com/42711898/219337251-34013a86-0bd5-47f7-8404-168c1d21b7c1.jpg)

Awesome! That's amazing, I can't beleve it. I spent about 2 years (not active searching, because sometimes I lost motivation to search), but now it's good.

Tell me someone, how I can calc default `max_extrude_only_accel` for 0.4 nozzle diameter?