### PR TITLE
Various TMC improvements

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3083,6 +3083,14 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#   This field is also known as vpwmthrs or TPWMTHRS.
+#vhigh:
+#   The velocity (in mm/s) to set the "high velocity" threshold to. When
+#   set, "stealthChop" mode will be disabled if the stepper motor
+#   velocity is above this value. StallGuard and CoolStep will also get
+#   disabled above this velocity. The default value is equivalent to
+#   infinity (thigh = 0).
+#   This field is also known as THIGH.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441
@@ -3208,6 +3216,7 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#   This field is also known as vpwmthrs or TPWMTHRS.
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 20
 #driver_TBL: 2
@@ -3432,6 +3441,14 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#   This field is also known as vpwmthrs or TPWMTHRS.
+#vhigh:
+#   The velocity (in mm/s) to set the "high velocity" threshold to. When
+#   set, "stealthChop" mode will be disabled if the stepper motor
+#   velocity is above this value. StallGuard and CoolStep will also get
+#   disabled above this velocity. The default value is equivalent to
+#   infinity (thigh = 0).
+#   This field is also known as THIGH.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3097,6 +3097,12 @@ run_current:
 #   values used by the driver. The value must be specified as a decimal integer
 #   (hex form is not supported). In order to compute the wave table fields,
 #   see the tmc2130 "Calculation Sheet" from the Trinamic website.
+#driver_SMALL_HYSTERESYS: False
+#   This option should only be used if the microcontroller is capable of
+#   generating stable STEP signals (jitter will negatively impact the stability
+#   in combination with this option). Enabling this option results in a tighter
+#   hysteresis around all velocity based thresholds (internally based on TSTEP).
+#   This option could prove useful if the desired velocity is high.
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 0
 #driver_TBL: 1
@@ -3376,6 +3382,12 @@ run_current:
 #   values used by the driver. The value must be specified as a decimal integer
 #   (hex form is not supported). In order to compute the wave table fields,
 #   see the tmc2130 "Calculation Sheet" from the Trinamic website.
+#driver_SMALL_HYSTERESYS: False
+#   This option should only be used if the microcontroller is capable of
+#   generating stable STEP signals (jitter will negatively impact the stability
+#   in combination with this option). Enabling this option results in a tighter
+#   hysteresis around all velocity based thresholds (internally based on TSTEP).
+#   This option could prove useful if the desired velocity is high.
 #driver_IHOLDDELAY: 6
 #driver_TPOWERDOWN: 10
 #driver_TBL: 2

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3091,6 +3091,14 @@ run_current:
 #   disabled above this velocity. The default value is equivalent to
 #   infinity (thigh = 0).
 #   This field is also known as THIGH.
+#vcoolthrs:
+#   The velocity (in mm/s) to set the StallGuard (and CoolStep) minimum
+#   threshold. When set, StallGuard and CoolStep will be disabled if the
+#   stepper motor velocity is below this value. This value only applies while
+#   not homing. The default value is equivalent to infinity (tcoolthrs = 0),
+#   so by default StallGuard and CoolStep are completely disabled while not
+#   homing. Set this value in order to be able to use CoolStep.
+#   This field is also known as TCOOLTHRS.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441
@@ -3267,6 +3275,14 @@ run_current:
 #sense_resistor: 0.110
 #stealthchop_threshold: 0
 #   See the "tmc2208" section for the definition of these parameters.
+#vcoolthrs:
+#   The velocity (in mm/s) to set the StallGuard (and CoolStep) minimum
+#   threshold. When set, StallGuard and CoolStep will be disabled if the
+#   stepper motor velocity is below this value. This value only applies while
+#   not homing. The default value is equivalent to infinity (tcoolthrs = 0),
+#   so by default StallGuard and CoolStep are completely disabled while not
+#   homing. Set this value in order to be able to use CoolStep.
+#   This field is also known as TCOOLTHRS.
 #uart_address:
 #   The address of the TMC2209 chip for UART messages (an integer
 #   between 0 and 3). This is typically used when multiple TMC2209
