### PR TITLE
Fix heater with low sample rate temperature sensor, specifically BME680

### DIFF
--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -7,6 +7,7 @@ import logging
 from . import bus
 
 REPORT_TIME = .8
+REPORT_TIME_BME680 = .8 * 4
 BME280_CHIP_ADDR = 0x76
 BME280_REGS = {
     'RESET': 0xE0, 'CTRL_HUM': 0xF2,
@@ -124,7 +125,7 @@ class BME280:
         self._callback = cb
 
     def get_report_time_delta(self):
-        return REPORT_TIME
+        return REPORT_TIME_BME680 if self.chip_type == 'BME680' else REPORT_TIME
 
     def _init_bmxx80(self):
         def read_calibration_data_bmp280(calib_data_1):
@@ -269,7 +270,7 @@ class BME280:
                 % (self.temp, self.min_temp, self.max_temp))
         measured_time = self.reactor.monotonic()
         self._callback(self.mcu.estimated_print_time(measured_time), self.temp)
-        return measured_time + REPORT_TIME
+        return measured_time + self.get_report_time_delta()
 
     def _sample_bme680(self, eventtime):
         self.write_register('CTRL_HUM', self.os_hum & 0x07)
@@ -332,7 +333,7 @@ class BME280:
                 % (self.temp, self.min_temp, self.max_temp))
         measured_time = self.reactor.monotonic()
         self._callback(self.mcu.estimated_print_time(measured_time), self.temp)
-        return measured_time + REPORT_TIME * 4
+        return measured_time + get_report_time_delta
 
     def _compensate_temp(self, raw_temp):
         dig = self.dig

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -68,7 +68,7 @@ class Heater:
             and abs(value - self.last_pwm_value) < 0.05):
             # No significant change in value - can suppress update
             return
-        pwm_time = read_time + self.pwm_delay
+        pwm_time = read_time - self.pwm_delay
         self.next_pwm_time = pwm_time + 0.75 * MAX_HEAT_TIME
         self.last_pwm_value = value
         self.mcu_pwm.set_pwm(pwm_time, value)


### PR DESCRIPTION
Two separate issues fixed:
* `get_report_time_delta` returns the wrong thing for BME680 sensors. It returns the time for BME280, but the BME680 callback is set to be longer.
* In `heater.py`, for any temp sensor with a report cycle longer than `MAX_HEAT_TIME * 0.25` seconds, `next_pwm_time` can exceed `MAX_HEAT_TIME`. This means even if a sensor report is received within `MAX_HEAT_TIME`, it may be ignored by the PWM value update suppression. This looks like it's a bug/typo/oversight in how `next_pwm_time` is being set, it's unclear why a max delay from now of `0.75 * MAX_HEAT_TIME + self.pwm_delay` would make sense, but `0.75 * MAX_HEAT_TIME - self.pwm_delay` makes sense as preventing time to the next report from exceeding `MAX_HEAT_TIME`, plus some margin.
The second issue is the likely cause of #5189 