### PR TITLE
Fix flash linux when OUT argument provided

### DIFF
--- a/scripts/flash-linux.sh
+++ b/scripts/flash-linux.sh
@@ -7,6 +7,13 @@ if [ "$EUID" -ne 0 ]; then
 fi
 set -e
 
+# Setting build output directory
+if [ -z "${1}" ]; then
+    out='out'
+else
+    out=${1}
+fi
+
 # Install new micro-controller code
 echo "Installing micro-controller code to /usr/local/bin/"
 rm -f /usr/local/bin/klipper_mcu

--- a/scripts/flash-linux.sh
+++ b/scripts/flash-linux.sh
@@ -17,7 +17,7 @@ fi
 # Install new micro-controller code
 echo "Installing micro-controller code to /usr/local/bin/"
 rm -f /usr/local/bin/klipper_mcu
-cp out/klipper.elf /usr/local/bin/klipper_mcu
+cp ${out}/klipper.elf /usr/local/bin/klipper_mcu
 sync
 
 # Restart (if system install script present)

--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -11,4 +11,4 @@ CFLAGS_klipper.elf += -lutil -lrt -lpthread
 
 flash: $(OUT)klipper.elf
 	@echo "  Flashing"
-	$(Q)sudo ./scripts/flash-linux.sh
+	$(Q)sudo ./scripts/flash-linux.sh $(OUT)


### PR DESCRIPTION
flash-linux, linux/Makefile: fix flash when OUT argument provided

Configure for mcu with "Micro-controller Architecture (Linux process)"
Make failes when using "make flash" with "OUT=" argument provided.
Example:
make flash KCONFIG_CONFIG=klipper_mcu.cfg OUT=out_mcu/
Pathing through scripts OUT argument fixed it.

Signed-off-by: Ilya Vislotsky <write2ilya@gmail.com>