### PR TITLE
Add modules Recore and Thermocouple, add config files for Recore A6 and A7

### DIFF
--- a/config/generic-recore-a6.cfg
+++ b/config/generic-recore-a6.cfg
@@ -1,0 +1,234 @@
+# Generic Recore A6 config
+
+#[include mainsail.cfg]
+
+[recore]
+revision: A6
+gain_t0: 1
+gain_t1: 1
+gain_t2: 1
+gain_t3: 1
+pullup_t0: 1
+pullup_t1: 1
+pullup_t2: 1
+pullup_t3: 1
+offset_t0: 0
+offset_t1: 0
+offset_t2: 0
+offset_t3: 0
+
+# The STM32F031 mcu
+[mcu]
+serial: /dev/ttyS4
+baud: 250000
+restart_method: command
+
+# The AR100 mcu
+[mcu ar100]
+serial: /dev/ttyS1
+baud: 1500000
+
+[static_digital_output endstops_5V_enable]
+pins: ar100:PF2
+
+# pin high = 12V, pin low = 5V
+[static_digital_output endstop_ES0_5V_12V]
+pins: !ar100:PF0
+
+[static_digital_output temperature_5V_enable]
+pins: ar100:PF1
+
+[static_digital_output user_led_enable]
+pins: PA12
+
+# Load "thermocouple" sensor
+[thermocouple]
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[tmc2209 stepper_x]
+uart_pin: ar100:PB1
+tx_pin: ar100:PB0
+uart_address: 0
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_y]
+uart_pin: ar100:PB1
+tx_pin: ar100:PB0
+uart_address: 1
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_z]
+uart_pin: ar100:PB1
+tx_pin: ar100:PB0
+uart_address: 2
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 extruder]
+uart_pin: ar100:PB1
+tx_pin: ar100:PB0
+uart_address: 3
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_x]
+step_pin: ar100:PL4
+dir_pin: ar100:PE8
+endstop_pin: !ar100:PH4
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[stepper_y]
+step_pin: ar100:PL5
+dir_pin: ar100:PE9
+endstop_pin: !ar100:PH5
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[stepper_z]
+step_pin: ar100:PL6
+dir_pin: ar100:PE10
+endstop_pin: !ar100:PH6
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[extruder]
+step_pin: ar100:PL7
+dir_pin: ar100:PE11
+heater_pin: PA8
+sensor_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+
+[extruder1]
+step_pin: ar100:PL8
+dir_pin: ar100:PE12
+heater_pin: PA9
+sensor_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+[extruder2]
+step_pin: ar100:PL9
+dir_pin: ar100:PE13
+heater_pin: PA10
+sensor_pin: PA2
+sensor_type: EPCOS 100K B57560G104F
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+[heater_bed]
+heater_pin: PA11
+sensor_pin: PA3
+sensor_type: EPCOS 100K B57560G104F
+control: watermark
+min_temp: -272
+max_temp: 300
+
+[fan]
+pin: PB0
+
+[output_pin fan1]
+pin: PB1
+
+[output_pin fan2]
+pin: PB5
+
+# Set up board voltage, current, temperature.
+
+[temperature_fan board]
+pin: PB4
+min_temp: 0
+max_temp: 100
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+control: watermark
+gcode_id: Board
+target_temp: 50
+
+[temperature_sensor cold_junction]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+gcode_id: CJ
+
+# Vout = Vin * 10K/110K = Vin*11
+[adc_temperature v]
+temperature1: 0.35
+voltage1: 0
+temperature2: 36.65
+voltage2: 3.3
+
+[temperature_sensor voltage]
+adc_voltage: 3.3
+sensor_pin: PA4
+sensor_type: v
+gcode_id: Voltage
+
+# 1 A = 20 mV
+[adc_temperature current]
+temperature1: 0
+voltage1: 0
+temperature2: 165
+voltage2: 3.3
+
+[temperature_sensor current]
+adc_voltage: 3.3
+sensor_pin: PA5
+sensor_type: current
+max_temp: 20
+gcode_id: Current
+
+[gcode_button over_current_alarm]
+pin: !ar100:PF6
+press_gcode: M112

