### PR TITLE
Printer configs

### DIFF
--- a/config/printer-voxelab-aquila-v1.0.0-2020.cfg
+++ b/config/printer-voxelab-aquila-v1.0.0-2020.cfg
@@ -1,0 +1,112 @@
+# This file contains pin mappings for the Voxelab Aquila with
+# HC32F460 on the X1_Main_Board_V1.0.0 mainboard (X1, more).
+# To use this config:
+# during: "make menuconfig" select the the HC32F460.
+# The V1.0.0 board uses 0x8000 for the Flash Application Address
+# The clock speed is 168MHz
+# Serial connection is PA15 & PA09
+
+# Flash this firmware by copying "out/klipper.bin" to
+#  /firmware/klipper.bin on an SD card (8GB works) and then
+#  turning on the printer with the card inserted.
+#  The file will be deleted upon success
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PC2
+dir_pin: PB9
+enable_pin: !PC3
+endstop_pin: ^PA6
+microsteps: 16
+rotation_distance: 40
+position_max: 220
+homing_speed: 50
+position_endstop: 0
+
+[stepper_y]
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PC3
+endstop_pin: ^PA7
+microsteps: 16
+rotation_distance: 40
+position_endstop: 0
+position_max: 220
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PC3
+endstop_pin: ^PC4
+microsteps: 16
+rotation_distance: 8
+position_endstop: 0.0
+position_max: 250
+homing_speed: 15
+homing_retract_dist: 4
+homing_retract_speed: 5
+second_homing_speed: 1
+
+[extruder]
+step_pin: PB4
+dir_pin: PB3
+enable_pin: !PC3
+sensor_pin: PA5
+heater_pin: PA1
+microsteps: 16
+rotation_distance: 34.406
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_kp = 31.976
+pid_ki = 2.450
+pid_kd = 104.322
+min_temp: 0
+max_temp: 260
+
+[firmware_retraction]
+retract_length: 2.5
+
+[heater_bed]
+sensor_pin: PA4
+heater_pin: PA0
+sensor_type: EPCOS 100K B57560G104F
+control: pid
+pid_Kp:  50.000
+pid_Ki:   1.000
+pid_Kd: 950.0
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA2
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[led mcu_led]
+red_pin: PA3
+initial_RED: 0.5
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 20
+max_z_accel: 100
+
+# the display pin signals are inverted on the MB - check menuconfig opt.
+[display]
+lcd_type: st7920
+cs_pin: PB12
+sclk_pin: PB13
+sid_pin: PB15
+encoder_pins: ^PB14, ^PC6
+click_pin: ^!PB1
+
+[output_pin beeper]
+pin: PB0

--- a/config/printer-voxelab-aquila-v1.0.3-2021.cfg
+++ b/config/printer-voxelab-aquila-v1.0.3-2021.cfg
@@ -1,0 +1,157 @@
+# This file contains pin mappings for the Voxelab Aquila with
+# HC32F460 on the 1.0.3 mainboard. Chassis sticker 'H32'
+To use this config, during
+# "make menuconfig" select the the HC32F460.
+# The V1.0.3 board uses 0xC000 for the Flash Application Address
+# The clock speed is 168MHz
+# Serial connection is PA15 & PA09
+# If you prefer a direct serial connection:
+# serial (on PC0/PC1), which is broken out on the 10 pin IDC
+# cable used for the LCD module as follows:
+# Pin 7: Tx, Pin 8: Rx Pin 2: GND, Pin 1: +5V
+
+# Flash this firmware by copying "out/klipper.bin" to
+#  /firmware/klipper.bin on an SD card (8GB works) and then
+#  turning on the printer with the card inserted.
+#  The file will be deleted upon success
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PC2
+dir_pin: PB9
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA5
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA6
+position_endstop: 0
+position_max: 235
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PA7
+position_endstop: 0.0
+position_max: 250
+
+[extruder]
+max_extrude_only_distance: 100.0
+step_pin: PB4
+dir_pin: PB3
+enable_pin: !PC3
+microsteps: 16
+rotation_distance: 34.406
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC5
+control: pid
+# tuned for stock hardware with 200 degree Celsius target
+pid_Kp: 21.527
+pid_Ki: 1.063
+pid_Kd: 108.982
+min_temp: 0
+max_temp: 250
+
+[firmware_retraction]
+retract_length: 2.5
+
+[filament_switch_sensor runoutSensor]
+switch_pin: !PA4
+
+[heater_bed]
+heater_pin: PA2
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+control: pid
+# tuned for stock hardware with 50 degree Celsius target
+pid_Kp: 54.027
+pid_Ki: 0.770
+pid_Kd: 948.182
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PA0
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[led mcu_led]
+red_pin: PA3
+initial_RED: 0.5
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+
+##########################################################
+##########################################################
+### additions for BLtouch - uncomment where needed
+# BLtouch configuration
+# The x-offset is in negative form if
+# bltouch is mounted on left side of hotend.
+
+#[bltouch]
+#sensor_pin: ^PB1
+#control_pin: PB0
+#x_offset: -40.0
+#y_offset: 0
+#z_offset: 0.5
+#pin_move_time: 0.4
+#speed: 20
+
+#[bed_mesh]
+#speed: 120
+#horizontal_move_z: 5
+#mesh_min: 10, 20
+#mesh_max: 190, 190
+#probe_count: 5, 3
+#algorithm: bicubic
+
+#[gcode_macro g29]
+#gcode:
+# BED_MESH_CALIBRATE
+# BED_MESH_OUTPUT
+
+#[homing_override]
+#gcode:
+# G90 ; Use absolute position mode
+# G1 Z10 ; Move up 10mm
+# G28 X Y
+# G1 X166 Y120 F6000 ; Change X & Y to center of your print bed
+# G28 Z
+# set_position_z: 0.0
+
+##########################################################
+### modification to Z for BLtouch
+##  and comment out the line: position_endstop: 0.0
+#[stepper_z]
+#step_pin: PB6
+#dir_pin: !PB5
+#enable_pin: !PC3
+#microsteps: 16
+#rotation_distance: 8
+#position_max: 250
+#endstop_pin: probe:z_virtual_endstop


### PR DESCRIPTION
Config: for Voxelab Aquia with v1.0.0 (X1, etc.) and v1.0.3 boards with HC32F460

These are updated with the company specific choices for the hc32f460 Kconfig

Signed-off-by: Steven Gotthardt <gotthardt@gmail.com>
