### PR TITLE
tmc: Configurable `multistep_filt`

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -11,6 +11,9 @@ All dates in this document are approximate.
 20230407: The `stalled_bytes` counter in the log and in the
 `printer.mcu.last_stats` field has been renamed to `upcoming_bytes`.
 
+20230323: On tmc5160 drivers `multistep_filt` is now enabled by default. Set
+`driver_MULTISTEP_FILT: False` in the tmc5160 config for the previous behavior.
+
 20230304: The `SET_TMC_CURRENT` command now properly adjusts the globalscaler
 register for drivers that have it. This removes a limitation where on tmc5160,
 the currents could not be raised higher with `SET_TMC_CURRENT` than the

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3166,6 +3166,7 @@ run_current:
 #   set, "stealthChop" mode will be enabled if the stepper motor
 #   velocity is below this value. The default is 0, which disables
 #   "stealthChop" mode.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 20
 #driver_TBL: 2
@@ -3207,6 +3208,7 @@ run_current:
 #   The address of the TMC2209 chip for UART messages (an integer
 #   between 0 and 3). This is typically used when multiple TMC2209
 #   chips are connected to the same UART pin. The default is zero.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 8
 #driver_TPOWERDOWN: 20
 #driver_TBL: 2
@@ -3381,6 +3383,7 @@ run_current:
 #   to tune a motor with unbalanced coils. See the `Sine Wave Lookup Table`
 #   section in the datasheet for information about this field and how to tune
 #   it.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 6
 #driver_IRUNDELAY: 4
 #driver_TPOWERDOWN: 10
@@ -3496,6 +3499,7 @@ run_current:
 #   values used by the driver. The value must be specified as a decimal integer
 #   (hex form is not supported). In order to compute the wave table fields,
 #   see the tmc2130 "Calculation Sheet" from the Trinamic website.
+#driver_MULTISTEP_FILT: True
 #driver_IHOLDDELAY: 6
 #driver_TPOWERDOWN: 10
 #driver_TBL: 2

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -197,10 +197,11 @@ class TMC2208:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # GCONF
+        set_config_field(config, "multistep_filt", True)
         # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -73,10 +73,11 @@ class TMC2209:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
+        # GCONF
+        set_config_field(config, "multistep_filt", True)
         # CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -354,12 +354,13 @@ class TMC2240:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         self.fields.set_config_field(config, "offset_sin90", 0)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
-        #   CHOPCONF
         set_config_field = self.fields.set_config_field
+        #   GCONF
+        set_config_field(config, "multistep_filt", True)
+        #   CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)
         set_config_field(config, "hend", 2)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -327,10 +327,11 @@ class TMC5160:
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values
-        self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         set_config_field = self.fields.set_config_field
+        #   GCONF
+        set_config_field(config, "multistep_filt", True)
         #   CHOPCONF
         set_config_field(config, "toff", 3)
         set_config_field(config, "hstrt", 5)


### PR DESCRIPTION
This PR aims to address a regression discovered in #6118. While enabling `multistep_filt` is a good idea in general, there are cases where this option will cause issues, as was discovered by @Virtualchronos. In order to address these cases, the `multistep_filt` is now configurable in the config file. I also added some notes about this in docs/Config_Changes.md and in the config reference.