### PR TITLE
Config: remove move_to_previous from Ender 3 S1 configs

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -120,7 +120,6 @@ home_xy_position: 147, 154
 speed: 75
 z_hop: 10
 z_hop_speed: 5
-move_to_previous: true
 
 [filament_switch_sensor e0_sensor]
 switch_pin: !PC15

--- a/config/printer-creality-ender3-s1plus-2022.cfg
+++ b/config/printer-creality-ender3-s1plus-2022.cfg
@@ -120,7 +120,6 @@ home_xy_position: 187, 192
 speed: 75
 z_hop: 10
 z_hop_speed: 5
-move_to_previous: true
 
 [filament_switch_sensor e0_sensor]
 switch_pin: !PC15


### PR DESCRIPTION
This PR is to remove `move_to_previous: true` from the Ender 3 S1 and S1 plus configs. This is a confusing option, it is not really useful on these type of printers and can cause issue to the end user

Thanks
James

Signed_off_by: James Hartley <james@hartleyns.com>