### PR TITLE
armcm_link: Add exception index table

### DIFF
--- a/src/generic/armcm_link.lds.S
+++ b/src/generic/armcm_link.lds.S
@@ -26,6 +26,12 @@ SECTIONS
         *(.rodata .rodata*)
     } > rom
 
+    .ARM.exidx : {
+      __exidx_start = .;
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+      __exidx_end = .;
+    } > rom
+
     . = ALIGN(4);
     _data_flash = .;
 


### PR DESCRIPTION
This fixes building on newlib 4.3.0 which seems to require this for unwinding.

Fix by Piezo, taken from this discussion:
https://klipper.discourse.group/t/link-error-with-newlib-4-3-0-on-armv7/6820