### PR TITLE
docs/Measuring_Resonances: Improved information on I2C accelerometers and AVR support

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -7,7 +7,7 @@ compensate for resonances. Note that using accelerometers requires some
 soldering and crimping. The ADXL345 can be connected to the SPI interface of a
 Raspberry Pi or MCU board (it needs to be reasonably fast). The MPU family can
 be connected to the I2C interface of a Raspberry Pi directly, or to an I2C
-interface of an MCU board (it needs to support 400kbit/s *fast mode*).
+interface of an MCU board that supports 400kbit/s *fast mode* in Klipper.
 
 When sourcing accelerometers, be aware that there are a variety of different PCB
 board designs and different clones of them. If it is going to be connected to a
@@ -19,6 +19,14 @@ boards appear to be hard-configured for I2C by pulling SDO to GND).
 For MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500s there are also a variety of
 board designs and clones with different I2C pull-up resistors which will need
 supplementing.
+
+## MCUs with Klipper I2C *fast-mode* Support
+
+| MCU Family | MCU(s) Tested | MCU(s) with Support |
+|:--:|:--|:--|
+| Raspberry Pi | 3B+, Pico | 3A, 3A+, 3B, 4 |
+| AVR ATmega | ATmega328p | ATmega32u4, ATmega128, ATmega168, ATmega328, ATmega644p, ATmega1280, ATmega1284, ATmega2560 |
+| AVR AT90 | - | AT90usb646, AT90usb1286 |
 
 ## Installation instructions
 

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -1,35 +1,52 @@
 # Measuring Resonances
 
-Klipper has built-in support for ADXL345 accelerometer, which can be used to
-measure resonance frequencies of the printer for different axes, and auto-tune
-[input shapers](Resonance_Compensation.md) to compensate for resonances.
-Note that using ADXL345 requires some soldering and crimping. ADXL345 can be
-connected to a Raspberry Pi directly, or to an SPI interface of an MCU
-board (it needs to be reasonably fast).
+Klipper has built-in support for the ADXL345 and MPU-9250 compatible
+accelerometers which can be used to measure resonance frequencies of the printer
+for different axes, and auto-tune [input shapers](Resonance_Compensation.md) to
+compensate for resonances. Note that using accelerometers requires some
+soldering and crimping. The ADXL345 can be connected to the SPI interface of a
+Raspberry Pi or MCU board (it needs to be reasonably fast). The MPU family can
+be connected to the I2C interface of a Raspberry Pi directly, or to an I2C
+interface of an MCU board (it needs to support 400kbit/s *fast mode*).
 
-When sourcing ADXL345, be aware that there is a variety of different PCB
-board designs and different clones of them. Make sure that the board supports
-SPI mode (small number of boards appear to be hard-configured for I2C by
-pulling SDO to GND), and, if it is going to be connected to a 5V printer MCU,
-that it has a voltage regulator and a level shifter.
+When sourcing accelerometers, be aware that there are a variety of different PCB
+board designs and different clones of them. If it is going to be connected to a
+5V printer MCU ensure it has a voltage regulator and level shifters.
 
+For ADXL345s, make sure that the board supports SPI mode (a small number of
+boards appear to be hard-configured for I2C by pulling SDO to GND).
+
+For MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500s there are also a variety of
+board designs and clones with different I2C pull-up resistors which will need
+supplementing.
 
 ## Installation instructions
 
 ### Wiring
 
 An ethernet cable with shielded twisted pairs (cat5e or better) is recommended
-for signal integrity over a long distance. If you still experience signal integrity
-issues (SPI/I2C errors), shorten the cable.
+for signal integrity over a long distance. If you still experience signal
+integrity issues (SPI/I2C errors):
 
