### PR TITLE
tmc: external clock support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3052,6 +3052,9 @@ cs_pin:
 #   define the stepper position in the chain and the total chain length.
 #   Position 1 corresponds to the stepper that connects to the MOSI signal.
 #   The default is to not use an SPI daisy chain.
+#external_clock_frequency: 13200000
+#   Configure only if an external clock oscillator is connected to the TMC
+#   driver clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This interpolation does
@@ -3145,6 +3148,9 @@ uart_pin:
 #   A comma separated list of pins to set prior to accessing the
 #   tmc2208 UART. This may be useful for configuring an analog mux for
 #   UART communication. The default is to not configure any pins.
+#external_clock_frequency: 12000000
+#   Configure only if an external clock oscillator is connected to the TMC
+#   driver clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). This interpolation does
@@ -3197,6 +3203,9 @@ by the name of the corresponding stepper config section (for example,
 uart_pin:
 #tx_pin:
 #select_pins:
+#external_clock_frequency: 12000000
+#   Configure only if an external clock oscillator is connected to the TMC
+#   driver clock input.
 #interpolate: True
 run_current:
 #hold_current:
@@ -3333,6 +3342,9 @@ cs_pin:
 #   define the stepper position in the chain and the total chain length.
 #   Position 1 corresponds to the stepper that connects to the MOSI signal.
 #   The default is to not use an SPI daisy chain.
+#external_clock_frequency: 12500000
+#   Configure only if an external clock oscillator is connected to the TMC
+#   driver clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.
@@ -3453,6 +3465,9 @@ cs_pin:
 #   define the stepper position in the chain and the total chain length.
 #   Position 1 corresponds to the stepper that connects to the MOSI signal.
 #   The default is to not use an SPI daisy chain.
+#external_clock_frequency: 12000000
+#   Configure only if an external clock oscillator is connected to the TMC
+#   driver clock input.
 #interpolate: True
 #   If true, enable step interpolation (the driver will internally
 #   step at a rate of 256 micro-steps). The default is True.

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -6,7 +6,6 @@
 import math, logging
 from . import bus, tmc
 
-TMC_FREQUENCY=13200000.
 
 Registers = {
     "GCONF": 0x00, "GSTAT": 0x01, "IOIN": 0x04, "IHOLD_IRUN": 0x10,
@@ -282,10 +281,12 @@ class MCU_TMC_SPI:
 
 class TMC2130:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('external_clock_frequency',
+            13200000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, self.fields,
-                                   TMC_FREQUENCY)
+                                   self.tmc_frequency)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
@@ -296,7 +297,7 @@ class TMC2130:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -6,7 +6,6 @@
 import logging
 from . import tmc, tmc_uart, tmc2130
 
-TMC_FREQUENCY=12000000.
 
 Registers = {
     "GCONF": 0x00, "GSTAT": 0x01, "IFCNT": 0x02, "SLAVECONF": 0x03,
@@ -184,10 +183,12 @@ FieldFormatters.update({
 
 class TMC2208:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('external_clock_frequency',
+            12000000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 0,
-                                             TMC_FREQUENCY)
+                                             self.tmc_frequency)
         self.fields.set_field("pdn_disable", True)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
@@ -198,7 +199,7 @@ class TMC2208:
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import tmc2208, tmc2130, tmc, tmc_uart
 
-TMC_FREQUENCY=12000000.
 
 Registers = dict(tmc2208.Registers)
 Registers.update({
@@ -55,11 +54,13 @@ FieldFormatters = dict(tmc2208.FieldFormatters)
 
 class TMC2209:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('external_clock_frequency',
+            12000000., minval=4000000., maxval=16000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, tmc2208.SignedFields,
                                       FieldFormatters)
         self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields, 3,
-                                             TMC_FREQUENCY)
+                                             self.tmc_frequency)
         # Setup fields for UART
         self.fields.set_field("pdn_disable", True)
         self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart
@@ -74,7 +75,7 @@ class TMC2209:
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)
         self.fields.set_field("multistep_filt", True)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         # CHOPCONF

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -7,7 +7,6 @@
 import math, logging
 from . import bus, tmc, tmc2130
 
-TMC_FREQUENCY=12500000.
 
 Registers = {
     "GCONF":            0x00,
@@ -341,10 +340,12 @@ class TMC2240CurrentHelper:
 
 class TMC2240:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('external_clock_frequency',
+            12500000., minval=8000000., maxval=20000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
-                                           TMC_FREQUENCY)
+                                           self.tmc_frequency)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
@@ -357,7 +358,7 @@ class TMC2240:
         self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
         self.fields.set_config_field(config, "offset_sin90", 0)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         #   CHOPCONF
         set_config_field = self.fields.set_config_field
         set_config_field(config, "toff", 3)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -6,7 +6,6 @@
 import math, logging
 from . import bus, tmc, tmc2130
 
-TMC_FREQUENCY=12000000.
 
 Registers = {
     "GCONF":            0x00,
@@ -314,10 +313,12 @@ class TMC5160CurrentHelper:
 
 class TMC5160:
     def __init__(self, config):
+        self.tmc_frequency = config.getfloat('external_clock_frequency',
+            12000000., minval=4000000., maxval=18000000.)
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
         self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
-                                           TMC_FREQUENCY)
+                                           self.tmc_frequency)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
@@ -329,7 +330,7 @@ class TMC5160:
         # Setup basic register values
         self.fields.set_field("multistep_filt", True)
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, self.tmc_frequency)
         set_config_field = self.fields.set_config_field
         #   CHOPCONF
         set_config_field(config, "toff", 3)


### PR DESCRIPTION
Allow the clock frequency of the tmc driver to be specified in case the user uses an external clock oscillator for the driver so that the velocity based thresholds are calculated correctly.
If the external clock frequency is not specified, it is assumed that the internal clock is the one that is used, so the old behaviour is preserved. The valid range for the clock frequency was set according to the datasheet electrical characteristics values.

In terms of hardware support, the Prusa MK3.5, MK3.9, MK4 and XL need this change since they all use a shared 16MHz external clock for the TMC drivers. Without this change, all velocity based thresholds are calculated incorrectly. There is also support for an external clock with the SilentStepStick TMC5160 v1.3, but I doubt anyone is using that hardware configuration.