### PR TITLE
tmc: DUMP_TMC optional REGISTER parameter

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1219,8 +1219,9 @@ The following commands are available when any of the
 are enabled.
 
 #### DUMP_TMC
-`DUMP_TMC STEPPER=<name>`: This command will read the TMC driver
-registers and report their values.
+`DUMP_TMC STEPPER=<name>` [REGISTER=<name>]: This command will read all TMC
+driver registers and report their values. If a REGISTER is provided, only
+the specified register will be dumped.
 
 #### INIT_TMC
 `INIT_TMC STEPPER=<name>`: This command will initialize the TMC


### PR DESCRIPTION
Add an optional REGISTER parameter to DUMP_TMC so that the output is more filtered/cleaner for manual TMC calibration.
This is a follow-up of #6136.