### PR TITLE
bme280: use consistent report time for BME680

### DIFF
--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -332,7 +332,7 @@ class BME280:
                 % (self.temp, self.min_temp, self.max_temp))
         measured_time = self.reactor.monotonic()
         self._callback(self.mcu.estimated_print_time(measured_time), self.temp)
-        return measured_time + REPORT_TIME * 4
+        return measured_time + REPORT_TIME
 
     def _compensate_temp(self, raw_temp):
         dig = self.dig


### PR DESCRIPTION
This PR supersedes #6221, fixing the BME680 issue by reporting every .8 seconds.  As before I have tested this change against a BME280, however it would be useful if someone would like to make sure the BME680 works as intended.