--- a/config/generic-recore-a7.cfg
+++ b/config/generic-recore-a7.cfg
@@ -1,0 +1,242 @@
+# Generic Recore A7 config
+
+#[include mainsail.cfg]
+
+[recore]
+revision: A7
+gain_t0: 1
+gain_t1: 1
+gain_t2: 1
+gain_t3: 1
+pullup_t0: 1
+pullup_t1: 1
+pullup_t2: 1
+pullup_t3: 1
+offset_t0: 0
+offset_t1: 0
+offset_t2: 0
+offset_t3: 0
+
+# The STM32F031 mcu
+[mcu]
+serial: /dev/ttyS2
+baud: 250000
+restart_method: command
+
+# The AR100 mcu
+[mcu ar100]
+serial: /dev/ttyS1
+baud: 1500000
+
+[static_digital_output endstops_5V_enable]
+pins: ar100:PF2
+
+# pin high = 12V, pin low = 5V
+[static_digital_output endstop_ES0_5V_12V]
+pins: !ar100:PF0
+
+[static_digital_output temperature_5V_enable]
+pins: ar100:PF1
+
+[static_digital_output user_led_enable]
+pins: PA12
+
+# Load "thermocouple" sensor
+[thermocouple]
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[tmc2209 stepper_x]
+uart_pin: ar100:PE16
+uart_address: 0
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_y]
+uart_pin: ar100:PE16
+uart_address: 1
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 stepper_z]
+uart_pin: ar100:PE16
+uart_address: 2
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[tmc2209 extruder]
+uart_pin: ar100:PE16
+uart_address: 3
+run_current: 0.500
+hold_current: 0.500
+stealthchop_threshold: 250
+
+[stepper_x]
+step_pin: ar100:PL4
+dir_pin: ar100:PE8
+endstop_pin: !ar100:PH4
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[stepper_y]
+step_pin: ar100:PL5
+dir_pin: ar100:PE9
+endstop_pin: !ar100:PH5
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[stepper_z]
+step_pin: ar100:PL6
+dir_pin: ar100:PE10
+endstop_pin: !ar100:PH6
+rotation_distance: 40
+microsteps: 16
+position_endstop: 0
+position_max: 200
+homing_speed: 2.0
+
+[extruder]
+step_pin: ar100:PL7
+dir_pin: ar100:PE11
+heater_pin: PA8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA0
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+[extruder1]
+step_pin: ar100:PL8
+dir_pin: ar100:PE12
+heater_pin: PA9
+sensor_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+[extruder2]
+step_pin: ar100:PL9
+dir_pin: ar100:PE13
+heater_pin: PA10
+sensor_pin: PA2
+sensor_type: EPCOS 100K B57560G104F
+rotation_distance: 40
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_extrude_temp: 30
+min_temp: -272
+max_temp: 300
+
+[heater_bed]
+heater_pin: PA11
+sensor_pin: PA3
+sensor_type: EPCOS 100K B57560G104F
+control: watermark
+min_temp: -272
+max_temp: 300
+
+[fan]
+pin: PF0
+
+[output_pin fan1]
+pin: PB1
+
+[output_pin fan2]
+pin: PB5
+
+# Set up board voltage, current, temperature.
+
+[temperature_fan board]
+pin: PB4
+min_temp: 0
+max_temp: 100
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA6
+control: watermark
+gcode_id: Board
+target_temp: 50
+
+[temperature_sensor cold_junction]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA7
+gcode_id: CJ
+
+# Vout = Vin * 10K/110K = Vin*11
+[adc_temperature v]
+temperature1: 0.35
+voltage1: 0
+temperature2: 36.65
+voltage2: 3.3
+
+[temperature_sensor voltage]
+adc_voltage: 3.3
+sensor_pin: PA4
+sensor_type: v
+gcode_id: Voltage
+
+# 1 A = 20 mV
+[adc_temperature current]
+temperature1: 0
+voltage1: 0
+temperature2: 165
+voltage2: 3.3
+
+[temperature_sensor current]
+adc_voltage: 3.3
+sensor_pin: PA5
+sensor_type: current
+max_temp: 20
+gcode_id: Current
+
+[adc_temperature fan_current]
+temperature1: 0
+voltage1: 0
+temperature2: 33
+voltage2: 3.3
+
+[temperature_sensor fan_current]
+adc_voltage: 3.3
+sensor_pin: PB0
+sensor_type: fan_current
+max_temp: 2.0
+gcode_id: FanCurrent
+
+[gcode_button over_current_alarm]
+pin: !ar100:PF6
+press_gcode: M112

