### PR TITLE
probe: allow overriding horizontal_move_z on gcode

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -146,14 +146,15 @@ The following commands are available when the
 (also see the [bed mesh guide](Bed_Mesh.md)).
 
 #### BED_MESH_CALIBRATE
-`BED_MESH_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]
-[<mesh_parameter>=<value>]`: This command probes the bed using
-generated points specified by the parameters in the config. After
-probing, a mesh is generated and z-movement is adjusted according to
-the mesh. See the PROBE command for details on the optional probe
-parameters. If METHOD=manual is specified then the manual probing tool
-is activated - see the MANUAL_PROBE command above for details on the
-additional commands available while this tool is active.
+`BED_MESH_CALIBRATE [METHOD=manual] [HORIZONTAL_MOVE_Z=<value>]
+[<probe_parameter>=<value>] [<mesh_parameter>=<value>]`: This command probes
+the bed using generated points specified by the parameters in the config. After
+probing, a mesh is generated and z-movement is adjusted according to the mesh.
+See the PROBE command for details on the optional probe parameters. If
+METHOD=manual is specified then the manual probing tool is activated - see the
+MANUAL_PROBE command above for details on the additional commands available
+while this tool is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
+`horizontal_move_z` option specified in the config file.
 
 #### BED_MESH_OUTPUT
 `BED_MESH_OUTPUT PGP=[<0:1>]`: This command outputs the current probed
