### PR TITLE
Config: SKR3, update for second chip choice

### DIFF
--- a/config/generic-bigtreetech-skr-3.cfg
+++ b/config/generic-bigtreetech-skr-3.cfg
@@ -1,6 +1,8 @@
 # This file contains common pin mappings for the BigTreeTech SKR 3.
+# This board can ship with one of two chips, STM32H743 or STM32H723.
 # To use this config, during "make menuconfig" enable "low-level
-# options", "STM32H743", "128KiB bootloader", and "25MHz clock".
+# options", "STM32H743" or "STM32H723", "128KiB bootloader", 
+# and "25MHz clock".
 
 # See docs/Config_Reference.md for a description of parameters.
 

--- a/config/generic-bigtreetech-skr-3.cfg
+++ b/config/generic-bigtreetech-skr-3.cfg
@@ -1,7 +1,7 @@
 # This file contains common pin mappings for the BigTreeTech SKR 3.
 # This board can ship with one of two chips, STM32H743 or STM32H723.
 # To use this config, during "make menuconfig" enable "low-level
-# options", "STM32H743" or "STM32H723", "128KiB bootloader", 
+# options", "STM32H743" or "STM32H723", "128KiB bootloader",
 # and "25MHz clock".
 
 # See docs/Config_Reference.md for a description of parameters.


### PR DESCRIPTION
As found on the discord by user Qtin, this board now ships with one of STM32H743 or STM32H723 Example config updated to reflect this. This has been tested on the users board. To note, the H743 bin will flash to the H723 chip, but will not work.

Thanks
James

signed-off-by: James Hartley <james@hartleyns.com>