### PR TITLE
Report repo version as "dirty" if there are untracked python files

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -343,12 +343,30 @@ def main():
     else:
         logging.getLogger().setLevel(debuglevel)
     logging.info("Starting Klippy...")
-    start_args['software_version'] = util.get_git_version()
+    git_vers, git_status = util.get_git_version()
+    extra_files = [fname for code, fname in git_status
+                   if (code in ('??', '!!') and fname.endswith('.py')
+                       and (fname.startswith('klippy/kinematics/')
+                            or fname.startswith('klippy/extras/')))]
+    modified_files = [fname for code, fname in git_status if code == 'M']
+    extra_git_desc = ""
+    if extra_files:
+        if not git_vers.endswith('-dirty'):
+            git_vers = git_vers + '-dirty'
+        if len(extra_files) > 10:
+            extra_files[10:] = ["(+%d files)" % (len(extra_files) - 10,)]
+        extra_git_desc += "\nUntracked files: %s" % (', '.join(extra_files),)
+    if modified_files:
+        if len(modified_files) > 10:
+            modified_files[10:] = ["(+%d files)" % (len(modified_files) - 10,)]
+        extra_git_desc += "\nModified files: %s" % (', '.join(modified_files),)
+    start_args['software_version'] = git_vers
     start_args['cpu_info'] = util.get_cpu_info()
     if bglogger is not None:
         versions = "\n".join([
             "Args: %s" % (sys.argv,),
-            "Git version: %s" % (repr(start_args['software_version']),),
+            "Git version: %s%s" % (repr(start_args['software_version']),
+                                   extra_git_desc),
             "CPU: %s" % (start_args['cpu_info'],),
             "Python: %s" % (repr(sys.version),)])
         logging.info(versions)

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -23,7 +23,7 @@ def main(argv):
         help='Name of distro this package is intended for'
     )
     args = p.parse_args()
-    print(util.get_git_version(from_file=False),
+    print(util.get_git_version(from_file=False)[0],
           args.distroname.replace(' ', ''), sep='-')
 
 


### PR DESCRIPTION
Check for untracked files in the klippy/extras/ and klippy/kinematics/ directories and report those files in the log.  This helps identify code modifications when inspecting a log.

This does mean that users that have modified the Klipper code by manually adding an "extras" module will see a code version that reports "dirty".

Klipper does not have a "plugin" system.  The "extras" module system is an internal abstraction intended to facilitate long-term code maintenance.  Code in an "extras" module can easily alter the behavior of Klipper, including changing the behavior of other Klipper modules.  Thus introducing an "extras" module is a modification of the Klipper code.

-Kevin