### PR TITLE
Controller fan idle speed

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2656,8 +2656,8 @@ watched component.
 #   The default is 1.0
 #idle_timeout:
 #   The amount of time (in seconds) after a stepper driver or heater
-#   was active and the fan should be kept running. If the value is 
-#   set to -1, the fan will keep from shutting off while idle. The 
+#   was active and the fan should be kept running. If the value is
+#   set to -1, the fan will keep from shutting off while idle. The
 #   default is 30 seconds.
 #idle_speed:
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2656,8 +2656,9 @@ watched component.
 #   The default is 1.0
 #idle_timeout:
 #   The amount of time (in seconds) after a stepper driver or heater
-#   was active and the fan should be kept running. The default
-#   is 30 seconds.
+#   was active and the fan should be kept running. If the value is 
+#   set to -1, the fan will keep from shutting off while idle. The 
+#   default is 30 seconds.
 #idle_speed:
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
 #   will be set to when a heater or stepper driver was active and


### PR DESCRIPTION
I have one fan that sits over my electronics and want to keep it at an idle speed to keep the pi cool but also hit active speed when my motor drivers are active. The current way the controller fan works is that it only stays in the idle speed for however long you set the timer for. I made the option of keeping it going by adding in a -1 value that would disable the timeout feature. This means that it will run at active speed when called for but any other time it will be at the idle speed including on start up.