### PR TITLE
Add printer configuration for Anycubic Kobra Go

### DIFF
--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -9,7 +9,7 @@
 # Installation:
 #  1. Rename the klipper bin to `firmware.bin` and copy it to an SD Card.
 #  2. Power off the Printer, insert the SD Card and power it on.
-#  3. The the LCD will be stuck on the Firmware-update screen. 
+#  3. The the LCD will be stuck on the Firmware-update screen.
 #     Just Wait for 3-5 minutes to ensure the firmware is flashed.
 #  4. After waiting, shutdown the printer and remove the SD Card.
 
@@ -138,9 +138,9 @@ pin: PB13
 
 [fan]
 pin: PB5
-#cycle_time: 0.0000318471 #This may be needed for the part fan. 
+#cycle_time: 0.0000318471 #This may be needed for the part fan.
                           #According to some users, the default value of klipper may kill the fan.
 
-[output_pin enable_pin] 
+[output_pin enable_pin]
 pin: PB6 #This pin enables the bed, hotend, extruder fan, part fan.
 static_value: 1

--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -108,16 +108,15 @@ z_hop_speed: 15
 
 [controller_fan controller_fan]
 pin: PB12
+cycle_time: 0.00005 #20kHz
 
 [heater_fan extruder_fan]
 pin: PB13
+cycle_time: 0.00005
 
 [fan]
 pin: PB5
-cycle_time: 0.0000318471
-    #This cycle_time may be needed for the part fan.
-    #According to some users,
-    #the default value of klipper may kill the fan.
+cycle_time: 0.00005
 
 [output_pin enable_pin]
 pin: PB6

--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -108,15 +108,13 @@ z_hop_speed: 15
 
 [controller_fan controller_fan]
 pin: PB12
-cycle_time: 0.00005 #20kHz
 
 [heater_fan extruder_fan]
 pin: PB13
-cycle_time: 0.00005
 
 [fan]
 pin: PB5
-cycle_time: 0.00005
+cycle_time: 0.00005 #20kHz
 
 [output_pin enable_pin]
 pin: PB6

--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -1,0 +1,146 @@
+# This file contains a configuration for the Anycubic Kobra Go printer.
+#
+# See docs/Config_Reference.md for a description of parameters.
+#
+# To build the firmware, use the following configuration:
+#   - Micro-controller: Huada Semiconductor HC32F460
+#   - Communication interface: Serial (PA3 & PA2) - Anycubic
+#
+# Installation:
+#  1. Rename the klipper bin to `firmware.bin` and copy it to an SD Card.
+#  2. Power off the Printer, insert the SD Card and power it on.
+#  3. The the LCD will be stuck on the Firmware-update screen. 
+#     Just Wait for 3-5 minutes to ensure the firmware is flashed.
+#  4. After waiting, shutdown the printer and remove the SD Card.
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 1000
+max_z_velocity: 40
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PA12
+dir_pin: PA11
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 40
+position_endstop: -13
+position_min:-13
+position_max: 237.5
+homing_speed: 65
+endstop_pin: !PH2
+homing_retract_dist: 0
+
+[stepper_y]
+step_pin: PA9
+dir_pin: PA8
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 40
+position_endstop: -8
+position_min:-8
+position_max: 233
+homing_speed: 65
+endstop_pin: ^!PC13
+homing_retract_dist: 0
+
+[stepper_z]
+step_pin: PC7
+dir_pin: !PC6
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PC14
+position_min: -1
+position_max: 255
+position_endstop: 7 # A safe distance for the default nozzle, some custom adjustment is needed.
+homing_speed: 10
+second_homing_speed:2
+homing_retract_dist: 2
+
+[safe_z_home]
+home_xy_position: 20, 20
+speed: 65
+z_hop: 10
+z_hop_speed: 15
+
+[extruder]
+max_extrude_only_distance: 100.0
+max_extrude_only_velocity: 60
+max_extrude_only_accel: 1000
+step_pin: PB15
+dir_pin: PB14
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 31.07
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB8
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PC3
+min_extrude_temp: 170
+min_temp: 0
+max_temp: 250
+control: pid
+pid_kp: 20.559
+pid_ki: 1.071
+pid_kd: 98.683
+pressure_advance: 0.1 #This is a great start for PLA
+
+[firmware_retraction]
+retract_length: 6
+retract_speed: 45
+unretract_extra_length: 0.1
+unretract_speed: 45
+
+[heater_bed]
+heater_pin: PB9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC1
+min_temp: 0
+max_temp: 120
+control: pid
+pid_kp: 60.325
+pid_ki: 1.010
+pid_kd: 900.345
+
+[bed_mesh]
+speed: 200
+horizontal_move_z: 2.5
+mesh_min: 5, 5
+mesh_max: 214, 214
+probe_count: 6, 6
+algorithm: bicubic
+
+[probe]
+pin: PA1
+x_offset: -20.8
+y_offset: 0
+z_offset: 2
+samples: 3
+samples_result: average
+samples_tolerance_retries: 3
+sample_retract_dist: 0.3
+speed: 1
+lift_speed: 5
+
+[controller_fan controller_fan]
+pin: PB12
+
+[heater_fan extruder_fan]
+pin: PB13
+
+[fan]
+pin: PB5
+#cycle_time: 0.0000318471 #This may be needed for the part fan. 
+                          #According to some users, the default value of klipper may kill the fan.
+
+[output_pin enable_pin] 
+pin: PB6 #This pin enables the bed, hotend, extruder fan, part fan.
+static_value: 1

