### PR TITLE
doc: use correct mpu9250 i2c_bus on pico

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -195,7 +195,7 @@ serial: /dev/serial/by-id/<your PICO's serial ID>
 
 [mpu9250]
 i2c_mcu: pico
-i2c_bus: i2c1a
+i2c_bus: i2c0a
 
 [resonance_tester]
 accel_chip: mpu9250


### PR DESCRIPTION
refs https://github.com/Klipper3d/klipper/pull/6030#issuecomment-1416707228 by @Sineos 