### PR TITLE
Added socket activation support

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -366,9 +366,14 @@ class WebHooks:
         state_message, state = self.printer.get_state_message()
         src_path = os.path.dirname(__file__)
         klipper_path = os.path.normpath(os.path.join(src_path, ".."))
-        response = {'state': state, 'state_message': state_message,
+        response = {'state': state,
+                    'state_message': state_message,
                     'hostname': socket.gethostname(),
-                    'klipper_path': klipper_path, 'python_path': sys.executable}
+                    'klipper_path': klipper_path,
+                    'python_path': sys.executable,
+                    'process_id': os.getpid(),
+                    'user_id': os.getuid(),
+                    'group_id': os.getgid()}
         start_args = self.printer.get_start_args()
         for sa in ['log_file', 'config_file', 'software_version', 'cpu_info']:
             response[sa] = start_args.get(sa)


### PR DESCRIPTION
This PR allows the usage of SystemD sockets.
The benefit would be that you can set permissions / user / group of the socket outside of klipper.
Allowing to isolate klipper more easily and moonraker to be run from different users.

https://github.com/Klipper3d/klipper/pull/6194

Committing the change suggested by @Piezoid
See the PR above.