### PR TITLE
Led command improvements

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -775,18 +775,21 @@ WHITE=<value> [INDEX=<index>] [TRANSMIT=0] [SYNC=1]`: This sets the
 LED output. Each color `<value>` must be between 0.0 and 1.0. The
 WHITE option is only valid on RGBW LEDs. If the LED supports multiple
 chips in a daisy-chain then one may specify INDEX to alter the color
-of just the given chip (1 for the first chip, 2 for the second,
-etc.). If INDEX is not provided then all LEDs in the daisy-chain will
-be set to the provided color. If TRANSMIT=0 is specified then the
-color change will only be made on the next SET_LED command that does
-not specify TRANSMIT=0; this may be useful in combination with the
-INDEX parameter to batch multiple updates in a daisy-chain. By
-default, the SET_LED command will sync it's changes with other ongoing
-gcode commands.  This can lead to undesirable behavior if LEDs are
-being set while the printer is not printing as it will reset the idle
-timeout. If careful timing is not needed, the optional SYNC=0
-parameter can be specified to apply the changes without resetting the
-idle timeout.
+of just the given chips (1 for the first chip, 2 for the second,
+etc. You can specify multiple LEDs by either separate Indices by comma:
+INDEX=1,3,4; specify a range by using a dash: INDEX=1-4, which would
+update LED1, LED2, LED3 and LED4 or mix and match both methods: INDEX=
+1,2-5,7 would update LED1, LED2, LED3, LED4, LED5 and LED 7). If INDEX
+is not provided then all LEDs in the daisy-chain will be set to the
+provided color. If TRANSMIT=0 is specified then the color change will
+only be made on the next SET_LED command that doesnot specify
+TRANSMIT=0; this may be useful in combination with the INDEX parameter
+to batch multiple updates in a daisy-chain. By default, the SET_LED
+command will sync it's changes with other ongoing gcode commands.
+This can lead to undesirable behavior if LEDs are being set while the
+printer is not printing as it will reset the idle timeout. If careful
+timing is not needed, the optional SYNC=0 parameter can be specified
+to apply the changes without resetting the idle timeout.
 
 #### SET_LED_TEMPLATE
 `SET_LED_TEMPLATE LED=<led_name> TEMPLATE=<template_name>
@@ -800,11 +803,10 @@ numbers corresponding to red, green, blue, and white color settings.
 The template will be continuously evaluated and the LED will be
 automatically set to the resulting colors. One may set
 display_template parameters to use during template evaluation