-Connect ethernet cable shielding to the controller board/RPI ground.
+  * Double check the wiring with a digital multimeter for:
+    * Correct connections when turned off (continuity)
+    * Correct power and ground voltages
+  * I2C only:
+    * Check the SCL and SDA lines' resistances to 3.3V are in the range of 900
+      ohms to 1.8K
+    * For full technical details consult [chapter 7 of the I2C-bus specification
+      and user manual UM10204](https://www.pololu.com/file/0J435/UM10204.pdf)
+      for *fast-mode*
+  * Shorten the cable
+
+Connect ethernet cable shielding only to the MCU board/Pi ground.
 
 ***Double-check your wiring before powering up to prevent
 damaging your MCU/Raspberry Pi or the accelerometer.***
 
-#### SPI Accelerometers
+### SPI Accelerometers
 
-Suggested twisted pair order:
+Suggested twisted pair order for three twisted pairs:
 
 ```
 GND+MISO
@@ -37,12 +54,15 @@ GND+MISO
 SCLK+CS
 ```
 
-##### ADXL345
+Note that unlike a cable shield, GND must be connected at both ends.
+
+#### ADXL345
 
 ###### Direct to Raspberry Pi
 
-**Note: Many MCUs will work with an ADXL345 in SPI mode(eg Pi Pico), wiring and
-configuration will vary according to your specific board and available pins.**
+**Note: Many MCUs will work with an ADXL345 in SPI mode (e.g. Pi Pico), wiring
+and configuration will vary according to your specific board and available
+pins.**
 
 You need to connect ADXL345 to your Raspberry Pi via SPI. Note that the I2C
 connection, which is suggested by ADXL345 documentation, has too low throughput
@@ -86,20 +106,56 @@ Wiring diagrams for some of the ADXL345 boards:
 
 ![ADXL345-Pico](img/adxl345-pico.png)
 
-#### I2C Accelerometers
+###### Using Raspberry Pi Pico
 
-Suggested twisted pair order:
+You may connect the ADXL345 to your Raspberry Pi Pico and then connect the
+Pico to your Raspberry Pi via USB. This makes it easy to reuse the
+accelerometer on other Klipper devices, as you can connect via USB instead
+of GPIO. The Pico does not have much processing power, so make sure it is
+only running the accelerometer and not performing any other duties.
+
+In order to avoid damage to your RPi make sure to connect the ADXL345 to 3.3V
+only. Depending on the board's layout, a level shifter may be present, which
+makes 5V dangerous for your RPi.
+
+| ADXL345 pin | Pico pin | Pico pin name |
+|:--:|:--:|:--:|
+| 3V3 (or VCC) | 36 | 3.3V DC power |
+| GND | 38 | Ground |
+| CS | 2 | GP1 (SPI0_CSn) |
+| SDO | 1 | GP0 (SPI0_RX) |
+| SDA | 5 | GP3 (SPI0_TX) |
+| SCL | 4 | GP2 (SPI0_SCK) |
+
+Wiring diagrams for some of the ADXL345 boards:
+
+![ADXL345-Pico](img/adxl345-pico.png)
+
+### I2C Accelerometers
+
+Suggested twisted pair order for three pairs (preferred):
+
+```
+3.3V+GND
+SDA+GND
+SCL+GND
+```
+
+or for two pairs:
 
 ```
 3.3V+SDA
 GND+SCL
 ```
 
-##### MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500
+Note that unlike a cable shield, any GND(s) should be connected at both ends.
 
-Alternatives to the ADXL345 are MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500.
-These accelerometers have been tested to work over I2C on the RPi or RP2040(pico)
-at 400kbaud.
+#### MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500
+
+These accelerometers have been tested to work over I2C on the RPi, RP2040 (Pico)
+and AVR at 400kbit/s (*fast mode*). Some MPU accelerometer modules include
+pull-ups, but some are too large at 10K and must be changed or supplemented by
+smaller parallel resistors.
 
 Recommended connection scheme for I2C on the Raspberry Pi:
 
@@ -110,18 +166,34 @@ Recommended connection scheme for I2C on the Raspberry Pi:
 | SDA | 03 | GPIO02 (SDA1) |
 | SCL | 05 | GPIO03 (SCL1) |
 
-![MPU-9250 connected to RPI](img/mpu9250-PI-fritzing.png)
+The RPi has buit-in 1.8K pull-ups on both SCL and SDA.
 
-Recommended connection scheme for I2C(i2c0a) on the RP2040:
+![MPU-9250 connected to Pi](img/mpu9250-PI-fritzing.png)
 
-| MPU-9250 pin | RP2040 pin | RPi pin name |
+Recommended connection scheme for I2C (i2c0a) on the RP2040:
+
+| MPU-9250 pin | RP2040 pin | RP2040 pin name |
 |:--:|:--:|:--:|
 | VCC | 39 | 3v3 |
 | GND | 38 | Ground |
 | SDA | 01 | GP0 (I2C0 SDA) |
 | SCL | 02 | GP1 (I2C0 SCL) |
 
-![MPU-9250 connected to PICO](img/mpu9250-PICO-fritzing.png)
+The Pico does not include any built-in I2C pull-up resistors.
+
+![MPU-9250 connected to Pico](img/mpu9250-PICO-fritzing.png)
+
+##### Recommended connection scheme for I2C(TWI) on the AVR ATmega328P Arduino Nano:
+
+| MPU-9250 pin | Atmega328P TQFP32 pin | Atmega328P pin name | Arduino Nano pin |
+|:--:|:--:|:--:|:--:|
+| VCC | 39 | - | - |
+| GND | 38 | Ground | GND |
+| SDA | 27 | SDA | A4 |
+| SCL | 28 | SCL | A5 |
+
+The Arduino Nano does not include any built-in pull-up resistors nor a 3.3V
+power pin.
 
 ### Mounting the accelerometer
 
@@ -269,14 +341,14 @@ probe_points:
     100, 100, 20  # an example
 ```
 
-#### Configure MPU-6000/9000 series With PICO
+#### Configure MPU-9520 Compatibles With Pico
 
-PICO I2C is set to 400000 on default. Simply add the following to the
+Pico I2C is set to 400000 on default. Simply add the following to the
 printer.cfg:
 
 ```
 [mcu pico]
-serial: /dev/serial/by-id/<your PICO's serial ID>
+serial: /dev/serial/by-id/<your Pico's serial ID>
 
 [mpu9250]
 i2c_mcu: pico
@@ -289,6 +361,24 @@ probe_points:
 
 [static_digital_output pico_3V3pwm] # Improve power stability
 pin: pico:gpio23
+```
+
+#### Configure MPU-9520 Compatibles with AVR
+
+AVR I2C will be set to 400000 by the mpu9250 option. Simply add the following
+to the printer.cfg:
+
+```
+[mcu nano]
+serial: /dev/serial/by-id/<your nano's serial ID>
+
+[mpu9250]
+i2c_mcu: nano
+
+[resonance_tester]
+accel_chip: mpu9250
+probe_points:
+    100, 100, 20  # an example
 ```
 
 Restart Klipper via the `RESTART` command.
@@ -319,8 +409,8 @@ problem with ADXL345,
 or the faulty sensor. Double-check the power, the wiring (that it matches
 the schematics, no wire is broken or loose, etc.), and soldering quality.
 
-**If you are using MPU-6000/9000 series accelerometer and it show up as `mpu-unknown`, use with
-caution! They are probably refurbished chips!**
+**If you are using a MPU-9250 compatible accelerometer and it shows up as
+`mpu-unknown`, use with caution! They are probably refurbished chips!**
 
 Next, try running `MEASURE_AXES_NOISE` in Octoprint, you should get some
 baseline numbers for the noise of accelerometer on the axes (should be
@@ -409,10 +499,11 @@ of the accelerometer between the measurements for X and Y axes: measure the
 resonances of X axis with the accelerometer attached to the toolhead and the
 resonances of Y axis - to the bed (the usual bed slinger setup).
 
-However, you can also connect two accelerometers simultaneously, though they
-must be connected to different boards (say, to an RPi and printer MCU board), or
-to two different physical SPI interfaces on the same board (rarely available).
-Then they can be configured in the following manner:
+However, you can also connect two accelerometers simultaneously, though the
+ADXL345 must be connected to different boards (say, to an RPi and printer MCU
+board), or to two different physical SPI interfaces on the same board (rarely
+available). Then they can be configured in the following manner:
+
 ```
 [adxl345 hotend]
 # Assuming `hotend` chip is connected to an RPi
@@ -428,6 +519,30 @@ accel_chip_x: adxl345 hotend
 accel_chip_y: adxl345 bed
 probe_points: ...
 ```
+
+Two MPUs can share one I2C bus, but they **cannot** measure simultaneously as
+the 400kbit/s I2C bus is not fast enough. One must have its AD0 pin pulled-down
+to 0V (address 104) and the other its AD0 pin pulled-up to 3.3V (address 105):
+
+```
+[mpu9250 hotend]
+i2c_mcu: rpi
+i2c_bus: i2c.1
+i2c_address: 104 # This MPU has pin AD0 pulled low
+
+[mpu9250 bed]
+i2c_mcu: rpi
+i2c_bus: i2c.1
+i2c_address: 105 # This MPU has pin AD0 pulled high
+
+[resonance_tester]
+# Assuming the typical setup of the bed slinger printer
+accel_chip_x: mpu9250 hotend
+accel_chip_y: mpu9250 bed
+probe_points: ...
+```
+[Test with each MPU individually before connecting both to the bus for easy
+debugging.]
 
 Then the commands `TEST_RESONANCES AXIS=X` and `TEST_RESONANCES AXIS=Y`
 will use the correct accelerometer for each axis.


### PR DESCRIPTION
This PR updates the documentation on I2C Accelerometers to:
  1. Document AVR support for MPU in general and add the ATmega328P Arduino Nano (I added AVR I2C *fast-mode* support in PR #6111)
  2. Improve the technical information on connecting and wiring up the MPU accelerometers with I2C
  3. Highlight some electrical requirements with the suggested I2C examples
  4. Added example config file snippets for dual MPU on one I2C bus and AVR
  5. [Added a few minor cleanups on spacing and English]

Ref PR #6115 , these docs have been split out from that oversized PR. 

Signed-off-by: Matthew Swabey [matthew@swabey.org](mailto:matthew@swabey.org)