### PR TITLE
Improve json encoding error handling

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -268,8 +268,14 @@ class ClientConnection:
         self.send(result)
 
     def send(self, data):
-        jmsg = json.dumps(data, separators=(',', ':'))
-        self.send_buffer += jmsg.encode() + b"\x03"
+        try:
+            jmsg = json.dumps(data, separators=(',', ':'))
+            self.send_buffer += jmsg.encode() + b"\x03"
+        except (TypeError, ValueError) as e:
+            msg = ("json encoding error: %s" % (str(e),))
+            logging.exception(msg)
+            self.printer.invoke_shutdown(msg)
+            return
         if not self.is_blocking:
             self._do_send()
 


### PR DESCRIPTION
Json encoding errors currently force a shutdown with no context as to why. This can be verified by adding the following to a config, which triggers a silent TypeError:

```
[gcode_macro crasher]
variable_crash: {(1, 1): 1}
gcode:
    # empty
```

This change just logs the error (including a console message) so it's easier to diagnose what went wrong. In the case of the above error, the message is:

```
json encoding error: keys must be str, int, float, bool or None, not tuple
```

_**Edit:** Also added code to prevent setting bad variables inside `gcode_macro.py`._