--- a/klippy/extras/recore.py
+++ b/klippy/extras/recore.py
@@ -1,0 +1,97 @@
+# Config for Recore,
+#
+# Copyright (C) 2017-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2023  Elias Bakken <elias@iagent.no>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging, os
+import pins, mcu
+
+pins = {
+    "A7": {
+        'enable_pin': 'ar100:PF5',
+        'oc_reset_pin': 'ar100:PF4',
+        'gain_enable_t0': 'ar100:PD4',
+        'gain_enable_t1': 'ar100:PH11',
+        'gain_enable_t2': 'ar100:PE17',
+        'gain_enable_t3': 'ar100:PB2',
+        'pullup_t0': 'ar100:PG10',
+        'pullup_t1': 'ar100:PG11',
+        'pullup_t2': 'ar100:PG12',
+        'pullup_t3': 'ar100:PG13',
+        'offset_t0': 'ar100:PG0',
+        'offset_t1': 'ar100:PG1',
+        'offset_t2': 'ar100:PG2',
+        'offset_t3': 'ar100:PG3'
+    }
+}
+
+
+class recore:
+    def __init__(self, config):
+        printer = config.get_printer()
+        ppins = printer.lookup_object('pins')
+        ppins.register_chip('recore', self)
+        revisions = {'A6':'A6', 'A7':'A7'}
+        self.revision = config.getchoice('revision', revisions)
+
+        pins["A6"] = pins["A7"]
+        # Setup enable pin
+        enable_pin = config.get('enable_pin',
+                                pins[self.revision]['enable_pin'])
+        mcu_power_enable = ppins.setup_pin('digital_out', enable_pin)
+        mcu_power_enable.setup_start_value(start_value=0.,
+                                           shutdown_value=1.,
+                                           is_static=False)
+        mcu_power_enable.setup_max_duration(0.)
+
+        # Reset over current alarm
+        oc_reset_pin = config.get('oc_reset_pin',
+                                  pins[self.revision]['oc_reset_pin'])
+        oc_reset = ppins.setup_pin('digital_out', oc_reset_pin)
+        mcu = oc_reset.get_mcu()
+        pin = oc_reset._pin
+        mcu.add_config_cmd("set_digital_out pin=%s value=%d" % (pin, 0), True)
+        mcu.add_config_cmd("set_digital_out pin=%s value=%d" % (pin, 1), True)
+
+        for idx in range(4):
+            gain = config.get('gain_t' + str(idx), '1')
+            if gain not in ['1', '100']:
+                raise Exception("Gain not 1 or 100")
+            pin_name = pins[self.revision]['gain_enable_t' + str(idx)]
+            if gain == '1':
+                # Set pin to input
+                pin = ppins.setup_pin('endstop', pin_name)
+            else:
+                pin = ppins.setup_pin('digital_out', pin_name)
+                value = 1.0
+                pin.setup_start_value(start_value=value,
+                                      shutdown_value=value,
+                                      is_static=True)
+
+            pullup = config.get('pullup_t' + str(idx), '1')
+            if pullup not in ['0', '1']:
+                raise Exception("Pullup not 0 or 1")
+            pin_name = pins[self.revision]['pullup_t' + str(idx)]
+            if pullup == '0':
+                pin = ppins.setup_pin('endstop', pin_name)
+            else:
+                pin = ppins.setup_pin('digital_out', pin_name)
+                pin.setup_start_value(start_value=1.,
+                                      shutdown_value=1.,
+                                      is_static=True)
+            offset = config.get('offset_t' + str(idx), '1')
+            if offset not in ['0', '1']:
+                raise Exception("Offset not 0 or 1")
+            pin_name = pins[self.revision]['offset_t' + str(idx)]
+            if offset == '0':
+                pin = ppins.setup_pin('endstop', pin_name)
+            else:
+                pin = ppins.setup_pin('digital_out', pin_name)
+                pin.setup_start_value(start_value=1.,
+                                      shutdown_value=1.,
+                                      is_static=True)
+
+
+def load_config(config):
+    return recore(config)

