### PR TITLE
spi_flash: add MKS RN 1.* support

### DIFF
--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -97,7 +97,7 @@
 */
 
 
-#define FF_USE_LFN		0
+#define FF_USE_LFN		2
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -116,6 +116,24 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
+    },
+    'mks-rn-1.3': {
+        'mcu': "stm32f407xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        "firmware_path": "robin_nano35.bin",
+        "current_firmware_path": "robin_nano35.cur",
+        "skip_verify": True
+    },
+    'mks-rn-1.1': {
+        'mcu': "stm32f103xe",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        "firmware_path": "robin_nano35.bin",
+        "current_firmware_path": "robin_nano35.cur",
+        "skip_verify": True
     }
 }
 
@@ -162,7 +180,10 @@ BOARD_ALIASES = {
     'fysetc-spider-v1': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v1.2': BOARD_DEFS['fysetc-spider'],
     'fysetc-s6-v2': BOARD_DEFS['fysetc-spider'],
-    'robin_v3': BOARD_DEFS['monster8']
+    'robin_v3': BOARD_DEFS['monster8'],
+    'mks-rn-1.2': BOARD_DEFS['mks-rn-1.1'],
+    'mks-rn-1.3s': BOARD_DEFS['mks-rn-1.3']
+
 }
 
 def list_boards():

--- a/scripts/spi_flash/fatfs_api.h
+++ b/scripts/spi_flash/fatfs_api.h
@@ -26,7 +26,7 @@ struct ff_file_info {
     uint16_t modified_date;
     uint16_t modified_time;
     uint8_t  attrs;
-    char     name[13];
+    char     name[256];
 };
 
 struct ff_disk_info {

--- a/scripts/spi_flash/fatfs_lib.py
+++ b/scripts/spi_flash/fatfs_lib.py
@@ -32,7 +32,7 @@ FATFS_CDEFS = """
         uint16_t modified_date;
         uint16_t modified_time;
         uint8_t  attrs;
-        char     name[13];
+        char     name[256];
     };
 
     struct ff_disk_info {


### PR DESCRIPTION
Add support spi_flash for MKS Robin Nano 1.1, 1.2 (stm32f103), 1.3 and 1.3s (stm32f407) boards.

Filename for bootloader, "robin_nano35.bin", requires long filename support to be enabled.

Tested on MKS Robin Nano 1.1 and MKS Robin Nano 1.3s
