### PR TITLE
probe: expose name on status report

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -346,6 +346,7 @@ The following information is available in the
 [probe](Config_Reference.md#probe) object (this object is also
 available if a [bltouch](Config_Reference.md#bltouch) config section
 is defined):
+- `name`: Returns the name of the probe in use.
 - `last_query`: Returns True if the probe was reported as "triggered"
   during the last QUERY_PROBE command. Note, if this is used in a
   macro, due to the order of template expansion, the QUERY_PROBE

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -195,7 +195,8 @@ class PrinterProbe:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     def get_status(self, eventtime):
-        return {'last_query': self.last_state,
+        return {'name': self.name,
+                'last_query': self.last_state,
                 'last_z_result': self.last_z_result}
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
     def cmd_PROBE_ACCURACY(self, gcmd):


### PR DESCRIPTION
Adds the probe name to the probe status object.

I know one can infer this from the config file (check for "bltouch", "smart_effector" or "probe" sections), but seems to me easier to just expose it here.