### PR TITLE
Allow specifying probe target location and moving until untriggered in PROBE command.

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -922,8 +922,11 @@ see the [probe calibrate guide](Probe_Calibrate.md)).
 #### PROBE
 `PROBE [PROBE_SPEED=<mm/s>] [LIFT_SPEED=<mm/s>] [SAMPLES=<count>]
 [SAMPLE_RETRACT_DIST=<mm>] [SAMPLES_TOLERANCE=<mm>]
-[SAMPLES_TOLERANCE_RETRIES=<count>] [SAMPLES_RESULT=median|average]`:
-Move the nozzle downwards until the probe triggers. If any of the
+[SAMPLES_TOLERANCE_RETRIES=<count>] [SAMPLES_RESULT=median|average]
+[TARGET_X=<pos>] [TARGET_Y=<pos>] [TARGET_Z=<pos>] [TRIGGERED=0]`:
+Move the nozzle until the probe triggers. By default the target is
+directly below the current position. If TRIGGERED=0 is specified then
+the nozzle will move until the probe becomes untriggered. If any of the
 optional parameters are provided they override their equivalent
 setting in the [probe config section](Config_Reference.md#probe).
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -351,10 +351,15 @@ is defined):
   during the last QUERY_PROBE command. Note, if this is used in a
   macro, due to the order of template expansion, the QUERY_PROBE
   command must be run prior to the macro containing this reference.
-- `last_z_result`: Returns the Z result value of the last PROBE
-  command. Note, if this is used in a macro, due to the order of
-  template expansion, the PROBE (or similar) command must be run prior
-  to the macro containing this reference.
+- `last_result`: Returns the result value of the last PROBE
+  command. It is possible to access the x, y, and z components of this
+  position (eg, `last_result.z`). Note, if this is used in a macro,
+  due to the order of template expansion, the PROBE (or similar) command
+  must be run prior to the macro containing this reference.
+- `last_z_result`: Returns only the z component of the `last_result`.
+  Note, if this is used in a macro, due to the order of template expansion,
+  the PROBE (or similar) command must be run prior to the macro containing
+  this reference.
 
 ## quad_gantry_level
 

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -239,17 +239,19 @@ class PrinterHoming:
                 raise self.printer.command_error(
                     "Homing failed due to printer shutdown")
             raise
-    def probing_move(self, mcu_probe, pos, speed):
+    def probing_move(self, mcu_probe, pos, speed, triggered=True):
         endstops = [(mcu_probe, "probe")]
         hmove = HomingMove(self.printer, endstops)
         try:
-            epos = hmove.homing_move(pos, speed, probe_pos=True)
+            epos = hmove.homing_move(pos, speed, probe_pos=True,
+                triggered=triggered)
         except self.printer.command_error:
             if self.printer.is_shutdown():
                 raise self.printer.command_error(
                     "Probing failed due to printer shutdown")
             raise
-        if hmove.check_no_movement() is not None:
+
+        if all([sp.start_pos == sp.trig_pos for sp in hmove.stepper_positions]):
             raise self.printer.command_error(
                 "Probe triggered prior to movement")
         return epos


### PR DESCRIPTION
CNC workflow can necessitate probing along the X or Y axis to determine the precise location of a workpiece.

This PR will allow implementation of the the commonly found G38.2-G38.5 codes via `gcode_macro`.
https://marlinfw.org/docs/gcode/G038.html
https://linuxcnc.org/docs/2.5/html/gcode/gcode.html#sec:G38-probe

Additional parameters `TARGET_X` `TARGET_Y` `TARGET_Z` and `TRIGGERED` have been added to the `PROBE` command.
Specifying a target will cause a move in a straight line towards the target. Retractions will move in the opposite direction.
Specifying `TRIGGERED=0` will move until the probe becomes untriggered (needed for G38.4 and G38.5)
Default probing behavior is unchanged.

Command output now includes more X and Y axis information.
Probe status object gains an additional `last_result` field. `last_z_result` is kept for backwards compatibility.

`TARGET_X` and friends ignore the gcode offset. I think that is appropriate, yes?

The `PROBE_ACCURACY` command does not currently gain this new functionality.

I'm not entirely happy with the parameter name `TRIGGERED`. I just copied the variable name from the existing code.
I'm open to suggestions.

edit: The build tests don't like that I'm using `numpy`. Hopefully the tester can have `numpy` installed?