### PR TITLE
tmc5160: add  DRV_CONF Register for TMC5160

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3524,6 +3524,10 @@ run_current:
 #driver_SEDN: 0
 #driver_SEIMIN: 0
 #driver_SFILT: 0
+#driver_DRVSTRENGTH: 0
+#driver_BBMCLKS: 4
+#driver_BBMTIME: 0
+#driver_FILT_ISENSE: 0
 #   Set the given register during the configuration of the TMC5160
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -105,6 +105,13 @@ Fields["CHOPCONF"] = {
     "diss2g":                   0x01 << 30,
     "diss2vs":                  0x01 << 31
 }
+Fields["DRV_CONF"] = {
+    "bbmtime":                  0x1F << 0,
+    "bbmclks":                  0x0F << 8,
+    "otselect":                 0x03 << 16,
+    "drvstrength":              0x03 << 18,
+    "filt_isense":              0x03 << 20,
+}
 Fields["DRV_STATUS"] = {
     "sg_result":                0x3FF << 0,
     "s2vsa":                    0x01 << 12,
@@ -352,6 +359,11 @@ class TMC5160:
         set_config_field(config, "seimin", 0)
         set_config_field(config, "sgt", 0)
         set_config_field(config, "sfilt", 0)
+        #   DRV_CONF
+        set_config_field(config, "drvstrength", 0)
+        set_config_field(config, "bbmclks", 4)
+        set_config_field(config, "bbmtime", 0)
+        set_config_field(config, "filt_isense", 0)
         #   IHOLDIRUN
         set_config_field(config, "iholddelay", 6)
         #   PWMCONF


### PR DESCRIPTION
In some condition ，“drvstrength 2” does not work. According to page 17, some mosfets need “drvstrength” set to 0 .

signed-off-by:  Albert Lin   <vcore85@gmail.com>