### PR TITLE
Function and parameters for retraction and dwell after homing

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -188,6 +188,16 @@ position_max:
 #second_homing_speed:
 #   Velocity (in mm/s) of the stepper when performing the second home.
 #   The default is homing_speed/2.
+#homing_retract_after: 0.
+#   Distance to backoff (in mm) after homing to prevent carriage lock
+#   in corexy machines. The home retract after variable uses the same
+#   homing_retract_speed as homing_retract_dist variable adjust speed.
+#   Set this to zero to disable the retract.
+#   The default is 0mm.
+#homing_retract_dwell: 0.
+#   Seconds dwell time after retract to prevent triggering when homing
+#   multiple axes at the same time in sensorless in corexy machines
+#   The default is 0 seconds
 #homing_positive_dir:
 #   If true, homing will cause the stepper to move in a positive
 #   direction (away from zero); if false, home towards zero. It is

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -204,6 +204,18 @@ class Homing:
                 raise self.printer.command_error(
                     "Endstop %s still triggered after retract"
                     % (hmove.check_no_movement(),))
+        # Trigger a retract after homing to prevent CORExy locking up if set
+        if hi.homing_retract_after:
+            # Retract after finished homing
+            startpos = self._fill_coord(forcepos)
+            homepos = self._fill_coord(movepos)
+            axes_d = [hp - sp for hp, sp in zip(homepos, startpos)]
+            move_d = math.sqrt(sum([d*d for d in axes_d[:3]]))
+            retract_r = min(1., hi.homing_retract_after / move_d)
+            retractpos = [hp - ad * retract_r
+                          for hp, ad in zip(homepos, axes_d)]
+            self.toolhead.move(retractpos, hi.retract_speed)
+            self.toolhead.dwell(hi.homing_retract_dwell)
         # Signal home operation complete
         self.toolhead.flush_step_generation()
         self.trigger_mcu_pos = {sp.stepper_name: sp.trig_pos

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -334,6 +334,10 @@ class PrinterRail:
             'homing_retract_speed', self.homing_speed, above=0.)
         self.homing_retract_dist = config.getfloat(
             'homing_retract_dist', 5., minval=0.)
+        self.homing_retract_after= config.getfloat(
+            'homing_retract_after', 0., minval=0.)
+        self.homing_retract_dwell= config.getfloat(
+            'homing_retract_dwell', 0., minval=0.)
         self.homing_positive_dir = config.getboolean(
             'homing_positive_dir', None)
         if self.homing_positive_dir is None:
@@ -359,10 +363,12 @@ class PrinterRail:
     def get_homing_info(self):
         homing_info = collections.namedtuple('homing_info', [
             'speed', 'position_endstop', 'retract_speed', 'retract_dist',
-            'positive_dir', 'second_homing_speed'])(
+            'positive_dir', 'second_homing_speed','homing_retract_after',
+            'homing_retract_dwell'])(
                 self.homing_speed, self.position_endstop,
                 self.homing_retract_speed, self.homing_retract_dist,
-                self.homing_positive_dir, self.second_homing_speed)
+                self.homing_positive_dir, self.second_homing_speed,
+                self.homing_retract_after,self.homing_retract_dwell)
         return homing_info
     def get_steppers(self):
         return list(self.steppers)


### PR DESCRIPTION
Now with "signed off by" commit messages

Adding parameters you can use in printer.cfg to retract toolhead by a specific distance after homing, this is quite importent in sensorless corexy devices because they will experience lockup if you home the y axis with the x axis in connection with the frame (or the other way around), It allso includes a dwell time you can set to prevent retriggering of the other axis which can happen if the next axis starts homing just as the first axis retract is settling. This gives you an easy way to retract the axis before it homes the next one without making a custom homing script.