### PR TITLE
tmc2240: register as temperature sensor

### DIFF
--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -396,6 +396,9 @@ class TMC2240:
         set_config_field(config, "tpowerdown", 10)
         #   SG4_THRS
         set_config_field(config, "sg4_angle_offset", 1)
+        # Register temperature sensor
+        pheaters = config.get_printer().load_object(config, 'heaters')
+        pheaters.register_sensor(config, self)
 
 def load_config_prefix(config):
     return TMC2240(config)


### PR DESCRIPTION
Following up on #6145, this registers the `tmc2240` as a temperature sensor so that Moonraker can cache the temperature readings automatically.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>