### PR TITLE
temperature_driver: adds driver temperature sensor

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2506,6 +2506,17 @@ sensor_type: temperature_mcu
 #   micro-controller specification.
 ```
 
+### Builtin stepper driver temperature sensor
+
+The TMC2240 stepper driver contain an internal temperature sensor. One can
+use the "temperature_driver" sensor to monitor this temperatures.
+
+```
+sensor_type: temperature_driver
+sensor_driver:
+#   The stepper driver to read from.
+```
+
 ### Host temperature sensor
 
 Temperature from the machine (eg Raspberry Pi) running the host software.

--- a/klippy/extras/temperature_driver.py
+++ b/klippy/extras/temperature_driver.py
@@ -1,0 +1,58 @@
+# Support for micro-controller chip based temperature sensors
+#
+# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+DRIVER_REPORT_TIME = 1.0
+
+class PrinterTemperatureDriver:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+
+        driver_name = config.get('sensor_driver')
+        self.driver = self.printer.lookup_object(driver_name)
+
+        self.temp = self.min_temp = self.max_temp = 0.0
+
+        self.reactor = self.printer.get_reactor()
+        self.sample_timer = self.reactor.register_timer(
+            self._sample_driver_temperature)
+
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+
+    def handle_connect(self):
+        self.reactor.update_timer(self.sample_timer, self.reactor.NOW)
+
+    def setup_callback(self, temperature_callback):
+        self.temperature_callback = temperature_callback
+
+    def setup_minmax(self, min_temp, max_temp):
+        self.min_temp = min_temp
+        self.max_temp = max_temp
+
+    def get_report_time_delta(self):
+        return DRIVER_REPORT_TIME
+
+    def _sample_driver_temperature(self, eventtime):
+        self.temp = self.driver.get_temperature()
+
+        if self.temp is not None:
+            if self.temp < self.min_temp or self.temp > self.max_temp:
+                self.printer.invoke_shutdown(
+                    "DRIVER temperature %0.1f outside range of %0.1f:%.01f"
+                    % (self.temp, self.min_temp, self.max_temp))
+
+        measured_time = self.reactor.monotonic()
+
+        if self.temp is not None:
+            mcu = self.driver.get_mcu()
+            self.temperature_callback(
+                mcu.estimated_print_time(measured_time),
+                self.temp)
+
+        return measured_time + DRIVER_REPORT_TIME
+
+def load_config(config):
+    pheaters = config.get_printer().load_object(config, "heaters")
+    pheaters.add_sensor_factory("temperature_driver", PrinterTemperatureDriver)

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -33,6 +33,9 @@
 # Load "temperature_mcu" sensor
 [temperature_mcu]
 
+# Load "temperature_driver" sensor
+[temperature_driver]
+
 
 ########################################
 # Default thermistors

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -204,12 +204,14 @@ class TMCErrorCheck:
             if cleared_flags & reset_mask:
                 return True
         return False
+    def get_temperature(self):
+        if self.check_timer is None or self.adc_temp is None:
+            return None
+        return round((self.adc_temp - 2038) / 7.7, 2)
     def get_status(self, eventtime=None):
         if self.check_timer is None:
             return {'drv_status': None, 'temperature': None}
-        temp = None
-        if self.adc_temp is not None:
-            temp = round((self.adc_temp - 2038) / 7.7, 2)
+        temp = self.get_temperature()
         last_value, reg_name = self.drv_status_reg_info[:2]
         if last_value != self.last_drv_status:
             self.last_drv_status = last_value
@@ -404,6 +406,10 @@ class TMCCommandHelper:
             self._init_registers()
         except self.printer.command_error as e:
             logging.info("TMC %s failed to init: %s", self.name, str(e))
+    def get_temperature(self):
+        return self.echeck_helper.get_temperature()
+    def get_mcu(self):
+        return self.mcu_tmc.get_mcu()
     # get_status information export
     def get_status(self, eventtime=None):
         cpos = None

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -223,6 +223,8 @@ class MCU_TMC_SPI_chain:
         pr = pr[(self.chain_len - chain_pos) * 5 :
                 (self.chain_len - chain_pos + 1) * 5]
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]
+    def get_mcu(self):
+        return self.spi.get_mcu()
 
 # Helper to setup an spi daisy chain bus from settings in a config section
 def lookup_tmc_spi_chain(config):
@@ -274,6 +276,8 @@ class MCU_TMC_SPI:
             "Unable to write tmc spi '%s' register %s" % (self.name, reg_name))
     def get_tmc_frequency(self):
         return self.tmc_frequency
+    def get_mcu(self):
+        return self.tmc_spi.get_mcu()
 
 
 ######################################################################
@@ -293,6 +297,8 @@ class TMC2130:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -194,6 +194,8 @@ class TMC2208:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -70,6 +70,8 @@ class TMC2209:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         self.fields.set_field("mstep_reg_select", True)

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -352,6 +352,8 @@ class TMC2240:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -223,6 +223,8 @@ class MCU_TMC2660_SPI:
             self.spi.spi_send(msg, minclock)
     def get_tmc_frequency(self):
         return None
+    def get_mcu(self):
+        return self.spi.get_mcu()
 
 
 ######################################################################
@@ -240,6 +242,8 @@ class TMC2660:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
 
         # CHOPCONF

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -332,6 +332,8 @@ class TMC5160:
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_temperature = cmdhelper.get_temperature
+        self.get_mcu = cmdhelper.get_mcu
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -184,6 +184,8 @@ class MCU_TMC_uart_bitbang:
             self.analog_mux.activate(instance_id)
         msg = self._encode_write(0xf5, addr, reg | 0x80, val)
         self.tmcuart_send_cmd.send([self.oid, msg, 0], minclock=minclock)
+    def get_mcu(self):
+        return self.mcu
 
 # Lookup a (possibly shared) tmc uart
 def lookup_tmc_uart_bitbang(config, max_addr):
@@ -253,3 +255,5 @@ class MCU_TMC_uart:
             "Unable to write tmc uart '%s' register %s" % (self.name, reg_name))
     def get_tmc_frequency(self):
         return self.tmc_frequency
+    def get_mcu(self):
+        return self.mcu_uart.get_mcu()


### PR DESCRIPTION
(This is a follow up on #6145 and discussion on PR #6205)

The following PR adds a new Temperature Sensor called `temperature_driver` that allows monitoring and reporting of the drivers temperature.

Note: right now, only TMC2240 supports temperature reporting, but I've added no validation on the type of driver, so users will still be able to use any driver, however temperature reported will always be 0 for non-TMC2240!

With this change there is no change required either on Moonraker, Fluidd, Mainsail or any other UI, as it will be up to the user to add the temperature sensor.

Here's a sample config:

```ini
[tmc2240 stepper_x]
cs_pin: PD9
spi_bus: spi2
run_current: 0.800
stealthchop_threshold: 999999

[temperature_sensor stepper_x]
sensor_type: temperature_driver
sensor_driver: tmc2240 stepper_x
```

I took the above configuration and put it on a test system with a TMC2240 and this is the output in Fluidd (code changes only the ones on this Klipper PR and nothing more)

![image](https://github.com/Klipper3d/klipper/assets/85504/71de66bb-7714-41cd-8d8e-744eb418490a)

Signed-off-by: Pedro Lamas pedrolamas@gmail.com