### PR TITLE
Simultaneous activation of steppers

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230611: The `stepper` parameter in command SET_STEPPER_ENABLE has
+been renamed to `steppers`. Now it accepts multiple steppers.
+The `stepper` parameter is deprecated and will be removed in the near future.
+
 20230530: The default canbus frequency in "make menuconfig" is
 now 1000000. If using canbus and using canbus with some other
 frequency is required, then be sure to select "Enable extra low-level

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1193,8 +1193,10 @@ settings. Requires `control_pin` to be provided in the config section.
 The stepper_enable module is automatically loaded.
 
 #### SET_STEPPER_ENABLE
-`SET_STEPPER_ENABLE STEPPER=<config_name> ENABLE=[0|1]`: Enable or
-disable only the given stepper. This is a diagnostic and debugging
+`SET_STEPPER_ENABLE STEPPERS=<config_name> [ENABLE=[0|1]]`: Enable or
+disable only the given steppers. `<config_name>` can be one or
+more configured steppers, delimited with comma, for example
+`STEPPERS=stepper_x,stepper_y`. This is a diagnostic and debugging
 tool and must be used with care. Disabling an axis motor does not
 reset the homing information. Manually moving a disabled stepper may
 cause the machine to operate the motor outside of safe limits. This

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -106,7 +106,7 @@ class PrinterStepperEnable:
                 el.motor_enable(print_time)
             else:
                 el.motor_disable(print_time)
-        logging.info("%s have been manually %s", steppers, 
+        logging.info("%s have been manually %s", steppers,
                      "enabled" if enable else "disabled")
     def get_status(self, eventtime):
         steppers = { name: et.is_motor_enabled()

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -106,8 +106,9 @@ class PrinterStepperEnable:
                 el.motor_enable(print_time)
             else:
                 el.motor_disable(print_time)
-        logging.info("%s have been manually %s", steppers,
+        logging.info("%s have been manually %s", steppers, 
                      "enabled" if enable else "disabled")
+        toolhead.dwell(DISABLE_STALL_TIME)
     def get_status(self, eventtime):
         steppers = { name: et.is_motor_enabled()
                            for (name, et) in self.enable_lines.items() }

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -106,7 +106,7 @@ class PrinterStepperEnable:
                 el.motor_enable(print_time)
             else:
                 el.motor_disable(print_time)
-        logging.info("%s have been manually %s", steppers, 
+        logging.info("%s have been manually %s", steppers,
                      "enabled" if enable else "disabled")
         toolhead.dwell(DISABLE_STALL_TIME)
     def get_status(self, eventtime):

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -120,11 +120,15 @@ class PrinterStepperEnable:
         self.motor_off()
     cmd_SET_STEPPER_ENABLE_help = "Enable/disable individual stepper by name"
     def cmd_SET_STEPPER_ENABLE(self, gcmd):
-        steppers_str = gcmd.get('STEPPER', None)
+        steppers_str = gcmd.get('STEPPERS', None)
         stepper_enable = gcmd.get_int('ENABLE', 1)
         steppers = []
         if steppers_str is None:
             steppers = [None]
+            old_stepper_str = gcmd.get('STEPPER', None)
+            if old_stepper_str is not None:
+                steppers = old_stepper_str.split(',')
+                gcmd.respond_info('"STEPPER" parameter is deprecated')
         else:
             steppers = steppers_str.split(',')
         for stepper_name in steppers:

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -124,7 +124,7 @@ class PrinterStepperEnable:
         stepper_enable = gcmd.get_int('ENABLE', 1)
         steppers = []
         if steppers_str is None:
-            steppers = None
+            steppers = [None]
         else:
             steppers = steppers_str.split(',')
         for stepper_name in steppers:

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -104,11 +104,10 @@ class PrinterStepperEnable:
             el = self.enable_lines[stepper_name]
             if enable:
                 el.motor_enable(print_time)
-                logging.info("%s has been manually enabled", steppers)
             else:
                 el.motor_disable(print_time)
-                logging.info("%s has been manually disabled", steppers)
-        toolhead.dwell(DISABLE_STALL_TIME)
+        logging.info("%s have been manually %s", steppers, 
+                     "enabled" if enable else "disabled")
     def get_status(self, eventtime):
         steppers = { name: et.is_motor_enabled()
                            for (name, et) in self.enable_lines.items() }


### PR DESCRIPTION
Adding the functionality of simultaneous activation or deactivation of specified motors.
It is needed in printers with multiple steppers per axis to synchronize steppers positions without parking.

Signed-off-by: Evgenii Shavrin [shavrin0591@gmail.com](mailto:shavrin0591@gmail.com)