### PR TITLE
avr/i2c: Allow I2C bus speed to be set by Klipper

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4508,20 +4508,20 @@ SPI bus.
 The following parameters are generally available for devices using an
 I2C bus.
 
-Note that Klipper's current micro-controller support for i2c is
-generally not tolerant to line noise. Unexpected errors on the i2c
+Note that Klipper's current micro-controller support for I2C is
+generally not tolerant to line noise. Unexpected errors on the I2C
 wires may result in Klipper raising a run-time error. Klipper's
 support for error recovery varies between each micro-controller type.
-It is generally recommended to only use i2c devices that are on the
+It is generally recommended to only use I2C devices that are on the
 same printed circuit board as the micro-controller.
 
 Most Klipper micro-controller implementations only support an
-`i2c_speed` of 100000. The Klipper "linux" micro-controller supports a
-400000 speed, but it must be
+`i2c_speed` of 100000 (*standard mode*, 100kbit/s). The Klipper "Linux"
+micro-controller supports a 400000 speed (*fast mode*, 400kbit/s), but it must be
 [set in the operating system](RPi_microcontroller.md#optional-enabling-i2c)
 and the `i2c_speed` parameter is otherwise ignored. The Klipper
-"rp2040" micro-controller supports a rate of 400000 via the
-`i2c_speed` parameter. All other Klipper micro-controllers use a
+"RP2040" micro-controller and ATmega AVR family support a rate of 400000
+via the `i2c_speed` parameter. All other Klipper micro-controllers use a
 100000 rate and ignore the `i2c_speed` parameter.
 
 ```
@@ -4539,5 +4539,5 @@ and the `i2c_speed` parameter is otherwise ignored. The Klipper
 #   The I2C speed (in Hz) to use when communicating with the device.
 #   The Klipper implementation on most micro-controllers is hard-coded
 #   to 100000 and changing this value has no effect. The default is
-#   100000.
+#   100000. Linux, RP2040 and ATmega support 400000.
 ```

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -27,31 +27,46 @@ static const uint8_t SCL = GPIO('D', 0), SDA = GPIO('D', 1);
 DECL_CONSTANT_STR("BUS_PINS_twi", "PD0,PD1");
 #endif
 
-static void
-i2c_init(uint32_t rate)
-{
-    if (TWCR & (1<<TWEN))
-        // Already setup
-        return;
-
+//static void
+//i2c_init(uint32_t rate)
+//{
+//    if (TWCR & (1<<TWEN))
+//       // Already setup
+//        return;
+//
     // Setup output pins and enable pullups
-    gpio_out_setup(SDA, 1);
-    gpio_out_setup(SCL, 1);
+//    gpio_out_setup(SDA, 1);
+//    gpio_out_setup(SCL, 1);
 
     // Set frequency
-    TWSR = 0;
-    TWBR = ((CONFIG_CLOCK_FREQ / rate) - 16) / 2;
+//    TWSR = 0;
+//    TWBR = ((CONFIG_CLOCK_FREQ / rate) - 16) / 2;
 
     // Enable interface
-    TWCR = (1<<TWEN);
-}
+//    TWCR = (1<<TWEN);
+//}
 
 struct i2c_config
 i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
 {
     if (bus)
         shutdown("Unsupported i2c bus");
-    i2c_init(rate);
+
+    if (!(TWCR & (1<<TWEN))) {
+        // Setup output pins and enable pullups
+        gpio_out_setup(SDA, 1);
+        gpio_out_setup(SCL, 1);
+
+        // Set frequency avoiding pulling in integer divide
+        TWSR = 0;
+        if (rate >= 400000)
+            TWBR = ((CONFIG_CLOCK_FREQ / 400000) - 16) / 2;
+        else
+            TWBR = ((CONFIG_CLOCK_FREQ / 100000) - 16) / 2;
+
+        // Enable interface
+        TWCR = (1<<TWEN);
+    }
     return (struct i2c_config){ .addr=addr<<1 };
 }
 

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -27,25 +27,6 @@ static const uint8_t SCL = GPIO('D', 0), SDA = GPIO('D', 1);
 DECL_CONSTANT_STR("BUS_PINS_twi", "PD0,PD1");
 #endif
 
-//static void
-//i2c_init(uint32_t rate)
-//{
-//    if (TWCR & (1<<TWEN))
-//       // Already setup
-//        return;
-//
-    // Setup output pins and enable pullups
-//    gpio_out_setup(SDA, 1);
-//    gpio_out_setup(SCL, 1);
-
-    // Set frequency
-//    TWSR = 0;
-//    TWBR = ((CONFIG_CLOCK_FREQ / rate) - 16) / 2;
-
-    // Enable interface
-//    TWCR = (1<<TWEN);
-//}
-
 struct i2c_config
 i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
 {

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -28,7 +28,7 @@ DECL_CONSTANT_STR("BUS_PINS_twi", "PD0,PD1");
 #endif
 
 static void
-i2c_init(void)
+i2c_init(uint32_t rate)
 {
     if (TWCR & (1<<TWEN))
         // Already setup
@@ -38,9 +38,9 @@ i2c_init(void)
     gpio_out_setup(SDA, 1);
     gpio_out_setup(SCL, 1);
 
-    // Set 100Khz frequency
+    // Set frequency
     TWSR = 0;
-    TWBR = ((CONFIG_CLOCK_FREQ / 100000) - 16) / 2;
+    TWBR = ((CONFIG_CLOCK_FREQ / rate) - 16) / 2;
 
     // Enable interface
     TWCR = (1<<TWEN);
@@ -51,7 +51,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
 {
     if (bus)
         shutdown("Unsupported i2c bus");
-    i2c_init();
+    i2c_init(rate);
     return (struct i2c_config){ .addr=addr<<1 };
 }
 


### PR DESCRIPTION
Allows Klipper to set the I2C bus speed. Previously the bus was fixed to 100kHz regardless of configured parameters. Tested at 100kHz and 400kHz.

Signed-off-by: Matthew Swabey [matthew@swabey.org](mailto:matthew@swabey.org)