@@ -3449,6 +3465,14 @@ run_current:
 #   disabled above this velocity. The default value is equivalent to
 #   infinity (thigh = 0).
 #   This field is also known as THIGH.
+#vcoolthrs:
+#   The velocity (in mm/s) to set the StallGuard (and CoolStep) minimum
+#   threshold. When set, StallGuard and CoolStep will be disabled if the
+#   stepper motor velocity is below this value. This value only applies while
+#   not homing. The default value is equivalent to infinity (tcoolthrs = 0),
+#   so by default StallGuard and CoolStep are completely disabled while not
+#   homing. Set this value in order to be able to use CoolStep.
+#   This field is also known as TCOOLTHRS.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3052,6 +3052,9 @@ cs_pin:
 #   define the stepper position in the chain and the total chain length.
 #   Position 1 corresponds to the stepper that connects to the MOSI signal.
 #   The default is to not use an SPI daisy chain.
+#tmc_frequency: 13200000
+#   Configure if an external clock oscillator is connected to the TMC driver
+#   clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This interpolation does
@@ -3167,6 +3170,9 @@ uart_pin:
 #   A comma separated list of pins to set prior to accessing the
 #   tmc2208 UART. This may be useful for configuring an analog mux for
 #   UART communication. The default is to not configure any pins.
