### PR TITLE
rp2040/i2c: Update i2c_do_read() to match Pico-SDK

### DIFF
--- a/src/rp2040/i2c.c
+++ b/src/rp2040/i2c.c
@@ -181,7 +181,7 @@ i2c_do_read(i2c_hw_t *i2c, uint8_t addr, uint8_t read_len, uint8_t *read
 
         while(!i2c->rxflr) {
             if (!timer_is_before(timer_read_time(), timeout))
-                shutdown("i2c read timeout");            
+                shutdown("i2c read timeout");
         }
 
         *read++ = (uint8_t)i2c->data_cmd;


### PR DESCRIPTION
The current i2c_do_read() in Klipper implements different logic to the equivalent function i2c_read_blocking_internal(), namely the current Klipper implementation may be able to issue multiple read commands and read multiple bytes out of sequence with each other. As no documentation suggests the current approach is safe, simplify the code, and to be cautious and possibly compatible with further RP-X microcontrollers implement algorithm from current Pico-SDK using the style and strategy of Klipper i2c_do_write(). (Add a couple of extra words to error messages to make future debugging easier.)

The Pico-SDK blocking read [1] algorithm:
1. Wait for space in the command FIFO w. timeout
2. Write read command into command FIFO
3. Wait for data in the recieve FIFO w. timeout
4. Read data from the recieve FIFO

The current Klipper algorithm:
1. Loop until number of bytes read: 
    1. Check for timeout
    2. If space in command FIFO write read command into it
    4. If there is data in the receive FIFO read it

This patch proposes simpler code as it does not need to track two independent activities, and it matches the style and approach of Klipper i2c_do_write().

[1] https://github.com/raspberrypi/pico-sdk/blob/f396d05f8252d4670d4ea05c8b7ac938ef0cd381/src/rp2_common/hardware_i2c/i2c.c#L260

Signed-off-by: Matthew Swabey [matthew@swabey.org](mailto:matthew@swabey.org)