--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -55,8 +55,7 @@ dir_pin: PB14
 enable_pin: !PA15
 microsteps: 16
 rotation_distance: 31.07
-max_extrude_only_distance: 100.0
-max_extrude_only_velocity: 60
+max_extrude_only_velocity: 25
 max_extrude_only_accel: 1000
 nozzle_diameter: 0.400
 filament_diameter: 1.750
@@ -86,15 +85,14 @@ pid_kd: 1675.16
 speed: 200
 horizontal_move_z: 2.5
 mesh_min: 5, 5
-mesh_max: 214, 214
-probe_count: 6, 6
-algorithm: bicubic
+mesh_max: 217.2, 207.8
+probe_count: 5, 5
 
 [probe]
 pin: PA1
 x_offset: -20.8
 y_offset: 0
-z_offset: 2
+z_offset: 0
 samples: 3
 samples_result: average
 samples_tolerance_retries: 3
@@ -104,7 +102,7 @@ lift_speed: 4
 
 [safe_z_home]
 home_xy_position: 0, 0
-speed: 30
+speed: 5
 z_hop: 10
 z_hop_speed: 15
 
@@ -132,7 +130,7 @@ restart_method: command
 
 [printer]
 kinematics: cartesian
-max_velocity: 500
-max_accel: 1000
-max_z_velocity: 40
+max_velocity: 300
+max_accel: 500
+max_z_velocity: 4
 max_z_accel: 100

--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -13,29 +13,17 @@
 #     Just Wait for 3-5 minutes to ensure the firmware is flashed.
 #  4. After waiting, shutdown the printer and remove the SD Card.
 
-[mcu]
-serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
-restart_method: command
-
-[printer]
-kinematics: cartesian
-max_velocity: 500
-max_accel: 1000
-max_z_velocity: 40
-max_z_accel: 100
-
 [stepper_x]
 step_pin: PA12
 dir_pin: PA11
 enable_pin: !PA15
 microsteps: 16
 rotation_distance: 40
+endstop_pin: !PH2
 position_endstop: -13
 position_min:-13
-position_max: 237.5
-homing_speed: 65
-endstop_pin: !PH2
-homing_retract_dist: 0
+position_max: 238
+homing_speed: 50
 
 [stepper_y]
 step_pin: PA9
@@ -43,12 +31,11 @@ dir_pin: PA8
 enable_pin: !PA15
 microsteps: 16
 rotation_distance: 40
-position_endstop: -8
-position_min:-8
-position_max: 233
-homing_speed: 65
 endstop_pin: ^!PC13
-homing_retract_dist: 0
+position_endstop: -9
+position_min:-9
+position_max: 238
+homing_speed: 50
 
 [stepper_z]
 step_pin: PC7
@@ -57,28 +44,20 @@ enable_pin: !PA15
 microsteps: 16
 rotation_distance: 8
 endstop_pin: ^PC14
-position_min: -1
-position_max: 255
-position_endstop: 7 # A safe distance for the default nozzle, some custom adjustment is needed.
-homing_speed: 10
-second_homing_speed:2
-homing_retract_dist: 2
-
-[safe_z_home]
-home_xy_position: 20, 20
-speed: 65
-z_hop: 10
-z_hop_speed: 15
+position_endstop: 0
+position_min: -10
+position_max: 250
+homing_speed: 5
 
 [extruder]