+#tmc_frequency: 12000000
+#   Configure if an external clock oscillator is connected to the TMC driver
+#   clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This interpolation does
@@ -3222,6 +3228,9 @@ by the name of the corresponding stepper config section (for example,
 uart_pin:
 #tx_pin:
 #select_pins:
+#tmc_frequency: 12000000
+#   Configure if an external clock oscillator is connected to the TMC driver
+#   clock input.
 #interpolate: True
 run_current:
 #hold_current:
@@ -3366,6 +3375,9 @@ cs_pin:
 #   define the stepper position in the chain and the total chain length.
 #   Position 1 corresponds to the stepper that connects to the MOSI signal.
 #   The default is to not use an SPI daisy chain.
+#tmc_frequency: 12000000
+#   Configure if an external clock oscillator is connected to the TMC driver
+#   clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3068,6 +3068,13 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#homing_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is performing a homing move. It can be useful for TMC
+#   drivers if the run current is too high or too low and it causes StallGuard
+#   to perform poorly. It can also be used as a safety measure so the printer
+#   can't damage itself if homing fails.
+#   The default is to not adjust the driver currents during homing.
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -3186,6 +3193,13 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#homing_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is performing a homing move. It can be useful for TMC
+#   drivers if the run current is too high or too low and it causes StallGuard
+#   to perform poorly. It can also be used as a safety measure so the printer
+#   can't damage itself if homing fails.
+#   The default is to not adjust the driver currents during homing.
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -3234,6 +3248,13 @@ uart_pin:
 #interpolate: True
 run_current:
 #hold_current:
+#homing_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is performing a homing move. It can be useful for TMC
+#   drivers if the run current is too high or too low and it causes StallGuard
+#   to perform poorly. It can also be used as a safety measure so the printer
+#   can't damage itself if homing fails.
+#   The default is to not adjust the driver currents during homing.
 #sense_resistor: 0.110
 #stealthchop_threshold: 0
 #   See the "tmc2208" section for the definition of these parameters.
@@ -3309,6 +3330,13 @@ cs_pin:
 run_current:
 #   The amount of current (in amps RMS) used by the driver during
 #   stepper movement. This parameter must be provided.
+#homing_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is performing a homing move. It can be useful for TMC
+#   drivers if the run current is too high or too low and it causes StallGuard
+#   to perform poorly. It can also be used as a safety measure so the printer
+#   can't damage itself if homing fails.
+#   The default is to not adjust the driver currents during homing.
 #sense_resistor:
 #   The resistance (in ohms) of the motor sense resistor. This
 #   parameter must be provided.
@@ -3389,6 +3417,13 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#homing_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is performing a homing move. It can be useful for TMC
+#   drivers if the run current is too high or too low and it causes StallGuard
+#   to perform poorly. It can also be used as a safety measure so the printer
+#   can't damage itself if homing fails.
+#   The default is to not adjust the driver currents during homing.
 #sense_resistor: 0.075
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.075 ohms.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3109,11 +3109,27 @@ run_current:
 #driver_TOFF: 4
 #driver_HEND: 7
 #driver_HSTRT: 0
+#driver_FD3: 0
+#driver_DISFDCC: 0
+#driver_RNDTF: 0
+#driver_CHM: 0
+#driver_VHIGHFS: 0
+#driver_VHIGHCHM: 0
+#driver_SYNC: 0
+#driver_DISS2G: 0
 #driver_PWM_AUTOSCALE: True
+#driver_PWM_SYMMETRIC: False
 #driver_PWM_FREQ: 1
+#driver_FREEWHEEL: 0
 #driver_PWM_GRAD: 4
 #driver_PWM_AMPL: 128
 #driver_SGT: 0
+#driver_SEMIN: 0
+#driver_SEUP: 0
+#driver_SEMAX: 0
+#driver_SEDN: 0
+#driver_SEIMIN: 0
+#driver_SFILT: 0
 #   Set the given register during the configuration of the TMC2130
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
@@ -3178,11 +3194,14 @@ run_current:
 #driver_TOFF: 3
 #driver_HEND: 0
 #driver_HSTRT: 5
+#driver_DISS2G: 0
+#driver_DISS2VS: 0
 #driver_PWM_AUTOGRAD: True
 #driver_PWM_AUTOSCALE: True
 #driver_PWM_LIM: 12
 #driver_PWM_REG: 8
 #driver_PWM_FREQ: 1
+#driver_FREEWHEEL: 0
 #driver_PWM_GRAD: 14
 #driver_PWM_OFS: 36
 #   Set the given register during the configuration of the TMC2208
@@ -3219,14 +3238,22 @@ run_current:
 #driver_TOFF: 3
 #driver_HEND: 0
 #driver_HSTRT: 5
+#driver_DISS2G: 0
+#driver_DISS2VS: 0
 #driver_PWM_AUTOGRAD: True
 #driver_PWM_AUTOSCALE: True
 #driver_PWM_LIM: 12
 #driver_PWM_REG: 8
 #driver_PWM_FREQ: 1
+#driver_FREEWHEEL: 0
 #driver_PWM_GRAD: 14
 #driver_PWM_OFS: 36
 #driver_SGTHRS: 0
+#driver_SEMIN: 0
+#driver_SEUP: 0
+#driver_SEMAX: 0
+#driver_SEDN: 0
+#driver_SEIMIN: 0
 #   Set the given register during the configuration of the TMC2209
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3228,6 +3228,7 @@ run_current:
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
 #   This field is also known as vpwmthrs or TPWMTHRS.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 20
 #driver_TBL: 2
@@ -3293,6 +3294,7 @@ run_current:
 #   The address of the TMC2209 chip for UART messages (an integer
 #   between 0 and 3). This is typically used when multiple TMC2209
 #   chips are connected to the same UART pin. The default is zero.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 20
 #driver_TBL: 2
@@ -3512,6 +3514,7 @@ run_current:
 #   in combination with this option). Enabling this option results in a tighter
 #   hysteresis around all velocity based thresholds (internally based on TSTEP).
 #   This option could prove useful if the desired velocity is high.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 6
 #driver_TPOWERDOWN: 10
 #driver_TBL: 2

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3099,6 +3099,9 @@ run_current:
 #   so by default StallGuard and CoolStep are completely disabled while not
 #   homing. Set this value in order to be able to use CoolStep.
 #   This field is also known as TCOOLTHRS.
+#homing_vcoolthrs:
+#   Same as `vcoolthrs`, except it is applied only during the homing move.
+#   If not specified, it defaults to `vcoolthrs`.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441
@@ -3283,6 +3286,9 @@ run_current:
 #   so by default StallGuard and CoolStep are completely disabled while not
 #   homing. Set this value in order to be able to use CoolStep.
 #   This field is also known as TCOOLTHRS.
+#homing_vcoolthrs:
+#   Same as `vcoolthrs`, except it is applied only during the homing move.
+#   If not specified, it defaults to `vcoolthrs`.
 #uart_address:
 #   The address of the TMC2209 chip for UART messages (an integer
 #   between 0 and 3). This is typically used when multiple TMC2209
@@ -3473,6 +3479,9 @@ run_current:
 #   so by default StallGuard and CoolStep are completely disabled while not
 #   homing. Set this value in order to be able to use CoolStep.
 #   This field is also known as TCOOLTHRS.
+#homing_vcoolthrs:
+#   Same as `vcoolthrs`, except it is applied only during the homing move.
+#   If not specified, it defaults to `vcoolthrs`.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -230,8 +230,6 @@ class TMCCommandHelper:
                                             self._handle_mcu_identify)
         self.printer.register_event_handler("klippy:connect",
                                             self._handle_connect)
