### PR TITLE
tmc2209: Remove duplicate `pdn_disable` initialization

### DIFF
--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -71,7 +71,6 @@ class TMC2209:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
-        self.fields.set_field("pdn_disable", True)
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)


### PR DESCRIPTION
I don't think this can break anything. `pdn_disable` was already initialized to 1 a few lines higher. Only tmc2209 had this duplicate code.