### PR TITLE
tmc: Beautify initialization code

### DIFF
--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -295,17 +295,22 @@ class TMC2130:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 4)
         set_config_field(config, "hstrt", 0)
         set_config_field(config, "hend", 7)
         set_config_field(config, "tbl", 1)
+        # COOLCONF
+        set_config_field(config, "sgt", 0)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 0)
+        # PWMCONF
         set_config_field(config, "pwm_ampl", 128)
         set_config_field(config, "pwm_grad", 4)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
-        set_config_field(config, "sgt", 0)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 0)
 
 def load_config_prefix(config):
     return TMC2130(config)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -200,12 +200,14 @@ class TMC2208:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 20)
+        # PWMCONF
         set_config_field(config, "pwm_ofs", 36)
         set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
@@ -213,6 +215,8 @@ class TMC2208:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 20)
     def read_translate(self, reg_name, val):
         if reg_name == "IOIN":
             drv_type = self.fields.get_field("sel_a", val)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -77,12 +77,14 @@ class TMC2209:
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 0)
         set_config_field(config, "tbl", 2)
+        # IHOLDIRUN
         set_config_field(config, "iholddelay", 8)
-        set_config_field(config, "tpowerdown", 20)
+        # PWMCONF
         set_config_field(config, "pwm_ofs", 36)
         set_config_field(config, "pwm_grad", 14)
         set_config_field(config, "pwm_freq", 1)
@@ -90,6 +92,9 @@ class TMC2209:
         set_config_field(config, "pwm_autograd", True)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
+        # TPOWERDOWN
+        set_config_field(config, "tpowerdown", 20)
+        # SGTHRS
         set_config_field(config, "sgthrs", 0)
 
 def load_config_prefix(config):

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -322,8 +322,8 @@ class TMC5160:
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
-        #   CHOPCONF
         set_config_field = self.fields.set_config_field
+        #   CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 2)


### PR DESCRIPTION
Purely esthetic. Make all tmc driver init code similar to one another. The various fields were grouped based on the register which they affect or the function they perform.

Based on PR https://github.com/Klipper3d/klipper/pull/6074.