### PR TITLE
tmc: Do not override tcoolthrs if it is configured

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -452,13 +452,6 @@ class TMCVirtualPinHelper:
         if self.diag_pin is None:
             raise ppins.error("tmc virtual endstop requires diag pin config")
         # Setup for sensorless homing
-        reg = self.fields.lookup_register("en_pwm_mode", None)
-        if reg is None:
-            self.en_pwm = not self.fields.get_field("en_spreadcycle")
-            self.pwmthrs = self.fields.get_field("tpwmthrs")
-        else:
-            self.en_pwm = self.fields.get_field("en_pwm_mode")
-            self.pwmthrs = 0
         self.printer.register_event_handler("homing:homing_move_begin",
                                             self.handle_homing_move_begin)
         self.printer.register_event_handler("homing:homing_move_end",
@@ -468,19 +461,24 @@ class TMCVirtualPinHelper:
     def handle_homing_move_begin(self, hmove):
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
+        self.pwmthrs = self.fields.get_field("tpwmthrs")
+        self.coolthrs = self.fields.get_field("tcoolthrs")
         reg = self.fields.lookup_register("en_pwm_mode", None)
         if reg is None:
             # On "stallguard4" drivers, "stealthchop" must be enabled
+            self.en_pwm = not self.fields.get_field("en_spreadcycle")
             tp_val = self.fields.set_field("tpwmthrs", 0)
             self.mcu_tmc.set_register("TPWMTHRS", tp_val)
             val = self.fields.set_field("en_spreadcycle", 0)
         else:
             # On earlier drivers, "stealthchop" must be disabled
+            self.en_pwm = self.fields.get_field("en_pwm_mode")
             self.fields.set_field("en_pwm_mode", 0)
             val = self.fields.set_field(self.diag_pin_field, 1)
         self.mcu_tmc.set_register("GCONF", val)
-        tc_val = self.fields.set_field("tcoolthrs", 0xfffff)
-        self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
+        if self.coolthrs == 0:
+            tc_val = self.fields.set_field("tcoolthrs", 0xfffff)
+            self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
     def handle_homing_move_end(self, hmove):
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
@@ -493,7 +491,7 @@ class TMCVirtualPinHelper:
             self.fields.set_field("en_pwm_mode", self.en_pwm)
             val = self.fields.set_field(self.diag_pin_field, 0)
         self.mcu_tmc.set_register("GCONF", val)
-        tc_val = self.fields.set_field("tcoolthrs", 0)
+        tc_val = self.fields.set_field("tcoolthrs", self.coolthrs)
         self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
 
 


### PR DESCRIPTION
If tcoolthrs is configured (not the default 0), then do not force the value of tcoolthrs=0xfffff during homing. This way, tcoolthrs can be set to a custom value during homing.

`tpwmthrs` and `en_pwm_mode`/`en_spreadcycle` are now also correctly restored if they were changed after startup.

Without this change, it is not possible to use a value different than tcoolthrs=0xfffff during homing, which makes tmc homing less reliable than it can be. After this change, a delayed_gcode can be used at startup to set tcoolthrs to a specific velocity (eg 15mm/s) and make homing more reliable. Once I have finalized my homing macros, I'll make them available as well.