### PR TITLE
tmc2240: overheat_threshold

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3352,6 +3352,9 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#overheat_threshold: 120.
+#   The temperature threshold in degrees Celsius above which the driver is
+#   considered to be overheating.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -105,6 +105,8 @@ class TMCErrorCheck:
         self.irun_field = "irun"
         reg_name = "DRV_STATUS"
         mask = err_mask = cs_actual_mask = 0
+        err_fields = ["ot", "s2ga", "s2gb", "s2vsa", "s2vsb"]
+        warn_fields = ["otpw", "t120", "t143", "t150", "t157"]
         if name_parts[0] == 'tmc2130':
             # TMC2130 driver quirks
             self.clear_gstat = False
@@ -114,8 +116,10 @@ class TMCErrorCheck:
             self.irun_field = "cs"
             reg_name = "READRSP@RDSEL2"
             cs_actual_mask = self.fields.all_fields[reg_name]["se"]
-        err_fields = ["ot", "s2ga", "s2gb", "s2vsa", "s2vsb"]
-        warn_fields = ["otpw", "t120", "t143", "t150", "t157"]
+        if name_parts[0] == 'tmc2240':
+            # Treat otpw as an error on tmc2240 since the threshold can be
+            # configured.
+            err_fields.append("otpw")
         for f in err_fields + warn_fields:
             if f in self.fields.all_fields[reg_name]:
                 mask |= self.fields.all_fields[reg_name][f]


### PR DESCRIPTION
Configurable overtemperature prewarning of the tmc2240 driver using `overtempprewarning_vth`.
This is used as an alternative to constant polling of `adc_temp`.