### PR TITLE
config: printer-anycubic-vyper-2021.cfg added controller fan FAN1 on PA14 to the config

### DIFF
--- a/config/printer-anycubic-vyper-2021.cfg
+++ b/config/printer-anycubic-vyper-2021.cfg
@@ -102,6 +102,10 @@ max_temp: 110
 [fan]
 pin: PA0
 
+[controller_fan controller_fan]
+pin: PA14
+stepper: stepper_x,stepper_y,stepper_z,stepper_z1
+
 [probe]
 pin: !PB12
 z_offset: 0


### PR DESCRIPTION
Having the controller fan FAN1 on PA14 in the config is important for the stepper drivers not to overheat and skip steps.

After experiencing layer-shifts on the y-axis and some troubleshooting, i recognized that the controller fan would never spin.
Reasearch showed that FAN1 is controlled by PA14 and could be simply triggered when ever a stepper is active.
There seem to be even [mcu-temperature-controlled](https://forum.drucktipps3d.de/forum/thread/15171-vyper-klipper-mcu-mainboard-l%C3%BCfter-ansteuern/) configuration-options with klipper, but the simple two lines should prevent others from trouble and failed prints.

Signed-off-by: Robert Lilienthal <13837429+RobLil@users.noreply.github.com>