### PR TITLE
fix install issue on ubuntu 22.04

### DIFF
--- a/scripts/install-ubuntu-22.04.sh
+++ b/scripts/install-ubuntu-22.04.sh
@@ -10,7 +10,7 @@ KLIPPER_GROUP=$KLIPPER_USER
 install_packages()
 {
     # Packages for python cffi
-    PKGLIST="virtualenv python3-dev libffi-dev build-essential"
+    PKGLIST="virtualenv python2-dev libffi-dev build-essential python2-pip-whl python2-setuptools-whl"
     # kconfig requirements
     PKGLIST="${PKGLIST} libncurses-dev"
     # hub-ctrl
@@ -18,7 +18,7 @@ install_packages()
     # AVR chip installation and building
     PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
     # ARM chip installation and building
-    PKGLIST="${PKGLIST} stm32flash dfu-util libnewlib-arm-none-eabi"
+    PKGLIST="${PKGLIST} stm32flash libnewlib-arm-none-eabi"
     PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0"
 
     # Update system package info
@@ -36,7 +36,7 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
 
     # Install/update dependencies
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt


### PR DESCRIPTION
Hi,
There are dependencies to python2 that were not taken into account in the install-ubuntu-22.04.sh script.
This patch manage them and is working at least in simulation mode and inside a docker image.
Signed-off-by: Damien Hardy damien.hardy@irisa.fr