### PR TITLE
scripts: add install script for Ubuntu 22.04 LTS 

### DIFF
--- a/scripts/install-ubuntu-22.04.sh
+++ b/scripts/install-ubuntu-22.04.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# This script installs Klipper on an Ubuntu 22.04 ("Jammy") machine
+
+PYTHONDIR="${HOME}/klippy-env"
+SYSTEMDDIR="/etc/systemd/system"
+KLIPPER_USER=$USER
+KLIPPER_GROUP=$KLIPPER_USER
+
+# Step 1: Install system packages
+install_packages()
+{
+    # Packages for python cffi
+    PKGLIST="virtualenv python3-dev libffi-dev build-essential"
+    # kconfig requirements
+    PKGLIST="${PKGLIST} libncurses-dev"
+    # hub-ctrl
+    PKGLIST="${PKGLIST} libusb-dev"
+    # AVR chip installation and building
+    PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
+    # ARM chip installation and building
+    PKGLIST="${PKGLIST} stm32flash dfu-util libnewlib-arm-none-eabi"
+    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0"
+
+    # Update system package info
+    report_status "Running apt-get update..."
+    sudo apt-get update
+
+    # Install desired packages
+    report_status "Installing packages..."
+    sudo apt-get install --yes ${PKGLIST}
+}
+
+# Step 2: Create python virtual environment
+create_virtualenv()
+{
+    report_status "Updating python virtual environment..."
+
+    # Create virtualenv if it doesn't already exist
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
+
+    # Install/update dependencies
+    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+}
+
+# Step 3: Install startup script
+install_script()
+{
+# Create systemd service file
+    KLIPPER_LOG=/tmp/klippy.log
+    report_status "Installing system start script..."
+    sudo /bin/sh -c "cat > $SYSTEMDDIR/klipper.service" << EOF
+#Systemd service file for klipper
+[Unit]
+Description=Starts klipper on startup
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+User=$KLIPPER_USER
+RemainAfterExit=yes
+ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l ${KLIPPER_LOG}
+EOF
+# Use systemctl to enable the klipper systemd service script
+    sudo systemctl enable klipper.service
+}
+
+# Step 4: Start host software
+start_software()
+{
+    report_status "Launching Klipper host software..."
+    sudo systemctl start klipper
+}
+
+# Helper functions
+report_status()
+{
+    echo -e "\n\n###### $1"
+}
+
+verify_ready()
+{
+    if [ "$EUID" -eq 0 ]; then
+        echo "This script must not run as root"
+        exit -1
+    fi
+}
+
+# Force script to exit if an error occurs
+set -e
+
+# Find SRCDIR from the pathname of this script
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+# Run installation steps defined above
+verify_ready
+install_packages
+create_virtualenv
+install_script
+start_software


### PR DESCRIPTION
The python-dev package is not available on 22.04 Jammy, specifies the python3-dev package and python3 when creating a new virtualenv.

Signed-off-by: Jess Sullivan [jess@sulliwood.org](mailto:jess@sulliwood.org)