### PR TITLE
Prevent heater next_pwm_time from exceeding timeout for slow updating…

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -69,7 +69,7 @@ class Heater:
             # No significant change in value - can suppress update
             return
         pwm_time = read_time + self.pwm_delay
-        self.next_pwm_time = pwm_time + 0.75 * MAX_HEAT_TIME
+        self.next_pwm_time = min(pwm_time + 0.75 * MAX_HEAT_TIME, read_time + MAX_HEAT_TIME - self.pwm_delay)
         self.last_pwm_value = value
         self.mcu_pwm.set_pwm(pwm_time, value)
         #logging.debug("%s: pwm=%.3f@%.3f (from %.3f@%.3f [%.3f])",


### PR DESCRIPTION
In `heater.py`, for any temp sensor with a report cycle longer than `MAX_HEAT_TIME * 0.25` seconds, `next_pwm_time` can exceed `MAX_HEAT_TIME`. This means even if a sensor report is received within `MAX_HEAT_TIME`, it may be ignored by the PWM value update suppression. Fix by making sure we update before the next `pwm_delay` would take us past `MAX_HEAT_TIME`

Fixes likely cause of https://github.com/Klipper3d/klipper/issues/5189