### PR TITLE
docs: Remove comment about default profile loading

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -390,9 +390,7 @@ to write the profile to printer.cfg.
 Profiles can be loaded by executing `BED_MESH_PROFILE LOAD=<name>`.
 
 It should be noted that each time a BED_MESH_CALIBRATE occurs, the current
-state is automatically saved to the _default_ profile.  If this profile
-exists it is automatically loaded when Klipper starts.  If this behavior
-is not desirable the _default_ profile can be removed as follows:
+state is automatically saved to the _default_ profile. The _default_ profile can be removed as follows:
 
 `BED_MESH_PROFILE REMOVE=default`
 


### PR DESCRIPTION
In the docs, it said "If this profile exists it is automatically loaded when Klipper starts.". This was reffering to the "default" profile.
This is not true anymore as it was changed in #5877 (and mentioned in #5983).