### PR TITLE
Add X twist compensation module

### DIFF
--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -25,8 +25,8 @@ first use mechanical means to fix it prior to applying software corrections.
 perform `AXIS_TWIST_COMPENSATION_CALIBRATE`
 * The calibration wizard will prompt you to measure the probe Z offset at a few
 points along the bed
-* The calibration defaults to 3 points but you can use the option `N_POINTS=` to
-use a different number.
+* The calibration defaults to 3 points but you can use the option
+`SAMPLE_COUNT=` to use a different number.
 2. [Adjust your Z offset](Probe_Calibrate.md#calibrating-probe-z-offset)
 3. Perform automatic/probe-based bed tramming operations, such as
 [Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust),

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -16,6 +16,9 @@ This module uses manual measurements by the user to correct the probe's results.
 Note that if your axis is significantly twisted it is strongly recommended to
 first use mechanical means to fix it prior to applying software corrections.
 
+**Warning**: This module is not compatible with dockable probes yet and will
+try to probe the bed without attaching the probe if you use it.
+
 ## Overview of compensation usage
 
 > **Tip:** Make sure the [probe X and Y offsets](Config_Reference.md#probe) are

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -2,8 +2,8 @@
 
 This document describes the [axis_twist_compensation] module.
 
-Some printers exhibit different Z offsets depending on the X position of the
-probed point, and this is independent of the bed being not flat or not trammed.
+Some printers may have a small twist in their X rail which can skew the results
+of a probe attached to the X carriage.
 This is common in printers with designs like the Prusa MK3, Sovol SV06 etc and is
 further described under [probe location
 bias](Probe_Calibrate.md#location-bias-check). It may result in
@@ -20,9 +20,6 @@ first use mechanical means to fix it prior to applying software corrections.
 
 > **Tip:** Make sure the [probe X and Y offsets](Config_Reference.md#probe) are
 > correctly set as they greatly influence calibration.
-
-> **Tip:** A feeler gauge is recommended in place of paper for more accurate
-> measurements
 
 1. After setting up the [axis_twist_compensation] module,
 perform `AXIS_TWIST_COMPENSATION_CALIBRATE`
@@ -41,9 +38,9 @@ use a different number.
 > **Tip:** Bed temperature and nozzle temperature and size do not seem to have
 > an influence to the calibration process.
 
-> **Tip:** Disable the Axis twist compensation using `AXIS_TWIST_PROFILE_CLEAR`
-> and perform Screws Tilt Adjust/Z Tilt Adjust/Bed Mesh to compare the
-> difference
+> **Tip:** Disable the Axis twist compensation using
+> `AXIS_TWIST_COMPENSATION_CLEAR` and perform Screws Tilt Adjust/Z Tilt
+> Adjust/Bed Mesh to compare the difference
 
 ## [axis_twist_compensation] setup and commands
 
@@ -69,25 +66,3 @@ interpolate linearly between each pair of points.
 
 > **Tip:** It is not necessary to redo a calibration when switching between
 > linear and multilinear.
-
-### Fine-tuning
-
-If required, the user may fine tune the `z_compensations` values.
-
-For example, the value of `0.12` represents the `z_compensation` applied
-when the printer is probing at `start_x`. This means that if the non-compensated
-z-height measured at `start_x` was `2.0`, the compensated z-height is now `2.0 +
-0.12 = 2.12`, resulting in a higher point on the recorded mesh.
-
-Should the squish on the side of the bed represented by `start_x` be
-insufficient, the user may specify a lower `z_compensation` value in place of
-`0.12`, such as `0.02`. This would result in the mesh being lowered by
-`0.12 - 0.02 = 0.1mm` at points along `start_x`.
-
-## Reference
-
-The calculations for this module are largely based off those found in
-[Marlin PR #23238](https://github.com/MarlinFirmware/Marlin/pull/23238).
-
-A visualization of the issue can be found in
-[this discussion thread](https://github.com/MarlinFirmware/Marlin/issues/22791).

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -45,20 +45,3 @@ Configuration options for [axis_twist_compensation] can be found in the
 
 Commands for [axis_twist_compensation] can be found in the
 [G-Codes Reference](G-Codes.md#axis_twist_compensation)
-
-### Type of compensation
-
-This module supports two interpolation methods for the Z offset compensation:
-linear and multilinear.
-
-Some printers which have a slight twist only require a linear compensation, so
-you can use the 'linear' mode to do a linear regression to fit a line through
-the measured compensation.
-
-It is not uncommon for printers to have multiple combined non-linear twists
-(e.g. the tool head leaning forward in the middle of the axis due to its own
-weight). For that, it is recommended to use the 'multilinear' mode which will
-interpolate linearly between each pair of points.
-
-> **Tip:** It is not necessary to redo a calibration when switching between
-> linear and multilinear.

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -38,10 +38,6 @@ points along the bed
 > **Tip:** Bed temperature and nozzle temperature and size do not seem to have
 > an influence to the calibration process.
 
-> **Tip:** Disable the Axis twist compensation using
-> `AXIS_TWIST_COMPENSATION_CLEAR` and perform Screws Tilt Adjust/Z Tilt
-> Adjust/Bed Mesh to compare the difference
-
 ## [axis_twist_compensation] setup and commands
 
 Configuration options for [axis_twist_compensation] can be found in the

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -1,0 +1,93 @@
+# Axis Twist Compensation
+
+This document describes the [axis_twist_compensation] module.
+
+Some printers exhibit different Z offsets depending on the X position of the
+probed point, and this is independent of the bed being not flat or not trammed.
+This is common in printers with designs like the Prusa MK3, Sovol SV06 etc and is
+further described under [probe location
+bias](Probe_Calibrate.md#location-bias-check). It may result in
+probe operations such as [Bed Mesh](Bed_Mesh.md),
+[Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust),
+[Z Tilt Adjust](G-Codes.md#z_tilt_adjust) etc returning inaccurate
+representations of the bed.
+
+This module uses manual measurements by the user to correct the probe's results.
+Note that if your axis is significantly twisted it is strongly recommended to
+first use mechanical means to fix it prior to applying software corrections.
+
+## Overview of compensation usage
+
+> **Tip:** Make sure the [probe X and Y offsets](Config_Reference.md#probe) are
+> correctly set as they greatly influence calibration.
+
+> **Tip:** A feeler gauge is recommended in place of paper for more accurate
+> measurements
+
+1. After setting up the [axis_twist_compensation] module,
+perform `AXIS_TWIST_COMPENSATION_CALIBRATE`
+* The calibration wizard will prompt you to measure the probe Z offset at a few
+points along the bed
+* The calibration defaults to 3 points but you can use the option `N_POINTS=` to
+use a different number.
+2. [Adjust your Z offset](Probe_Calibrate.md#calibrating-probe-z-offset)
+3. Perform automatic/probe-based bed tramming operations, such as
+[Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust),
+[Z Tilt Adjust](G-Codes.md#z_tilt_adjust) etc
+4. Home all axis, then perform a [Bed Mesh](Bed_Mesh.md) if required
+5. Perform a test print, followed by any
+[fine-tuning](Axis_Twist_Compensation.md#fine-tuning) as desired
+
+> **Tip:** Bed temperature and nozzle temperature and size do not seem to have
+> an influence to the calibration process.
+
+> **Tip:** Disable the Axis twist compensation using `AXIS_TWIST_PROFILE_CLEAR`
+> and perform Screws Tilt Adjust/Z Tilt Adjust/Bed Mesh to compare the
+> difference
+
+## [axis_twist_compensation] setup and commands
+
+Configuration options for [axis_twist_compensation] can be found in the
+[Configuration Reference](Config_Reference.md#axis_twist_compensation).
+
+Commands for [axis_twist_compensation] can be found in the
+[G-Codes Reference](G-Codes.md#axis_twist_compensation)
+
+### Type of compensation
+
+This module supports two interpolation methods for the Z offset compensation:
+linear and multilinear.
+
+Some printers which have a slight twist only require a linear compensation, so
+you can use the 'linear' mode to do a linear regression to fit a line through
+the measured compensation.
+
+It is not uncommon for printers to have multiple combined non-linear twists
+(e.g. the tool head leaning forward in the middle of the axis due to its own
+weight). For that, it is recommended to use the 'multilinear' mode which will
+interpolate linearly between each pair of points.
+
+> **Tip:** It is not necessary to redo a calibration when switching between
+> linear and multilinear.
+
+### Fine-tuning
+
+If required, the user may fine tune the `z_compensations` values.
+
+For example, the value of `0.12` represents the `z_compensation` applied
+when the printer is probing at `start_x`. This means that if the non-compensated
+z-height measured at `start_x` was `2.0`, the compensated z-height is now `2.0 +
+0.12 = 2.12`, resulting in a higher point on the recorded mesh.
+
+Should the squish on the side of the bed represented by `start_x` be
+insufficient, the user may specify a lower `z_compensation` value in place of
+`0.12`, such as `0.02`. This would result in the mesh being lowered by
+`0.12 - 0.02 = 0.1mm` at points along `start_x`.
+
+## Reference
+
+The calculations for this module are largely based off those found in
+[Marlin PR #23238](https://github.com/MarlinFirmware/Marlin/pull/23238).
+
+A visualization of the issue can be found in
+[this discussion thread](https://github.com/MarlinFirmware/Marlin/issues/22791).

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1959,6 +1959,42 @@ z_offset:
 #   See the "probe" section for more information on the parameters above.
 ```
 
+### [axis_twist_compensation]
+
+Axis twist dependent toolhead Z position adjustment. Compensate for vertical
+toolhead movement caused by the rotation of the toolhead about the X axis due to
+a twist. See the [Axis Twist Compensation Guide](X_Twist_Compensation.md) for
+more detailed information regarding symptoms, configuration and setup.
+
+```
+[axis_twist_compensation]
+#speed: 50
+#   The speed (in mm/s) of non-probing moves during the calibration.
+#   The default is 50.
+#horizontal_move_z: 5
+#   The height (in mm) that the head should be commanded to move to
+#   just prior to starting a probe operation. The default is 5.
+start_x: 20
+#   Defines the minimum X coordinate of the calibration
+#   This should be the X coordinate that positions the nozzle at the starting
+#   calibration position. This parameter must be provided.
+end_x: 200
+#   Defines the maximum X coordinate of the calibration
+#   This should be the X coordinate that positions the nozzle at the ending
+#   calibration position. This parameter must be provided.
+y: 112.5
+#   Defines the Y coordinate of the calibration
+#   This should be the Y coordinate that positions the nozzle during the
+#   calibration process. This parameter must be provided and is recommended to
+#   be near the center of the bed
+#type: multilinear
+#   Defines the type of correction to apply. The choices are 'linear' or
+#   'multilinear'. 'linear' uses a linear regression to fit a line with the
+#   calibration points. 'multilinear' will interpolate linearly between each
+#   pair of points. It is not necessary to redo a calibration after changing
+#   this setting.
+```
+
 ## Additional stepper motors and extruders
 
 ### [stepper_z1]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1986,12 +1986,6 @@ calibrate_y: 112.5
 #   This should be the Y coordinate that positions the nozzle during the
 #   calibration process. This parameter must be provided and is recommended to
 #   be near the center of the bed
-#compensation_type: multilinear
-#   Defines the type of correction to apply. The choices are 'linear' or
-#   'multilinear'. 'linear' uses a linear regression to fit a line with the
-#   calibration points. 'multilinear' will interpolate linearly between each
-#   pair of points. It is not necessary to redo a calibration after changing
-#   this setting.
 ```
 
 ## Additional stepper motors and extruders

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1961,10 +1961,9 @@ z_offset:
 
 ### [axis_twist_compensation]
 
-Axis twist dependent toolhead Z position adjustment. Compensate for vertical
-toolhead movement caused by the rotation of the toolhead about the X axis due to
-a twist. See the [Axis Twist Compensation Guide](X_Twist_Compensation.md) for
-more detailed information regarding symptoms, configuration and setup.
+A tool to compensate for inaccurate probe readings due to twist in X gantry. See
+the [Axis Twist Compensation Guide](Axis_Twist_Compensation.md) for more
+detailed information regarding symptoms, configuration and setup.
 
 ```
 [axis_twist_compensation]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1973,20 +1973,20 @@ detailed information regarding symptoms, configuration and setup.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
-start_x: 20
+calibrate_start_x: 20
 #   Defines the minimum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the starting
 #   calibration position. This parameter must be provided.
-end_x: 200
+calibrate_end_x: 200
 #   Defines the maximum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the ending
 #   calibration position. This parameter must be provided.
-y: 112.5
+calibrate_y: 112.5
 #   Defines the Y coordinate of the calibration
 #   This should be the Y coordinate that positions the nozzle during the
 #   calibration process. This parameter must be provided and is recommended to
 #   be near the center of the bed
-#type: multilinear
+#compensation_type: multilinear
 #   Defines the type of correction to apply. The choices are 'linear' or
 #   'multilinear'. 'linear' uses a linear regression to fit a line with the
 #   calibration points. 'multilinear' will interpolate linearly between each

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1326,9 +1326,6 @@ section](Config_Reference.md#axis_twist_compensation) is enabled.
 twist calibration wizard. `SAMPLE_COUNT` specifies the number of points along
 the X axis to calibrate at and defaults to 3.
 
-#### AXIS_TWIST_COMPENSATION_CLEAR
-`AXIS_TWIST_COMPENSATION_CLEAR`: Clears the current compensation values.
-
 ### [z_thermal_adjust]
 
 The following commands are available when the

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1322,9 +1322,9 @@ The following commands are available when the
 section](Config_Reference.md#axis_twist_compensation) is enabled.
 
 #### AXIS_TWIST_COMPENSATION_CALIBRATE
-`AXIS_TWIST_COMPENSATION_CALIBRATE [N_POINTS=<value>]`: Initiates the X twist calibration
-wizard. `N_POINTS` specifies the number of points along the X axis to calibrate
-at and defaults to 3.
+`AXIS_TWIST_COMPENSATION_CALIBRATE [SAMPLE_COUNT=<value>]`: Initiates the X
+twist calibration wizard. `SAMPLE_COUNT` specifies the number of points along
+the X axis to calibrate at and defaults to 3.
 
 #### AXIS_TWIST_COMPENSATION_CLEAR
 `AXIS_TWIST_COMPENSATION_CLEAR`: Clears the current compensation values.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1315,6 +1315,20 @@ print.
 #### SDCARD_RESET_FILE
 `SDCARD_RESET_FILE`: Unload file and clear SD state.
 
+### [axis_twist_compensation]
+
+The following commands are available when the
+[axis_twist_compensation config
+section](Config_Reference.md#axis_twist_compensation) is enabled.
+
+#### AXIS_TWIST_COMPENSATION_CALIBRATE
+`AXIS_TWIST_COMPENSATION_CALIBRATE [N_POINTS=<value>]`: Initiates the X twist calibration
+wizard. `N_POINTS` specifies the number of points along the X axis to calibrate
+at and defaults to 3.
+
+#### AXIS_TWIST_COMPENSATION_CLEAR
+`AXIS_TWIST_COMPENSATION_CLEAR`: Clears the current compensation values.
+
 ### [z_thermal_adjust]
 
 The following commands are available when the

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -35,6 +35,8 @@ communication with the Klipper developers.
     locations.
   - [Endstop phase](Endstop_Phase.md): Stepper assisted Z endstop
     positioning.
+  - [Axis Twist Compensation](Axis_Twist_Compensation.md): A tool to compensate
+    for inaccurate probe readings due to twist in X gantry.
 - [Resonance compensation](Resonance_Compensation.md): A tool to
   reduce ringing in prints.
   - [Measuring resonances](Measuring_Resonances.md): Information on

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - Manual_Level.md
       - Bed_Mesh.md
       - Endstop_Phase.md
+      - Axis_Twist_Compensation.md
     - Resonance Compensation:
       - Resonance_Compensation.md
       - Measuring_Resonances.md

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -1,0 +1,347 @@
+# Axis Twist Compensation
+
+# Copyright (C) 2022  Jeremy Tan <jeremytkw98@gmail.com>
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+"""
+[axis_twist_compensation]
+horizontal_move_z: 5
+speed: 50
+start_x: 0 ; nozzle's x coordinate at the start of the calibration ! required
+end_x: 200 ; nozzle's x coordinate at the end of the calibration ! required
+y: 100 ; nozzle's y coordinate during the calibration ! required
+type: multilinear
+"""
+
+import logging
+import math
+from . import manual_probe as ManualProbe, bed_mesh as BedMesh
+
+
+DEFAULT_N_POINTS = 3
+
+
+class Config:
+    DEFAULT_SPEED = 50.
+    DEFAULT_HORIZONTAL_MOVE_Z = 5.
+    REQUIRED = True
+    OPTIONAL = False
+    CONFIG_OPTIONS = {
+        'horizontal_move_z': (float, OPTIONAL, DEFAULT_HORIZONTAL_MOVE_Z),
+        'speed': (float, OPTIONAL, DEFAULT_SPEED),
+        'start_x': (float, REQUIRED, None),
+        'end_x': (float, REQUIRED, None),
+        'y': (float, REQUIRED, None),
+        'type': (str, OPTIONAL, 'multilinear'),
+        'z_compensations': (str, OPTIONAL, None),
+    }
+
+    @staticmethod
+    def save_to_config(name, z_compensations, configfile):
+        values_as_str = ', '.join([Helpers.format_float_to_n_decimals(x)
+                                   for x in z_compensations])
+        configfile.set(name, 'z_compensations', values_as_str)
+
+
+class AxisTwistCompensation:
+    def __init__(self, config):
+        # get printer
+        self.config = config
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+
+        # get values from [axis_twist_compensation] section in printer .cfg
+        for config_key, \
+            (config_type, required, default) in Config.CONFIG_OPTIONS.items():
+            value = None
+            if config_type == float:
+                value = config.getfloat(config_key, default)
+            elif config_key == 'z_compensations':
+                value = Helpers.parse_comma_separated_floats(
+                    config.get('z_compensations', default=""))
+            else:
+                value = config.get(config_key, default)
+            if required and value is None:
+                raise config.error(
+                    "Missing required config option for section [{}]: {}"
+                    .format(config.get_name(), config_key))
+            setattr(self, config_key, value)
+
+        if self.type not in ['linear', 'multilinear']:
+                raise config.error(
+                    "Invalid axis_twist_compensation.type value: {}"
+                    .format(self.type))
+
+        self.m = None
+        self.b = None
+
+        # setup calibrater
+        self.calibrater = Calibrater(self)
+
+        self._register_gcode_handlers()
+
+    def get_z_compensation_value(self, x_coord):
+        if not self.z_compensations:
+            return 0
+        self._ensure_init()
+
+        if self.type == 'linear':
+            return self._get_z_compensation_value_linear(x_coord)
+        elif self.type == 'multilinear':
+            return self._get_z_compensation_value_multilinear(x_coord)
+
+    def _get_z_compensation_value_linear(self, x_coord):
+        return self.m * x_coord + self.b
+
+
+    def _get_z_compensation_value_multilinear(self, x_coord):
+        z_compensations = self.z_compensations
+        n_points = len(z_compensations)
+        spacing = (self.end_x - self.start_x) / (n_points - 1)
+        interpolate_t = (x_coord - self.start_x) / spacing
+        interpolate_i = int(math.floor(interpolate_t))
+        interpolate_i = BedMesh.constrain(interpolate_i, 0, n_points - 2)
+        interpolate_t -= interpolate_i
+        interpolated_z_compensation = BedMesh.lerp(
+            interpolate_t, z_compensations[interpolate_i],
+            z_compensations[interpolate_i + 1])
+        return interpolated_z_compensation
+
+    def _ensure_init(self):
+        if self.type == 'linear' and self.m is None:
+            z_compensations = self.z_compensations
+            n_points = len(z_compensations)
+            interval_dist = \
+                (self.end_x - self.start_x) / (n_points - 1)
+            indexes = [self.start_x + i*interval_dist
+                       for i in range(0, n_points)]
+
+            # Calculate the mean of x and y values
+            mean_indexes = sum(indexes) / n_points
+            mean_z_compensations = sum(z_compensations) / n_points
+
+            # Calculate the covariance and variance
+            covar = sum((indexes[i] - mean_indexes) *
+                        (z_compensations[i] - mean_z_compensations)
+                        for i in range(n_points))
+            var = sum((indexes[i] - mean_indexes)**2 for i in range(n_points))
+
+            # Compute the slope (m) and intercept (b) of the best-fit line
+            self.m = covar / var
+            self.b = mean_z_compensations - self.m * mean_indexes
+
+    def clear_compensations(self):
+        self.z_compensations = []
+        self.m = None
+        self.b = None
+
+    def _register_gcode_handlers(self):
+        self.gcode.register_command(
+            'AXIS_TWIST_COMPENSATION_CLEAR',
+            self.cmd_AXIS_TWIST_COMPENSATION_CLEAR,
+            desc=self.cmd_AXIS_TWIST_COMPENSATION_CLEAR_help)
+
+    cmd_AXIS_TWIST_COMPENSATION_CLEAR_help = \
+        "Clears the active axis twist compensation"
+
+    def cmd_AXIS_TWIST_COMPENSATION_CLEAR(self, gcmd):
+        self.clear_compensations()
+
+
+class Calibrater:
+    def __init__(self, compensation):
+        # setup self attributes
+        self.compensation = compensation
+        self.printer = compensation.printer
+        self.config = compensation.config
+        self.gcode = self.printer.lookup_object('gcode')
+        self.probe = None
+        # probe settings are set to none, until they are available
+        self.lift_speed, self.probe_x_offset, self.probe_y_offset, _ = \
+            None, None, None, None
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_connect())
+        self.speed = compensation.speed
+        self.horizontal_move_z = compensation.horizontal_move_z
+        self.start_point = (compensation.start_x, compensation.y)
+        self.end_point = (compensation.end_x, compensation.y)
+        self.results = None
+        self.current_point_index = None
+        self.gcmd = None
+
+        # register gcode handlers
+        self._register_gcode_handlers()
+
+    def _handle_connect(self):
+        # gets probe settings when they are available
+        def callback():
+            self.probe = self.printer.lookup_object('probe', None)
+            if (self.probe is None):
+                raise self.config.error(
+                    "AXIS_TWIST_COMPENSATION requires [probe] to be defined")
+            self.lift_speed = self.probe.get_lift_speed()
+            self.probe_x_offset, self.probe_y_offset, _ = \
+                self.probe.get_offsets()
+        return callback
+
+    def _register_gcode_handlers(self):
+        # register gcode handlers
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command(
+            'AXIS_TWIST_COMPENSATION_CALIBRATE',
+            self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE,
+            desc=self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_help)
+
+    cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_help = """
+    Performs the x twist calibration wizard
+    Measure z probe offset at n points along the x axis,
+    and calculate x twist compensation
+    """
+
+    def cmd_AXIS_TWIST_COMPENSATION_CALIBRATE(self, gcmd):
+        self.gcmd = gcmd
+        n_points = gcmd.get_int('N_POINTS', DEFAULT_N_POINTS)
+
+        # check for valid n_points
+        if n_points is None or n_points < 2:
+            raise self.gcmd.error(
+                "N_POINTS to probe must be at least 2")
+
+        # clear the current config
+        self.compensation.clear_compensations()
+
+        # calculate some values
+        x_range = self.end_point[0] - self.start_point[0]
+        interval_dist = x_range / (n_points - 1)
+        nozzle_points = self._calculate_nozzle_points(n_points, interval_dist)
+        probe_points = self._calculate_probe_points(
+            nozzle_points, self.probe_x_offset, self.probe_y_offset)
+
+        # verify no other manual probe is in progress
+        ManualProbe.verify_no_manual_probe(self.printer)
+
+        # begin calibration
+        self.current_point_index = 0
+        self.results = []
+        self._calibration(probe_points, nozzle_points, interval_dist)
+
+    def _calculate_nozzle_points(self, n_points, interval_dist):
+        # calculate the points to put the probe at, returned as a list of tuples
+        nozzle_points = []
+        for i in range(n_points):
+            x = self.start_point[0] + i * interval_dist
+            y = self.start_point[1]
+            nozzle_points.append((x, y))
+        return nozzle_points
+
+    def _calculate_probe_points(self, nozzle_points,
+        probe_x_offset, probe_y_offset):
+        # calculate the points to put the nozzle at
+        # returned as a list of tuples
+        probe_points = []
+        for point in nozzle_points:
+            x = point[0] - probe_x_offset
+            y = point[1] - probe_y_offset
+            probe_points.append((x, y))
+        return probe_points
+
+    def _move_helper(self, target_coordinates, override_speed=None):
+        # pad target coordinates
+        target_coordinates = \
+            (target_coordinates[0], target_coordinates[1], None) \
+            if len(target_coordinates) == 2 else target_coordinates
+        toolhead = self.printer.lookup_object('toolhead')
+        speed = self.speed if target_coordinates[2] == None else self.lift_speed
+        speed = override_speed if override_speed is not None else speed
+        toolhead.manual_move(target_coordinates, speed)
+
+    def _calibration(self, probe_points, nozzle_points, interval):
+        # begin the calibration process
+        self.gcmd.respond_info("AXIS_TWIST_COMPENSATION_CALIBRATE: "
+                               "Probing point %d of %d" % (
+                                   self.current_point_index + 1,
+                                   len(probe_points)))
+
+        # horizontal_move_z (to prevent probe trigger or hitting bed)
+        self._move_helper((None, None, self.horizontal_move_z))
+
+        # move to point to probe
+        self._move_helper((probe_points[self.current_point_index][0],
+                           probe_points[self.current_point_index][1], None))
+
+        # probe the point
+        self.current_measured_z = self.probe.run_probe(self.gcmd)[2]
+
+        # horizontal_move_z (to prevent probe trigger or hitting bed)
+        self._move_helper((None, None, self.horizontal_move_z))
+
+        # move the nozzle over the probe point
+        self._move_helper((nozzle_points[self.current_point_index]))
+
+        # start the manual (nozzle) probe
+        ManualProbe.ManualProbeHelper(
+            self.printer, self.gcmd,
+            self._manual_probe_callback_factory(
+                probe_points, nozzle_points, interval))
+
+    def _manual_probe_callback_factory(self, probe_points,
+        nozzle_points, interval):
+        # returns a callback function for the manual probe
+        is_end = self.current_point_index == len(probe_points) - 1
+
+        def callback(kin_pos):
+            if kin_pos is None:
+                # probe was cancelled
+                self.gcmd.respond_info(
+                    "AXIS_TWIST_COMPENSATION_CALIBRATE: Probe cancelled, "
+                    "calibration aborted")
+                return
+            z_offset = self.current_measured_z - kin_pos[2]
+            self.results.append(z_offset)
+            if is_end:
+                # end of calibration
+                self._finalize_calibration()
+            else:
+                # move to next point
+                self.current_point_index += 1
+                self._calibration(probe_points, nozzle_points, interval)
+        return callback
+
+    def _finalize_calibration(self):
+        # finalize the calibration process
+        # calculate average of results
+        avg = sum(self.results) / len(self.results)
+        # subtract average from each result
+        # so that they are independent of z_offset
+        self.results = [avg - x for x in self.results]
+        # save the config
+        configfile = self.printer.lookup_object('configfile')
+        Config.save_to_config(self.config.get_name(), self.results, configfile)
+        self.gcode.respond_info(
+            "AXIS_TWIST_COMPENSATION state has been saved "
+            "for the current session.  The SAVE_CONFIG command will "
+            "update the printer config file and restart the printer.")
+        # output result
+        self.gcmd.respond_info(
+            "AXIS_TWIST_COMPENSATION_CALIBRATE: Calibration complete, "
+            "offsets: %s, mean z_offset: %f"
+            % (self.results, avg))
+
+
+class Helpers:
+    @staticmethod
+    def format_float_to_n_decimals(raw_float, n=6):
+        # format float to n decimals, defaults to 6
+        return "{:.{}f}".format(raw_float, n)
+
+    @staticmethod
+    def parse_comma_separated_floats(comma_separated_floats):
+        if not comma_separated_floats:
+            return []
+        # parse comma separated floats into list of floats
+        return [float(value) for value in comma_separated_floats.split(', ')]
+
+# klipper's entry point using [axis_twist_compensation] section in printer.cfg
+
+def load_config(config):
+    return AxisTwistCompensation(config)

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -1,6 +1,7 @@
 # Axis Twist Compensation
-
+#
 # Copyright (C) 2022  Jeremy Tan <jeremytkw98@gmail.com>
+#
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 """
@@ -80,15 +81,15 @@ class AxisTwistCompensation:
 
         self._register_gcode_handlers()
 
-    def get_z_compensation_value(self, x_coord):
+    def get_z_compensation_value(self, pos):
         if not self.z_compensations:
             return 0
         self._ensure_init()
 
         if self.type == 'linear':
-            return self._get_z_compensation_value_linear(x_coord)
+            return self._get_z_compensation_value_linear(pos[0])
         elif self.type == 'multilinear':
-            return self._get_z_compensation_value_multilinear(x_coord)
+            return self._get_z_compensation_value_multilinear(pos[0])
 
     def _get_z_compensation_value_linear(self, x_coord):
         return self.m * x_coord + self.b
@@ -160,7 +161,7 @@ class Calibrater:
         self.lift_speed, self.probe_x_offset, self.probe_y_offset, _ = \
             None, None, None, None
         self.printer.register_event_handler("klippy:connect",
-                                            self._handle_connect())
+                                            self._handle_connect)
         self.speed = compensation.speed
         self.horizontal_move_z = compensation.horizontal_move_z
         self.start_point = (compensation.start_x, compensation.y)
@@ -173,16 +174,13 @@ class Calibrater:
         self._register_gcode_handlers()
 
     def _handle_connect(self):
-        # gets probe settings when they are available
-        def callback():
-            self.probe = self.printer.lookup_object('probe', None)
-            if (self.probe is None):
-                raise self.config.error(
-                    "AXIS_TWIST_COMPENSATION requires [probe] to be defined")
-            self.lift_speed = self.probe.get_lift_speed()
-            self.probe_x_offset, self.probe_y_offset, _ = \
-                self.probe.get_offsets()
-        return callback
+        self.probe = self.printer.lookup_object('probe', None)
+        if (self.probe is None):
+            raise self.config.error(
+                "AXIS_TWIST_COMPENSATION requires [probe] to be defined")
+        self.lift_speed = self.probe.get_lift_speed()
+        self.probe_x_offset, self.probe_y_offset, _ = \
+            self.probe.get_offsets()
 
     def _register_gcode_handlers(self):
         # register gcode handlers

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -8,8 +8,10 @@
 [axis_twist_compensation]
 horizontal_move_z: 5
 speed: 50
-calibrate_start_x: 0 ; nozzle's x coordinate at the start of the calibration ! required
-calibrate_end_x: 200 ; nozzle's x coordinate at the end of the calibration ! required
+calibrate_start_x: 0 ; nozzle's x coordinate at the start of the calibration
+    ! required
+calibrate_end_x: 200 ; nozzle's x coordinate at the end of the calibration
+    ! required
 calibrate_y: 100 ; nozzle's y coordinate during the calibration ! required
 compensation_type: multilinear
 """
@@ -30,17 +32,21 @@ class AxisTwistCompensation:
         self.gcode = self.printer.lookup_object('gcode')
 
         # get values from [axis_twist_compensation] section in printer .cfg
-        self.horizontal_move_z = config.getfloat('horizontal_move_z', DEFAULT_HORIZONTAL_MOVE_Z)
+        self.horizontal_move_z = config.getfloat('horizontal_move_z',
+                                                 DEFAULT_HORIZONTAL_MOVE_Z)
         self.speed = config.getfloat('speed', DEFAULT_SPEED)
         self.calibrate_start_x = config.getfloat('calibrate_start_x')
         self.calibrate_end_x = config.getfloat('calibrate_end_x')
         self.calibrate_y = config.getfloat('calibrate_y')
         TYPES = ['linear', 'multilinear']
-        self.compensation_type = config.getchoice('compensation_type', {t: t for t in TYPES})
+        self.compensation_type = config.getchoice('compensation_type',
+                                                  {t: t for t in TYPES})
         self.z_compensations = config.getlists('z_compensations',
                                                default=[], parser=float)
-        self.compensation_start_x = config.getfloat('compensation_start_x', default=None)
-        self.compensation_end_x = config.getfloat('compensation_start_y', default=None)
+        self.compensation_start_x = config.getfloat('compensation_start_x',
+                                                    default=None)
+        self.compensation_end_x = config.getfloat('compensation_start_y',
+                                                  default=None)
 
         self.m = None
         self.b = None
@@ -66,7 +72,8 @@ class AxisTwistCompensation:
     def _get_z_compensation_value_multilinear(self, x_coord):
         z_compensations = self.z_compensations
         sample_count = len(z_compensations)
-        spacing = (self.calibrate_end_x - self.calibrate_start_x) / (sample_count - 1)
+        spacing = ((self.calibrate_end_x - self.calibrate_start_x)
+                   / (sample_count - 1))
         interpolate_t = (x_coord - self.calibrate_start_x) / spacing
         interpolate_i = int(math.floor(interpolate_t))
         interpolate_i = BedMesh.constrain(interpolate_i, 0, sample_count - 2)
@@ -80,8 +87,8 @@ class AxisTwistCompensation:
         if self.compensation_type == 'linear' and self.m is None:
             z_compensations = self.z_compensations
             sample_count = len(z_compensations)
-            interval_dist = \
-                (self.calibrate_end_x - self.calibrate_start_x) / (sample_count - 1)
+            interval_dist = ((self.calibrate_end_x - self.calibrate_start_x)
+                             / (sample_count - 1))
             indexes = [self.calibrate_start_x + i*interval_dist
                        for i in range(0, sample_count)]
 
@@ -93,7 +100,8 @@ class AxisTwistCompensation:
             covar = sum((indexes[i] - mean_indexes) *
                         (z_compensations[i] - mean_z_compensations)
                         for i in range(sample_count))
-            var = sum((indexes[i] - mean_indexes)**2 for i in range(sample_count))
+            var = sum((indexes[i] - mean_indexes)**2
+                      for i in range(sample_count))
 
             # Compute the slope (m) and intercept (b) of the best-fit line
             self.m = covar / var
@@ -131,8 +139,10 @@ class Calibrater:
                                             self._handle_connect)
         self.speed = compensation.speed
         self.horizontal_move_z = compensation.horizontal_move_z
-        self.start_point = (compensation.calibrate_start_x, compensation.calibrate_y)
-        self.end_point = (compensation.calibrate_end_x, compensation.calibrate_y)
+        self.start_point = (compensation.calibrate_start_x,
+                            compensation.calibrate_y)
+        self.end_point = (compensation.calibrate_end_x,
+                          compensation.calibrate_y)
         self.results = None
         self.current_point_index = None
         self.gcmd = None
@@ -180,7 +190,8 @@ class Calibrater:
         # calculate some values
         x_range = self.end_point[0] - self.start_point[0]
         interval_dist = x_range / (sample_count - 1)
-        nozzle_points = self._calculate_nozzle_points(sample_count, interval_dist)
+        nozzle_points = self._calculate_nozzle_points(sample_count,
+                                                      interval_dist)
         probe_points = self._calculate_probe_points(
             nozzle_points, self.probe_x_offset, self.probe_y_offset)
 
@@ -286,8 +297,10 @@ class Calibrater:
         values_as_str = ', '.join(["{:.6f}".format(x)
                                    for x in self.results])
         configfile.set(self.configname, 'z_compensations', values_as_str)
-        configfile.set(self.configname, 'compensation_start_x', self.start_point[0])
-        configfile.set(self.configname, 'compensation_end_x', self.end_point[0])
+        configfile.set(self.configname, 'compensation_start_x',
+                       self.start_point[0])
+        configfile.set(self.configname, 'compensation_end_x',
+                       self.end_point[0])
         self.compensation.z_compensations = self.results
         self.compensation.compensation_start_x = self.start_point[0]
         self.compensation.compensation_end_x = self.end_point[0]

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -54,8 +54,6 @@ class AxisTwistCompensation:
         # setup calibrater
         self.calibrater = Calibrater(self, config)
 
-        self._register_gcode_handlers()
-
     def get_z_compensation_value(self, pos):
         if not self.z_compensations:
             return 0
@@ -111,18 +109,6 @@ class AxisTwistCompensation:
         self.z_compensations = []
         self.m = None
         self.b = None
-
-    def _register_gcode_handlers(self):
-        self.gcode.register_command(
-            'AXIS_TWIST_COMPENSATION_CLEAR',
-            self.cmd_AXIS_TWIST_COMPENSATION_CLEAR,
-            desc=self.cmd_AXIS_TWIST_COMPENSATION_CLEAR_help)
-
-    cmd_AXIS_TWIST_COMPENSATION_CLEAR_help = \
-        "Clears the active axis twist compensation"
-
-    def cmd_AXIS_TWIST_COMPENSATION_CLEAR(self, gcmd):
-        self.clear_compensations()
 
 
 class Calibrater:

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -39,6 +39,8 @@ class AxisTwistCompensation:
         self.compensation_type = config.getchoice('compensation_type', {t: t for t in TYPES})
         self.z_compensations = config.getlists('z_compensations',
                                                default=[], parser=float)
+        self.compensation_start_x = config.getfloat('compensation_start_x', default=None)
+        self.compensation_end_x = config.getfloat('compensation_start_y', default=None)
 
         self.m = None
         self.b = None
@@ -284,6 +286,11 @@ class Calibrater:
         values_as_str = ', '.join(["{:.6f}".format(x)
                                    for x in self.results])
         configfile.set(self.configname, 'z_compensations', values_as_str)
+        configfile.set(self.configname, 'compensation_start_x', self.start_point[0])
+        configfile.set(self.configname, 'compensation_end_x', self.end_point[0])
+        self.compensation.z_compensations = self.results
+        self.compensation.compensation_start_x = self.start_point[0]
+        self.compensation.compensation_end_x = self.end_point[0]
         self.gcode.respond_info(
             "AXIS_TWIST_COMPENSATION state has been saved "
             "for the current session.  The SAVE_CONFIG command will "

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -4,18 +4,6 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-"""
-[axis_twist_compensation]
-horizontal_move_z: 5
-speed: 50
-calibrate_start_x: 0 ; nozzle's x coordinate at the start of the calibration
-    ! required
-calibrate_end_x: 200 ; nozzle's x coordinate at the end of the calibration
-    ! required
-calibrate_y: 100 ; nozzle's y coordinate during the calibration ! required
-compensation_type: multilinear
-"""
-
 import math
 from . import manual_probe as ManualProbe, bed_mesh as BedMesh
 

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -127,6 +127,13 @@ class PrinterProbe:
             if "Timeout during endstop homing" in reason:
                 reason += HINT_TIMEOUT
             raise self.printer.command_error(reason)
+        # get z compensation from axis_twist_compensation
+        axis_twist_compensation = self.printer.lookup_object(
+            'axis_twist_compensation', None)
+        z_compensation = 0 if not axis_twist_compensation \
+            else axis_twist_compensation.get_z_compensation_value(pos[0])
+        # add z compensation to probe position
+        epos[2] += z_compensation
         self.gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
                                 % (epos[0], epos[1], epos[2]))
         return epos[:3]

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -130,8 +130,10 @@ class PrinterProbe:
         # get z compensation from axis_twist_compensation
         axis_twist_compensation = self.printer.lookup_object(
             'axis_twist_compensation', None)
-        z_compensation = 0 if not axis_twist_compensation \
-            else axis_twist_compensation.get_z_compensation_value(pos[0])
+        z_compensation = 0
+        if axis_twist_compensation is not None:
+            z_compensation = (
+                axis_twist_compensation.get_z_compensation_value(pos))
         # add z compensation to probe position
         epos[2] += z_compensation
         self.gcode.respond_info("probe at %.3f,%.3f is z=%.6f"


### PR DESCRIPTION
Hi,

This is a fork of the PR #6048. This is a feature I'd very like to see merged, so I took the liberty of taking the commits of @koonweee and fixing the comments made on his PR.

I can squash my commits if you prefer a cleaner history.

The changes include:
- A few bug fixes
- Some typos pointed out in the review
- Removal of the profile system, the rationale is that the twist only depends on the printer, not the temperature etc
- Rename of the module to axis_twist_compensation so that if we need some day to calibrate for another axis, there will be less changes to make to the user's configuration

On another note, I kept the recommended z offset feature from the original PR, which is also present in the Marlin implementation. This z offset has always been off in my tests. I also don't understand how making the average of the z offset from left to right makes sense to calculate a single z offset. The printer will only probe the middle of the bed when homing anyway, so that's the only offset that we should apply.

Also, a small difference from the original PR is that since I removed the profile system, there is always a configuration loaded when klipper starts.

TODO:

- [x] documentation (still unmodified from original PR, waiting for a first review)