### PR TITLE
Config: addition of slicer specific gcode for START_PRINT

### DIFF
--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -10,7 +10,18 @@
 ######################################################################
 
 # Replace the slicer's custom start and end g-code scripts with
-# START_PRINT and END_PRINT.
+# Cura:
+# ; M190 S{material_bed_temperature_layer_0}
+# ; M109 S{material_print_temperature_layer_0}
+# START_PRINT BED_TEMP={material_bed_temperature_layer_0} EXTRUDER_TEMP={material_print_temperature_layer_0}
+# Slic3r variants:
+# M140 S0
+# M104 S0
+# START_PRINT BED_TEMP={first_layer_bed_temperature[0]} EXTRUDER_TEMP={first_layer_temperature[0]}
+#
+# the addition of extra heat gcodes to these commands will tell
+# the individual slicer not to send its own heat gcodes. Note that
+# Cura needs these commented while Slic3r variants do not
 
 [gcode_macro START_PRINT]
 gcode:


### PR DESCRIPTION
It is confusing that this macro only specifies to use START_PRINT, when specific parameters are needed to pass the variables in most slicers.

Thanks
James