### PR TITLE
sensor_mpu9250: Improve reliability of MPU9250 accelerometers

### DIFF
--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -221,7 +221,7 @@ class MPU9250:
         systime = self.printer.get_reactor().monotonic()
         print_time = self.mcu.estimated_print_time(systime) + MIN_MSG_TIME
         reqclock = self.mcu.print_time_to_clock(print_time)
-        rest_ticks = self.mcu.seconds_to_clock(1. / self.data_rate)
+        rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
         self.query_rate = self.data_rate
         self.query_mpu9250_cmd.send([self.oid, reqclock, rest_ticks],
                                     reqclock=reqclock)


### PR DESCRIPTION
Fixes common MPU-9250 accelerometer issues for RPi Linux MCU and improves reliability on all other architectures by adjusting the MPU-* reading algorithm to only read whole Klipper messages' worth of data from MPU-* and eliminating many unnecessary checks of the MPU FIFO fill-level that consumed bus bandwidth needed for data transfer. Improves intermittent "Lost communication with MCU 'rpi'" due to "Timer too close" and transposed / corrupted data due to FIFO overrun/data loss when using MPU-* accelerometers.

Minor: FIFO overrun checks are performed by testing the MPU interrupt flag vs. inferring from the FIFO fill level which can be unreliable, especially as different MPU chips have different FIFO sizes.

Stress tested for 13hrs with two MPU-6500 attached to one I2C bus on RPi
and one on a PR2040
Stress tested for 23hrs with two MPU-6500 attached to one I2C bus on RPi
and one on a ATmega328P (Seeduino Nano)

This finishes the PR set created from https://github.com/Klipper3d/klipper/pull/6115

Signed-off-by: Matthew Swabey [matthew@swabey.org](mailto:matthew@swabey.org)