### PR TITLE
Docs : use colon notation in printer.cfg

### DIFF
--- a/docs/Pressure_Advance.md
+++ b/docs/Pressure_Advance.md
@@ -79,7 +79,7 @@ corners, it's worth remembering that a good pressure advance
 configuration also reduces ooze throughout the print.
 
 At the completion of this test, set
-`pressure_advance = <calculated_value>` in the `[extruder]` section of
+`pressure_advance: <calculated_value>` in the `[extruder]` section of
 the configuration file and issue a RESTART command. The RESTART
 command will clear the test state and return the acceleration and
 cornering speeds to their normal values.


### PR DESCRIPTION
This is a very small detail, i'll leave it to you maintainers to merge this or not

The Pressure Advance page instructs users to set `pressure_advance = <calculated_value>` in `printer.cfg`, but it appears that `pressure_advance: <calculated_value>` is more consistent with the style of the provided default configurations. 

This PR therefore changes the style to use colon notation. 

Cheers,