### PR TITLE
tmc: Fix s2vs field formatters

### DIFF
--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -544,7 +544,7 @@ hot. Typical solutions are to decrease the stepper motor current,
 increase cooling on the stepper motor driver, and/or increase cooling
 on the stepper motor.
 
-#### TMC reports error: `... ShortToGND` OR `LowSideShort`
+#### TMC reports error: `... ShortToGND` OR `ShortToSupply`
 
 This indicates the driver has disabled itself because it detected very
 high current passing through the driver. This may indicate a loose or

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -173,8 +173,8 @@ SignedFields = ["cur_a", "cur_b", "pwm_scale_auto"]
 FieldFormatters = dict(tmc2130.FieldFormatters)
 FieldFormatters.update({
     "sel_a":            (lambda v: "%d(%s)" % (v, ["TMC222x", "TMC220x"][v])),
-    "s2vsa":            (lambda v: "1(LowSideShort_A!)" if v else ""),
-    "s2vsb":            (lambda v: "1(LowSideShort_B!)" if v else ""),
+    "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
+    "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
 })
 
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -239,6 +239,10 @@ Fields["TSTEP"] = {
 SignedFields = ["cur_a", "cur_b", "sgt", "xactual", "vactual", "pwm_scale_auto"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
+FieldFormatters.update({
+    "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
+    "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
+})
 
 
 ######################################################################


### PR DESCRIPTION
Fixed the s2vs field formatters. So instead of the misleading `LowSideShort_A`, it's now `ShortToSupply_A` (and the same for the B coil). Also implemented this field formatter for TMC5160 since it was missing there.

Based on PR #6074.