### PR TITLE
Adding a parameter 'SETTLE' to TEMPERATURE_WAIT.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -840,6 +840,12 @@ max_temp:
 #   heater and sensor hardware failures. Set this range just wide
 #   enough so that reasonable temperatures do not result in an error.
 #   These parameters must be provided.
+#settle_slope: 0.1
+#   The maximum allowable (absolute) slope in temperature for the
+#   heater to signal that it reached target temperature.
+#   The smaller the value, the more the temperature needs to stabilize.
+#   Only used for M109/190 and TEMPERATURE_WAIT
+#   The default is 0.1
 ```
 
 ### [heater_bed]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -656,8 +656,10 @@ the config file.
 
 #### TEMPERATURE_WAIT
 `TEMPERATURE_WAIT SENSOR=<config_name> [MINIMUM=<target>]
-[MAXIMUM=<target>]`: Wait until the given temperature sensor is at or
+[MAXIMUM=<target>] [SETTLE=0]`: Wait until the given temperature sensor is at or
 above the supplied MINIMUM and/or at or below the supplied MAXIMUM.
+If the SETTLE parameter is enabled, the temperature also needs to settle according to the
+'settle_slope' [extruder config section](Config_Reference.md#extruder) parameter.
 
 #### SET_HEATER_TEMPERATURE
 `SET_HEATER_TEMPERATURE HEATER=<heater_name>


### PR DESCRIPTION
This pull request adds a "settling" feature to TEMPERATURE_WAIT.
Some people have issues with large beds or extruders which have a high thermal mass and depending on the physical position of your thermal sensor and the heater it takes some time for the heat to creep to the sensor.
The issue with TEMPERATURE_WAIT is, that you don't have an option to set a maximum slope for the temperature.
The result is, that minimum temperature is reached and the wait cycle gets completed, but the temperature keeps increasing.
Depending on the hardware, you can get huge overshoots. If you tune down the PID, heating takes forever.
With this PR there is no need to use 'legacy' G-Code commands anymore to get a "settling" feature.

To keep it simple and not add any more code than really needed, I edited the 'check_busy' method of 'Heater' - which calls the corresponding method in 'PIDControl' - and added a 'compat' parameter. This way we don't need to add another method and we can just call the existing one from within 'cmd_TEMPERATURE_WAIT'.
I think this is a simple change, even M109/190 can benefit from.

I chose to set the slope parameter via config file, because it should be set-and-forget (in my experience).
Tested on extruder, heater_bed and heater_generic.

This is a follow-up to my PR #6047, because only improving legacy G-Code commands is being discouraged.

Signed-off-by: Henning Rumpf [henning_ru@protonmail.com](mailto:henning_ru@protonmail.com)