@@ -207,13 +208,14 @@ The following commands are available when the
 [bed_tilt config section](Config_Reference.md#bed_tilt) is enabled.
 
 #### BED_TILT_CALIBRATE
-`BED_TILT_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`: This
-command will probe the points specified in the config and then
-recommend updated x and y tilt adjustments. See the PROBE command for
-details on the optional probe parameters. If METHOD=manual is
-specified then the manual probing tool is activated - see the
-MANUAL_PROBE command above for details on the additional commands
-available while this tool is active.
+`BED_TILT_CALIBRATE [METHOD=manual] [HORIZONTAL_MOVE_Z=<value>]
+[<probe_parameter>=<value>]`: This command will probe the points specified in
+the config and then recommend updated x and y tilt adjustments. See the PROBE
+command for details on the optional probe parameters. If METHOD=manual is
+specified then the manual probing tool is activated - see the MANUAL_PROBE
+command above for details on the additional commands available while this tool
+is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
+`horizontal_move_z` option specified in the config file.
 
 ### [bltouch]
 
@@ -262,13 +264,14 @@ The following commands are available when the
 is enabled (also see the [delta calibrate guide](Delta_Calibrate.md)).
 
 #### DELTA_CALIBRATE
-`DELTA_CALIBRATE [METHOD=manual] [<probe_parameter>=<value>]`: This
-command will probe seven points on the bed and recommend updated
-endstop positions, tower angles, and radius. See the PROBE command for
-details on the optional probe parameters. If METHOD=manual is
-specified then the manual probing tool is activated - see the
-MANUAL_PROBE command above for details on the additional commands
-available while this tool is active.
+`DELTA_CALIBRATE [METHOD=manual] [HORIZONTAL_MOVE_Z=<value>]
+[<probe_parameter>=<value>]`: This command will probe seven points on the bed
+and recommend updated endstop positions, tower angles, and radius. See the
+PROBE command for details on the optional probe parameters. If METHOD=manual is
+specified then the manual probing tool is activated - see the MANUAL_PROBE
+command above for details on the additional commands available while this tool
+is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
+`horizontal_move_z` option specified in the config file.
 
 #### DELTA_ANALYZE
 `DELTA_ANALYZE`: This command is used during enhanced delta
@@ -1078,16 +1081,17 @@ is enabled (also see the
 
 #### SCREWS_TILT_CALCULATE
 `SCREWS_TILT_CALCULATE [DIRECTION=CW|CCW] [MAX_DEVIATION=<value>]
-[<probe_parameter>=<value>]`: This command will invoke the bed screws
-adjustment tool. It will command the nozzle to different locations (as
-defined in the config file) probing the z height and calculate the
-number of knob turns to adjust the bed level. If DIRECTION is
-specified, the knob turns will all be in the same direction, clockwise
-(CW) or counterclockwise (CCW). See the PROBE command for details on
-the optional probe parameters. IMPORTANT: You MUST always do a G28
-before using this command. If MAX_DEVIATION is specified, the command
-will raise a gcode error if any difference in the screw height
-relative to the base screw height is greater than the value provided.
+[HORIZONTAL_MOVE_Z=<value>] [<probe_parameter>=<value>]`: This command will
+invoke the bed screws adjustment tool. It will command the nozzle to different
+locations (as defined in the config file) probing the z height and calculate
+the number of knob turns to adjust the bed level. If DIRECTION is specified,
+the knob turns will all be in the same direction, clockwise (CW) or
+counterclockwise (CCW). See the PROBE command for details on the optional probe
+parameters. IMPORTANT: You MUST always do a G28 before using this command. If
+MAX_DEVIATION is specified, the command will raise a gcode error if any
+difference in the screw height relative to the base screw height is greater
+than the value provided. The optional `HORIZONTAL_MOVE_Z` value overrides the
+`horizontal_move_z` option specified in the config file.
 
 ### [sdcard_loop]
 
@@ -1329,7 +1333,8 @@ The following commands are available when the
 [z_tilt config section](Config_Reference.md#z_tilt) is enabled.
 
 #### Z_TILT_ADJUST
-`Z_TILT_ADJUST [<probe_parameter>=<value>]`: This command will probe
-the points specified in the config and then make independent
-adjustments to each Z stepper to compensate for tilt. See the PROBE
-command for details on the optional probe parameters.
+`Z_TILT_ADJUST [HORIZONTAL_MOVE_Z=<value>] [<probe_parameter>=<value>]`: This
+command will probe the points specified in the config and then make independent
+adjustments to each Z stepper to compensate for tilt. See the PROBE command for
+details on the optional probe parameters. The optional `HORIZONTAL_MOVE_Z`
+value overrides the `horizontal_move_z` option specified in the config file.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -362,7 +362,8 @@ class ProbePointsHelper:
         if default_points is None or config.get('points', None) is not None:
             self.probe_points = config.getlists('points', seps=(',', '\n'),
                                                 parser=float, count=2)
-        self.horizontal_move_z = config.getfloat('horizontal_move_z', 5.)
+        def_move_z = config.getfloat('horizontal_move_z', 5.)
+        self.default_horizontal_move_z = def_move_z
         self.speed = config.getfloat('speed', 50., above=0.)
         self.use_offsets = False
         # Internal probing state
@@ -408,6 +409,9 @@ class ProbePointsHelper:
         probe = self.printer.lookup_object('probe', None)
         method = gcmd.get('METHOD', 'automatic').lower()
         self.results = []
+        def_move_z = self.default_horizontal_move_z
+        self.horizontal_move_z = gcmd.get_float('HORIZONTAL_MOVE_Z',
+                                                def_move_z)
         if probe is None or method != 'automatic':
             # Manual probe
             self.lift_speed = self.speed


### PR DESCRIPTION
This adds the ability to override `horizontal_move_z` in gcode commands using the `ProbePointsHelper` utility. This includes Z tilt, QGL, Bed mesh, Bed tilt, Screws tilt adjust, and Delta calibration.

These currently always use a static `horizontal_move_z`. This patch allows overriding this per-call with a `MOVE_Z` gcode parameter. The configured value is always used unless `MOVE_Z` is given for a specific command(the value does not "stick around").

The main use case is the ability to perform a "two stage" QGL or Z tilt adjust. One can (e.g. from a macro) perform a high-z-move high-tolerance run first(to guard against a heavily misaligned bed), and then a low-move, low-tolerance run after. This can significantly speed up the process, especially when using a probe like Beacon.

Best regards,
Lasse