### PR TITLE
spi_flash: Support Creality CR-FDM-v2

### DIFF
--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -144,6 +144,10 @@ The following fields may be specified:
   power-cycle to complete flashing.  To verify the firmware afterward, run
   the script again with the `-c` option to perform the verification step.
   [See caveats with SDIO cards](#caveats)
+- `requires_unique_filename`: Set this to `True` if the board requires a
+  unique filename for each firmware update. The filename will be based on
+  the firmware hash, and will be directly appended to `firmware_path`.  The
+  default is `False`.
 
 If software SPI is required, the `spi_bus` field should be set to `swspi`
 and the following additional field should be specified:

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -99,7 +99,18 @@ BOARD_DEFS = {
         'spi_bus': "swspi",
         'spi_pins': "PC8,PD2,PC12",
         'cs_pin': "PC11",
-        'skip_verify': True
+        'skip_verify': True,
+        'requires_unique_filename': True,
+        'firmware_path': ""
+    },
+    'creality-cr-fdm-v2': {
+        'mcu': "stm32f401xc",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True,
+        'requires_unique_filename': True,
+        'firmware_path': "STM32F~1/"
     },
     'monster8': {
         'mcu': "stm32f407xx",


### PR DESCRIPTION
Supports Creality CR-FDM-v2 boards.
Possible to use unique filenames based on firmware hash
 by using %%HASH%% codeword in filename