-max_extrude_only_distance: 100.0
-max_extrude_only_velocity: 60
-max_extrude_only_accel: 1000
 step_pin: PB15
 dir_pin: PB14
 enable_pin: !PA15
 microsteps: 16
 rotation_distance: 31.07
+max_extrude_only_distance: 100.0
+max_extrude_only_velocity: 60
+max_extrude_only_accel: 1000
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB8
@@ -88,16 +67,9 @@ min_extrude_temp: 170
 min_temp: 0
 max_temp: 250
 control: pid
-pid_kp: 20.559
-pid_ki: 1.071
-pid_kd: 98.683
-pressure_advance: 0.1 #This is a great start for PLA
-
-[firmware_retraction]
-retract_length: 6
-retract_speed: 45
-unretract_extra_length: 0.1
-unretract_speed: 45
+pid_kp: 19.56
+pid_ki: 1.62
+pid_kd: 200.00
 
 [heater_bed]
 heater_pin: PB9
@@ -106,9 +78,9 @@ sensor_pin: PC1
 min_temp: 0
 max_temp: 120
 control: pid
-pid_kp: 60.325
-pid_ki: 1.010
-pid_kd: 900.345
+pid_kp: 97.1
+pid_ki: 1.41
+pid_kd: 1675.16
 
 [bed_mesh]
 speed: 200
@@ -126,9 +98,15 @@ z_offset: 2
 samples: 3
 samples_result: average
 samples_tolerance_retries: 3
-sample_retract_dist: 0.3
-speed: 1
-lift_speed: 5
+sample_retract_dist: 0.5
+speed: 2
+lift_speed: 4
+
+[safe_z_home]
+home_xy_position: 0, 0
+speed: 30
+z_hop: 10
+z_hop_speed: 15
 
 [controller_fan controller_fan]
 pin: PB12
@@ -138,9 +116,23 @@ pin: PB13
 
 [fan]
 pin: PB5
-#cycle_time: 0.0000318471 #This may be needed for the part fan.
-                          #According to some users, the default value of klipper may kill the fan.
+cycle_time: 0.0000318471
+    #This cycle_time may be needed for the part fan.
+    #According to some users,
+    #the default value of klipper may kill the fan.
 
 [output_pin enable_pin]
-pin: PB6 #This pin enables the bed, hotend, extruder fan, part fan.
+pin: PB6
 static_value: 1
+    #This pin enables the bed, hotend, extruder fan, part fan.
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 1000
+max_z_velocity: 40
+max_z_accel: 100

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -257,8 +257,8 @@ CONFIG ../../config/generic-bigtreetech-skr-pico-v1.0.cfg
 
 # Anycubic Printers using trigorilla board with the hc32f460
 DICTIONARY hc32f460-serial-PA3PA2.dict
-CONFIG ../../config/printer-anycubic-kobra-plus-2022.cfg
 CONFIG ../../config/printer-anycubic-kobra-go-2022.cfg
+CONFIG ../../config/printer-anycubic-kobra-plus-2022.cfg
 
 # Printers using the PRU
 DICTIONARY pru.dict host=linuxprocess.dict

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -258,6 +258,7 @@ CONFIG ../../config/generic-bigtreetech-skr-pico-v1.0.cfg
 # Anycubic Printers using trigorilla board with the hc32f460
 DICTIONARY hc32f460-serial-PA3PA2.dict
 CONFIG ../../config/printer-anycubic-kobra-plus-2022.cfg
+CONFIG ../../config/printer-anycubic-kobra-go-2022.cfg
 
 # Printers using the PRU
 DICTIONARY pru.dict host=linuxprocess.dict


### PR DESCRIPTION
This adds support for the Anycubic Kobra Go, based on the Huada HC32f460KCT6 microcontroller.
The configuration is mostly based on the [official Marlin firmware](https://github.com/ANYCUBIC-3D/Kobra_Go). 
You can find more information about this printer on [KobraGoNeoInsights](https://1coderookie.github.io/KobraGoNeoInsights/).
I posted this confi originally on this Reddit post [Install Klipper on Kobra Go or Neo](https://www.reddit.com/r/anycubic/comments/10cwm16/install_klipper_on_kobra_go_or_neo/).
There is a variant of this printer. It is Kobra Neo. They share the same mainboard model, so many of their configs are the same. But I only have Kobra Go home and it looks like the variant of a printer is treated in Klipprer for a new .cfg file. That's why this config is only labeled for Kobra Go, not Neo.