### PR TITLE
Fix "MCU 'rpi' shutdown: Timer too close" intermittent error with MPU-* accelerometers using I2C from Raspberry Pi

### DIFF
--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -221,7 +221,7 @@ class MPU9250:
         systime = self.printer.get_reactor().monotonic()
         print_time = self.mcu.estimated_print_time(systime) + MIN_MSG_TIME
         reqclock = self.mcu.print_time_to_clock(print_time)
-        rest_ticks = self.mcu.seconds_to_clock(1. / self.data_rate)
+        rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
         self.query_rate = self.data_rate
         self.query_mpu9250_cmd.send([self.oid, reqclock, rest_ticks],
                                     reqclock=reqclock)


### PR DESCRIPTION
I have never been able to reliably use multiple MPU-6500's attached via I2C to my Raspberry Pi 3B+. Both `ACCELEROMETER_QUERY` G-code commands and `TEST_RESONANCES` runs would intermittently fail, with perhaps a 1 in 10 chance of success.

There is an intermittent timing error streaming bytes from the MPU-* series over I2C to the Linux MCU process. The error is likely triggered more often in the Linux MCU process than in actual MCUs. 

The problem is a too small value set in the `mp->rest_ticks` field of `struct mpu9250` in `sensor_mpu9250.c` by `mpu9250.py` line 224. For the ADXL345 the equivalent value is set to `4. / self.data_rate` (`adxl345.py` line 394), while in the MPU-* it is set to `1. / self.data_rate`. This small value of `mp->rest_ticks` often causes the `static void mp9250_reschedule_timer(struct mpu9250 *mp)` function to schedule the timer so close to the current time that when `void sched_add_timer(struct timer *add)` is executed in `sched.c` the requested time is now in the past. This error is detected by the sanity checks in that function and triggers the `try_shutdown("Timer too close")` shutdown on line 94.

Adjusting the divisor from 1 -> 4 while observing the MPU FIFO fill fixes this error while not causing FIFO overflows. After several test runs adding a debugging `output()` function to report the FIFO bytes and `awk -F= 'BEGIN{fifo=0} /fifo_bytes/ {if ($2>fifo) fifo=$2} END{print fifo}' ~/printer_data /logs/klippy.log` the largest buffer fill I have obtained is 180 after 5 runs, which is far smaller than the 512 byte FIFO in the MPU-* series.

(I also tested divisors of 2, 4, 5, 6 and 8 while checking the max. FIFO fill level, and I believe 4 seems appropriate, although 5 and 6 may work too. 8 led to a maximum FIFO fill of 494 vs. the MPU's FIFO of 512, and 2 seemed to have very little margin from triggering the problem again.)

Log showing the "Timer too close" errors, along with various debugging `output()` outputs: [klippy.log](https://github.com/Klipper3d/klipper/files/10879356/klippy.log)

Files from a successful run, including raw data:

![shaper_calibrate_x](https://user-images.githubusercontent.com/4684331/222660721-6ecd0dfa-2f24-45b6-a461-251af1fa7583.png)
![shaper_calibrate_y](https://user-images.githubusercontent.com/4684331/222660723-3251d201-515c-4919-af34-62e95ba93c3e.png)
[raw_data_y_20230303_015518.csv](https://github.com/Klipper3d/klipper/files/10879333/raw_data_y_20230303_015518.csv)
[raw_data_x_20230303_020021.csv](https://github.com/Klipper3d/klipper/files/10879329/raw_data_x_20230303_020021.csv)
[resonances_x_20230303_020021.csv](https://github.com/Klipper3d/klipper/files/10879336/resonances_x_20230303_020021.csv)
[resonances_y_20230303_015518.csv](https://github.com/Klipper3d/klipper/files/10879337/resonances_y_20230303_015518.csv)

I traced the I2C bus and MPU FIFO fill electrically with my [MSO6034A](https://www.keysight.com/us/en/product/MSO6034A/mixed-signal-oscilloscope-300-mhz-4-analog-16-digital-channels.html) scope in addition to stressing the MPUs with several standalone C programs to eliminate possible errors with my wiring or electrical noise etc. which finally led me to this problem.