### PR TITLE
rp2040: running without external flash

### DIFF
--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -53,40 +53,51 @@ config STACK_SIZE
 # Bootloader options
 ######################################################################
 
-config RP2040_HAVE_STAGE2
-    bool
-config RP2040_HAVE_BOOTLOADER
-    bool
-    default y if !RP2040_HAVE_STAGE2
-
 choice
-    prompt "Bootloader offset"
-    config RP2040_FLASH_START_0100
-        bool "No bootloader"
-        select RP2040_HAVE_STAGE2
-    config RP2040_FLASH_START_4000
-        bool "16KiB bootloader"
-endchoice
-config FLASH_APPLICATION_ADDRESS
-    hex
-    default 0x10004000 if RP2040_FLASH_START_4000
-    default 0x10000100
+    prompt "NOR Flash Model" if LOW_LEVEL_OPTIONS
+    default RP2040_FLASH_W25Q080
 
-choice
-    prompt "Flash chip" if LOW_LEVEL_OPTIONS && RP2040_HAVE_STAGE2
+    config RP2040_FLASH_NOFLASH
+        bool "No NOR Flash"
     config RP2040_FLASH_W25Q080
         bool "W25Q080 with CLKDIV 2"
     config RP2040_FLASH_GENERIC_03
         bool "GENERIC_03H with CLKDIV 4"
 endchoice
 
+choice
+    prompt "Bootloader" if LOW_LEVEL_OPTIONS
+    default RP2040_BOOTLOADER_NO_BOOTLOADER
+
+    config RP2040_BOOTLOADER_NO_BOOTLOADER
+        bool "No bootloader"
+    config RP2040_BOOTLOADER_16KiB_BOOTLOADER
+        depends on !RP2040_FLASH_NOFLASH
+        bool "Generic ARM 16KiB bootloader"
+endchoice
+
+config RP2040_HAVE_STAGE2
+    bool # link with boot stage2
+    default y if RP2040_FLASH_W25Q080
+    default y if RP2040_FLASH_GENERIC_03
+    default n if RP2040_FLASH_NOFLASH
+    default y
+
+config FLASH_APPLICATION_ADDRESS
+    hex
+    default 0x10004000 if RP2040_BOOTLOADER_16KiB_BOOTLOADER
+    default 0x20000000 if RP2040_FLASH_NOFLASH
+    default 0x10000100
+
 config RP2040_STAGE2_FILE
     string
+    default "" if !RP2040_HAVE_STAGE2
     default "boot2_generic_03h.S" if RP2040_FLASH_GENERIC_03
     default "boot2_w25q080.S"
 
 config RP2040_STAGE2_CLKDIV
     int
+    default 0 if RP2040_FLASH_NOFLASH
     default 4 if RP2040_FLASH_GENERIC_03
     default 2
 

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -45,6 +45,11 @@ $(OUT)klipper.uf2: $(OUT)klipper.elf $(OUT)lib/rp2040/elf2uf2/elf2uf2
 	@echo "  Creating uf2 file $@"
 	$(Q)$(OUT)lib/rp2040/elf2uf2/elf2uf2 $< $@
 
+rptarget-$(CONFIG_RP2040_FLASH_NOFLASH) := $(OUT)klipper.uf2
+rplink-$(CONFIG_RP2040_FLASH_NOFLASH)   := $(OUT)src/rp2040/rp2040_noflash_link.ld
+# rp2040 bootrom will jump to 0x20000000 with thumb-bit. elf2uf2 requires a thumb-bit setted address.
+ldflags-$(CONFIG_RP2040_FLASH_NOFLASH)  := --entry=0x20000001
+
 rptarget-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)klipper.uf2
 rplink-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)src/rp2040/rp2040_link.ld
 stage2-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)stage2.o
@@ -54,12 +59,12 @@ $(OUT)klipper.bin: $(OUT)klipper.elf
 	@echo "  Creating bin file $@"
 	$(Q)$(OBJCOPY) -O binary $< $@
 
-rptarget-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)klipper.bin
-rplink-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)src/generic/armcm_link.ld
+rptarget-$(CONFIG_RP2040_BOOTLOADER_16KiB_BOOTLOADER) := $(OUT)klipper.bin
+rplink-$(CONFIG_RP2040_BOOTLOADER_16KiB_BOOTLOADER) := $(OUT)src/generic/armcm_link.ld
 
 # Set klipper.elf linker rules
 target-y += $(rptarget-y)
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs -T $(rplink-y)
+CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs -T $(rplink-y) $(ldflags-y) -fno-lto
 OBJS_klipper.elf += $(stage2-y)
 $(OUT)klipper.elf: $(stage2-y) $(rplink-y)
 

