### PR TITLE
src/linux/main: Lock Memory and Increase Priority

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -4,10 +4,11 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
-#include </usr/include/sched.h> // sched_setscheduler
+#include </usr/include/sched.h> // sched_setscheduler sched_get_priority_max
 #include <stdio.h> // fprintf
 #include <string.h> // memset
 #include <unistd.h> // getopt
+#include <sys/mman.h> // mlockall MCL_CURRENT MCL_FUTURE
 #include "board/misc.h" // console_sendf
 #include "command.h" // DECL_CONSTANT
 #include "internal.h" // console_setup
@@ -25,10 +26,16 @@ realtime_setup(void)
 {
     struct sched_param sp;
     memset(&sp, 0, sizeof(sp));
-    sp.sched_priority = 1;
+    sp.sched_priority = sched_get_priority_max(SCHED_FIFO) / 2;
     int ret = sched_setscheduler(0, SCHED_FIFO, &sp);
     if (ret < 0) {
         report_errno("sched_setscheduler", ret);
+        return -1;
+    }
+    // Lock ourselves into memory
+    ret = mlockall(MCL_CURRENT | MCL_FUTURE);
+    if (ret) {
+        report_errno("mlockall", ret);
         return -1;
     }
     return 0;


### PR DESCRIPTION
Realtime programming best practice is to lock realtime code memory to prevent paging which will lead to unbounded latencies. The Linux MCU process has well bounded memory and small RAM footprint (or it would not run on real MCUs) so locking the entire process' RAM has no downsides and will improve behavior when the system comes under memory pressure. (See bootlin training and Linux Foundation documentation linked below.) RT process priority ranges from 0-99 (although POSIX only requires 32), boost MCU process priority to half the max/2 to improve robustness when the system comes under pressure from other RT Kernel or user processes.

I have run the Linux MCU with this patch while stress testing MPU I2C for over a week including 23+ hr I2C MPU reads from the RPi and it is very well behaved and provides a significant boost to responsiveness / reduction of "Timer too close" shutdowns.

This has been split from #6115 by request.

This has been discussed for Klipper before in past issues re. Linux MCU "Timer too close" shutdowns:
https://github.com/Klipper3d/klipper/issues/3387#issuecomment-705161786

Reference links:
bootlin: https://bootlin.com/doc/training/preempt-rt/preempt-rt-slides.pdf Linux Foundation: https://wiki.linuxfoundation.org/realtime/documentation/howto/applications/application_base#howto_build_a_simple_rt_application

Signed-off-by: Matthew Swabey [matthew@swabey.org](mailto:matthew@swabey.org)