### PR TITLE
Add SET_MAX_EXTRUDE_ONLY_ACCEL option to extruder.py

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -426,7 +426,7 @@ will be desynchronized from all extruder movement.
 #### SET_MAX_EXTRUDE_ONLY_ACCEL
 `SET_MAX_EXTRUDE_ONLY_ACCEL ACCEL=<float>`. This command sets the
 max_extrude_only_accel parameter of [extruder]. Value must be bigger
-than 0. If `ACCEL` value is not provided the command will return 
+than 0. If `ACCEL` value is not provided the command will return
 the currently set max_extrude_only_accel.
 
 #### SET_EXTRUDER_STEP_DISTANCE

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -423,6 +423,12 @@ MOTION_QUEUE (as defined in an [extruder](Config_Reference.md#extruder)
 config section). If MOTION_QUEUE is an empty string then the stepper
 will be desynchronized from all extruder movement.
 
+#### SET_MAX_EXTRUDE_ONLY_ACCEL
+`SET_MAX_EXTRUDE_ONLY_ACCEL ACCEL=<float>`. This command sets the
+max_extrude_only_accel parameter of [extruder]. Value must be bigger
+than 0. If `ACCEL` value is not provided the command will return 
+the currently set max_extrude_only_accel.
+
 #### SET_EXTRUDER_STEP_DISTANCE
 This command is deprecated and will be removed in the near future.
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -44,6 +44,7 @@ class ExtruderStepper:
         gcode.register_mux_command("SYNC_STEPPER_TO_EXTRUDER", "STEPPER",
                                    self.name, self.cmd_SYNC_STEPPER_TO_EXTRUDER,
                                    desc=self.cmd_SYNC_STEPPER_TO_EXTRUDER_help)
+        
     def _handle_connect(self):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_step_generator(self.stepper.generate_steps)
@@ -208,6 +209,9 @@ class PrinterExtruder:
             toolhead.set_extruder(self, 0.)
             gcode.register_command("M104", self.cmd_M104)
             gcode.register_command("M109", self.cmd_M109)
+            gcode.register_mux_command("SET_MAX_EXTRUDE_ONLY_ACCEL", "EXTRUDER", None, self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL,
+                                   desc=self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help)
+            
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
@@ -308,6 +312,13 @@ class PrinterExtruder:
         toolhead.flush_step_generation()
         toolhead.set_extruder(self, self.last_position)
         self.printer.send_event("extruder:activate_extruder")
+        
+    cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help = "Set extruder max_extrude_only_accel"
+    def cmd_SET_MAX_EXTRUDE_ONLY_ACCEL(self, gcmd):
+        accel = gcmd.get_float("ACCEL", self.max_e_accel, above=0.)
+        if accel is not None:
+            self.max_e_accel = accel
+            gcmd.respond_info("'extrude_only_accel': %s" % (accel,))
 
 # Dummy extruder class used when a printer has no extruder at all
 class DummyExtruder:

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -209,7 +209,7 @@ class PrinterExtruder:
             toolhead.set_extruder(self, 0.)
             gcode.register_command("M104", self.cmd_M104)
             gcode.register_command("M109", self.cmd_M109)
-            gcode.register_mux_command("SET_MAX_EXTRUDE_ONLY_ACCEL", "EXTRUDER", 
+            gcode.register_mux_command("SET_MAX_EXTRUDE_ONLY_ACCEL","EXTRUDER",
                                None, self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL,
                                desc=self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help)
 

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -44,7 +44,7 @@ class ExtruderStepper:
         gcode.register_mux_command("SYNC_STEPPER_TO_EXTRUDER", "STEPPER",
                                    self.name, self.cmd_SYNC_STEPPER_TO_EXTRUDER,
                                    desc=self.cmd_SYNC_STEPPER_TO_EXTRUDER_help)
-        
+
     def _handle_connect(self):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_step_generator(self.stepper.generate_steps)
@@ -209,9 +209,10 @@ class PrinterExtruder:
             toolhead.set_extruder(self, 0.)
             gcode.register_command("M104", self.cmd_M104)
             gcode.register_command("M109", self.cmd_M109)
-            gcode.register_mux_command("SET_MAX_EXTRUDE_ONLY_ACCEL", "EXTRUDER", None, self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL,
-                                   desc=self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help)
-            
+            gcode.register_mux_command("SET_MAX_EXTRUDE_ONLY_ACCEL", "EXTRUDER", 
+                               None, self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL,
+                               desc=self.cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help)
+
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
@@ -312,7 +313,6 @@ class PrinterExtruder:
         toolhead.flush_step_generation()
         toolhead.set_extruder(self, self.last_position)
         self.printer.send_event("extruder:activate_extruder")
-        
     cmd_SET_MAX_EXTRUDE_ONLY_ACCEL_help = "Set extruder max_extrude_only_accel"
     def cmd_SET_MAX_EXTRUDE_ONLY_ACCEL(self, gcmd):
         accel = gcmd.get_float("ACCEL", self.max_e_accel, above=0.)


### PR DESCRIPTION
extruder: add SET_MAX_EXTRUDE_ONLY_ACCEL command

This PR implements the command `SET_MAX_EXTRUDE_ONLY_ACCEL ACCEL=<float>`
which sets max_extrude_only_accel parameter of the currently active extruder
for use mainly with the TUNING_TOWER command. Tuning this parameter enables 
faster retractions and as such less pausing on retractions, leading to print
speed improvements. 

Signed-off-by: Patrick Bohn <patrick.bohn.pb@gmail.com>