### PR TITLE
Strip leading zeros from traditional gcode commands

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -135,6 +135,9 @@ class GCodeDispatch:
             if cmd in self.base_gcode_handlers:
                 del self.base_gcode_handlers[cmd]
             return old_cmd
+        if cmd != self.get_canonical_command(cmd):
+            raise self.printer.config_error(
+                "%s is not a canonical gcode command" % (cmd,))
         if cmd in self.ready_gcode_handlers:
             raise self.printer.config_error(
                 "gcode command %s already registered" % (cmd,))


### PR DESCRIPTION
Some tools such as gcodetools in Inkscape generate gcode commands that have been zero padded (e.g., G01). These commands are currently not handled by Klipper. It's technically possible to register custom macros that forward such "non-canonical" commands to their canonical command handler. However, that approach is very cumbersome and doesn't scale well.

This PR modifies Klippers gcode parser to introduce a notion of canonical gcode commands.  Such commands are upper case and in the case of traditional commands don't have any leading zeros. The command dispatcher has been modified to transform commands into their canonical form before looking up the corresponding handler. This ensures that tools that generate non-canonical gcode work as expected.

Additional, this PR introduces a change that prevents non-canonical commands from being registered with Klipper. This is mainly a safety mechanism to prevent unexpected behaviour when users have registered a non-canonical command.

This is a follow-up from https://github.com/Klipper3d/klipper/pull/6078 which was rejected in favour of this solution.