### PR TITLE
Fix stm32 usbotg irq wakeup notification

### DIFF
--- a/src/stm32/usbotg.c
+++ b/src/stm32/usbotg.c
@@ -397,11 +397,11 @@ OTG_FS_IRQHandler(void)
     }
     if (sts & USB_OTG_GINTSTS_IEPINT) {
         // Can transmit data - disable irq and notify endpoint
-        uint32_t daint = OTGD->DAINT;
-        OTGD->DAINTMSK &= ~daint;
-        if (daint & (1 << 0))
+        uint32_t daint = OTGD->DAINT, msk = OTGD->DAINTMSK, pend = daint & msk;
+        OTGD->DAINTMSK = msk & ~daint;
+        if (pend & (1 << 0))
             usb_notify_ep0();
-        if (daint & (1 << USB_CDC_EP_BULK_IN))
+        if (pend & (1 << USB_CDC_EP_BULK_IN))
             usb_notify_bulk_in();
     }
 }


### PR DESCRIPTION
The stm32 usb code on stm32f4, stm32f2, and stm32h7 devices will unnecessarily wake up the receive handlers.  This can cause confusingly high "awake time" statistics.

In particular, when using "usb to canbus bridge" mode it could result in effectively continuous wakeups leading to very high "awake time" reports.

These spurious wakeups are unlikely to directly cause a problem, but they make it harder to diagnose other issues.

-Kevin