### PR TITLE
Updated bed mesh configuration for Creality Ender 3 S1 and S1 Pro

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -110,8 +110,8 @@ stow_on_each_sample: false
 
 [bed_mesh]
 speed: 120
-mesh_min: 20, 20
-mesh_max: 200, 197
+mesh_min: 10, 10
+mesh_max: 200, 194
 probe_count: 4,4
 algorithm: bicubic
 


### PR DESCRIPTION
Existing `mesh_min` values start probing too far away from the edge.

Additionally `mesh_max` Y value of 197 is out of bed movement range (197 + `bltouch.y_offset` = 237.5) and causes Y stepper to overhit, which can potentially damage the printer in the long run.

Signed-off-by: Aleksandr Ivanov <aux@hexmode.org>