### PR TITLE
Adding a config for the anycubic-chiron

### DIFF
--- a/config/printer-anycubic-chiron-2021.cfg
+++ b/config/printer-anycubic-chiron-2021.cfg
@@ -51,7 +51,7 @@ step_pin: PA4
 dir_pin: PA6
 enable_pin: !PA2
 microsteps: 16
-rotation_distance: 7.71 
+rotation_distance: 7.71
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 heater_pin: PB4
@@ -64,7 +64,7 @@ pid_Kd: 132.707
 min_temp: 0
 max_temp: 245
 
-[heater_fan extruder_fan] 
+[heater_fan extruder_fan]
 pin: PL5
 
 [heater_bed]
@@ -78,7 +78,7 @@ pid_Kd: 730.153
 min_temp: 0
 max_temp: 110
 
-[fan] 
+[fan]
 pin: PH6
 
 [mcu]
@@ -92,7 +92,7 @@ max_accel: 3000
 max_z_velocity: 10
 max_z_accel: 60
 
-[heater_fan stepstick_fan] 
+[heater_fan stepstick_fan]
 pin: PH4
 
 [filament_switch_sensor filament_sensor]
@@ -124,7 +124,7 @@ gcode:
     RESTORE_GCODE_STATE NAME=WIPE_LINE_state MOVE=0
   {% endif %}
 
-## Cura slicer adds m205 commands to the gcode that klipper doesn't understand and it logs a warning for it 
+## Cura slicer adds m205 commands to the gcode that klipper doesn't understand and it logs a warning for it
 ## Using this empty gcode_macro for it get rids of that warning
 [gcode_macro m205]
 gcode:

--- a/config/printer-anycubic-chiron-2021.cfg
+++ b/config/printer-anycubic-chiron-2021.cfg
@@ -1,0 +1,130 @@
+# This file contains pin mappings for the Anycubic Chiron
+# Klipper firmware config file for Anycubic Chiron. To use this config,
+# the firmware should be compiled for the AVR atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+
+[stepper_x]
+step_pin: PF0
+dir_pin: !PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!PE5
+position_min: -14
+position_endstop: -14
+position_max: 400
+homing_speed: 100
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 32
+endstop_pin: ^!PL7
+position_endstop: 0
+position_max: 400
+homing_speed: 80.0
+
+[stepper_z]
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_max: 450
+homing_speed: 5.0
+
+[stepper_z1]
+step_pin: PC1
+dir_pin: !PC3
+enable_pin: !PC7
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PL6
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 7.71 
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PK5
+control: pid
+pid_Kp: 13.664
+pid_Ki: 0.352
+pid_Kd: 132.707
+min_temp: 0
+max_temp: 245
+
+[heater_fan extruder_fan] 
+pin: PL5
+
+[heater_bed]
+heater_pin: PL4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: pid
+pid_Kp: 62.207
+pid_Ki: 1.325
+pid_Kd: 730.153
+min_temp: 0
+max_temp: 110
+
+[fan] 
+pin: PH6
+
+[mcu]
+serial: /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
+
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 10
+max_z_accel: 60
+
+[heater_fan stepstick_fan] 
+pin: PH4
+
+[filament_switch_sensor filament_sensor]
+switch_pin: ^!PC4
+pause_on_runout: True
+
+
+# Purge filament line
+[gcode_macro START_PRINT]
+gcode:
+  {% set z = params.Z|default(0.30)|float %}
+  {% set n = params.N|default(0.6)|float %}
+
+  {% if printer.toolhead.homed_axes != "xyz" %}
+    {action_respond_info("Please home XYZ first")}
+  {% elif printer.extruder.temperature < 170 %}
+    {action_respond_info("Extruder temperature too low")}
+  {% else %}
+    SAVE_GCODE_STATE NAME=WIPE_LINE_state
+    M82
+    G90
+    G92 E0
+    G1 X10 Y20 Z5 F3000
+    G1 Z{z} F3000
+    G1 X10 Y150 F1500 E10.83
+    G1 X{ n + 10.0 } F5000
+    G1 Y22 F1500 E21.5
+    G1 Y20 F5000
+    RESTORE_GCODE_STATE NAME=WIPE_LINE_state MOVE=0
+  {% endif %}
+
+## Cura slicer adds m205 commands to the gcode that klipper doesn't understand and it logs a warning for it 
+## Using this empty gcode_macro for it get rids of that warning
+[gcode_macro m205]
+gcode:


### PR DESCRIPTION
This is a fully working config for the anycubic chiron, from my research anycubic stopped shipping them with a bootloader installed sometime between 2018 and 2021.

I don't see those kind of details included in other configs but it may be relevant ?
Here is my write-up on getting a bootloader on the trigorilla v.0.0.2
https://github.com/gbit-is/Trigorilla-v0.0.2-burn-bootloader/

There is one thing I wasn't sure about, that is if I should keep the extruder rotation_distance value I measured and tuned or round it up to the nearest whole number

[extruder]
rotation_distance: 7.71

vs.

[extruder]
rotation_distance: 8