-        # Set microstep config options
-        TMCMicrostepHelper(config, mcu_tmc)
         # Register commands
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("SET_TMC_FIELD", "STEPPER", self.name,

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -538,19 +538,30 @@ def TMCMicrostepHelper(config, mcu_tmc):
     fields.set_field("mres", mres)
     fields.set_field("intpol", config.getboolean("interpolate", True))
 
-# Helper to configure "stealthchop" mode
-def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
+# Helper for calculating TSTEP based values from velocity
+def TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, default_val):
     fields = mcu_tmc.get_fields()
-    en_pwm_mode = False
-    velocity = config.getfloat('stealthchop_threshold', 0., minval=0.)
-    if velocity:
+    if velocity is None:
+        return default_val
+    elif velocity > 0:
         stepper_name = " ".join(config.get_name().split()[1:])
         sconfig = config.getsection(stepper_name)
         rotation_dist, steps_per_rotation = stepper.parse_step_distance(sconfig)
         step_dist = rotation_dist / steps_per_rotation
         step_dist_256 = step_dist / (1 << fields.get_field("mres"))
         threshold = int(tmc_freq * step_dist_256 / velocity + .5)
-        fields.set_field("tpwmthrs", max(0, min(0xfffff, threshold)))
+        return max(0, min(0xfffff, threshold))
+    else:
+        return 0xfffff
+
+# Helper to configure stealthChop-spreadCycle transition velocity
+def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    en_pwm_mode = False
+    velocity = config.getfloat('stealthchop_threshold', None, minval=0.)
+    tpwmthrs = TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0xfffff)
+    fields.set_field("tpwmthrs", tpwmthrs)
+    if velocity is not None:
         en_pwm_mode = True
     reg = fields.lookup_register("en_pwm_mode", None)
     if reg is not None:

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -579,6 +579,15 @@ def TMCTHIGHHelper(config, mcu_tmc, tmc_freq):
     fields.set_field("thigh",
         TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))
 
+# Helper to configure coolStep and stallGuard lower velocity limit
+def TMCcoolStepHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    velocity = config.getfloat(
+        'vcoolthrs', None, minval=0.)
+    fields.set_field("tcoolthrs",
+        TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))
+
+
 class TMCHomingCurrentHelper:
     def __init__(self, config, mcu_tmc, current_helper):
         self.printer = config.get_printer()

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -570,6 +570,15 @@ def TMCStealthchopHelper(config, mcu_tmc, tmc_freq):
         # TMC2208 uses en_spreadCycle
         fields.set_field("en_spreadcycle", not en_pwm_mode)
 
