### PR TITLE
Allow configuring THIGH register for TMC5160

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3531,6 +3531,7 @@ run_current:
 #driver_CHM: 0
 #driver_VHIGHFS: 0
 #driver_VHIGHCHM: 0
+#driver_THIGH: 0
 #driver_DISS2G: 0
 #driver_DISS2VS: 0
 #driver_PWM_AUTOSCALE: True

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -239,6 +239,9 @@ Fields["TPWMTHRS"] = {
 Fields["TCOOLTHRS"] = {
     "tcoolthrs":                0xfffff << 0
 }
+Fields["THIGH"] = {
+    "thigh":                	0xfffff << 0
+}
 Fields["TSTEP"] = {
     "tstep":                    0xfffff << 0
 }

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -380,6 +380,7 @@ class TMC5160:
         set_config_field(config, "pwm_lim", 12)
         #   TPOWERDOWN
         set_config_field(config, "tpowerdown", 10)
+        set_config_field(config, "thigh", 0)
 
 def load_config_prefix(config):
     return TMC5160(config)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -240,7 +240,7 @@ Fields["TCOOLTHRS"] = {
     "tcoolthrs":                0xfffff << 0
 }
 Fields["THIGH"] = {
-    "thigh":                	0xfffff << 0
+    "thigh":                    0xfffff << 0
 }
 Fields["TSTEP"] = {
     "tstep":                    0xfffff << 0


### PR DESCRIPTION
Signed-off-by: Joshua Longenecker eddietheengr@gmail.com

Hello team!

This is a pretty basic change, I was trying to modify the "THIGH" register but it is not defined as a FIELD, so I was unable to set the register using the SET_TMC_FIELD command. 


<img width="1213" alt="Screenshot 2023-05-27 at 12 35 46 PM" src="https://github.com/Klipper3d/klipper/assets/11861478/1c1f7aca-5f30-4779-8880-86992d2f8e13">

https://github.com/Klipper3d/klipper/blob/5f0d252b408ef0cd182367ba4cc224b8d105f0ec/klippy/extras/tmc5160.py#L29

I have done three changes:

- Add FIELD definition for "THIGH" with a 20 bit length
- Add default config definition to 0 (so THIGH is disabled by default)
- Update Config_Reference to show that driver_THIGH: 0 is supported as an adjustable parameter in the config for 5160s.

Here is an oscilloscope shot demonstrating switching to full stepping at approximately 1000mm/s. 

![LDO_42STH48-2504AC_5 27c](https://github.com/Klipper3d/klipper/assets/11861478/71cfbbe0-35fd-40ed-91d0-a491006b2de7)

Note that my driver configuration settings for this test were:
```
driver_TBL: 1 #default 2
driver_TOFF: 1 #default 3
driver_HEND: 3 #default 2
driver_HSTRT: 0 #default 5
driver_VHIGHFS: 1 #0
driver_VHIGHCHM: 1
driver_TPFD: 0 #critical parameter
driver_THIGH: 8
```