### PR TITLE
Probe offset example typo at mesh_max location

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -62,7 +62,7 @@ The illustration below demonstrates how the `mesh_min`, `mesh_max`, and
 `probe_count` options are used to generate probe points.  The arrows indicate
 the direction of the probing procedure, beginning at `mesh_min`.  For reference,
 when the probe is at `mesh_min` the nozzle will be at (11, 1), and when the probe
-is at `mesh_max`, the nozzle will be at (206, 193).
+is at `mesh_max`, the nozzle will be at (216, 193).
 
 ![bedmesh_rect_basic](img/bedmesh_rect_basic.svg)
 


### PR DESCRIPTION
Fixed typo in nozzle position at mesh_max nozzle (206, 193) at location (240, 198), it should be at (216,193) with the offset value for the probe X-offset 24,Y-offset 5