+# Helper to configure spreadCycle-highVelocity transition velocity
+# It is also the top speed for coolStep and stallGuard operation
+def TMCTHIGHHelper(config, mcu_tmc, tmc_freq):
+    fields = mcu_tmc.get_fields()
+    velocity = config.getfloat(
+        'vhigh', None, minval=0.)
+    fields.set_field("thigh",
+        TMCtstepHelper(config, mcu_tmc, tmc_freq, velocity, 0))
+
 class TMCHomingCurrentHelper:
     def __init__(self, config, mcu_tmc, current_helper):
         self.printer = config.get_printer()

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -282,6 +282,8 @@ class TMC2130:
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields)
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -293,6 +293,7 @@ class TMC2130:
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -286,7 +286,7 @@ class TMC2130:
         # Set microstep config options
         tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Register commands
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -298,6 +298,7 @@ class TMC2130:
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         tmc.TMCTHIGHHelper(config, self.mcu_tmc, self.tmc_frequency)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # GCONF

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -297,6 +297,8 @@ class TMC2130:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # GCONF
+        set_config_field(config, "small_hysteresis", False)
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -297,6 +297,7 @@ class TMC2130:
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
+        tmc.TMCTHIGHHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # GCONF

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -299,17 +299,22 @@ class TMC2130:
         set_config_field = self.fields.set_config_field
         # GCONF
         set_config_field(config, "small_hysteresis", False)
+        # CHOPCONF
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)
         set_config_field(config, "tbl", 1)
+        # COOLCONF
+        set_config_field(config, "sgt", 0)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 0)
+        # PWMCONF
         set_config_field(config, "pwm_ampl", 128)
         set_config_field(config, "pwm_grad", 4)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
-        set_config_field(config, "sgt", 0)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 0)
 
 def load_config_prefix(config):
     return TMC2130(config)

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -303,9 +303,23 @@ class TMC2130:
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)
+        set_config_field(config, "fd3", 0)
+        set_config_field(config, "disfdcc", 0)
+        set_config_field(config, "rndtf", 0)
+        set_config_field(config, "chm", 0)
         set_config_field(config, "tbl", 1)
+        set_config_field(config, "vhighfs", 0)
+        set_config_field(config, "vhighchm", 0)
+        set_config_field(config, "sync", 0)
+        set_config_field(config, "diss2g", 0)
         # COOLCONF
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
         set_config_field(config, "sgt", 0)
+        set_config_field(config, "sfilt", 0)
         # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
         # PWMCONF
@@ -313,6 +327,8 @@ class TMC2130:
         set_config_field(config, "pwm_grad", 4)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
+        set_config_field(config, "pwm_symmetric", False)
+        set_config_field(config, "freewheel", 0)
         # TPOWERDOWN
         set_config_field(config, "tpowerdown", 0)
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -6,7 +6,6 @@
 import math, logging
 from . import bus, tmc
 
