### PR TITLE
linux/i2c: Fast(er) Linux MCU i2c_read() with I2C_RDRW

### DIFF
--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -45,6 +45,7 @@ void gpio_pwm_write(struct gpio_pwm g, uint16_t val);
 
 struct i2c_config {
     int fd;
+    uint8_t addr;
 };
 
 struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);


### PR DESCRIPTION
Reading an I2C device from the Linux MCU process used a separate write(2) to select the target register & read(2) to get the content(s). This implementation uses ioctl(file, I2C_RDWR, ...) to skip a large bus idle period between the write() and read()
and an extra switch by combining them.

I2C_RDRW requires the I2C_FUNC_I2C feature flag in the I2C driver. I2C_FUNC_I2C is defined in:

BCM2835: Pi 1 Models A, A+, B, B+, the Raspberry Pi Zero, the
    Raspberry Pi Zero W, and the Raspberry Pi Compute Module 1
BCM2836: Pi 2 Model B
    Identical to BCM2835 except Cortex
BCM2837: Pi 3 Model B, later models of the Raspberry Pi 2 Model B,
    and the Raspberry Pi Compute Module 3
BCM2837B0: Pi 3 Models A+, B+, and the Raspberry Pi Compute Module 3+ BCM2711: Pi 4 Model B, the Raspberry Pi 400, and the Raspberry Pi
    Compute Module 4
RK3xxx: Rockchips SoCs NanoPi, RockPi, Tinker, etc. SUNXI: H2, H3, etc. Orange Pi
AMLOGIC: S905x, Banana Pi, Odroid, etc.
TEGRA: NVidia Jetson etc.
MediaTek: Several SBCs in other ranges

Signed-off-by: Matthew Swabey matthew@swabey.org