### PR TITLE
linux/timer: Use volatile sig_atomic_t in signal handler to avoid undefined behavior

### DIFF
--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -5,6 +5,7 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <time.h> // struct timespec
+#include <signal.h> // sig_atomic_t
 #include "autoconf.h" // CONFIG_CLOCK_FREQ
 #include "board/io.h" // readl
 #include "board/irq.h" // irq_disable

--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -19,8 +19,8 @@ static struct {
     uint32_t last_read_time;
     // Fields for converting from a systime to ticks
     time_t start_sec;
-    // Flags for tracking irq_enable()/irq_disable()
-    uint32_t must_wake_timers;
+    // Flags for tracking irq_enable()/irq_disable() ref SIG31-C
+    volatile sig_atomic_t must_wake_timers; 
     // Time of next software timer (also used to convert from ticks to systime)
     uint32_t next_wake_counter;
     struct timespec next_wake;
@@ -268,7 +268,7 @@ void
 irq_wait(void)
 {
     // Must atomically sleep until signaled
-    if (!readl(&TimerInfo.must_wake_timers)) {
+    if (!TimerInfo.must_wake_timers) {
         timer_disable_signals();
         if (!TimerInfo.must_wake_timers)
             console_sleep(&TimerInfo.ss_sleep);
@@ -280,6 +280,6 @@ irq_wait(void)
 void
 irq_poll(void)
 {
-    if (readl(&TimerInfo.must_wake_timers))
+    if (TimerInfo.must_wake_timers)
         timer_dispatch();
 }

--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -20,7 +20,7 @@ static struct {
     // Fields for converting from a systime to ticks
     time_t start_sec;
     // Flags for tracking irq_enable()/irq_disable() ref SIG31-C
-    volatile sig_atomic_t must_wake_timers; 
+    volatile sig_atomic_t must_wake_timers;
     // Time of next software timer (also used to convert from ticks to systime)
     uint32_t next_wake_counter;
     struct timespec next_wake;


### PR DESCRIPTION
Convert flag variable to `volatile sig_atomic_t` for simplicity and to avoid potential undefined behavior, ref SIG31-C [1] and `man 2 signal` on Linux. This has the additional side benefit of eliminating the ARM specific code for readl() and writel() functions and will be portable.

Tested extensively by inserting timing output messages into timed events, no performance difference noted.

[1] https://wiki.sei.cmu.edu/confluence/display/c/sig31-c.+do+not+access+shared+objects+in+signal+handlers

Signed-off-by: Matthew Swabey matthew@swabey.org
