### PR TITLE
Reading steppers' mcu_position from macros

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -399,6 +399,23 @@ The following information is available in
 - `printer["servo <config_name>"].value`: The last setting of the PWM
   pin (a value between 0.0 and 1.0) associated with the servo.
 
+## stepper_*
+
+The following information is available in the `stepper_*`, and
+`manual_stepper some_name`:
+- `mcu_position`: The total number of steps the micro-controller has issued
+  in a positive direction minus the number of steps issued in a negative
+  direction since the micro-controller was last reset. This is the "mcu"
+  position reported by `GET_POSITION`. See the developer documentation of
+  [GET_POSITION output](Code_Overview.md#coordinate-systems) for more
+  information.
+
+If the robot is in motion when the query is issued then the reported value
+includes moves buffered on the micro-controller, but does not include moves
+on the look-ahead queue. One may execute `M400` before evaluating a macro
+that reads `mcu_position` to fully flush the look-ahead and step generation
+code.
+
 ## stepper_enable
 
 The following information is available in the `stepper_enable` object (this

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -250,7 +250,7 @@ def PrinterStepper(config, units_in_radians=False):
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params,
                               rotation_dist, steps_per_rotation,
                               step_pulse_duration, units_in_radians)
-    if 'stepper' in name:
+    if not name.startswith('stepper'):
         printer.add_object(name, mcu_stepper)
     # Register with helper modules
     for mname in ['stepper_enable', 'force_move', 'motion_report']:

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -228,6 +228,10 @@ class MCU_stepper:
         ffi_main, ffi_lib = chelper.get_ffi()
         a = axis.encode()
         return ffi_lib.itersolve_is_active_axis(self._stepper_kinematics, a)
+    def get_status(self, eventtime):
+        return {
+            'mcu_position': self.get_mcu_position(),
+         }
 
 # Helper code to build a stepper object from a config section
 def PrinterStepper(config, units_in_radians=False):
@@ -246,6 +250,8 @@ def PrinterStepper(config, units_in_radians=False):
     mcu_stepper = MCU_stepper(name, step_pin_params, dir_pin_params,
                               rotation_dist, steps_per_rotation,
                               step_pulse_duration, units_in_radians)
+    if 'stepper' in name:
+        printer.add_object(name, mcu_stepper)
     # Register with helper modules
     for mname in ['stepper_enable', 'force_move', 'motion_report']:
         m = printer.load_object(config, mname)


### PR DESCRIPTION
**tl;dr**: This PR introduces a `get_status()` function for stepper objects, allowing macros and frontends to access the internal step counter `mcu_position`. This feature is especially useful for detecting skipped steps during calibration routines.

*edit 110823:* I shortened the OP message to better reflect the reduced scope of the PR after discussion, also replacing the "zero dwells" recommendation with `M400`. To see the original proposal, please lookup the Github edits.

Some macros aim to identify skipped steps, like [Ellis's macro](https://ellis3dp.com/Print-Tuning-Guide/articles/determining_max_speeds_accels.html#determining-if-skipping-occured) for determining a printer's absolute maximum speeds and accelerations. This relies on users comparing the "mcu" positions of two GET_POSITION outputs. Unfortunately, there is currently no way to read a stepper's step position from a macro, which hinders the automated detection of skipped steps.

While GET_POSITION resides in `gcode_move`, I decided against adding overhead to its `get_status()` method with multiple FFI calls per stepper, as this method is frequently queried or subscribed by front-ends. Instead, this PR adds a `get_status()` method to `MCU_stepper` objects. Additionally, this PR registers newly created MCU_stepper objects in PrinterStepper using their config section name, except for the extruder stepper, which would collide with the `extruder` printer object. The ad-hoc rule is that the section name must contain the sub-string "stepper".

*Important Note:* To ensure accurate results when using this status, a pipeline flush is required, as discussed in the Klipper3d documentation. Executing M400 before evaluating a macro that reads mcu_position is recommended to fully flush the look-ahead and step generation code. The same applies to GET_POSITION's "mcu" and "stepper" lines.

<details>
<summary>Gcode macros demonstrating the effect of pipeline flushes:</summary>

```
[gcode_macro TEST_REPORT_X_POSITION]
gcode:
    REPORT_X_POSITION MSG="Before first move"
    G1 X100
    REPORT_X_POSITION MSG="After first move"
    M400
    REPORT_X_POSITION MSG="After first wait_moves"
    M400
    REPORT_X_POSITION MSG="After second move"
    M400
    REPORT_X_POSITION MSG="After second wait_moves"

[gcode_macro REPORT_X_POSITION]
gcode:
    M118 {params.MSG} stepper_x:{printer["stepper_x"]["mcu_position"]}
```

The lines indicating "After * move" report  old positions, whereas the lines with "After * wait_moves" are current. Additionally, it is important to keep in mind that the flush should be placed in a separate macro from the one used to evaluate the status.
</details>