### PR TITLE
Update Config_Reference.md

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3018,6 +3018,7 @@ aliases may not be used with stepper motor pins.
 pins:
 #   A comma separated list of pins associated with this alias. This
 #   parameter must be provided.
+#   Multi_pin configurations must be placed above of any other configurations you wish use the aliases in.
 ```
 
 ## TMC stepper driver configuration


### PR DESCRIPTION
Added to clarify that you need to put [multi_pin] config above any other configs you wish to use the pin aliases on.  This stumped me earlier today while setting up multi-pin.