### PR TITLE
Support for USART5 on STM32G0B1

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -385,6 +385,10 @@ choice
         bool "Serial (on UART4 PA0/PA1)"
         depends on MACH_STM32H7
         select SERIAL
+    config STM32_SERIAL_USART5
+        bool "Serial (on USART5 PD2/PD3)" if LOW_LEVEL_OPTIONS
+        depends on MACH_STM32G0Bx
+        select SERIAL
     config STM32_CANBUS_PA11_PA12
         bool "CAN bus (on PA11/PA12)"
         depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS

--- a/src/stm32/stm32f0_serial.c
+++ b/src/stm32/stm32f0_serial.c
@@ -78,6 +78,13 @@
   #define USARTx_FUNCTION GPIO_FUNCTION(8)
   #define USARTx UART4
   #define USARTx_IRQn UART4_IRQn
+#elif CONFIG_STM32_SERIAL_USART5
+  DECL_CONSTANT_STR("RESERVE_PINS_serial", "PD2,PD3");
+  #define GPIO_Rx GPIO('D', 2)
+  #define GPIO_Tx GPIO('D', 3)
+  #define USARTx_FUNCTION GPIO_FUNCTION(3)
+  #define USARTx USART5
+  #define USARTx_IRQn USART5_IRQn
 #endif
 
 #if CONFIG_MACH_STM32F031
@@ -90,6 +97,10 @@
   // Some of the stm32g0 MCUs have slightly different register names
   #if CONFIG_MACH_STM32G0B1
     #define USART2_IRQn USART2_LPUART2_IRQn
+    #define USART3_IRQn USART3_4_5_6_LPUART1_IRQn
+    #define USART4_IRQn USART3_4_5_6_LPUART1_IRQn
+    #define USART5_IRQn USART3_4_5_6_LPUART1_IRQn
+    #define USART6_IRQn USART3_4_5_6_LPUART1_IRQn
   #endif
   #define USART_CR1_RXNEIE USART_CR1_RXNEIE_RXFNEIE
   #define USART_CR1_TXEIE USART_CR1_TXEIE_TXFNFIE

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -32,6 +32,14 @@ lookup_clock_line(uint32_t periph_base)
         uint32_t bit = 1 << ((periph_base - AHBPERIPH_BASE) / 0x400);
         return (struct cline){.en=&RCC->AHBENR, .rst=&RCC->AHBRSTR, .bit=bit};
     }
+#ifdef USART5_BASE
+    if (periph_base == USART5_BASE)
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<8};
+#endif
+#ifdef USART6_BASE
+    if (periph_base == USART6_BASE)
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<9};
+#endif
 #if defined(FDCAN1_BASE) || defined(FDCAN2_BASE)
     if ((periph_base == FDCAN1_BASE) || (periph_base == FDCAN2_BASE))
         return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<12};


### PR DESCRIPTION
Hello!

I'm using an SKR mini E3 V3 board and I needed to access the USART5 pins which are on PD2, PD3.
Thought it would be as simple as extending that configuration in Kconfig with my combination of pins, but that didn't work.

Many headaches later, turns out that the bits to enable/reset USART5 & 6 do not follow the rule from `stm32g0.c` regarding the offset from APBPERIPH_BASE, but needed to be added as exceptions similar to the USB and others.

While I've fixed the RCC bits for USART6 as well, I was only able to test the configuration I needed, USART5 on PD2, PD3. That's why I only included this in the Kconfig.

Hoping this saves other people some time.