### PR TITLE
Added Important Info to Config_Reference.md

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3018,6 +3018,7 @@ aliases may not be used with stepper motor pins.
 pins:
 #   A comma separated list of pins associated with this alias. This
 #   parameter must be provided.
+#   Multi-pin configurations must be put before any configuration options you wish to utilize the multi_pin functionality. 
 ```
 
 ## TMC stepper driver configuration


### PR DESCRIPTION
I specified that you need to put the multi-pin configurations above any other configurations that you want to use the multi-pin alias(es).