--- a/src/rp2040/chipid.c
+++ b/src/rp2040/chipid.c
@@ -5,7 +5,7 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <string.h> // memcpy
-#include "autoconf.h" // CONFIG_USB_SERIAL_NUMBER_CHIPID
+#include "autoconf.h" // CONFIG_*
 #include "board/irq.h" // irq_disable, irq_enable
 #include "board/canserial.h" // canserial_set_uuid
 #include "generic/usb_cdc.h" // usb_fill_serial

--- a/src/rp2040/chipid.c
+++ b/src/rp2040/chipid.c
@@ -75,6 +75,12 @@ flash_enter_xip_perform(void)
 static void _ramfunc
 read_unique_id(uint8_t *out)
 {
+#if CONFIG_RP2040_FLASH_NOFLASH
+    // from PicoSDK: On PICO_NO_FLASH builds the unique id is set to all 0xEE.
+    memset(out, 0xEE, 8);
+    return;
+#endif
+
     uint8_t txbuf[FLASH_RUID_TOTAL_BYTES] = {0};
     uint8_t rxbuf[FLASH_RUID_TOTAL_BYTES] = {0};
 

--- a/src/rp2040/gpio.h
+++ b/src/rp2040/gpio.h
@@ -4,7 +4,7 @@
 #include <stdint.h> // uint32_t
 
 struct gpio_out {
-    uint32_t bit;
+    uint8_t pin;
 };
 struct gpio_out gpio_out_setup(uint8_t pin, uint8_t val);
 void gpio_out_reset(struct gpio_out g, uint8_t val);
@@ -13,7 +13,7 @@ void gpio_out_toggle(struct gpio_out g);
 void gpio_out_write(struct gpio_out g, uint8_t val);
 
 struct gpio_in {
-    uint32_t bit;
+    uint8_t pin;
 };
 struct gpio_in gpio_in_setup(uint8_t pin, int8_t pull_up);
 void gpio_in_reset(struct gpio_in g, int8_t pull_up);

--- a/src/rp2040/rp2040_noflash_link.lds.S
+++ b/src/rp2040/rp2040_noflash_link.lds.S
@@ -1,0 +1,67 @@
+// rp2040 linker script (based on armcm_link.lds.S and customized for no flash device)
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_FLASH_SIZE
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+MEMORY
+{
+  ram (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_RAM_SIZE
+}
+
+SECTIONS
+{
+    .main : {
+        . = ALIGN(4);
+        KEEP(*(.rp2040_main_noflash))
+        __logical_binary_start = .;
+    } > ram
+
+    .text : {
+        . = ALIGN(256);
+        KEEP(*(.vector_table))
+        _text_vectortable_end = .;
+        *(.text .text.*)
+        *(.rodata .rodata*)
+    } > ram
+
+    . = ALIGN(4);
+    _data_flash = .;
+
+    .data : AT (_data_flash)
+    {
+        . = ALIGN(4);
+        _data_start = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _data_end = .;
+    } > ram
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _bss_end = .;
+    } > ram
+
+    _stack_start = CONFIG_RAM_START + CONFIG_RAM_SIZE - CONFIG_STACK_SIZE ;
+    .stack _stack_start (NOLOAD) :
+    {
+        . = . + CONFIG_STACK_SIZE;
+        _stack_end = .;
+    } > ram
+
+    /DISCARD/ : {
+        // The .init/.fini sections are used by __libc_init_array(), but
+        // that isn't needed so no need to include them in the binary.
+        *(.init)
+        *(.fini)
+    }
+}


### PR DESCRIPTION
Added a new option for rp2040, RP2040_FLASH_NOFLASH, to enable it to run without external flash. This option allows the rp2040 to boot from its internal bootloader and execute code directly from RAM.

With this build option, firmware must be loaded into rp2040 every time it is powered on or reset this can be done by using an external debugger via SWD or using USB to upload a U2F file into bootrom.

This commit also repurposes 6 IO pins that were originally reserved for QSPI to be used as GPIO pins.