### PR TITLE
Tweak prioritization in USB to canbus bridge mode

### DIFF
--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -224,7 +224,7 @@ canserial_notify_rx(void)
 DECL_CONSTANT("RECEIVE_WINDOW", ARRAY_SIZE(CanData.receive_buf));
 
 // Handle incoming data (called from IRQ handler)
-int
+void
 canserial_process_data(struct canbus_msg *msg)
 {
     uint32_t id = msg->id;
@@ -233,7 +233,7 @@ canserial_process_data(struct canbus_msg *msg)
         int rpos = CanData.receive_pos;
         uint32_t len = CANMSG_DATA_LEN(msg);
         if (len > sizeof(CanData.receive_buf) - rpos)
-            return -1;
+            return;
         memcpy(&CanData.receive_buf[rpos], msg->data, len);
         CanData.receive_pos = rpos + len;
         canserial_notify_rx();
@@ -243,13 +243,12 @@ canserial_process_data(struct canbus_msg *msg)
         uint32_t pushp = CanData.admin_push_pos;
         if (pushp >= CanData.admin_pull_pos + ARRAY_SIZE(CanData.admin_queue))
             // No space - drop message
-            return -1;
+            return;
         uint32_t pos = pushp % ARRAY_SIZE(CanData.admin_queue);
         memcpy(&CanData.admin_queue[pos], msg, sizeof(*msg));
         CanData.admin_push_pos = pushp + 1;
         canserial_notify_rx();
     }
-    return 0;
 }
 
 // Remove from the receive buffer the given number of bytes

--- a/src/generic/canserial.h
+++ b/src/generic/canserial.h
@@ -9,7 +9,7 @@
 // canserial.c
 void canserial_notify_tx(void);
 struct canbus_msg;
-int canserial_process_data(struct canbus_msg *msg);
+void canserial_process_data(struct canbus_msg *msg);
 void canserial_set_uuid(uint8_t *raw_uuid, uint32_t raw_uuid_len);
 
 #endif // canserial.h

--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -204,19 +204,15 @@ usbcan_task(void)
             msg.dlc = gs->can_dlc;
             msg.data32[0] = gs->data32[0];
             msg.data32[1] = gs->data32[1];
+            if (host_status & HS_TX_LOCAL) {
+                canserial_process_data(&msg);
+                UsbCan.host_status = host_status = host_status & ~HS_TX_LOCAL;
+            }
             if (host_status & HS_TX_HW) {
                 ret = canhw_send(&msg);
                 if (ret < 0)
                     return;
                 UsbCan.host_status = host_status = host_status & ~HS_TX_HW;
-            }
-            if (host_status & HS_TX_LOCAL) {
-                ret = canserial_process_data(&msg);
-                if (ret < 0) {
-                    usb_notify_bulk_out();
-                    return;
-                }
-                UsbCan.host_status = host_status & ~HS_TX_LOCAL;
             }
             continue;
         }

