### PR TITLE
Always set TCOOLTHRS to 0xfffff during homing.

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -516,9 +516,8 @@ class TMCVirtualPinHelper:
             self.fields.set_field("en_pwm_mode", 0)
             val = self.fields.set_field(self.diag_pin_field, 1)
         self.mcu_tmc.set_register("GCONF", val)
-        if self.coolthrs == 0:
-            tc_val = self.fields.set_field("tcoolthrs", 0xfffff)
-            self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
+        tc_val = self.fields.set_field("tcoolthrs", 0xfffff)
+        self.mcu_tmc.set_register("TCOOLTHRS", tc_val)
     def handle_homing_move_end(self, hmove):
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return


### PR DESCRIPTION
"tmc: Do not override tcoolthrs if it is configured" allows a configured tcoolthrs to be used during homing.

Unfortunately, it appears that the datasheet for the TMC2240 is incorrect. It states that if the step rate is below tcoolthrs, stall detection should be enabled. This does not seem to be true, and having this register set to 0xfffff appears to be necessary for sensorless homing to work. I have seen the status register record a stall but the diagnostic pin not register with tcoolthrs set to other values, even values greater than tstep at the time.

Since homing moves should be slow anyway, it seems unnecessary to provide configuration for this, and setting 0xfffff for all chips that support CoolStep should be adequate.

This does retain the other functionality of resetting tcoolthrs to its previous value when the homing move finishes.