### PR TITLE
Update and rename generic-th3d-ezboard-lite-v2.0.cfg to generic-th3d-…

### DIFF
--- a/config/generic-th3d-ezboard-v2.0.cfg
+++ b/config/generic-th3d-ezboard-v2.0.cfg
@@ -1,4 +1,4 @@
-# This file contains common pin mappings for the TH3D EZBoard Lite v2.
+# This file contains common pin mappings for the TH3D EZBoard v2.
 # To use this config, check "Enable extra low-level configuration options"
 # and compile the firmware for the STM32F405 with 12mhz Crystal,
 # 48KiB Bootloader, and USB communication.

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -135,7 +135,7 @@ CONFIG ../../config/generic-bigtreetech-skr-v1.4.cfg
 CONFIG ../../config/generic-mks-sgenl.cfg
 CONFIG ../../config/generic-re-arm.cfg
 CONFIG ../../config/generic-smoothieboard.cfg
-CONFIG ../../config/generic-th3d-ezboard-lite-v1.2.cfg
+CONFIG ../../config/generic-th3d-ezboard-v1.2.cfg
 
 # Printers using the stm32f070
 DICTIONARY stm32f070.dict

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -135,7 +135,7 @@ CONFIG ../../config/generic-bigtreetech-skr-v1.4.cfg
 CONFIG ../../config/generic-mks-sgenl.cfg
 CONFIG ../../config/generic-re-arm.cfg
 CONFIG ../../config/generic-smoothieboard.cfg
-CONFIG ../../config/generic-th3d-ezboard-v1.2.cfg
+CONFIG ../../config/generic-th3d-ezboard-lite-v1.2.cfg
 
 # Printers using the stm32f070
 DICTIONARY stm32f070.dict
@@ -214,7 +214,7 @@ CONFIG ../../config/generic-mellow-fly-cdy-v3.cfg
 CONFIG ../../config/generic-mellow-super-infinty-hv.cfg
 CONFIG ../../config/generic-mks-robin-nano-v3.cfg
 CONFIG ../../config/generic-prusa-buddy.cfg
-CONFIG ../../config/generic-th3d-ezboard-lite-v2.0.cfg
+CONFIG ../../config/generic-th3d-ezboard-v2.0.cfg
 CONFIG ../../config/printer-biqu-b1-se-plus-2022.cfg
 CONFIG ../../config/printer-prusa-mini-plus-2020.cfg
 


### PR DESCRIPTION
module: generic-th3d-ezboard-v2.0.cfg

The actual board name is EZBoard V2 without the lite. Renaming the file and correcting the intro text to reflect the actual board name.

Signed-off-by: Anthony Dellett <anthony.dellett@gmail.com>