### PR TITLE
atsamd: Fix compiler optimization and ADC bugs

### DIFF
--- a/src/atsamd/fdcan.c
+++ b/src/atsamd/fdcan.c
@@ -119,7 +119,8 @@ canhw_send(struct canbus_msg *msg)
     txfifo->dlc_section = (msg->dlc & 0x0f) << 16;
     txfifo->data[0] = msg->data32[0];
     txfifo->data[1] = msg->data32[1];
-    barrier();
+    __DMB();
+    CANx->TXBAR.reg;
     CANx->TXBAR.reg = ((uint32_t)1 << w_index);
     return CANMSG_DATA_LEN(msg);
 }


### PR DESCRIPTION
The `O2` build flag was leading to broken CAN Tx code for the atsamc21.