--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -117,7 +117,7 @@ static struct usbcan_data {
 
     // Data from physical canbus interface
     uint32_t pull_pos, push_pos;
-    struct canbus_msg queue[8];
+    struct canbus_msg queue[32];
 } UsbCan;
 
 enum {

--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -112,7 +112,7 @@ static struct usbcan_data {
     uint8_t host_status;
 
     // Canbus data routed locally
-    uint8_t notify_local;
+    uint8_t notify_local, usb_send_busy;
     uint32_t assigned_id;
 
     // Data from physical canbus interface
@@ -166,20 +166,24 @@ send_frame(struct canbus_msg *msg)
 }
 
 // Send any pending hw frames to host
-static int
+static void
 drain_hw_queue(void)
 {
     uint32_t pull_pos = UsbCan.pull_pos;
     for (;;) {
         uint32_t push_pos = readl(&UsbCan.push_pos);
-        if (push_pos == pull_pos)
+        if (push_pos == pull_pos) {
             // No more data to send
-            return 0;
+            UsbCan.usb_send_busy = 0;
+            return;
+        }
         uint32_t pos = pull_pos % ARRAY_SIZE(UsbCan.queue);
         int ret = send_frame(&UsbCan.queue[pos]);
-        if (ret < 0)
+        if (ret < 0) {
             // USB is busy - retry later
-            return -1;
+            UsbCan.usb_send_busy = 1;
+            return;
+        }
         UsbCan.pull_pos = pull_pos = pull_pos + 1;
     }
 }
@@ -189,12 +193,11 @@ usbcan_task(void)
 {
     if (!sched_check_wake(&UsbCan.wake))
         return;
-    for (;;) {
-        // Send any pending hw frames to host
-        int ret = drain_hw_queue();
-        if (ret < 0)
-            return;
 
+    // Send any pending hw frames to host
+    drain_hw_queue();
+
+    for (;;) {
         // See if previous host frame needs to be transmitted
         uint_fast8_t host_status = UsbCan.host_status;
         if (host_status & (HS_TX_HW | HS_TX_LOCAL)) {
@@ -209,53 +212,50 @@ usbcan_task(void)
                 UsbCan.host_status = host_status = host_status & ~HS_TX_LOCAL;
             }
             if (host_status & HS_TX_HW) {
-                ret = canhw_send(&msg);
+                int ret = canhw_send(&msg);
                 if (ret < 0)
-                    return;
+                    break;
                 UsbCan.host_status = host_status = host_status & ~HS_TX_HW;
             }
-            continue;
         }
 
         // Send any previous echo frames
         if (host_status) {
-            ret = usb_send_bulk_in(&UsbCan.host_frame
-                                   , sizeof(UsbCan.host_frame));
+            if (UsbCan.usb_send_busy)
+                // Don't send echo frame until other traffic is sent
+                return;
+            int ret = usb_send_bulk_in(&UsbCan.host_frame
+                                       , sizeof(UsbCan.host_frame));
             if (ret < 0)
                 return;
             UsbCan.host_status = 0;
-            continue;
         }
 
-        // See if can read a new frame from host
-        ret = usb_read_bulk_out(&UsbCan.host_frame, USB_CDC_EP_BULK_OUT_SIZE);
-        if (ret > 0) {
-            uint32_t id = UsbCan.host_frame.can_id;
-            UsbCan.host_status = HS_TX_ECHO | HS_TX_HW;
-            if (id == CANBUS_ID_ADMIN)
-                UsbCan.host_status = HS_TX_ECHO | HS_TX_HW | HS_TX_LOCAL;
-            else if (UsbCan.assigned_id && UsbCan.assigned_id == id)
-                UsbCan.host_status = HS_TX_ECHO | HS_TX_LOCAL;
-            continue;
-        }
-
-        // No more work to be done
-        if (UsbCan.notify_local) {
-            UsbCan.notify_local = 0;
-            canserial_notify_tx();
-        }
-        return;
+        // Read next frame from host
+        int ret = usb_read_bulk_out(&UsbCan.host_frame
+                                    , USB_CDC_EP_BULK_OUT_SIZE);
+        if (ret <= 0)
+            // No frame available - no more work to be done
+            break;
+        uint32_t id = UsbCan.host_frame.can_id;
+        UsbCan.host_status = HS_TX_ECHO | HS_TX_HW;
+        if (id == CANBUS_ID_ADMIN)
+            UsbCan.host_status = HS_TX_ECHO | HS_TX_HW | HS_TX_LOCAL;
+        else if (UsbCan.assigned_id && UsbCan.assigned_id == id)
+            UsbCan.host_status = HS_TX_ECHO | HS_TX_LOCAL;
     }
+
+    if (UsbCan.notify_local && !UsbCan.usb_send_busy)
+        canserial_notify_tx();
 }
 DECL_TASK(usbcan_task);
 
 int
 canbus_send(struct canbus_msg *msg)
 {
-    int ret = drain_hw_queue();
-    if (ret < 0)
+    if (UsbCan.usb_send_busy)
         goto retry_later;
-    ret = send_frame(msg);
+    int ret = send_frame(msg);
     if (ret < 0)
         goto retry_later;
     UsbCan.notify_local = 0;


### PR DESCRIPTION
The existing Klipper code repeatedly tries to drain the incoming canbus rx queue.  This can lead to higher task processing time and can lead to non-optimal USB bandwidth utilization when there are a large number of messages to be transmitted over the canbus.

This PR alters the prioritization - both to simplify the code and to improve handling in the tx case.

-Kevin