### PR TITLE
tmc: Enable `multistep_filt` for drivers that support it

### DIFF
--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -353,6 +353,7 @@ class TMC2240:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
+        self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         self.fields.set_config_field(config, "offset_sin90", 0)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -326,6 +326,7 @@ class TMC5160:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
+        self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         set_config_field = self.fields.set_config_field


### PR DESCRIPTION
`multistep_filt` was not configured at all on tmc2240 and tmc5160. As such, it would default to the value of 0 when the GCONF field was sent to the driver. However, that field has a default value of 1 in the driver, so klipper was overriding the defaults by accident. This field improves the stability of velocity based thresholds (it's effectively TSTEP filtering) and it also improves the current regulation stability in stealthchop2 (according to the datasheet). This field was already set to 1 correctly in the tmc2208/tmc2209 driver code.

It should not cause any breaking change. It should just improve StealthChop2 operation.