### PR TITLE
RFC: gcode_aliases: Add support for specifying g-code aliases

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1346,6 +1346,19 @@ information.
 
 ## G-Code macros and events
 
+### [gcode_aliases]
+G-Code aliases (one may define any number of sections with a
+"gcode_aliases" prefix). Use this to define aliases for g-code
+commands.
+
+```
+[gcode_aliases my_aliases]
+aliases:
+aliases_<name>:
+#   A comma separated list of "name=value" G-Code aliases to create.
+#   Any number of options starting with "aliases_" may be specified.
+```
+
 ### [gcode_macro]
 
 G-Code macros (one may define any number of sections with a

--- a/klippy/extras/gcode_aliases.py
+++ b/klippy/extras/gcode_aliases.py
@@ -1,0 +1,21 @@
+# Add ability to define custom g-code aliases
+#
+# Copyright (C) 2023  Andreas Sandberg <andreas@sandberg.uk>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+class GCodeAliases:
+    def __init__(self, config):
+        printer = config.get_printer()
+        gcode = printer.lookup_object('gcode')
+        options = ["aliases"] + config.get_prefix_options("aliases_")
+        for opt in options:
+            aliases = config.getlists(opt, seps=('=', ','), count=2)
+            for name, value in aliases:
+                gcode.register_alias(name.upper(), value)
+
+def load_config_prefix(config):
+    return GCodeAliases(config)
+
+def load_config(config):
+    return GCodeAliases(config)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -138,6 +138,13 @@ class GCodeDispatch:
             self.base_gcode_handlers[cmd] = func
         if desc is not None:
             self.gcode_help[cmd] = desc
+    def register_alias(self, cmd, target):
+        target_func = self.ready_gcode_handlers.get(target)
+        when_not_ready = target in self.base_gcode_handlers
+
+        self.register_command(cmd, target_func,
+                              when_not_ready=when_not_ready,
+                              desc="Alias for %s" % (target, ))
     def register_mux_command(self, cmd, key, value, func, desc=None):
         prev = self.mux_commands.get(cmd)
         if prev is None:


### PR DESCRIPTION
Some g-code dialects use a leading zero in G and M commands. For example, such dialects use G01 instead of G1. Add a mechanism to specify G-Code aliases in configuration files to provide a mechanism to support such dialects. For example, a user could add the following configuration snippet to support such a dialect:

    [gcode_aliases G0X]
    aliases:
        G00=G0, G01=G1, G02=G2, G03=G3, G04=G4

I'm posting this as an RFC. An alternative solution would be to teach Klipper's gcode parser to strip the leading zero from these commands if the specific command hasn't been defined. The aliases mechanism might still be useful though.