-(parameters will be parsed as Python literals). If INDEX is not
-specified then all chips in the LED's daisy-chain will be set to the
-template, otherwise only the chip with the given index will be
-updated. If TEMPLATE is an empty string then this command will clear
-any previous template assigned to the LED (one can then use `SET_LED`
+(parameters will be parsed as Python literals). For INDEX see the
+description on INDEX in the [LED](Config_Reference.md#leds) section.
+If TEMPLATE is an empty string then this command will clear any
+previous template assigned to the LED (one can then use `SET_LED`
 commands to manage the LED's color settings).
 
 ### [output_pin]
@@ -868,12 +870,16 @@ in the config file.
 
 #### PID_CALIBRATE
 `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
-[WRITE_FILE=1]`: Perform a PID calibration test. The specified heater
-will be enabled until the specified target temperature is reached, and
-then the heater will be turned off and on for several cycles. If the
-WRITE_FILE parameter is enabled, then the file /tmp/heattest.txt will
-be created with a log of all temperature samples taken during the
-test.
+[WRITE_FILE=1]`: Perform a PID calibration test. The
+specified heater will be enabled until the specified target temperature
+is reached, and then the heater will be turned off and on for several
+cycles. If the WRITE_FILE parameter is enabled, then the file
+/tmp/heattest.txt will be created with a log of all temperature samples
+taken during the test. TOLERANCE defaults to 0.02 if not passed in. The
+tighter the tolerance the better the calibration result will be, but how
+tight you can achieve depends on how clean your sensor readings are. low
+noise readings might allow 0.01, to be used, while noisy reading might
+require a value of 0.03 or higher.
 
 ### [pause_resume]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -776,20 +776,22 @@ LED output. Each color `<value>` must be between 0.0 and 1.0. The
 WHITE option is only valid on RGBW LEDs. If the LED supports multiple
 chips in a daisy-chain then one may specify INDEX to alter the color
 of just the given chips (1 for the first chip, 2 for the second,
-etc. You can specify multiple LEDs by either separate Indices by comma:
-INDEX=1,3,4; specify a range by using a dash: INDEX=1-4, which would
+etc. You can specify multiple LEDs by either separating Indices by comma:
+INDEX=1,3,4; specifying a range by using a dash: INDEX=1-4, which would
 update LED1, LED2, LED3 and LED4 or mix and match both methods: INDEX=
-1,2-5,7 would update LED1, LED2, LED3, LED4, LED5 and LED 7). If INDEX
-is not provided then all LEDs in the daisy-chain will be set to the
-provided color. If TRANSMIT=0 is specified then the color change will
-only be made on the next SET_LED command that doesnot specify
-TRANSMIT=0; this may be useful in combination with the INDEX parameter
-to batch multiple updates in a daisy-chain. By default, the SET_LED
-command will sync it's changes with other ongoing gcode commands.
-This can lead to undesirable behavior if LEDs are being set while the
-printer is not printing as it will reset the idle timeout. If careful
-timing is not needed, the optional SYNC=0 parameter can be specified
-to apply the changes without resetting the idle timeout.
+1,2-5,7 would update LED1, LED2, LED3, LED4, LED5 and LED 7). You can
+also add |n behind a range, which would then only take every n LEDs in
+that range(e.g. INDEX=1-5|2 would update LED1, LED3 and LED5, INDEX1-7|3
+would update LED1, LED4 and LED7). If INDEX is not provided then all LEDs
+in the daisy-chain will be set to the provided color. If TRANSMIT=0 is
+specified then the color change will only be made on the next SET_LED
+command that doesnot specify TRANSMIT=0; this may be useful in combination
+with the INDEX parameter to batch multiple updates in a daisy-chain. By
+default, the SET_LED command will sync it's changes with other ongoing
+gcode commands. This can lead to undesirable behavior if LEDs are being
+set while the printer is not printing as it will reset the idle timeout.
+If careful timing is not needed, the optional SYNC=0 parameter can be
+specified to apply the changes without resetting the idle timeout.
 
 #### SET_LED_TEMPLATE
 `SET_LED_TEMPLATE LED=<led_name> TEMPLATE=<template_name>

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -870,16 +870,12 @@ in the config file.
 
 #### PID_CALIBRATE
 `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
-[WRITE_FILE=1]`: Perform a PID calibration test. The
-specified heater will be enabled until the specified target temperature
-is reached, and then the heater will be turned off and on for several
-cycles. If the WRITE_FILE parameter is enabled, then the file
-/tmp/heattest.txt will be created with a log of all temperature samples
-taken during the test. TOLERANCE defaults to 0.02 if not passed in. The
-tighter the tolerance the better the calibration result will be, but how
-tight you can achieve depends on how clean your sensor readings are. low
-noise readings might allow 0.01, to be used, while noisy reading might
-require a value of 0.03 or higher.
+[WRITE_FILE=1]`: Perform a PID calibration test. The specified heater
+will be enabled until the specified target temperature is reached, and
+then the heater will be turned off and on for several cycles. If the
+WRITE_FILE parameter is enabled, then the file /tmp/heattest.txt will
+be created with a log of all temperature samples taken during the
+test.
 
 ### [pause_resume]
 

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -31,32 +31,53 @@ class LEDHelper:
         try:
             i = int(index)
         except ValueError:
-            raise gcmd.error("'%s' is not a number, "
-                             "only numbers, ',' and '-' are allowed." % index)
+            raise gcmd.error("index '%s' is not a number, "
+                             "only numbers, ',', '-' and '|' are allowed."
+                             % index)
         if i < 1:
             raise gcmd.error("index can not be less than 1(was '%d')" % i)
         if i > led_count:
             raise gcmd.error("index can not exceed amount of "
-                             "led in chain(was '%d')" % i)
+                             "leds in chain(was '%d')"
+                             % i)
+        return i
+    def check_step(self, step, gcmd):
+        try:
+            i = int(step)
+        except ValueError:
+            raise gcmd.error("step '%s' is not a number, "
+                             "only numbers are allowed."
+                             % step)
+        if i < 1:
+            raise gcmd.error("step can not be less than 1(was '%d')" % i)
         return i
     def get_indices(self, gcmd, led_count):
-        command = gcmd.get("INDEX", None)
-        if command is None:
+        given_indices = gcmd.get("INDEX", None)
+        if given_indices is None:
             return range(1, (led_count + 1))
         indices = set()
-        for index in command.split(','):
-            if '-' in index:
-                group = index.split('-')
-                if len(group) > 2:
-                    raise gcmd.error("More than one '-' found in '%s', "
-                                     "only one allowed" % index)
-                for i in range(self.check_index(group[0], gcmd, led_count),
-                               (self.check_index(group[1],
-                                                 gcmd,
-                                                 led_count) + 1)):
-                    indices.add(i)
-            else:
+        for index in given_indices.split(','):
+            led_range = index.split('-')
+            if len(led_range) > 2:
+                raise gcmd.error("More than one '-' found in '%s', "
+                                 "only one allowed" % index)
+            elif len(led_range) == 1:
                 indices.add(self.check_index(index, gcmd, led_count))
+            else:
+                step = 1
+                min_val = led_range[0]
+                max_val = led_range[1]
+                range_steps = max_val.split('|')
+                if len(range_steps) > 2:
+                    raise gcmd.error("More than one '|' found in '%s', "
+                                     "only one allowed" % index)
+                elif len(range_steps) == 2:
+                    step = range_steps[1]
+                    max_val = range_steps[0]
+                for i in range(self.check_index(min_val, gcmd, led_count),
+                               (self.check_index(max_val, gcmd, led_count) + 1),
+                               self.check_step(step, gcmd)):
+                    indices.add(i)
         return indices
     def get_led_count(self):
         return self.led_count

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -27,19 +27,43 @@ class LEDHelper:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_LED", "LED", name, self.cmd_SET_LED,
                                    desc=self.cmd_SET_LED_help)
+    def check_index(self, index, gcmd, led_count):
+        try:
+            i = int(index)
+        except ValueError:
+            raise gcmd.error("'%s' is not a number, "
+                             "only numbers, ',' and '-' are allowed." % index)
+        if i < 1:
+            raise gcmd.error("index can not be less than 1(was '%d')" % i)
+        if i > led_count:
+            raise gcmd.error("index can not exceed amount of "
+                             "led in chain(was '%d')" % i)
+        return i
+    def get_indices(self, gcmd, led_count):
+        command = gcmd.get("INDEX", None)
+        if command is None:
+            return range(1, (led_count + 1))
+        indices = set()
+        for index in command.split(','):
+            if '-' in index:
+                group = index.split('-')
+                if len(group) > 2:
+                    raise gcmd.error("More than one '-' found in '%s', "
+                                     "only one allowed" % index)
+                for i in range(self.check_index(group[0], gcmd, led_count),
+                               (self.check_index(group[1],
+                                                 gcmd,
+                                                 led_count) + 1)):
+                    indices.add(i)
+            else:
+                indices.add(self.check_index(index, gcmd, led_count))
+        return indices
     def get_led_count(self):
         return self.led_count
     def set_color(self, index, color):
-        if index is None:
-            new_led_state = [color] * self.led_count
-            if self.led_state == new_led_state:
-                return
-        else:
-            if self.led_state[index - 1] == color:
-                return
-            new_led_state = list(self.led_state)
-            new_led_state[index - 1] = color
-        self.led_state = new_led_state
+        if self.led_state[index - 1] == color:
+            return
+        self.led_state[index - 1] = color
         self.need_transmit = True
     def check_transmit(self, print_time):
         if not self.need_transmit:
@@ -56,13 +80,13 @@ class LEDHelper:
         green = gcmd.get_float('GREEN', 0., minval=0., maxval=1.)
         blue = gcmd.get_float('BLUE', 0., minval=0., maxval=1.)
         white = gcmd.get_float('WHITE', 0., minval=0., maxval=1.)
-        index = gcmd.get_int('INDEX', None, minval=1, maxval=self.led_count)
         transmit = gcmd.get_int('TRANSMIT', 1)
         sync = gcmd.get_int('SYNC', 1)
         color = (red, green, blue, white)
         # Update and transmit data
         def lookahead_bgfunc(print_time):
-            self.set_color(index, color)
+            for index in self.get_indices(gcmd, self.led_count):
+                self.set_color(index, color)
             if transmit:
                 self.check_transmit(print_time)
         if sync:
@@ -152,7 +176,6 @@ class PrinterLED:
         if led_helper is None:
             raise gcmd.error("Unknown LED '%s'" % (led_name,))
         led_count = led_helper.get_led_count()
-        index = gcmd.get_int("INDEX", None, minval=1, maxval=led_count)
         template = None
         lparams = {}
         tpl_name = gcmd.get("TEMPLATE")
@@ -172,11 +195,8 @@ class PrinterLED:
                     lparams[p] = ast.literal_eval(v)
                 except ValueError as e:
                     raise gcmd.error("Unable to parse '%s' as a literal" % (v,))
-        if index is not None:
+        for index in led_helper.get_indices(gcmd, led_count):
             self._activate_template(led_helper, index, template, lparams)
-        else:
-            for i in range(led_count):
-                self._activate_template(led_helper, i+1, template, lparams)
         self._activate_timer()
 
 PIN_MIN_TIME = 0.100


### PR DESCRIPTION
Changed the handling of INDEX in the SET_LED and SET_LED_TEMPLATE command so you can use INDEX=a,b,c to set multiple LEDs at the same time and also use INDEX=a-b to set all LEDs between a and b and also mix and match those two
If you put |n behind a range, it will only update every n'th LED in that range(e.g. INDEX=1-5|2 would update LED1, LED3 and LED5)