### PR TITLE
Add gcode_button to the Status Reference docs

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -170,8 +170,8 @@ The following information is available in the
 
 ## gcode_button
 
-The following information is available in [gcode_button some_name](Config_Reference.md#gcode_button) objects:
-
+The following information is available in
+[gcode_button some_name](Config_Reference.md#gcode_button) objects:
 - `state`: The current button state returned as "PRESSED" or "RELEASED"
 
 ## gcode_macro

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -168,6 +168,12 @@ The following information is available in the
   module. These settings may differ from the config file if a
   `SET_RETRACTION` command alters them.
 
+## gcode_button
+
+The following information is available in [gcode_button some_name](Config_Reference.md#gcode_button) objects:
+
+- `state`: The current button state returned as "PRESSED" or "RELEASED"
+
 ## gcode_macro
 
 The following information is available in


### PR DESCRIPTION
The Status Reference documentation is missing a section for gcode_button.

This PR just adds that section.