-TMC_FREQUENCY=13200000.
 
 Registers = {
     "GCONF": 0x00, "GSTAT": 0x01, "IOIN": 0x04, "IHOLD_IRUN": 0x10,
@@ -279,6 +278,8 @@ class MCU_TMC_SPI:
 
 class TMC2130:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('tmc_frequency',
+            13200000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields)
@@ -294,7 +295,7 @@ class TMC2130:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # GCONF

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -188,6 +188,8 @@ class TMC2208:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
         self.fields.set_field("pdn_disable", True)
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -207,6 +207,8 @@ class TMC2208:
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        set_config_field(config, "diss2g", 0)
+        set_config_field(config, "diss2vs", 0)
         # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
         # PWMCONF
@@ -215,6 +217,7 @@ class TMC2208:
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
         # TPOWERDOWN

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -6,7 +6,6 @@
 import logging
 from . import tmc, tmc_uart, tmc2130
 
-TMC_FREQUENCY=12000000.
 
 Registers = {
     "GCONF": 0x00, "GSTAT": 0x01, "IFCNT": 0x02, "SLAVECONF": 0x03,
@@ -184,6 +183,8 @@ FieldFormatters.update({
 
 class TMC2208:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('tmc_frequency',
+            12000000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
@@ -199,7 +200,7 @@ class TMC2208:
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -197,6 +197,7 @@ class TMC2208:
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -202,12 +202,14 @@ class TMC2208:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 20)
+        # PWMCONF
         set_config_field(config, "pwm_ofs", 36)
         set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
@@ -215,6 +217,8 @@ class TMC2208:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 20)
     def read_translate(self, reg_name, val):
         if reg_name == "IOIN":
             drv_type = self.fields.get_field("sel_a", val)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -172,8 +172,8 @@ SignedFields = ["cur_a", "cur_b", "pwm_scale_auto"]
 FieldFormatters = dict(tmc2130.FieldFormatters)
 FieldFormatters.update({
     "sel_a":            (lambda v: "%d(%s)" % (v, ["TMC222x", "TMC220x"][v])),
-    "s2vsa":            (lambda v: "1(LowSideShort_A!)" if v else ""),
-    "s2vsb":            (lambda v: "1(LowSideShort_B!)" if v else ""),
+    "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
+    "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
 })
 
 

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -199,11 +199,13 @@ class TMC2208:
         self.get_status = cmdhelper.get_status
         tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
-        self.fields.set_field("mstep_reg_select", True)
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # GCONF
+        self.fields.set_field("pdn_disable", True)
+        self.fields.set_field("mstep_reg_select", True)
+        set_config_field(config, "multistep_filt", True)
         # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -73,6 +73,7 @@ class TMC2209:
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import tmc2208, tmc2130, tmc, tmc_uart
 
-TMC_FREQUENCY=12000000.
 
 Registers = dict(tmc2208.Registers)
 Registers.update({
@@ -55,6 +54,8 @@ FieldFormatters = dict(tmc2208.FieldFormatters)
 
 class TMC2209:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('tmc_frequency',
+            12000000., minval=4000000., maxval=16000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, tmc2208.SignedFields,
                                       FieldFormatters)
@@ -76,7 +77,7 @@ class TMC2209:
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -66,7 +66,7 @@ class TMC2209:
         # Set microstep config options
         tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -79,6 +79,7 @@ class TMC2209:
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -62,6 +62,8 @@ class TMC2209:
         # Setup fields for UART
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -84,6 +84,14 @@ class TMC2209:
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        set_config_field(config, "diss2g", 0)
+        set_config_field(config, "diss2vs", 0)
+        # COOLCONF
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
         # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
         # PWMCONF
@@ -92,6 +100,7 @@ class TMC2209:
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
         # TPOWERDOWN

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -75,13 +75,14 @@ class TMC2209:
         self.get_status = cmdhelper.get_status
         tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
-        self.fields.set_field("pdn_disable", True)
-        self.fields.set_field("mstep_reg_select", True)
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         tmc.TMCcoolStepHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # GCONF
+        self.fields.set_field("pdn_disable", True)
+        self.fields.set_field("mstep_reg_select", True)
+        set_config_field(config, "multistep_filt", True)
         # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -79,12 +79,14 @@ class TMC2209:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 20)
+        # PWMCONF
         set_config_field(config, "pwm_ofs", 36)
         set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
@@ -92,6 +94,9 @@ class TMC2209:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 20)
+        # SGTHRS
         set_config_field(config, "sgthrs", 0)
 
 def load_config_prefix(config):

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -233,6 +233,8 @@ class TMC2660:
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.fields.set_field("sdoff", 0) # Access DRVCTRL in step/dir mode
         self.mcu_tmc = MCU_TMC2660_SPI(config, Registers, self.fields)
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Register commands
         current_helper = TMC2660CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -241,6 +241,7 @@ class TMC2660:
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
 
         # CHOPCONF
         set_config_field = self.fields.set_config_field

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -324,6 +324,7 @@ class TMC5160:
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
+        tmc.TMCHomingCurrentHelper(config, self.mcu_tmc, current_helper)
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -313,6 +313,8 @@ class TMC5160:
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -332,6 +332,7 @@ class TMC5160:
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         tmc.TMCTHIGHHelper(config, self.mcu_tmc, self.tmc_frequency)
+        tmc.TMCcoolStepHelper(config, self.mcu_tmc, self.tmc_frequency)
         set_config_field = self.fields.set_config_field
         #   GCONF
         set_config_field(config, "small_hysteresis", False)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -320,7 +320,7 @@ class TMC5160:
         # Set microstep config options
         tmc.TMCMicrostepHelper(config, self.mcu_tmc)
         # Allow virtual pins to be created
-        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Register commands
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -6,7 +6,6 @@
 import math, logging
 from . import bus, tmc, tmc2130
 
-TMC_FREQUENCY=12000000.
 
 Registers = {
     "GCONF":            0x00,
@@ -310,6 +309,8 @@ class TMC5160CurrentHelper:
 
 class TMC5160:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('tmc_frequency',
+            12000000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
@@ -325,7 +326,7 @@ class TMC5160:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         set_config_field = self.fields.set_config_field
         #   GCONF
         set_config_field(config, "small_hysteresis", False)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -328,6 +328,8 @@ class TMC5160:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         #   CHOPCONF
         set_config_field = self.fields.set_config_field
+        #   GCONF
+        set_config_field(config, "small_hysteresis", False)
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 2)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -335,6 +335,7 @@ class TMC5160:
         tmc.TMCcoolStepHelper(config, self.mcu_tmc, self.tmc_frequency)
         set_config_field = self.fields.set_config_field
         #   GCONF
+        set_config_field(config, "multistep_filt", True)
         set_config_field(config, "small_hysteresis", False)
         #   CHOPCONF
         set_config_field(config, "toff", 3)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -326,10 +326,10 @@ class TMC5160:
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
-        #   CHOPCONF
         set_config_field = self.fields.set_config_field
         #   GCONF
         set_config_field(config, "small_hysteresis", False)
+        #   CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 2)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -260,19 +260,18 @@ class TMC5160CurrentHelper:
                                        above=0., maxval=MAX_CURRENT)
         self.req_hold_current = hold_current
         self.sense_resistor = config.getfloat('sense_resistor', 0.075, above=0.)
-        self._set_globalscaler(run_current)
-        irun, ihold = self._calc_current(run_current, hold_current)
+        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
+        self.fields.set_field("globalscaler", gscaler)
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
-    def _set_globalscaler(self, current):
+    def _calc_globalscaler(self, current):
         globalscaler = int((current * 256. * math.sqrt(2.)
                             * self.sense_resistor / VREF) + .5)
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0
-        self.fields.set_field("globalscaler", globalscaler)
-    def _calc_current_bits(self, current):
-        globalscaler = self.fields.get_field("globalscaler")
+        return globalscaler
+    def _calc_current_bits(self, current, globalscaler):
         if not globalscaler:
             globalscaler = 256
         cs = int((current * 256. * 32. * math.sqrt(2.) * self.sense_resistor)
@@ -280,9 +279,10 @@ class TMC5160CurrentHelper:
                  - 1. + .5)
         return max(0, min(31, cs))
     def _calc_current(self, run_current, hold_current):
-        irun = self._calc_current_bits(run_current)
-        ihold = self._calc_current_bits(min(hold_current, run_current))
-        return irun, ihold
+        gscaler = self._calc_globalscaler(max(hold_current, run_current))
+        irun = self._calc_current_bits(run_current, gscaler)
+        ihold = self._calc_current_bits(min(hold_current, run_current), gscaler)
+        return gscaler, irun, ihold
     def _calc_current_from_field(self, field_name):
         globalscaler = self.fields.get_field("globalscaler")
         if not globalscaler:
@@ -296,7 +296,9 @@ class TMC5160CurrentHelper:
         return run_current, hold_current, self.req_hold_current, MAX_CURRENT
     def set_current(self, run_current, hold_current, print_time):
         self.req_hold_current = hold_current
-        irun, ihold = self._calc_current(run_current, hold_current)
+        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
+        val = self.fields.set_field("globalscaler", gscaler)
+        self.mcu_tmc.set_register("GLOBALSCALER", val, print_time)
         self.fields.set_field("ihold", ihold)
         val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -241,6 +241,10 @@ Fields["TSTEP"] = {
 SignedFields = ["cur_a", "cur_b", "sgt", "xactual", "vactual", "pwm_scale_auto"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
+FieldFormatters.update({
+    "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
+    "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
+})
 
 
 ######################################################################

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -231,6 +231,9 @@ Fields["TPWMTHRS"] = {
 Fields["TCOOLTHRS"] = {
     "tcoolthrs":                0xfffff << 0
 }
+Fields["THIGH"] = {
+    "thigh":                    0xfffff << 0
+}
 Fields["TSTEP"] = {
     "tstep":                    0xfffff << 0
 }
@@ -328,6 +331,7 @@ class TMC5160:
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
+        tmc.TMCTHIGHHelper(config, self.mcu_tmc, self.tmc_frequency)
         set_config_field = self.fields.set_config_field
         #   GCONF
         set_config_field(config, "small_hysteresis", False)


### PR DESCRIPTION
# Summary of changes:
A ticked box means that a separate PR has been made with this change.
- [ ] Moved the initialization of the microstep settings in a place that makes more sense. This was needed because the TSTEP helper relies on the mres value to already be loaded.
- [ ] Added a boat load of fields to the config for the drivers besides tmc5160. For some reason only tmc5160 was very configurable, but now all of the drivers are.
- [x] Added the ability to specify the clock frequency of the tmc driver. This information is only used for calculating fields with the TSTEP helper. This option is useful if the driver has an external clock attached. - #6158
- [x] Configurable vhigh (THIGH) - #6139
- [x] Configurable vcoolthrs (TCOOLTHRS) - #6139
---
Already merged:
- [x] TMC5160 specific: Changed the way the current fields for the driver are calculated when the current is changed at runtime.
- [x] Code reorganization. The tmc2130 code and tmc220x code was a bit messy in the intialization method. tmc5160 init code was much more beautiful, so I made the other tmc code look like the tmc5160 code.
- [x] Fixed the s2vs field formatters. So instead of the misleading `LowSideShort_A`, it's now `ShortToSupply_A` (and the same for the B coil). Also implemented this field formatter for TMC5160.
- [x] TSTEP helper: Internal code for computing other fields such as TPWMTHRS, TCOOLTHRS, THIGH, etc...
- [x] Configurable homing_vcoolthrs - can be implemented with macros just like the homing current: https://github.com/Klipper3d/klipper/pull/6104#issuecomment-1464980909
---
Scrapped:
- [x] Added small_hysteresis and multistep_filt as config options for drivers that support it. - This was scrapped since few users will ever need to change these fields. In those cases, a delayed gcode can be used at startup to setup the fields. The patch for tmc2240 and tmc5160 default value was merged with PR #6118.
- [x] Ability to specify a homing current value. ~This current is automatically applied at the beginning of the homing move and the old current is restored at the end of homing. This both improves the StallGuard homing reliability (more tuning possible) and it makes printers safer (less chances of damage during homing if it fails).~. This idea was scrapped in favor of using macros. See https://github.com/Klipper3d/klipper/pull/6104#issuecomment-1464980909
---

For more details, read the commit comment and/or the documentation

All of these features combined should improve the reliability of StallGuard homing and make the tmc drivers more configurable in general. It also makes it possible to use CoolStep with all drivers that support it.
The homing related improvements were tested on a Prusa MK3S.
I do not have a way of testing anything besides tmc2130 and tmc2240 (todo) at the moment.