### PR TITLE
tmc: calculate max_current on all drivers

### DIFF
--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -189,7 +189,7 @@ class TMC2208:
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields)
         self.fields.set_field("pdn_disable", True)
         # Register commands
-        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc, 0.03)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         self.get_phase_offset = cmdhelper.get_phase_offset

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -65,7 +65,7 @@ class TMC2209:
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
-        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
+        current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc, 0.02)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -110,17 +110,16 @@ FieldFormatters.update({
 # TMC stepper current config helper
 ######################################################################
 
-MAX_CURRENT = 2.400
-
 class TMC2660CurrentHelper:
     def __init__(self, config, mcu_tmc):
         self.printer = config.get_printer()
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        self.current = config.getfloat('run_current', minval=0.1,
-                                       maxval=MAX_CURRENT)
         self.sense_resistor = config.getfloat('sense_resistor')
+        self.max_cur = 0.325 / ((self.sense_resistor) * math.sqrt(2.))
+        self.current = config.getfloat('run_current', minval=0.1,
+                                       maxval=self.max_cur)
         vsense, cs = self._calc_current(self.current)
         self.fields.set_field("cs", cs)
         self.fields.set_field("vsense", vsense)
@@ -177,7 +176,7 @@ class TMC2660CurrentHelper:
             self.mcu_tmc.set_register("DRVCONF", val, print_time)
 
     def get_current(self):
-        return self.current, None, None, MAX_CURRENT
+        return self.current, None, None, self.max_cur
 
     def set_current(self, run_current, hold_current, print_time):
         self.current = run_current

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -250,7 +250,6 @@ FieldFormatters.update({
 ######################################################################
 
 VREF = 0.325
-MAX_CURRENT = 3.000
 
 class TMC5160CurrentHelper:
     def __init__(self, config, mcu_tmc):
@@ -258,12 +257,13 @@ class TMC5160CurrentHelper:
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        run_current = config.getfloat('run_current',
-                                      above=0., maxval=MAX_CURRENT)
-        hold_current = config.getfloat('hold_current', MAX_CURRENT,
-                                       above=0., maxval=MAX_CURRENT)
-        self.req_hold_current = hold_current
         self.sense_resistor = config.getfloat('sense_resistor', 0.075, above=0.)
+        self.max_cur = 0.325 / ((self.sense_resistor) * math.sqrt(2.))
+        run_current = config.getfloat('run_current',
+                                      above=0., maxval=self.max_cur)
+        hold_current = config.getfloat('hold_current', self.max_cur,
+                                       above=0., maxval=self.max_cur)
+        self.req_hold_current = hold_current
         gscaler, irun, ihold = self._calc_current(run_current, hold_current)
         self.fields.set_field("globalscaler", gscaler)
         self.fields.set_field("ihold", ihold)
@@ -297,7 +297,7 @@ class TMC5160CurrentHelper:
     def get_current(self):
         run_current = self._calc_current_from_field("irun")
         hold_current = self._calc_current_from_field("ihold")
-        return run_current, hold_current, self.req_hold_current, MAX_CURRENT
+        return run_current, hold_current, self.req_hold_current, self.max_cur
     def set_current(self, run_current, hold_current, print_time):
         self.req_hold_current = hold_current
         gscaler, irun, ihold = self._calc_current(run_current, hold_current)


### PR DESCRIPTION
Just like with tmc2240, compute the maximum RMS current from the sense resistor and limit run_current and hold_current to that value. This way the user gets an error if their config has too high of a current instead of just maxing out IRUN and IHOLD.

Tested on tmc2130 with `sense_resistor=0.22` and `run_current: 2.0`: `Option 'run_current' in section 'tmc2130 stepper_z' must have maximum of 0.957540432857`