### PR TITLE
aht10: update comments and docs for AHT20/AHT21 support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2375,9 +2375,9 @@ sensor_type: BME280
 #   above parameters.
 ```
 
-### AHT10 temperature sensor
+### AHT10/AHT20/AHT21 temperature sensor
 
-AHT10 two wire interface (I2C) environmental sensor.
+AHT10/AHT20/AHT21 two wire interface (I2C) environmental sensors.
 Note that these sensors are not intended for use with extruders and
 heater beds, but rather for monitoring ambient temperature (C) and
 relative humidity. See
@@ -2386,6 +2386,7 @@ that may be used to report humidity in addition to temperature.
 
 ```
 sensor_type: AHT10
+#   Also use AHT10 for AHT20 and AHT21 sensors.
 #i2c_address:
 #   Default is 56 (0x38). Some AHT10 sensors give the option to use
 #   57 (0x39) by moving a resistor.

--- a/klippy/extras/aht10.py
+++ b/klippy/extras/aht10.py
@@ -1,4 +1,4 @@
-# AHT10 I2c-based humiditure sensor support
+# AHT10/AHT20/AHT21 I2c-based humiditure sensor support
 #
 # Copyright (C) 2023 Scott Mudge <mail@scottmudge.com>
 #
@@ -9,6 +9,8 @@ from . import bus
 ######################################################################
 # Compatible Sensors:
 #       AHT10      -    Tested w/ BTT GTR 1.0 MCU on i2c3
+#       AHT20      -    Untested but should work
+#       AHT21      -    Tested w/ BTT GTR 1.0 MCU on i2c3
 ######################################################################
 
 AHT10_I2C_ADDR= 0x38


### PR DESCRIPTION
The control bytes for the AHT20 and AHT21 are identical to the AHT10, but I had not been able to test just yet to ensure the sensor code supported the other sensors. I've wrapped up testing and updated the comments/docs to reflect this additional support.