--- a/klippy/extras/thermocouple.py
+++ b/klippy/extras/thermocouple.py
@@ -1,0 +1,85 @@
+# Temperature measurements with thermocouples. Only support for Type K for now.
+# Cold junction compensation
+#
+# Copyright (C) 2021  Elias Bakken <elias@iagent.no>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math, logging
+from . import adc_temperature
+
+TYPE_K_COEFFEICIENTS = [
+    0.000000E+00, 2.508355E+01, 7.860106E-02, -2.503131E-01, 8.315270E-02,
+    -1.228034E-02, 9.804036E-04, -4.413030E-05, 1.057734E-06, -1.052755E-08
+]
+TYPE_K_INVERSE = [
+    -0.176004136860E-01, 0.389212049750E-01, 0.185587700320E-04,
+    -0.994575928740E-07, 0.318409457190E-09, -0.560728448890E-12,
+    0.560750590590E-15, -0.320207200030E-18, 0.971511471520E-22,
+    -0.121047212750E-25
+]
+TYPE_K_A = [0.118597600000E+00, -0.118343200000E-03, 0.126968600000E+03]
+
+
+# Analog voltage to temperature converter for thermocouple
+class Thermocouple:
+    def __init__(self, gain, offset, vin, cj_temp):
+        self.gain = gain
+        self.offset = offset
+        self.vin = vin
+        self.cj_temp = cj_temp
+
+    def get_exp(self, temp):
+        return TYPE_K_A[0] * math.exp(TYPE_K_A[1] * (temp - TYPE_K_A[2])**2)
+
+    def v_to_temp(self, v):
+        return sum([
+            coeff * (v * 1000.0)**n
+            for n, coeff in enumerate(TYPE_K_COEFFEICIENTS)
+        ])
+
+    def temp_to_v(self, temp):
+        return 0.001 * (sum([(coeff * temp**n)
+                             for n, coeff in enumerate(TYPE_K_INVERSE)]) +
+                        self.get_exp(temp))
+
+    def calc_temp(self, adc):
+        adc_val = max(.00001, min(.99999, adc))
+        v_adc = self.vin * adc_val
+        v_opamp = v_adc / self.gain
+        v_in = (v_opamp - self.offset)
+        cj_temp = self.cj_temp.get_temp(0)[0]
+        v_cj = self.temp_to_v(cj_temp)
+        temp = self.v_to_temp(v_in + v_cj)
+        return temp
+
+    # We do not know the cj temp at the time of setting limits, setting to 30
+    def calc_adc(self, temp):
+        cj_temp = 30
+        v_in = self.temp_to_v(temp - cj_temp)
+        v_opamp = v_in + self.offset
+        v_adc = (v_opamp * self.gain)
+        adc_val = v_adc / self.vin
+        adc_val = max(.00001, min(.99999, adc_val))
+        return adc_val
+
+
+# Create an ADC converter with a thermocouple
+def PrinterThermocouple(config):
+    gain = config.getfloat('gain', 101.0)
+    offset = config.getfloat('offset', 0.0033)
+    vin = config.getfloat('adc_voltage', 3.3)
+    cj_sensor = config.get('cj_sensor', 'temperature_sensor cold_junction')
+    cj_temp = config.get_printer().load_object(config, cj_sensor)
+    thermocouple = Thermocouple(gain, offset, vin, cj_temp)
+    return adc_temperature.PrinterADCtoTemperature(config, thermocouple)
+
+
+# Default sensors
+Sensors = ["Type K"]
+
+
+def load_config(config):
+    pheaters = config.get_printer().load_object(config, "heaters")
+    for sensor_type in Sensors:
+        func = (lambda config: PrinterThermocouple(config))
+        pheaters.add_sensor_factory(sensor_type, func)


### PR DESCRIPTION
This is the final PR for adding full upstream support for Recore boards revision A6 and A7. 
The PR adds a module called recore that enables the high power input section on the board and sets up the temperature sections for either thermistor (gain 1) or thermocouple (gain 100). There is also support for programming the pull-up and adding a voltage offset. These settings are necessary in order to allow both a thermistor and a thermocouple to be used on the same inputs. The thermocouple modules adds the necessary calculations for type K thermocouples. 