### PR TITLE
WIP: Support broken TMC boards on the Anycubic Kobra

### DIFF
--- a/klippy/extras/tmchax.py
+++ b/klippy/extras/tmchax.py
@@ -1,0 +1,193 @@
+# TMCHAX frankensteined configuration
+#
+# Copyright (C) 2019  Stephan Oelze <stephan.oelze@gmail.com>
+# Copyright (C) 2023  Jookia <contact@jookia.org>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from . import tmc2208, tmc2130, tmc, tmc_uart
+import logging
+
+TMC_FREQUENCY=12000000.
+
+Registers = {
+    "GCONF": 0x00, "IFCNT": 0x02, "SLAVECONF": 0x03, "FACTORY_CONF": 0x07,
+    "IHOLD_IRUN": 0x10, "TPOWERDOWN": 0x11, "TSTEP": 0x12, "TPWMTHRS": 0x13,
+    "TCOOLTHRS": 0x14, "VACTUAL": 0x22, "COOLCONF": 0x42, "SGTHRS": 0x40,
+    "CHOPCONF": 0x6c, "PWMCONF": 0x70
+}
+
+Fields = {}
+
+Fields["GCONF"] = {
+    "i_scale_analog":      0x01,
+    "internal_rsense":     0x01 << 1,
+    "en_spreadcycle":      0x01 << 2,
+    "shaft":               0x01 << 3,
+    "index_otpw":          0x01 << 4,
+    "index_step":          0x01 << 5,
+    "pdn_disable":         0x01 << 6,
+    "mstep_reg_select":    0x01 << 7,
+    "multistep_filt":      0x01 << 8,
+    "test_mode":           0x01 << 9
+}
+Fields["IFCNT"] = {
+    "ifcnt":               0xff
+}
+Fields["SLAVECONF"] = {
+    "senddelay":           0x0f << 8
+}
+Fields["FACTORY_CONF"] = {
+    "fclktrim":            0x1f,
+    "ottrim":              0x03 << 8
+}
+Fields["IHOLD_IRUN"] = {
+    "ihold":               0x1f,
+    "irun":                0x1f << 8,
+    "iholddelay":          0x0f << 16
+}
+Fields["TPOWERDOWN"] = {
+    "tpowerdown":          0xff
+}
+Fields["TSTEP"] = {
+    "tstep":               0xfffff
+}
+Fields["TPWMTHRS"] = {
+    "tpwmthrs":            0xfffff
+}
+Fields["VACTUAL"] = {
+    "vactual":             0xffffff
+}
+Fields["CHOPCONF"] = {
+    "toff":                0x0f,
+    "hstrt":               0x07 << 4,
+    "hend":                0x0f << 7,
+    "tbl":                 0x03 << 15,
+    "vsense":              0x01 << 17,
+    "mres":                0x0f << 24,
+    "intpol":              0x01 << 28,
+    "dedge":               0x01 << 29,
+    "diss2g":              0x01 << 30,
+    "diss2vs":             0x01 << 31
+}
+Fields["PWMCONF"] = {
+    "pwm_ofs":             0xff,
+    "pwm_grad":            0xff << 8,
+    "pwm_freq":            0x03 << 16,
+    "pwm_autoscale":       0x01 << 18,
+    "pwm_autograd":        0x01 << 19,
+    "freewheel":           0x03 << 20,
+    "pwm_reg":             0xf << 24,
+    "pwm_lim":             0xf << 28
+}
+Fields["COOLCONF"] = {
+    "semin":        0x0F << 0,
+    "seup":         0x03 << 5,
+    "semax":        0x0F << 8,
+    "sedn":         0x03 << 13,
+    "seimin":       0x01 << 15
+}
+Fields["SGTHRS"] = {
+    "sgthrs":       0xFF << 0
+}
+Fields["TCOOLTHRS"] = {
+    "tcoolthrs": 0xfffff
+}
+
+class TMCCommandHelperF:
+    def __init__(self, config, mcu_tmc, current_helper):
+        self.printer = config.get_printer()
+        self.stepper_name = ' '.join(config.get_name().split()[1:])
+        self.name = config.get_name().split()[-1]
+        self.mcu_tmc = mcu_tmc
+        self.current_helper = current_helper
+        self.fields = mcu_tmc.get_fields()
+        self.toff = None
+        self.mcu_phase_offset = None
+        self.stepper = None
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_connect)
+        # Set microstep config options
+        tmc.TMCMicrostepHelper(config, mcu_tmc)
+    def _init_registers(self, print_time=None):
+        # Send registers
+        for reg_name, val in self.fields.registers.items():
+            self.mcu_tmc.set_register(reg_name, val, print_time)
+    def _handle_connect(self):
+        self._init_registers()
+
+# Helper code for communicating via TMC uart
+class MCU_TMC_uart_f:
+    def __init__(self, config, name_to_reg, fields, max_addr=0):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.name_to_reg = name_to_reg
+        self.fields = fields
+        self.ifcnt = None
+        self.instance_id, self.addr, self.mcu_uart = tmc_uart.lookup_tmc_uart_bitbang(
+            config, max_addr)
+        self.mutex = self.mcu_uart.mutex
+    def get_fields(self):
+        return self.fields
+    def _do_get_register(self, reg_name):
+        raise self.printer.command_error(
+            "f Unable to read tmc uart '%s' register %s" % (self.name, reg_name))
+    def get_register(self, reg_name):
+        with self.mutex:
+            return self._do_get_register(reg_name)
+    def set_register(self, reg_name, val, print_time=None):
+        reg = self.name_to_reg[reg_name]
+        if self.printer.get_start_args().get('debugoutput') is not None:
+            return
+        with self.mutex:
+            for retry in range(5):
+                self.mcu_uart.reg_write(self.instance_id, self.addr, reg, val,
+                                        print_time)
+        return
+
+
+######################################################################
+# TMC2209 printer object
+######################################################################
+
+mytmc = None
+
+class TMCHAX:
+    def __init__(self, config):
+        # Setup mcu communication
+        self.fields = tmc.FieldHelper(Fields)
+        self.mcu_tmc = MCU_TMC_uart_f(config, Registers, self.fields, 3)
+        # Setup fields for UART
+        self.fields.set_field("pdn_disable", True)
+        self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart
+        # Allow virtual pins to be created
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        # Register commands
+        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        cmdhelper = TMCCommandHelperF(config, self.mcu_tmc, current_helper)
+        # Setup basic register values
+        self.fields.set_field("pdn_disable", True)
+        self.fields.set_field("mstep_reg_select", True)
+        self.fields.set_field("multistep_filt", True)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        # Allow other registers to be set from the config
+        set_config_field = self.fields.set_config_field
+        set_config_field(config, "toff", 3)
+        set_config_field(config, "hstrt", 5)
+        set_config_field(config, "hend", 0)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "iholddelay", 8)
+        set_config_field(config, "tpowerdown", 20)
+        set_config_field(config, "pwm_ofs", 36)
+        set_config_field(config, "pwm_grad", 14)
+        set_config_field(config, "pwm_freq", 1)
+        set_config_field(config, "pwm_autoscale", True)
+        set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "pwm_reg", 8)
+        set_config_field(config, "pwm_lim", 12)
+        set_config_field(config, "sgthrs", 0)
+
+def load_config_prefix(config):
+    global mytmc
+    if mytmc is None:
+        mytmc = TMCHAX(config)
+    return mytmc

