### PR TITLE
tmc: SET_TMC_FIELD set VELOCITY

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1236,13 +1236,16 @@ if StealthChop2 is used, the stepper must be held at standstill for >130ms so
 that the driver executes the AT#1 calibration.
 
 #### SET_TMC_FIELD
-`SET_TMC_FIELD STEPPER=<name> FIELD=<field> VALUE=<value>`: This will
-alter the value of the specified register field of the TMC driver.
+`SET_TMC_FIELD STEPPER=<name> FIELD=<field> VALUE=<value> VELOCITY=<value>`:
+This will alter the value of the specified register field of the TMC driver.
 This command is intended for low-level diagnostics and debugging only
 because changing the fields during run-time can lead to undesired and
 potentially dangerous behavior of your printer. Permanent changes
 should be made using the printer configuration file instead. No sanity
 checks are performed for the given values.
+A VELOCITY can also be specified instead of a VALUE. This velocity is
+converted to the 20bit TSTEP based value representation. Only use the VELOCITY
+argument for fields that represent velocities.
 
 ### [toolhead]
 

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -248,13 +248,14 @@ def lookup_tmc_spi_chain(config):
 
 # Helper code for working with TMC devices via SPI
 class MCU_TMC_SPI:
-    def __init__(self, config, name_to_reg, fields):
+    def __init__(self, config, name_to_reg, fields, tmc_frequency):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
         self.tmc_spi, self.chain_pos = lookup_tmc_spi_chain(config)
         self.mutex = self.tmc_spi.mutex
         self.name_to_reg = name_to_reg
         self.fields = fields
+        self.tmc_frequency = tmc_frequency
     def get_fields(self):
         return self.fields
     def get_register(self, reg_name):
@@ -271,6 +272,8 @@ class MCU_TMC_SPI:
                     return
         raise self.printer.command_error(
             "Unable to write tmc spi '%s' register %s" % (self.name, reg_name))
+    def get_tmc_frequency(self):
+        return self.tmc_frequency
 
 
 ######################################################################
@@ -281,7 +284,8 @@ class TMC2130:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields)
+        self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields,
+                                   TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -186,7 +186,8 @@ class TMC2208:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
+        self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 0,
+                                             TMC_FREQUENCY)
         self.fields.set_field("pdn_disable", True)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -58,7 +58,8 @@ class TMC2209:
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, tmc2208.SignedFields,
                                       FieldFormatters)
-        self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3)
+        self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3,
+                                             TMC_FREQUENCY)
         # Setup fields for UART
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -343,7 +343,8 @@ class TMC2240:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
+        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
+                                           TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -221,6 +221,8 @@ class MCU_TMC2660_SPI:
         msg = [((val >> 16) | reg) & 0xff, (val >> 8) & 0xff, val & 0xff]
         with self.mutex:
             self.spi.spi_send(msg, minclock)
+    def get_tmc_frequency(self):
+        return None
 
 
 ######################################################################

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -316,7 +316,8 @@ class TMC5160:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields)
+        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
+                                           TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -210,7 +210,7 @@ def lookup_tmc_uart_bitbang(config, max_addr):
 
 # Helper code for communicating via TMC uart
 class MCU_TMC_uart:
-    def __init__(self, config, name_to_reg, fields, max_addr=0):
+    def __init__(self, config, name_to_reg, fields, max_addr, tmc_frequency):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
         self.name_to_reg = name_to_reg
@@ -219,6 +219,7 @@ class MCU_TMC_uart:
         self.instance_id, self.addr, self.mcu_uart = lookup_tmc_uart_bitbang(
             config, max_addr)
         self.mutex = self.mcu_uart.mutex
+        self.tmc_frequency = tmc_frequency
     def get_fields(self):
         return self.fields
     def _do_get_register(self, reg_name):
@@ -250,3 +251,5 @@ class MCU_TMC_uart:
                     return
         raise self.printer.command_error(
             "Unable to write tmc uart '%s' register %s" % (self.name, reg_name))
+    def get_tmc_frequency(self):
+        return self.tmc_frequency


### PR DESCRIPTION
This PR introduces the argument `VELOCITY` for `SET_TMC_FIELD`. It can be used instead of `VALUE` so that the velocity is automatically converted to the TSTEP based value of that velocity.

The aim of this change is to allow macros to change fields such as `TPWMTHRS`, `TCOOLTHRS` and `THIGH` at runtime without needing to hardcode values which might differ based on microstepping resolution and steps/mm of the axis.
To implement this change, I ported the TSTEP helper from my other PR (#6074).

Tested on TMC2240 on another branch of mine. TMC2660 needs to be tested since it's the odd one out.