### PR TITLE
config: Correct year in documentation for ender 3 v2 neo

### DIFF
--- a/config/printer-creality-ender3-v2-neo-2022.cfg
+++ b/config/printer-creality-ender3-v2-neo-2022.cfg
@@ -1,4 +1,4 @@
-# This file contains pin mappings for the stock 2020 Creality Ender 3
+# This file contains pin mappings for the stock 2022 Creality Ender 3
 # V2 Neo. To use this config, during "make menuconfig" select the
 # STM32F103 with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.


### PR DESCRIPTION
The header documentation currently shows the year the Creality Ender 3 V2 Neo as being the 2020 model. This is likely a copy/paste error from the header of the original Creality Ender 3 V2 config. The year the Creality Ender 3 V2 Neo came out was in 2022 as indicated by the name of this config file. This patch fixes the copy/paste typo by updating the year in the header documentation from 2020 to 2022.