--- a/kobra_xhack.cfg
+++ b/kobra_xhack.cfg
@@ -1,0 +1,268 @@
+# Anycubic Kobra configuration
+# Requires HC32F460 defconfig
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 2000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA5
+dir_pin: PA4
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: tmchax_stepper_x:virtual_endstop
+position_min: -42 # Marlin says -37.2
+position_endstop: -42 # Marlin says -37.2
+position_max: 224
+homing_speed: 100
+homing_retract_dist: 0
+
+[tmchax stepper_x]
+uart_pin: PA15
+run_current: 0.6
+stealthchop_threshold: 999999
+uart_address: 0
+# calibrated at homing_speed 100, max is 148, min is 71
+driver_SGTHRS: 97
+diag_pin: ^PA6
+
+[tmchax extruder]
+
+[stepper_y]
+step_pin: PC4
+dir_pin: PA7
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_min: -3 # Marlin says -0.2
+position_endstop: -3 # Marlin says -0.2
+position_max: 222
+homing_speed: 80
+homing_retract_dist: 0
+
+[tmc2209 stepper_y]
+uart_pin: PA15
+run_current: 0.6
+stealthchop_threshold: 999999
+uart_address: 1
+# calibrated at homing_speed 80, max is 158, min is 79
+driver_SGTHRS: 105
+diag_pin: ^PC5
+
+[stepper_z]
+step_pin: PC7
+dir_pin: !PC6
+enable_pin: !PC3
+rotation_distance: 4
+microsteps: 16
+endstop_pin: probe:z_virtual_endstop
+position_min: -5 # Marlin says -0.3
+position_max: 250
+homing_speed: 10
+
+[tmc2209 stepper_z]
+uart_pin: PA15
+run_current: 0.6
+stealthchop_threshold: 999999
+uart_address: 2
+driver_SGTHRS: 50
+diag_pin: ^PA8
+
+[extruder]
+step_pin: PC14
+dir_pin: PC15
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 7.794750 # Marlin says 8.205
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+max_extrude_only_distance: 105
+pressure_advance: 0.045
+heater_pin: PA1
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC1
+control: pid
+# default in Marlin:
+#pid_Kp: 22.20
+#pid_Ki: 1.08
+#pid_Kd: 119.00
+# calibrated to 200c with parts fan on and heat bed at 60c:
+pid_Kp: 17.111
+pid_Ki: 0.659
+pid_Kd: 111.06
+min_temp: 5
+max_temp: 240 # Marlin says 275, I cap to 230 to prevent PFTE fumes
+min_extrude_temp: 130 # For starting G-Code
+
+[heater_bed]
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC0
+control: pid
+# default in Marlin:
+#pid_Kp: 54.027
+#pid_Ki: 0.770
+#pid_Kd: 948.182
+# factory calibration:
+#pid_Kp: 97.10
+#pid_Ki: 1.41
+#pid_Kd: 1675.16
+# calibrated to 200c with parts fan on and heat bed at 60c:
+pid_Kp: 61.847
+pid_Ki: 0.902
+pid_Kd: 1059.902
+min_temp: 0
+max_temp: 130
+
+[bed_mesh]
+speed: 100
+mesh_min: 10, 10
+mesh_max: 210, 210
+probe_count: 6, 6
+
+[safe_z_home]
+home_xy_position: 110, 110
+
+[virtual_sdcard]
+path: /home/jookia/kobra/klipper/sdcard
+
+[probe]
+pin: PB8
+x_offset: 42 # Marlin says 43.50
+y_offset: 3 # Marlin says 4.70
+z_offset: 0.600 # Bigger = closer to bed
+samples: 5
+samples_tolerance_retries: 2
+
+[fan]
+pin: PB9
+
+[heater_fan extruder_fan]
+pin: PA13
+
+[controller_fan controller_fan]
+pin: PA14
+fan_speed: 0.4 # LOUD fan!
+
+[filament_switch_sensor my_sensor]
+switch_pin: ^!PC13
+
+[output_pin beeper]
+pin: PB5
+pwm: True
+value: 0
+shutdown_value: 0
+cycle_time: 0.01
+scale: 1
+
+[gcode_macro M300]
+gcode:
+    # Use a default 1kHz tone if S is omitted.
+    {% set S = params.S|default(1000)|int %}
+    # Use a 10ms duration is P is omitted.
+    {% set P = params.P|default(100)|int %}
+    SET_PIN PIN=beeper VALUE=0.5 CYCLE_TIME={ 1.0/S if S > 0 else 1 }
+    G4 P{P}
+    SET_PIN PIN=beeper VALUE=0
+
+# FIRMWARE_NAME:Marlin bugfix-2.0.x (Dec 22 2021 14:30:26) SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:Anycubic Viper EXTRUDER_COUNT:1 UUID:cede2a2f-41a2-4748-9b12-c55c62f367ff
+# Cap:SERIAL_XON_XOFF:0
+# Cap:BINARY_FILE_TRANSFER:0
+# Cap:EEPROM:1
+# Cap:VOLUMETRIC:1
+# Cap:AUTOREPORT_TEMP:1
+# Cap:PROGRESS:0
+# Cap:PRINT_JOB:1
+# Cap:AUTOLEVEL:1
+# Cap:RUNOUT:1
+# Cap:Z_PROBE:1
+# Cap:LEVELING_DATA:1
+# Cap:BUILD_PERCENT:0
+# Cap:SOFTWARE_POWER:0
+# Cap:TOGGLE_LIGHTS:0
+# Cap:CASE_LIGHT_BRIGHTNESS:0
+# Cap:EMERGENCY_PARSER:1
+# Cap:PROMPT_SUPPORT:0
+# Cap:SDCARD:1
+# Cap:REPEAT:1
+# Cap:AUTOREPORT_SD_STATUS:0
+# Cap:LONG_FILENAME:1
+# Cap:THERMAL_PROTECTION:1
+# Cap:MOTION_MODES:0
+# Cap:ARCS:1
+# Cap:BABYSTEPPING:1
+# Cap:CHAMBER_TEMPERATURE:0
+# echo:  G21    ; Units in mm (mm)
+# 
+# echo:; Filament settings: Disabled
+# echo:  M200 S0 D1.75
+# echo:; Steps per unit:
+# echo: M92 X80.00 Y80.00 Z800.00 E390.00
+# echo:; Maximum feedrates (units/s):
+# echo:  M203 X300.00 Y300.00 Z20.00 E80.00
+# echo:; Maximum Acceleration (units/s2):
+# echo:  M201 X700.00 Y600.00 Z50.00 E3000.00
+# echo:; Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>
+# echo:  M204 P1000.00 R2000.00 T1000.00
+# echo:; Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate> X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk> E<max_e_jerk>
+# echo:  M205 B20000.00 S0.00 T0.00 X8.00 Y8.00 Z0.30 E5.00
+# echo:; Home offset:
+# echo:  M206 X0.00 Y0.00 Z0.00
+# echo:; Auto Bed Leveling:
+# echo:  M420 S1 Z0.00
+# echo:  G29 W I0 J0 Z-0.77375
+# echo:  G29 W I1 J0 Z-0.43550
+# echo:  G29 W I2 J0 Z-0.06900
+# echo:  G29 W I3 J0 Z0.24025
+# echo:  G29 W I4 J0 Z0.48600
+# echo:  G29 W I0 J1 Z-0.65325
+# echo:  G29 W I1 J1 Z-0.30600
+# echo:  G29 W I2 J1 Z0.04975
+# echo:  G29 W I3 J1 Z0.38425
+# echo:  G29 W I4 J1 Z0.66925
+# echo:  G29 W I0 J2 Z-0.75900
+# echo:  G29 W I1 J2 Z-0.38550
+# echo:  G29 W I2 J2 Z0.00325
+# echo:  G29 W I3 J2 Z0.36975
+# echo:  G29 W I4 J2 Z0.69500
+# echo:  G29 W I0 J3 Z-0.84925
+# echo:  G29 W I1 J3 Z-0.43750
+# echo:  G29 W I2 J3 Z0.00050
+# echo:  G29 W I3 J3 Z0.38375
+# echo:  G29 W I4 J3 Z0.73825
+# echo:  G29 W I0 J4 Z-1.37525
+# echo:  G29 W I1 J4 Z-0.76450
+# echo:  G29 W I2 J4 Z-0.13275
+# echo:  G29 W I3 J4 Z0.43450
+# echo:  G29 W I4 J4 Z0.95575
+# echo:; PID settings:
+# echo:  M301 P22.20 I1.08 D119.00
+# echo:  M304 P97.10 I1.41 D1675.16
+# ; Controller Fan
+# echo:  M710 S255 I0 A1 D60 ; (100% 0%)
+# echo:; Power-Loss Recovery:
+# echo:  M413 S1
+# echo:; Z-Probe Offset (mm):
+# echo:  M851 X43.50 Y4.70 Z-1.20
+# echo:; Stepper driver current:
+# echo:  M906 X800 Y800 Z800
+# echo:  M906 T0 E600
+# 
+# echo:; StallGuard threshold:
+# echo:  M914 X90 Y100
+# echo:; Driver stepping mode:
+# echo:  M569 S1 X Y Z
+# echo:  M569 S1 T0 E
+# echo:; Filament load/unload lengths:
+# echo:  M603 L0.00 U100.00
+# echo:; Filament runout sensor:
+# echo:  M412 S1


