### PR TITLE
configfile: adds meta options

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1764,6 +1764,16 @@ pins:
 #   provided.
 ```
 
+### "meta_" prefixed options
+
+```
+[<section>]
+#meta_<name>:
+#   One may specify any number of options with a "meta_" prefix.
+#   These options are not used anywhere in Klipper, but will be available
+#   on the `configfile.config.<section>.meta_<name>` status object
+```
+
 ## Bed probing hardware
 
 ### [probe]

--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -300,7 +300,8 @@ class PrinterConfig:
                             % (section,))
             for option in fileconfig.options(section_name):
                 option = option.lower()
-                if (section, option) not in access_tracking:
+                if ((section, option) not in access_tracking and
+                        not option.startswith('meta_')):
                     raise error("Option '%s' is not valid in section '%s'"
                                 % (option, section))
         # Setup get_status()


### PR DESCRIPTION
This is a follow up on https://klipper.discourse.group/t/metadata-in-config-sections/8344

My intention here is to allow users to add `meta_` options to ANY section on the config with whatever value they would like.

These options will be completely ignored by Klipper and will only be available on the `configfile` status object, under `config.<section>.meta_<name>` property.

## Config example:

```ini
[mcu]
serial: /tmp/pseudoserial
restart_method: Arduino
meta_test: 1

[virtual_pins]
meta_other: whatever
```

## Moonraker output example:

![image](https://github.com/Klipper3d/klipper/assets/85504/2e88d9a2-6984-4b67-9a5a-1c9113126222)
