### PR TITLE
src/linux/main: Lock Memory and Increase Priority

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -4,10 +4,11 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
-#include </usr/include/sched.h> // sched_setscheduler
+#include </usr/include/sched.h> // sched_setscheduler sched_get_priority_max
 #include <stdio.h> // fprintf
 #include <string.h> // memset
 #include <unistd.h> // getopt
+#include <sys/mman.h> // mlockall MCL_CURRENT MCL_FUTURE
 #include "board/misc.h" // console_sendf
 #include "command.h" // DECL_CONSTANT
 #include "internal.h" // console_setup
@@ -25,10 +26,16 @@ realtime_setup(void)
 {
     struct sched_param sp;
     memset(&sp, 0, sizeof(sp));
-    sp.sched_priority = 1;
+    sp.sched_priority = sched_get_priority_max(SCHED_FIFO) / 2;
     int ret = sched_setscheduler(0, SCHED_FIFO, &sp);
     if (ret < 0) {
         report_errno("sched_setscheduler", ret);
+        return -1;
+    }
+    // Lock ourselves into memory
+    ret = mlockall(MCL_CURRENT | MCL_FUTURE);
+    if (ret) {
+        report_errno("mlockall", ret);
         return -1;
     }
     return 0;


### PR DESCRIPTION
Real-time programming best practice is to lock real-time processes memory to prevent paging under memory pressure.
As The Linux MCU process has well bounded memory and a small RAM footprint locking the entire process' current and
future memory has no downsides. (See bootlin training and Linux Foundation documentation linked below.) Additionally, RT 
process priority ranges from 0-99 (although POSIX only requires 32), boost MCU process priority to half the max/2 to improve behavior when the system is considering real-time kernel processes or user processes.

Reference links:
bootlin: https://bootlin.com/doc/training/preempt-rt/preempt-rt-slides.pdf Linux Foundation: https://wiki.linuxfoundation.org/realtime/documentation/howto/applications/application_base#howto_build_a_simple_rt_application

Signed-off-by: Matthew Swabey <matthew@swabey.org>