### PR DESCRIPTION
**This is not intended for merging but for discussion for now.**

The Trigorilla v1.0.4 used in the Kobra series (Anycubic Kobra, Anycubic Kobra Plus, Anycubic Kobra Max) has a serious hardware bug: It looks like last minute Anycubic swapped the extruder TMC2209 for a TMC2208 but didn't update the address pins on the board. This means the extruder and X axis both use address 0. This creates an interesting situation where we can write to the controller registers but reading will cause a bus conflict. 

Currently Klipper insists on reading registers from the controller to confirm writing was successful and to check status when there's an error driving it. Both of these aren't entirely necessary for the printer to work, which is why Marlin works on this board.

The controllers will always stop on error or host overload on error, and writing to registers seems fairly reliable in practice. Furthermore the only time we actually need to write to registers is for sensorless homing which happens once during the printer's on cycle. All other activity is controlled using pins not conflicting.

The only way to currently run Klipper on these boards is with microsoldering, which isn't accessible to most people, and as these boards are in active production and used in actual printing it seems like a good idea to add some kind of workaround so people can use Klipper.

This PR introduces the concept of a 'tmchax' controller. This controller does two things: Refuses to read from registers, and controls two controllers at once as if it's one controller with multiple outputs. This 'we pretend two controllers are one' ensures that coherency between registers is enforced.

I have tested this on my printer and aided someone setting it up on theirs and from what I can see this works fine in practice, aside from the code breaking due to use of a global variable. I wrote this code in a few hours so it's not intended to be a solution, but a proof of concept. I have included my printer config as 'kobra_xhack.cfg'. If you want to test this, see my hack branch named 'tmc2209f' here with a README and full details: https://github.com/Jookia/klipper/tree/tmc2209f

---

Code wise, I'm not sure where to go with this:

- It doesn't seem like Klipper supports the idea of 'one controller two motors' which I believe is necessary to enforce some type of coherency
- This solution only works because the TMC2209 and TMC2208 are register compatible
- If two TMC2209s are ever on the same bus address the same fix could be used but locking registers would be required for the sensorless homing
- I'm duplicating a bit of code and hand selecting which registers are usable
- I've removed the SET_TMC_REGISTER g-code but that should be added back for calibrating sensorless homing
- I try writing the register 5 times. This is 4 more times than Marlin and seems to work fine
- The code crashes on Klipper reset due to the global variable or something

I also haven't investigated what actually happens on a bus conflict and if we can gain any knowledge from this. Probably nothing: If both controllers are driving the bus and giving opposing answers then it will get decoded as a wrong value that we can't check.