### PR TITLE
filament_switch_sensor: Abort print if no filament is present

### DIFF
--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -31,6 +31,7 @@ class RunoutHelper:
         self.sensor_enabled = True
         # Register commands and event handlers
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.printer.register_event_handler("idle_timeout:printing", self._handle_print)
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_QUERY_FILAMENT_SENSOR,
@@ -41,6 +42,9 @@ class RunoutHelper:
             desc=self.cmd_SET_FILAMENT_SENSOR_help)
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
+    def _handle_print(self, eventtime):
+        if not self.filament_present:
+            raise self.printer.command_error("No filament present at print start")
     def _runout_event_handler(self, eventtime):
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.


### PR DESCRIPTION
Currently the filament sensor only does anything if the filament runs out during print. It will happily let your printer print without any filament available.

Change this by checking at print start and erroring if there's no filament. Running G-code to pause and insert filmanet here isn't possible as the printer may not be homed or ready to do that.