### PR TITLE
Change the position_max value of Kobra Go to the maximum allowed travel on the axis

### DIFF
--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -22,7 +22,7 @@ rotation_distance: 40
 endstop_pin: !PH2
 position_endstop: -13
 position_min:-13
-position_max: 238
+position_max: 236
 homing_speed: 50
 
 [stepper_y]
@@ -34,7 +34,7 @@ rotation_distance: 40
 endstop_pin: ^!PC13
 position_endstop: -9
 position_min:-9
-position_max: 238
+position_max: 230
 homing_speed: 50
 
 [stepper_z]
@@ -46,7 +46,7 @@ rotation_distance: 8
 endstop_pin: ^PC14
 position_endstop: 0
 position_min: -10
-position_max: 250
+position_max: 255
 homing_speed: 5
 
 [extruder]
@@ -85,7 +85,7 @@ pid_kd: 1675.16
 speed: 200
 horizontal_move_z: 2.5
 mesh_min: 5, 5
-mesh_max: 217.2, 207.8
+mesh_max: 215, 215
 probe_count: 5, 5
 
 [probe]


### PR DESCRIPTION
Also fixed the bed_mesh out-of-physical range issue.
The value is now tested on the original Kobra Go without any modification.
The previous [pr](https://github.com/Klipper3d/klipper/pull/6166)