### PR TITLE
Correct year in documentation for ender 3 v2 neo

### DIFF
--- a/config/printer-creality-ender3-v2-neo-2022.cfg
+++ b/config/printer-creality-ender3-v2-neo-2022.cfg
@@ -1,4 +1,4 @@
-# This file contains pin mappings for the stock 2020 Creality Ender 3
+# This file contains pin mappings for the stock 2022 Creality Ender 3
 # V2 Neo. To use this config, during "make menuconfig" select the
 # STM32F103 with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.


### PR DESCRIPTION
This is a very minor typo in the Ender 3 v2 neo sample config. However, it did cause me to pause to see if I had the correct config.