### PR TITLE
dockable_probe module

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1948,11 +1948,12 @@ detach_position: 0,0,0
 #travel_speed:
 #   Optional speeds used during moves.
 #   The default is to use `speed` of `probe` or 5.0.
-#check_open_attach: False
+#check_open_attach:
 #   The probe status should be verified prior to homing. Setting this option
-#   to true will ensure the probe "endstop" is "open" if the probe is attached
-#   and will abort probing if it reports "triggered" when docked.
-#   The default is False.
+#   to true will check the probe "endstop" is "open" after attaching and
+#   will abort probing if not, also checking for "triggered" after docking.
+#   Conversively, setting this to false, the probe should read "triggered"
+#   after attaching and "open" after docking. If not, probing will abort.
 #probe_sense_pin:
 #   This supplemental pin can be defined to determine an attached state
 #   instead of check_open_attach.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1970,8 +1970,6 @@ detach_position: 0,0,0
 #samples_result:
 #samples_tolerance:
 #samples_tolerance_retries:
-#activate_gcode:
-#deactivate_gcode:
 #   See the "probe" section for information on these parameters.
 ```
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1897,7 +1897,95 @@ control_pin:
 #   See the "probe" section for information on these parameters.
 ```
 
-### [smart_effector]
+## [dockable_probe]
+
+Certain probes are magnetically coupled to the toolhead and stowed
+in a dock when not in use. One should define this section instead
+of a probe section if the probe uses magnets to attach and a dock
+for storage. See [Dockable Probe Guide](Dockable_Probe.md)
+for more detailed information regarding configuration and setup.
+
+```
+[dockable_probe]
+dock_position: 0,0,0
+#   The physical position of the probe dock relative to the origin of
+#   the bed. The coordinates are specified as a comma separated x, y, z
+#   list of values. Certain dock designs are independent of the z axis.
+#   if a z value is provided for these configurations, the z axis will
+#   be raised to that amount in order to prevent collisions.
+#   This parameter is required.
+approach_position: 0,0
+#   The X,Y position where the toolhead needs to be prior to moving into the
+#   dock so that the probe is aligned properly for docking or attaching.
+#   This parameter is required.
+detach_position: 0,0
+#   Similar to the approach_position, the detach_position is the X,Y
+#   where the toolhead is moved after the probe has been docked.
+#   For magnetically coupled probes, this is typically perpendicular to
+#   the approach_position in a direction that does not cause the tool to
+#   collide with the printer.
+#   This parameter is required
+#safe_z_position: 0,0
+#   Optional parameter. If the probe is being used to home the Z
+#   axis, the toolhead will move to these xy coordinates prior to homing.
+#   If this value is not provided, the center of the bed will be used.
+#dock_retries:
+#   The number of times to attempt to attach/dock the probe before raising
+#   and error and aborting probing.
+#attach_speed:
+#detach_speed:
+#travel_speed:
+#   Optional speeds used during various moves. These will default to probe
+#   speed if not specified.
+check_open_attach:     True
+#   The probe status should be verified prior to homing. Setting this option
+#   to true will ensure the probe "endstop" is "open" if the probe is attached
+#   and will abort probing if it reports "triggered" when docked
+#probe_sense_pin:
+#   This supplemental pin can be defined to determine an attached state
+#   instead of check_open_attach
+#dock_sense_pin:
+#   This supplemental pin can be defined to determine a docked state in
+#   addition to probe_sense_pin or check_open_attach
+#allow_delayed_detach: False
+#   When true, the probe will stay attached to the toolhead after the
+#   completion of a command in case there is another command requiring the
+#   use of the probe in the command queue. Once all commands have completed,
+#   the probe is docked. It is recommended to add the DETACH_PROBE command to
+#   macros and slicer start gcode to ensure the probe is correctly detached.
+#   See Annexed_Probe.md for more information
+dock_fixed_z: True
+#   Whether or not the dock is located independently of the Z axis such as
+#   mounted to a moving gantry.
+#pre_attach_gcode:
+#   An optional list of gcode commands to execute prior to attaching the probe
+#attach_gcode:
+#   An optional list of gcode commands used to attach the probe
+#post_attach_gcode:
+#   An optional list of gcode commands to execute immediately after attaching
+#   the probe
+#pre_detach_gcode:
+#   An optional list of gcode commands to execute prior to detaching/docking
+#   the probe
+#detach_gcode:
+#   An optional list of gcode commands used to detach/dock the probe
+#post_detach_gcode:
+#   An optional list of gcode commands to execute immediately after
+#   detaching/docking the probe
+#x_offset:
+#y_offset:
+#z_offset:
+#lift_speed:
+#speed:
+#samples:
+#sample_retract_dist:
+#samples_result:
+#samples_tolerance:
+#samples_tolerance_retries:
+#activate_gcode:
+#deactivate_gcode:
+#   See the "probe" section for information on these parameters.
+```
 
 The "Smart Effector" from Duet3d implements a Z probe using a force
 sensor. One may define this section instead of `[probe]` to enable the

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1897,7 +1897,7 @@ control_pin:
 #   See the "probe" section for information on these parameters.
 ```
 
-## [dockable_probe]
+### [dockable_probe]
 
 Certain probes are magnetically coupled to the toolhead and stowed
 in a dock when not in use. One should define this section instead
@@ -1909,69 +1909,56 @@ for more detailed information regarding configuration and setup.
 [dockable_probe]
 dock_position: 0,0,0
 #   The physical position of the probe dock relative to the origin of
-#   the bed. The coordinates are specified as a comma separated x, y, z
-#   list of values. Certain dock designs are independent of the z axis.
-#   if a z value is provided for these configurations, the z axis will
-#   be raised to that amount in order to prevent collisions.
+#   the bed. The coordinates are specified as a comma separated X, Y, Z
+#   list of values. Certain dock designs are independent of the Z axis.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
 #   This parameter is required.
-approach_position: 0,0
-#   The X,Y position where the toolhead needs to be prior to moving into the
-#   dock so that the probe is aligned properly for docking or attaching.
+approach_position: 0,0,0
+#   The X, Y, Z position where the toolhead needs to be prior to moving into the
+#   dock so that the probe is aligned properly for attaching or detaching.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
 #   This parameter is required.
-detach_position: 0,0
-#   Similar to the approach_position, the detach_position is the X,Y
+detach_position: 0,0,0
+#   Similar to the approach_position, the detach_position is the coordinates
 #   where the toolhead is moved after the probe has been docked.
 #   For magnetically coupled probes, this is typically perpendicular to
 #   the approach_position in a direction that does not cause the tool to
 #   collide with the printer.
-#   This parameter is required
-#safe_z_position: 0,0
-#   Optional parameter. If the probe is being used to home the Z
-#   axis, the toolhead will move to these xy coordinates prior to homing.
-#   If this value is not provided, the center of the bed will be used.
+#   If Z is specified the toolhead will move to the Z location before the X, Y
+#   coordinates.
+#   This parameter is required.
+#z_hop: 15.0
+#   Distance (in mm) to lift the Z axis prior to attaching/detaching the probe.
+#   If the Z axis is already homed and the current Z position is less
+#   than `z_hop`, then this will lift the head to a height of `z_hop`. If
+#   the Z axis is not already homed the head is lifted by `z_hop`.
+#   The default is to not implement Z hop.
 #dock_retries:
 #   The number of times to attempt to attach/dock the probe before raising
-#   and error and aborting probing.
+#   an error and aborting probing.
+#   The default is 0.
+#auto_attach_detach: False
+#   Enable/Disable the automatic attaching/detaching of the probe during
+#   actions that require the probe.
+#   The default is True.
 #attach_speed:
 #detach_speed:
 #travel_speed:
-#   Optional speeds used during various moves. These will default to probe
-#   speed if not specified.
-check_open_attach:     True
+#   Optional speeds used during moves.
+#   The default is to use `speed` of `probe` or 5.0.
+#check_open_attach: False
 #   The probe status should be verified prior to homing. Setting this option
 #   to true will ensure the probe "endstop" is "open" if the probe is attached
-#   and will abort probing if it reports "triggered" when docked
+#   and will abort probing if it reports "triggered" when docked.
+#   The default is False.
 #probe_sense_pin:
 #   This supplemental pin can be defined to determine an attached state
-#   instead of check_open_attach
+#   instead of check_open_attach.
 #dock_sense_pin:
 #   This supplemental pin can be defined to determine a docked state in
-#   addition to probe_sense_pin or check_open_attach
-#allow_delayed_detach: False
-#   When true, the probe will stay attached to the toolhead after the
-#   completion of a command in case there is another command requiring the
-#   use of the probe in the command queue. Once all commands have completed,
-#   the probe is docked. It is recommended to add the DETACH_PROBE command to
-#   macros and slicer start gcode to ensure the probe is correctly detached.
-#   See Annexed_Probe.md for more information
-dock_fixed_z: True
-#   Whether or not the dock is located independently of the Z axis such as
-#   mounted to a moving gantry.
-#pre_attach_gcode:
-#   An optional list of gcode commands to execute prior to attaching the probe
-#attach_gcode:
-#   An optional list of gcode commands used to attach the probe
-#post_attach_gcode:
-#   An optional list of gcode commands to execute immediately after attaching
-#   the probe
-#pre_detach_gcode:
-#   An optional list of gcode commands to execute prior to detaching/docking
-#   the probe
-#detach_gcode:
-#   An optional list of gcode commands used to detach/dock the probe
-#post_detach_gcode:
-#   An optional list of gcode commands to execute immediately after
-#   detaching/docking the probe
+#   addition to probe_sense_pin or check_open_attach.
 #x_offset:
 #y_offset:
 #z_offset:
@@ -1986,6 +1973,8 @@ dock_fixed_z: True
 #deactivate_gcode:
 #   See the "probe" section for information on these parameters.
 ```
+
+### [smart_effector]
 
 The "Smart Effector" from Duet3d implements a Z probe using a force
 sensor. One may define this section instead of `[probe]` to enable the

--- a/docs/Dockable_Probe.md
+++ b/docs/Dockable_Probe.md
@@ -1,0 +1,409 @@
+
+
+This document is meant to describe behavior related to dockable probes.
+These probes are typically microswitches mounted to a printed body that
+attaches to the toolhead through some means of mechanical coupling.
+This coupling is commonly done with magnets though this module can support
+a variety of designs including servo and stepper actuated couplings.
+
+# Basic Configuration
+
+The minimum requirements for functionality are a config section where the
+following options are specified. Some users may be transitioning from a macro
+based set of commands and many of the options for the `[probe]` config section
+are the same. The `[dockable_probe]` module is first and foremost a `[probe]`
+with additional functionality added. Any options that can be specified in
+for `[probe]` are valid for `[dockable_probe]` as well.
+
+```
+[dockable_probe]
+pin:
+z_offset:
+sample_retract_dist:
+approach_position:
+detach_position:
+check_open_attach:
+dock_fixed_z:
+```
+
+Additional optional parameters are described in this guide as well as the
+required parameters. Certain optional parameters are not required, but highly recommended in order to ensure desired probe behavior is observed. Additionally
+the [probe calibrate guide](Probe_Calibrate.md) is recommended reading
+for users unfamiliar with probe setup in Klipper.
+
+## Attaching and Detaching Positions
+
+```
+    dock_position: 300, 295, 0
+```
+
+The first option to specify is the `dock_position`. This is simply the XYZ
+coordinates where the toolhead needs to be positioned in order to attach
+the probe. This parameter is X, Y and, Z separated by commas.
+
+Many configurations have the dock attached to a moving gantry. This effectively
+means that Z axis positioning is irrelevant. However, it may be necessary
+to move the gantry clear of the bed or other printer components before
+performing docking steps. Automatic Z hop distances are calculated based on the
+probe `z_offset` + `sample_retract_dist` to ensure travel moves are
+safe. If a Z axis amount is specified for this type of dock, the additional
+amount will be added to the Z hop distance.
+
+Other configurations may have the dock mounted next to the printer bed so
+that the Z position _must_ be known prior to attaching the probe. If the
+probe is mounted in such a way, the Z axis parameter _must_ be supplied,
+and the Z axis _must_ be homed prior to attaching the probe.
+
+```
+    approach_position: 300, 250
+```
+
+The most common dock designs utilize a sort of fork or arms that extend out
+from the dock. In order to attach the probe to the toolhead, the toolhead must
+move into and away from the dock at a particular angle so that these arms can
+capture the probe body. For magnetically coupled probes, the `approach_position`
+should be defined so that it is far enough away from the probe so that the
+magnets on the probe body are not attracted to the magnets on the toolhead.
+
+```
+    detach_position:  250, 295
+```
+
+Most probes that use magnets require the toolhead to move in a direction that
+strips the magnets off with a sliding motion. This is to prevent the magnets
+from becoming unseated from repeated pulling and thus affecting probe accuracy.
+The `detach_position` is typically defined as a point that is perpendicular to
+the dock so that when the toolhead moves, the probe stays docked but cleanly
+detaches from the toolhead mount. For magnetically coupled probes, the
+`detach_position` should be defined so that it is far enough away from the
+probe so that the magnets on the probe body are not attracted to the magnets on
+the toolhead.
+
+## Dock Z location
+
+```
+    dock_fixed_z:   default false
+```
+There are various locations that probe docks have been mounted. It seems the
+more common locations are next to a bed or on a moving gantry. If the probe
+is "fixed" on the Z axis, meaning, it's position relative to XY plane of the
+toolhead is always the same, this option should be set to "true".
+
+An example where `dock_fixed_z: True` is a corexy printer with a bed that moves
+up and down along the Z axis with the probe dock mounted to the frame next to a
+fixed gantry. The toolhead can move to the probe dock _regardless_ of where
+the bed is positioned.
+
+Another example would be a printer with a bed that is fixed to the base of the
+printer and the gantry moves along all 3 axes. The dock is mounted to a point on
+this moving gantry. This as well would be `dock_fixed_z: True`
+
+A example where `dock_fixed_z: False` would be a i3 style printer where the dock
+is located on the moving bed. When the Z axis moves, the dock's position changes
+relative to the toolhead.
+
+Another example of `dock_fixed_z: False` is a cartesian or hbot cube printer
+where the dock is mounted next to the moving bed on the Z axis itself.
+
+Any printer where `dock_fixed_z: False` requires that the z axis be homed prior
+to moving to the dock.
+
+```
+    safe_z_position:    0,0
+```
+An optional parameter may be defined for homing the Z axis using the probe.
+Similar to `safe_z_home`, a set of x y coordinates may be defined to use when
+homing. If this parameter is omitted, the center of the bed will be used.
+
+## Tool Velocities
+
+```
+    attach_speed:   default is probe speed or 5mm/s
+    detach_speed: default is probe speed or 5mm/s
+    travel_speed:   default is 50 mm/s
+```
+Various optional speeds can be defined for approaching, detaching and
+traveling. If these parameters are omitted, the module will use the `speed`
+parameter of the probe if defined. If this option is not supplied, 5mm/s
+will be used.
+
+## Probe Attachment Verification
+
+Given the nature of this type of probe, it is necessary to verify whether or
+not it has successfully attached prior to attempting a probing move. Several
+methods can be used to verify various probe attachment states.
+
+```
+    check_open_attach: default false
+```
+Certain probes when wired a certain way will report `OPEN` when they are
+attached and `TRIGGERED` when they are detached in a non-probing state. The
+`check_open_attach` option when set to `true` will check the state of the
+probe pin after performing a probe attach or docking maneuver. If the probe
+reports `TRIGGERED` immediately after the toolhead leaves the dock radius, an
+error will be raised and any further action will be aborted.
+
+This is intended to prevent crashing the nozzle into the bed since it is
+assumed if the probe pin reads `TRIGGERED` prior to probing, the probe is
+not attached.
+
+```
+    probe_sense_pin:
+```
+The probe may include a separate pin for attachment verification. This is a
+standard pin definition similar to an endstop pin that defines how to handle the
+input from the sensor. Much like the `check_open_attach` option, the check is
+done immediately after the tool attaches or docks the probe. If the probe
+is not attached after attempting to attach it, or it remains attached after
+attempting to dock it, an error will be raised and further action will be
+aborted.
+
+```
+    dock_sense_pin:
+```
+Certain docks may have a sensor or switch incorporated into their design in
+order to report that the probe is presently located in the dock. A
+`dock_sense_pin` may be provided to provide verification that the probe is
+correctly positioned in the dock. This is a standard pin definition similar
+to an endstop pin that defines how to handle the input from the sensor.
+Prior to attempting to attach the probe, and after attempting to dock it,
+this pin is checked. If the probe is not stowed, an error will be raised and
+further action will be aborted.
+
+```
+    dock_retries:   0
+```
+A magnetic probe may require repeated attempts to attach. If `dock_retries` is
+specified and the probe fails to attach or detach, the attach/detach action
+will be repeated until it succeeds. If the retry limit is reached and the probe
+is still not in the correct state, an error is raised and futher actions
+are aborted.
+
+```
+    allow_delayed_detach: False
+```
+Typically, a command that requires the use of the probe will cause the probe
+to be attached and then docked when it is no longer needed. In the context
+of start gcode, a homing macro, or any sequence with multiple commands requiring
+the use of the probe, this results in the probe repeatedly being attached and
+docked between commands. If the `allow_delayed_detach` option is set to True,
+the probe will wait for a short period of time before docking at the end of
+a command. This can result in calibration macros executing faster as the probe
+has to do less traveling. If this option is used, it is recommended to add
+the manual `DETACH_PROBE` command at the end of a macro or start gcode. Often
+the _next_ command will start to execute _prior_ to the probe detaching which
+can result in a collision.
+
+
+## Custom Actions
+
+```
+    pre_attach_gcode:
+    attach_gcode:
+    post_attach_gcode:
+    pre_detach_gcode:
+    detach_gcode:
+    post_detach_gcode:
+```
+
+As universal as this module attempts to be, all use cases cannot be accounted
+for. As such several "custom" gcode command templates may be supplied to be
+executed at various times during probe maneuvers. These optional gcode sections
+may be configured like standard gcode macro command templates with the exception
+that gcode macro variables, default parameters, and rename_existing options are
+excluded.
+
+These command templates are inserted at various points of the probe execution
+flow (below) so they may be used to activate a servo or move the toolhead to
+a position that aligns cabling or tubes so that they do not snag on parts of
+the printer.
+
+
+```
+    pre_attach_gcode:
+```
+If specified, the `pre_attach_gcode` is called prior to approaching the dock.
+If a servo is needed to move the dock, this is where that command should be
+issued.
+
+
+```
+    attach_gcode:
+```
+If specified, the `attach_gcode` commands are executed immediately _after_ the
+toolhead reaches the `dock_position`. This gcode may be repeated if the probe
+fails to attach and `dock_retries` are specified.
+
+```
+    post_attach_gcode:
+```
+If specified, the `post_attach_gcode` is called immediately after leaving the
+dock, but only if the probe was successfully attached.
+
+
+```
+    pre_detach_gcode:
+```
+If specified, the `pre_detach_gcode` is called prior to approaching the dock.
+If a servo is needed to move the dock, this is where that command should be
+issued.
+
+
+```
+    detach_gcode:
+```
+If specified, the `detach_gcode` commands are executed immediately _after_ the
+toolhead reaches the `dock_position`. This gcode may be repeated if the probe
+fails to detach and `dock_retries` are specified.
+
+```
+    post_detach_gcode:
+```
+If specified, the `post_detach_gcode` is called immediately after leaving the
+dock, but only if the probe was successfully docked.
+
+## Gcode commands
+
+There are 4 gcode commands that can be used with the probe to perform various
+tasks or obtain status information.
+
+```
+    ATTACH_PROBE
+```
+This command will move the toolhead to the dock, attach the probe, and then
+return to its previous position. If the probe is already attached, the command
+will not do anything
+
+```
+    DETACH_PROBE
+```
+This command will move the toolhead to the dock, detach the probe, and then
+return to its previous position. If the probe is already detached, the command
+will not do anything
+
+```
+    GET_PROBE_STATUS
+```
+Responds in the gcode terminal with the current status the probe is in. Valid
+states are UNKNOWN, ATTACHED, and DOCKED. This is useful during configuration
+to confirm probe validation methods are working as intended.
+
+## Typical probe execution flow
+
+    Probing is Started:
+
+    - A gcode command requiring the use of the probe is executed.
+
+    - This triggers the probe to attach
+
+    - If configured, the dock sense pin is checked to see if the probe is
+      presently in the dock
+
+    - If specified, the pre-attach gcode is executed
+
+    - The toolhead position is compared to the dock position.
+
+    - If the toolhead is outside of the minimum safe radius, the toolhead is
+      commanded to move to the the approach vector, that is, a position that is
+      the minimum safe distance from the dock in line with the dock angle
+
+    - If the toolhead is inside of the minimum safe radius, the toolhead is
+      commanded to move to the nearest point on the line of the approach vector
+
+    - The tool is moved along the approach vector to the dock coordinates
+
+    - If specified, the attach gcode is executed
+
+    - The toolhead is commanded to move out of the dock back to the minimum
+      safe distance in the reverse direction along the dock angle.
+
+    - If configured, the probe is checked to see if it is attached
+
+    - If the probe is not attached, the module retries until it is or an error
+      is raised
+
+    - If configured, the dock sense pin is checked to see if the probe is still
+      present, the module retries until it not or an error is raised
+
+    - If specified, the post-attach gcode is executed
+
+    - The probe moves to the first probing point and beings probing
+
+    Probing is Finished:
+
+    - After the probe is no longer needed, the probe is triggered to detach.
+
+    - If specified, the pre-detach gcode is executed
+
+    - The toolhead position is compared to the dock position.
+
+    - If the toolhead is outside of the minimum safe radius, the toolhead is
+      commanded to move to the the approach vector, that is, a position that is
+      the minimum safe distance from the dock in line with the dock angle
+
+    - If the toolhead is inside of the minimum safe radius, the toolhead is
+      commanded to move to the nearest point on the line of the approach vector
+
+    - The tool is moved along the approach vector to the dock coordinates
+
+    - If specified, the detach gcode is executed
+
+    - The tool is commanded to move along the detach vector if supplied or a
+      calculated direction based on axis parameters
+
+    - If configured, the probe is checked to see if it is detached
+
+    - If the probe is not detached, the module moves the tool back to the
+      approach vector and retries until it detaches or an error is raised
+
+    - If configured, the dock sense pin is checked to see if the probe is
+      present in the dock. If it is not the module moves the tool back to the
+      approach vector and retries until it detaches or an error is raised
+
+    - If specified, the post-detach gcode is executed
+
+
+# Use in macros
+
+The dockable_probe module can use a delayed detach so that it does not
+repeatedly dock and undock the probe from the toolhead while it is being
+used in the context of a homing macro or slicer start gcode. This works
+in most cases, but if a call to heat-and-wait (M109, M190) or a toolhead move
+comes too soon after probing is finished, it may result in the probe staying
+attached to the toolhead until after the heater is done heating or the gcode
+move completes. This can be avoided by placing a call to `DETACH_PROBE`
+immediately _after_ the last command requiring the probe.
+
+example 1:
+
+Gcode file from slicer
+```
+start_print b=90 e=250
+```
+
+Macro definition in Klipper
+```
+[gcode_macro start_print]
+gcode:
+    M190 S{b}           ;set bed temp and wait
+    G28                 ;home all axes
+    BED_MESH_CALIBRATE  ;generate a bed mesh
+    G28 Z0              ;rehome z axis
+    DETACH_PROBE        ;ensure probe is detached
+    M109 S{e}
+```
+
+example 2:
+
+Gcode file from slicer
+```
+M190 S[first_layer_bed_temperature]
+M109 S[first_layer_temperature]
+G28
+BED_MESH_CALIBRATE
+G28 Z0
+DETACH_PROBE
+G92 E0
+G1 X0.1 Y0 F8000 ;begin priming line
+G1 Z2.0 F3000
+```

--- a/docs/Dockable_Probe.md
+++ b/docs/Dockable_Probe.md
@@ -205,7 +205,7 @@ methods can be used to verify probe attachment states.
   This is intended to prevent crashing the nozzle into the bed since it is
   assumed if the probe pin reads `TRIGGERED` prior to probing, the probe is
   not attached.
-  
+
   Setting this to `False` will cause all action to be aborted if the probe
   does not read `TRIGGERED` after attaching.
 

--- a/docs/Dockable_Probe.md
+++ b/docs/Dockable_Probe.md
@@ -22,6 +22,7 @@ sample_retract_dist:
 approach_position:
 dock_position:
 detach_position:
+(check_open_attach: OR probe_sense_pin:) AND/OR dock_sense_pin:
 ```
 
 ### Attaching and Detaching Positions
@@ -192,18 +193,21 @@ Given the nature of this type of probe, it is necessary to verify whether or
 not it has successfully attached prior to attempting a probing move. Several
 methods can be used to verify probe attachment states.
 
-- `check_open_attach: False`\
-  _Default Value: False_\
+- `check_open_attach:`\
+  _Default Value: None_\
   Certain probes will report `OPEN` when they are attached and `TRIGGERED`
   when they are detached in a non-probing state. When `check_open_attach` is
   set to `True`, the state of the probe pin is checked after performing a
-  probe attach or detach maneuver. If the probe reports `TRIGGERED`
-  immediately after the toolhead leaves the dock radius, an error will be
-  raised and any further action will be aborted.
+  probe attach or detach maneuver. If the probe does not read `OPEN`
+  immediately after attaching the probe, an error will be raised and any
+  further action will be aborted.
 
   This is intended to prevent crashing the nozzle into the bed since it is
   assumed if the probe pin reads `TRIGGERED` prior to probing, the probe is
   not attached.
+  
+  Setting this to `False` will cause all action to be aborted if the probe
+  does not read `TRIGGERED` after attaching.
 
 - `probe_sense_pin:`\
   _Default Value: None_\

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -303,6 +303,30 @@ Also provided is the following extended G-Code command:
   setting the supplied `MSG` as the current display message.  If
   `MSG` is omitted the display will be cleared.
 
+## [dockable_probe]
+
+In addition to the normal commands available for a `[probe]`, the following
+commands are available when a
+[dockable_probe config section](Config_Reference.md#dockable_probe) is enabled
+(also see the [Dockable Probe guide](Dockable_Probe.md)):
+
+- `ATTACH_PROBE`: Move to dock and attach probe to the toolhead, the toolhead
+  will return to its previous position after attaching.
+- `DETACH_PROBE`: Move to dock and detach probe from the toolhead, the toolhead
+  will return to its previous position after detaching.
+- `QUERY_DOCKABLE_PROBE`: Respond with current probe state. This is useful for
+  verifying configuration settings are working as intended.
+- `SET_DOCKABLE_PROBE AUTO_ATTACH_DETACH=0|1`: Enable/Disable the automatic
+  attaching/detaching of the probe during actions that require the probe.
+- `MOVE_TO_APPROACH_PROBE`: Move to approach the probe dock.
+- `MOVE_TO_DOCK_PROBE`: Move to the probe dock (this should trigger the probe
+  to attach).
+- `MOVE_TO_EXTRACT_PROBE`: Move to leave the dock with the probe attached.
+- `MOVE_TO_INSERT_PROBE`: Move to insert position near the dock
+  with the probe attached.
+- `MOVE_TO_DETACH_PROBE`: Move away from the dock to disconnect the probe
+  from the toolhead.
+
 ### [dual_carriage]
 
 The following command is available when the
@@ -1332,23 +1356,6 @@ potentially cause upward tool movement as the adjustment is updated and applied.
 the config. `REF_TEMP` manually overrides the reference temperature typically
 set during homing (for use in e.g. non-standard homing routines) - will be reset
 automatically upon homing.
-
-## Annexed Probe
-
-In addition to the normal commands available for a [probe], the following
-commands are available when an
-[annexed_probe config section](Config_Reference.md#annexed_probe) is enabled
-(also see the [Annexed Probe guide](Annexed_Probe.md)):
-
-- `ATTACH_PROBE`: Move to dock and attach probe to the toolhead, the toolhead
-  will return to its previous position after attaching.
-- `DETACH_PROBE`: Move to dock and detach probe from the toolhead, the toolhead
-  will return to its previous position after detaching.
-- `GET_PROBE_STATUS`: Respond with current probe state. This is useful for
-  verifying configuration settings are working as intended.
-- `SET_PROBE_STATUS STATE=UNKNOWN|ATTACHED|DOCKED`: If configured, this allows
-  the probe state to be set manually in the event automated probe verification
-  methods cannot be used.
 
 ### [z_tilt]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1333,6 +1333,23 @@ the config. `REF_TEMP` manually overrides the reference temperature typically
 set during homing (for use in e.g. non-standard homing routines) - will be reset
 automatically upon homing.
 
+## Annexed Probe
+
+In addition to the normal commands available for a [probe], the following
+commands are available when an
+[annexed_probe config section](Config_Reference.md#annexed_probe) is enabled
+(also see the [Annexed Probe guide](Annexed_Probe.md)):
+
+- `ATTACH_PROBE`: Move to dock and attach probe to the toolhead, the toolhead
+  will return to its previous position after attaching.
+- `DETACH_PROBE`: Move to dock and detach probe from the toolhead, the toolhead
+  will return to its previous position after detaching.
+- `GET_PROBE_STATUS`: Respond with current probe state. This is useful for
+  verifying configuration settings are working as intended.
+- `SET_PROBE_STATUS STATE=UNKNOWN|ATTACHED|DOCKED`: If configured, this allows
+  the probe state to be set manually in the event automated probe verification
+  methods cannot be used.
+
 ### [z_tilt]
 
 The following commands are available when the

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -68,6 +68,16 @@ The following information is available in the `display_status` object
   `virtual_sdcard.progress` if no recent `M73` received).
 - `message`: The message contained in the last `M117` G-Code command.
 
+## dockable_probe
+
+The following information is available in the
+[dockable_probe](Config_Reference.md#dockable_probe):
+- `last_status`: The UNKNOWN/ATTACHED/DOCKED status of the probbe as
+  reported during the last QUERY_DOCKABLE_PROBE command. Note, if
+  this is used in a macro, due to the order of template expansion,
+  the QUERY_DOCKABLE_PROBE command must be run prior to the macro
+  containing this reference.
+
 ## endstop_phase
 
 The following information is available in the

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -1,0 +1,600 @@
+# Dockable Probe
+#   This provides support for probes that are magnetically coupled
+#   to the toolhead and stowed in a dock when not in use and
+#
+# Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2021       Paul McGowan <mental405@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import probe
+from math import sin, cos, atan2, pi, radians, degrees, sqrt
+
+PROBE_DETACH_DELAY         = .005
+PROBE_VERIFY_DELAY         = .1
+
+PROBE_UNKNOWN   = 0
+PROBE_ATTACHED  = 1
+PROBE_DOCKED    = 2
+
+MULTI_OFF       = 0
+MULTI_FIRST     = 1
+MULTI_ON        = 2
+
+HINT_VERIFICATION_ERROR = """
+{0}: A probe state verification method
+was not provided. A method to verify the probes attachment
+state must be specified to prevent unintended behavior.
+Please see {0}.md or config_reference.md for
+valid state verification methods and examples.
+"""
+
+# Helper class to handle polling pins for probe attachment states
+class PinPollingHelper:
+    def __init__(self, config, endstop):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler('klippy:connect',
+                                        self._handle_connect)
+        self.query_endstop = endstop
+        self.last_verify_time  = 0
+        self.last_verify_state = None
+    def _handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+    def query_pin(self, curtime):
+        if (curtime > (self.last_verify_time + PROBE_VERIFY_DELAY)
+            or self.last_verify_state is None):
+            self.last_verify_time = curtime
+            query_time = self.toolhead.get_last_move_time()
+            self.last_verify_state = not not self.query_endstop(query_time)
+        return self.last_verify_state
+    def query_pin_inv(self, curtime):
+        return not self.query_pin(curtime)
+
+# Helper class for manually set probe attachment states
+class ManualStateHelper:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command('SET_PROBE_STATUS',
+                                self.cmd_SET_PROBE_STATUS,
+                                desc=self.cmd_SET_PROBE_STATUS_help)
+
+        self.probe_state = PROBE_UNKNOWN
+    cmd_SET_PROBE_STATUS_help = ("Manually specify probe status, valid probe " +
+                                 "states are UNKNOWN, ATTACHED, and DOCKED")
+    def cmd_SET_PROBE_STATUS(self, gcmd):
+        probe_states = ['UNKNOWN', 'ATTACHED', 'DOCKED']
+        state = gcmd.get('STATE').upper()
+        if state in probe_states:
+            self.probe_state = next(k for k, v in enumerate(probe_states)
+                                     if state == v)
+        else:
+            e = "Invalid probe state: {0}. Valid probe states are [{1}]"
+            raise gcmd.error(e.format(state, probe_states))
+    def query_pin(self, curtime):
+        if self.probe_state == PROBE_ATTACHED:
+            return True
+    def query_pin_inv(self, curtime):
+        if self.probe_state == PROBE_DOCKED:
+            return True
+
+# Helper class to verify probe attachment status
+class ProbeState:
+    def __init__(self, config, aProbe):
+        self.printer = config.get_printer()
+        self.check_open_attach = config.getboolean('check_open_attach', False)
+        self.probe_sense_pin = config.get('probe_sense_pin', None)
+        self.dock_sense_pin = config.get('dock_sense_pin', None)
+        self.printer.register_event_handler('klippy:ready',
+                                            self._handle_ready)
+
+        ppins = self.printer.lookup_object('pins')
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command('GET_PROBE_STATUS',
+                                self.cmd_GET_PROBE_STATUS,
+                                self.cmd_GET_PROBE_STATUS_help)
+
+        if not any([self.check_open_attach,
+                    self.probe_sense_pin,
+                    self.dock_sense_pin]):
+            raise self.printer.config_error(HINT_VERIFICATION_ERROR.format(
+                                            aProbe.name))
+        else:
+            ehelper = PinPollingHelper(config, aProbe.query_endstop)
+
+            # Configure sense pins as endstops so they
+            # can be polled at specific times
+            def configEndstop(pin):
+                pin_params = ppins.lookup_pin(pin,
+                                              can_invert=True,
+                                              can_pullup=True)
+                mcu = pin_params['chip']
+                mcu_endstop = mcu.setup_pin('endstop', pin_params)
+                helper = PinPollingHelper(config, mcu_endstop.query_endstop)
+                return helper
+
+            probe_sense_helper = None
+            dock_sense_helper = None
+
+            if self.probe_sense_pin:
+                probe_sense_helper = configEndstop(self.probe_sense_pin)
+                self.probe_sense_pin = probe_sense_helper.query_pin
+            else:
+                self.probe_sense_pin = ehelper.query_pin_inv
+
+            if self.dock_sense_pin:
+                dock_sense_helper = configEndstop(self.dock_sense_pin)
+                self.dock_sense_pin = dock_sense_helper.query_pin
+            else:
+                if probe_sense_helper is not None:
+                    self.dock_sense_pin = probe_sense_helper.query_pin_inv
+                else:
+                    self.dock_sense_pin = ehelper.query_pin
+    cmd_GET_PROBE_STATUS_help = ("Prints the current probe state, valid probe" +
+                                 " states are UNKNOWN, ATTACHED, and DOCKED")
+    def cmd_GET_PROBE_STATUS(self, gcmd):
+        s = self.get_probe_state()
+        state = next(v for k, v
+                     in enumerate(['UNKNOWN', 'ATTACHED', 'DOCKED'])
+                     if s == k)
+        gcmd.respond_info('Probe Status: %s' % (state))
+    def _handle_ready(self):
+        self.last_verify_time = 0
+        self.last_verify_state = PROBE_UNKNOWN
+    def get_probe_state(self):
+        curtime = self.printer.get_reactor().monotonic()
+        last = self.last_verify_time
+        if (self.last_verify_state == PROBE_UNKNOWN
+            or curtime > self.last_verify_time + PROBE_VERIFY_DELAY):
+            self.last_verify_time = curtime
+            a = self.probe_sense_pin(curtime)
+            d = self.dock_sense_pin(curtime)
+            if a and not d:
+                self.last_verify_state = PROBE_ATTACHED
+            elif d and not a:
+                self.last_verify_state = PROBE_DOCKED
+            else:
+                self.last_verify_state = PROBE_UNKNOWN
+        return self.last_verify_state
+
+class DockableProbe:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.name = config.get_name()
+
+        # Configuration Options
+        self.position_endstop = config.getfloat('z_offset')
+        self.x_offset = config.getfloat('x_offset', 0.)
+        self.y_offset = config.getfloat('y_offset', 0.)
+        self.speed = config.getfloat('speed', 5.0, above=0.)
+        self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)
+        self.dock_retries = config.getint('dock_retries', 0) + 1
+        self.travel_speed = config.getfloat('travel_speed',
+                                             self.speed, above=0.)
+        self.attach_speed = config.getfloat('attach_speed',
+                                             self.travel_speed, above=0.)
+        self.detach_speed = config.getfloat('detach_speed',
+                                             self.travel_speed, above=0.)
+        self.dock_fixed_z = config.getboolean('dock_fixed_z', False)
+        self.allow_delayed_detach = config.getboolean('allow_delayed_detach',
+                                                       False)
+        self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
+                                                   above=0.)
+
+        def parseCoord(name, expected_dims=3):
+            val = config.get(name, None)
+            error_msg = "Unable to parse {0} in {1}: {2}"
+            if not val:
+                return None
+            try:
+                vals = [float(x.strip()) for x in val.split(',')]
+            except Exception as e:
+                raise config.error(error_msg.format(name, self.name, str(e)))
+            supplied_dims = len(vals)
+            if not 2 <= supplied_dims <= expected_dims:
+                raise config.error(error_msg.format(name, self.name,
+                                   "Invalid number of coordinates"))
+            p = [None] * 3
+            p[:supplied_dims] = vals
+            return p
+
+        self.approach_position = parseCoord('approach_position')
+        self.detach_position   = parseCoord('detach_position')
+        self.dock_position     = parseCoord('dock_position')
+        self.safe_z_position   = parseCoord('safe_z_position', 2)
+
+        self.dock_angle, self.approach_distance = self._get_vector(
+                                                        self.dock_position,
+                                                        self.approach_position)
+        self.detach_angle, self.detach_distance = self._get_vector(
+                                                        self.dock_position,
+                                                        self.detach_position)
+
+        #Pins
+        ppins = self.printer.lookup_object('pins')
+        pin = config.get('pin')
+        pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
+        mcu = pin_params['chip']
+        mcu.register_config_callback(self._build_config)
+        self.mcu_endstop = mcu.setup_pin('endstop', pin_params)
+
+        # Wrappers
+        self.get_mcu              = self.mcu_endstop.get_mcu
+        self.add_stepper          = self.mcu_endstop.add_stepper
+        self.get_steppers         = self.mcu_endstop.get_steppers
+        self.home_wait            = self.mcu_endstop.home_wait
+        self.query_endstop        = self.mcu_endstop.query_endstop
+        self.finish_home_complete = self.wait_trigger_complete = None
+
+        pstate = ProbeState(config, self)
+        self.get_probe_state = pstate.get_probe_state
+
+        #Custom User Macros
+        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.pre_attach_gcode = gcode_macro.load_template(
+            config, 'pre_attach_gcode', '')
+        self.attach_gcode = gcode_macro.load_template(
+            config, 'attach_gcode', '')
+        self.post_attach_gcode = gcode_macro.load_template(
+            config, 'post_attach_gcode', '')
+        self.pre_detach_gcode = gcode_macro.load_template(
+            config, 'pre_detach_gcode', '')
+        self.detach_gcode = gcode_macro.load_template(
+            config, 'detach_gcode', '')
+        self.post_detach_gcode = gcode_macro.load_template(
+            config, 'post_detach_gcode', '')
+
+        #Gcode Commands
+        self.gcode.register_command('ATTACH_PROBE',
+                                    self.cmd_ATTACH_PROBE)
+        self.gcode.register_command('DETACH_PROBE',
+                                    self.cmd_DETACH_PROBE)
+
+        #Event Handlers
+        self.printer.register_event_handler('klippy:connect',
+                                            self._handle_connect)
+        self.printer.register_event_handler('klippy:ready',
+                                            self._handle_ready)
+        self.printer.register_event_handler('homing:home_rails_begin',
+                                            self._handle_homing_rails_begin)
+        self.printer.register_event_handler('homing:home_rails_end',
+                                            self._handle_homing_rails_end)
+
+    def _build_config(self):
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        for stepper in kin.get_steppers():
+            if stepper.is_active_axis('z'):
+                self.add_stepper(stepper)
+        endstops = [es for rail in kin.rails
+                    for es, name in rail.get_endstops()]
+        if self in endstops and self.printer.lookup_object('safe_z_home', None):
+            e = ("{0}: cannot be used with safe_z_home if " +
+                "probe is used as z endstop")
+            raise self.printer.config_error(e.format(self.name))
+    def _handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+    def _handle_ready(self):
+        self.last_z = -9999
+        self.is_z_endstop = False
+        self.multi = MULTI_OFF
+        self._last_homed = None
+        self.init_pos = None
+        kin = self.printer.lookup_object('toolhead').get_kinematics()
+        if not self.safe_z_position:
+            home_xy = [0,0]
+            for rail in kin.rails:
+                hi = rail.get_homing_info()
+                rmin, rmax = rail.get_range()
+                if hi.positive_dir:
+                    mid = (hi.position_endstop - rmin) *.5
+                else:
+                    mid = rmax * .5
+                for s in rail.get_steppers():
+                    a = s.get_name(short=True)
+                    if a == 'x':
+                        home_xy[0] = mid - self.x_offset
+                    if a == 'x':
+                        home_xy[1] = mid - self.y_offset
+                    if a == 'z':
+                        if hi.positive_dir:
+                            self.z_homes_positive = True
+                        else:
+                            self.z_homes_positive = False
+            self.safe_z_position = home_xy
+    def cmd_ATTACH_PROBE(self, gcmd):
+        return_pos = self.toolhead.get_position()
+        self.attach_probe(return_pos)
+    def cmd_DETACH_PROBE(self, gcmd):
+        return_pos = self.toolhead.get_position()
+        self.detach_probe(return_pos)
+
+    #######################################################################
+    # Functions for calculating points and moving the toolhead
+    #######################################################################
+
+    # Move the toolhead to minimum safe distance aligned with angle
+    def _move_to_vector(self, angle):
+        x, y = self._get_point_on_vector(self.dock_position[:2],
+                                         angle,
+                                         self.approach_distance)
+        self.toolhead.manual_move([x,y,None], self.travel_speed)
+
+    # Move the toolhead to angle within minimium safe distance
+    def _align_to_vector(self, angle):
+        approach = self._get_intercept(self.toolhead.get_position(),
+                                       angle + (pi/2),
+                                       self.dock_position,
+                                       angle)
+        self.toolhead.manual_move([approach[0], approach[1], None],
+                                  self.attach_speed)
+
+    # Determine toolhead distance to dock coordinates
+    def _check_distance(self, pos=None, dist=None):
+        if not pos:
+            pos = self.toolhead.get_position()
+        dock = self.dock_position
+
+        if dist > sqrt((pos[0]-dock[0])**2 +
+                       (pos[1]-dock[1])**2 ):
+            return True
+        else:
+            return False
+
+    # Find a point on a vector line at a specific distance
+    def _get_point_on_vector(self, point, angle, magnitude=1):
+        x = point[0] - magnitude * cos(angle)
+        y = point[1] - magnitude * sin(angle)
+        return (x, y)
+
+    # Locate the intersection of two vectors
+    def _get_intercept(self, point1, angle1, point2, angle2):
+        x1, y1 = point1[:2]
+        x2, y2 = self._get_point_on_vector(point1, angle1, 10.0)
+        x3, y3 = point2[:2]
+        x4, y4 = self._get_point_on_vector(point2, angle2, 10.0)
+        det1 = ((x1 * y2) - (y1 * x2))
+        det2 = ((x3 * y4) - (y3 * x4))
+        d = ((x1 - x2) * (y3 - y4)) - ((y1 - y2) * (x3 - x4))
+        x = float((det1 * (x3 - x4)) - ((x1 - x2) * det2)) / d
+        y = float((det1 * (y3 - y4)) - ((y1 - y2) * det2)) / d
+        return (x, y)
+
+    # Determine the vector of two points
+    def _get_vector(self, point1, point2):
+        x1, y1 = point1[:2]
+        x2, y2 = point2[:2]
+        magnitude = sqrt((x2-x1)**2 + (y2-y1)**2 )
+        angle = atan2(y2-y1, x2-x1) + pi
+
+        return angle, magnitude
+
+    # Align z axis to prevent crashes
+    def _align_z(self):
+        if not self._last_homed:
+            curtime = self.printer.get_reactor().monotonic()
+            homed_axes = self.toolhead.get_status(curtime)['homed_axes']
+            self._last_homed = homed_axes
+        if self.dock_fixed_z:
+            dock_z = (self.dock_position[2] +
+                      self.position_endstop +
+                      self.sample_retract_dist)
+            tpos = self.toolhead.get_position()
+            if 'z' in self._last_homed:
+                if tpos[2] < dock_z:
+                    self.toolhead.set_position(tpos)
+                    self.toolhead.manual_move(
+                        [None, None, dock_z],
+                        self.lift_speed)
+            else:
+                self._force_z_hop()
+        else:
+            if 'z' in self._last_homed:
+                self.toolhead.manual_move(
+                                        [None, None, self.dock_position[2]],
+                                        self.lift_speed)
+            else:
+                raise self.printer.command_error(
+                    "Cannot attach/detach probe, must home Z axis first")
+
+    # Hop z and return to un-homed state
+    def _force_z_hop(self):
+        this_z = self.toolhead.get_position()[2]
+        if self.last_z != this_z:
+            tpos = self.toolhead.get_position()
+            dock_z = self.dock_position[2] + self.position_endstop
+            self.toolhead.set_position([tpos[0], tpos[1], 0.0, tpos[3]],
+                                homing_axes=[2])
+            self.toolhead.manual_move(
+                [None, None, dock_z],
+                self.lift_speed)
+            kin = self.toolhead.get_kinematics()
+            kin.note_z_not_homed()
+            self.last_z = self.toolhead.get_position()[2]
+
+    # Attaching actions
+    def attach_probe(self, return_pos=None):
+        self.pre_attach_gcode.run_gcode_from_command()
+        if self.get_probe_state() == PROBE_DOCKED:
+            self._align_z()
+        if not return_pos:
+            return_pos = self.init_pos
+        if self._check_distance(dist=self.approach_distance):
+            self._align_to_vector(self.dock_angle)
+        retry = 0
+        while (self.get_probe_state() != PROBE_ATTACHED
+               and retry < self.dock_retries):
+            self._do_attach()
+            retry += 1
+        if self.get_probe_state() != PROBE_ATTACHED:
+            raise self.printer.command_error('Probe attach failed!')
+        self.post_attach_gcode.run_gcode_from_command()
+        if return_pos:
+            if not self._check_distance(return_pos, self.approach_distance):
+                self.toolhead.manual_move(
+                    [return_pos[0], return_pos[1], None],
+                    self.travel_speed)
+    def _do_attach(self):
+        if self.get_probe_state() != PROBE_DOCKED:
+            raise self.printer.command_error(
+                'Attach Probe: Probe not detected in dock, aborting')
+        if self._check_distance(dist=self.approach_distance):
+            self._align_to_vector(self.dock_angle)
+        else:
+            self._move_to_vector(self.dock_angle)
+        self.toolhead.manual_move(
+            [self.dock_position[0],self.dock_position[1], None],
+             self.attach_speed)
+        self.attach_gcode.run_gcode_from_command()
+        if self._check_distance(dist=self.approach_distance):
+            self._align_to_vector(self.dock_angle)
+        self.toolhead.manual_move(
+            [self.approach_position[0], self.approach_position[1], None],
+             self.travel_speed)
+
+    # Detaching actions
+    def detach_probe(self, return_pos=None):
+        self.pre_detach_gcode.run_gcode_from_command()
+        if self.get_probe_state() == PROBE_ATTACHED:
+            self._align_z()
+        self.toolhead.manual_move(
+            [self.approach_position[0], self.approach_position[1], None],
+             self.travel_speed)
+        retry = 0
+        while (self.get_probe_state() != PROBE_DOCKED
+               and retry < self.dock_retries):
+            self._do_detach()
+            retry += 1
+        if self._check_distance(dist=self.detach_distance):
+            self._align_to_vector(self.detach_angle)
+            self.toolhead.manual_move(
+                [self.detach_position[0], self.detach_position[1], None],
+                 self.travel_speed)
+        if self.get_probe_state() != PROBE_DOCKED:
+            raise self.printer.command_error('Probe detach failed!')
+        self.post_detach_gcode.run_gcode_from_command()
+        if return_pos:
+            if not self._check_distance(return_pos, self.detach_distance):
+                self.toolhead.manual_move(
+                    [return_pos[0], return_pos[1], None],
+                    self.travel_speed)
+    def _do_detach(self):
+        if self._check_distance(dist=self.detach_distance):
+            self._align_to_vector(self.dock_angle)
+        else:
+            self.toolhead.manual_move(
+                [self.approach_position[0], self.approach_position[1], None],
+                 self.travel_speed)
+        self.toolhead.manual_move(
+            [self.dock_position[0], self.dock_position[1], None],
+             self.attach_speed)
+        self.detach_gcode.run_gcode_from_command()
+        self.toolhead.manual_move(
+            [self.detach_position[0], self.detach_position[1], None],
+             self.travel_speed)
+
+    # Register a callback to detach the probe in the future if
+    # no pending probing actions are queued
+    def _delayed_detach(self):
+        if self.init_pos:
+            return_pos = self.init_pos
+        else:
+            return_pos = self.toolhead.get_position()
+        def reactor_bgfunc(print_time):
+            if self.multi == MULTI_OFF:
+                with self.gcode.get_mutex():
+                    self.detach_probe(return_pos)
+        def lookahead_bgfunc(print_time):
+            reactor = self.printer.get_reactor()
+            reactor.register_callback(
+                ( lambda et: reactor_bgfunc(print_time + PROBE_DETACH_DELAY )))
+        self.toolhead.register_lookahead_callback(lookahead_bgfunc)
+
+    #######################################################################
+    # Events handlers
+    #######################################################################
+    def _handle_homing_rails_begin(self, homing_state, rails):
+        homing_axes = [a for i, a in enumerate(['x','y','z'])
+                        if i in homing_state.get_axes()]
+        if self in [es for rail in rails for es, name in rail.get_endstops()]:
+            self.is_z_endstop = True
+
+        # Get homed axes now as they will report they are
+        # homed later even if they arent
+        curtime = self.printer.get_reactor().monotonic()
+        self._last_homed = self.toolhead.get_status(curtime)['homed_axes']
+        if self.get_probe_state() == PROBE_UNKNOWN:
+                self._force_z_hop()
+        if self.get_probe_state() == PROBE_ATTACHED:
+            # If X and Y endstop are within the dock location,
+            # Move out of the dock before attempting to home Z
+            if any(a in ['x','y'] for a in homing_axes):
+                self._force_z_hop()
+                if 'xy' in self._last_homed:
+                    if self._check_distance(self.dock_position,
+                                            self.approach_distance):
+                        self._align_to_vector(self.dock_angle)
+                        self._move_to_vector(self.dock_angle)
+            if 'z' in homing_axes:
+                if self.is_z_endstop:
+                    self._align_z()
+                else:
+                    if ('xy' in self._last_homed
+                        and not self.z_homes_positive):
+                        self.detach_probe(self.toolhead.get_position())
+    def _handle_homing_rails_end(self, homing_state, rails):
+        self.is_z_endstop = False
+        self._last_homed = None
+
+    #######################################################################
+    # Probe Wrappers
+    #######################################################################
+
+    def multi_probe_begin(self):
+        self.multi = MULTI_FIRST
+        if not self.init_pos:
+            self.init_pos = self.toolhead.get_position()
+        if not self._last_homed:
+            curtime = self.printer.get_reactor().monotonic()
+            self._last_homed = self.toolhead.get_status(curtime)['homed_axes']
+        if (self.is_z_endstop
+          and self.dock_fixed_z
+          and 'xy' in self._last_homed):
+            self.init_pos = self.safe_z_position
+        self.attach_probe()
+    def multi_probe_end(self):
+        self.multi = MULTI_OFF
+        pos = self.toolhead.get_position()
+        retract_z = (self.position_endstop + self.sample_retract_dist)
+        if pos[2] < retract_z:
+            self.toolhead.manual_move(
+                [None,
+                None,
+                retract_z],
+                self.lift_speed)
+        if self.allow_delayed_detach:
+            self._delayed_detach()
+        else:
+            self.detach_probe()
+        self.init_pos = None
+    def probe_prepare(self, hmove):
+        if self.multi == MULTI_FIRST:
+            self.multi = MULTI_ON
+    def probe_finish(self, hmove):
+        self.wait_trigger_complete.wait()
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        self.finish_home_complete = self.mcu_endstop.home_start(
+            print_time, sample_time, sample_count, rest_time, triggered)
+        r = self.printer.get_reactor()
+        self.wait_trigger_complete = r.register_callback(self.wait_for_trigger)
+        return self.finish_home_complete
+    def wait_for_trigger(self, eventtime):
+        self.finish_home_complete.wait()
+    def get_position_endstop(self):
+        return self.position_endstop
+
+def load_config(config):
+    msp = DockableProbe(config)
+    config.get_printer().add_object('probe', probe.PrinterProbe(config, msp))
+    return msp

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -187,8 +187,8 @@ class DockableProbe:
         self.dock_position     = self._parse_coord(config, 'dock_position')
         self.z_hop             = config.getfloat('z_hop', 0., above=0.)
 
-        self.dock_requires_z = (self.approach_position[2] is not None
-                                or self.dock_position[2] is not None)
+        self.dock_requires_z = (len(self.approach_position) > 2
+                                or len(self.dock_position) > 2)
 
         self.dock_angle, self.approach_distance = self._get_vector(
                                                         self.dock_position,
@@ -280,7 +280,7 @@ class DockableProbe:
         if not 2 <= supplied_dims <= expected_dims:
             raise config.error(error_msg.format(name, self.name,
                                 "Invalid number of coordinates"))
-        p = [None] * 3
+        p = [None] * supplied_dims
         p[:supplied_dims] = vals
         return p
 
@@ -294,7 +294,7 @@ class DockableProbe:
         self.toolhead = self.printer.lookup_object('toolhead')
 
         # If neither position config options contain a Z coordinate return early
-        if len(self.dock_position) <= 2 and len(self.approach_position) <= 2:
+        if not self.dock_requires_z:
             return
 
         query_endstops = self.printer.lookup_object('query_endstops')

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -554,6 +554,15 @@ class DockableProbe:
     def multi_probe_begin(self):
         self.multi = MULTI_FIRST
 
+        # Attach probe before moving to the first probe point and
+        # return to current position. Move because this can be called
+        # before a multi _point_ probe and a multi probe at the same
+        # point but for the latter the toolhead is already in position.
+        # If the toolhead is not returned to the current position it
+        # will complete the probing next to the dock.
+        return_pos = self.toolhead.get_position()
+        self.auto_attach_probe(return_pos)
+
     def multi_probe_end(self):
         self.multi = MULTI_OFF
 

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -532,10 +532,9 @@ class DockableProbe:
 
     # Align z axis to prevent crashes
     def _align_z(self):
-        if not self._last_homed:
-            curtime = self.printer.get_reactor().monotonic()
-            homed_axes = self.toolhead.get_status(curtime)['homed_axes']
-            self._last_homed = homed_axes
+        curtime = self.printer.get_reactor().monotonic()
+        homed_axes = self.toolhead.get_status(curtime)['homed_axes']
+        self._last_homed = homed_axes
 
         if self.dock_requires_z:
             self._align_z_required()

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -255,7 +255,7 @@ class DockableProbe:
     #
     # e.g. "233, 10, 0" -> [233, 10, 0]
     def _parse_coord(self, config, name, expected_dims=3):
-        val = config.get(name, None)
+        val = config.get(name)
         error_msg = "Unable to parse {0} in {1}: {2}"
         if not val:
             return None

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -6,11 +6,9 @@
 # Copyright (C) 2021       Paul McGowan <mental405@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
 from . import probe
-from math import sin, cos, atan2, pi, radians, degrees, sqrt
+from math import sin, cos, atan2, pi, sqrt
 
-PROBE_DETACH_DELAY         = .005
 PROBE_VERIFY_DELAY         = .1
 
 PROBE_UNKNOWN   = 0
@@ -33,50 +31,21 @@ valid state verification methods and examples.
 class PinPollingHelper:
     def __init__(self, config, endstop):
         self.printer = config.get_printer()
-        self.printer.register_event_handler('klippy:connect',
-                                        self._handle_connect)
         self.query_endstop = endstop
         self.last_verify_time  = 0
         self.last_verify_state = None
-    def _handle_connect(self):
-        self.toolhead = self.printer.lookup_object('toolhead')
+
     def query_pin(self, curtime):
         if (curtime > (self.last_verify_time + PROBE_VERIFY_DELAY)
             or self.last_verify_state is None):
             self.last_verify_time = curtime
-            query_time = self.toolhead.get_last_move_time()
+            toolhead = self.printer.lookup_object('toolhead')
+            query_time = toolhead.get_last_move_time()
             self.last_verify_state = not not self.query_endstop(query_time)
         return self.last_verify_state
+
     def query_pin_inv(self, curtime):
         return not self.query_pin(curtime)
-
-# Helper class for manually set probe attachment states
-class ManualStateHelper:
-    def __init__(self, config):
-        self.printer = config.get_printer()
-        gcode = self.printer.lookup_object('gcode')
-        gcode.register_command('SET_PROBE_STATUS',
-                                self.cmd_SET_PROBE_STATUS,
-                                desc=self.cmd_SET_PROBE_STATUS_help)
-
-        self.probe_state = PROBE_UNKNOWN
-    cmd_SET_PROBE_STATUS_help = ("Manually specify probe status, valid probe " +
-                                 "states are UNKNOWN, ATTACHED, and DOCKED")
-    def cmd_SET_PROBE_STATUS(self, gcmd):
-        probe_states = ['UNKNOWN', 'ATTACHED', 'DOCKED']
-        state = gcmd.get('STATE').upper()
-        if state in probe_states:
-            self.probe_state = next(k for k, v in enumerate(probe_states)
-                                     if state == v)
-        else:
-            e = "Invalid probe state: {0}. Valid probe states are [{1}]"
-            raise gcmd.error(e.format(state, probe_states))
-    def query_pin(self, curtime):
-        if self.probe_state == PROBE_ATTACHED:
-            return True
-    def query_pin_inv(self, curtime):
-        if self.probe_state == PROBE_DOCKED:
-            return True
 
 # Helper class to verify probe attachment status
 class ProbeState:
@@ -88,67 +57,59 @@ class ProbeState:
         self.printer.register_event_handler('klippy:ready',
                                             self._handle_ready)
 
-        ppins = self.printer.lookup_object('pins')
-        gcode = self.printer.lookup_object('gcode')
-        gcode.register_command('GET_PROBE_STATUS',
-                                self.cmd_GET_PROBE_STATUS,
-                                self.cmd_GET_PROBE_STATUS_help)
-
         if not any([self.check_open_attach,
                     self.probe_sense_pin,
                     self.dock_sense_pin]):
             raise self.printer.config_error(HINT_VERIFICATION_ERROR.format(
                                             aProbe.name))
+
+        # Configure sense pins as endstops so they
+        # can be polled at specific times
+        ppins = self.printer.lookup_object('pins')
+        def configEndstop(pin):
+            pin_params = ppins.lookup_pin(pin,
+                                            can_invert=True,
+                                            can_pullup=True)
+            mcu = pin_params['chip']
+            mcu_endstop = mcu.setup_pin('endstop', pin_params)
+            helper = PinPollingHelper(config, mcu_endstop.query_endstop)
+            return helper
+
+        probe_sense_helper = None
+        dock_sense_helper = None
+
+        # Setup sensor pins, if configured, otherwise use probe endstop
+        # as a dummy sensor.
+        ehelper = PinPollingHelper(config, aProbe.query_endstop)
+        if self.probe_sense_pin:
+            probe_sense_helper = configEndstop(self.probe_sense_pin)
+            self.probe_sense_pin = probe_sense_helper.query_pin
         else:
-            ehelper = PinPollingHelper(config, aProbe.query_endstop)
+            self.probe_sense_pin = ehelper.query_pin_inv
 
-            # Configure sense pins as endstops so they
-            # can be polled at specific times
-            def configEndstop(pin):
-                pin_params = ppins.lookup_pin(pin,
-                                              can_invert=True,
-                                              can_pullup=True)
-                mcu = pin_params['chip']
-                mcu_endstop = mcu.setup_pin('endstop', pin_params)
-                helper = PinPollingHelper(config, mcu_endstop.query_endstop)
-                return helper
+        if self.dock_sense_pin:
+            dock_sense_helper = configEndstop(self.dock_sense_pin)
+            self.dock_sense_pin = dock_sense_helper.query_pin
+        elif probe_sense_helper is not None:
+            self.dock_sense_pin = probe_sense_helper.query_pin_inv
+        else:
+            self.dock_sense_pin = ehelper.query_pin
 
-            probe_sense_helper = None
-            dock_sense_helper = None
-
-            if self.probe_sense_pin:
-                probe_sense_helper = configEndstop(self.probe_sense_pin)
-                self.probe_sense_pin = probe_sense_helper.query_pin
-            else:
-                self.probe_sense_pin = ehelper.query_pin_inv
-
-            if self.dock_sense_pin:
-                dock_sense_helper = configEndstop(self.dock_sense_pin)
-                self.dock_sense_pin = dock_sense_helper.query_pin
-            else:
-                if probe_sense_helper is not None:
-                    self.dock_sense_pin = probe_sense_helper.query_pin_inv
-                else:
-                    self.dock_sense_pin = ehelper.query_pin
-    cmd_GET_PROBE_STATUS_help = ("Prints the current probe state, valid probe" +
-                                 " states are UNKNOWN, ATTACHED, and DOCKED")
-    def cmd_GET_PROBE_STATUS(self, gcmd):
-        s = self.get_probe_state()
-        state = next(v for k, v
-                     in enumerate(['UNKNOWN', 'ATTACHED', 'DOCKED'])
-                     if s == k)
-        gcmd.respond_info('Probe Status: %s' % (state))
     def _handle_ready(self):
         self.last_verify_time = 0
         self.last_verify_state = PROBE_UNKNOWN
+
     def get_probe_state(self):
         curtime = self.printer.get_reactor().monotonic()
-        last = self.last_verify_time
+        return self.get_probe_state_with_time(curtime)
+
+    def get_probe_state_with_time(self, curtime):
         if (self.last_verify_state == PROBE_UNKNOWN
             or curtime > self.last_verify_time + PROBE_VERIFY_DELAY):
             self.last_verify_time = curtime
             a = self.probe_sense_pin(curtime)
             d = self.dock_sense_pin(curtime)
+
             if a and not d:
                 self.last_verify_state = PROBE_ATTACHED
             elif d and not a:
@@ -164,45 +125,32 @@ class DockableProbe:
         self.name = config.get_name()
 
         # Configuration Options
-        self.position_endstop = config.getfloat('z_offset')
-        self.x_offset = config.getfloat('x_offset', 0.)
-        self.y_offset = config.getfloat('y_offset', 0.)
-        self.speed = config.getfloat('speed', 5.0, above=0.)
-        self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)
-        self.dock_retries = config.getint('dock_retries', 0) + 1
-        self.travel_speed = config.getfloat('travel_speed',
-                                             self.speed, above=0.)
-        self.attach_speed = config.getfloat('attach_speed',
-                                             self.travel_speed, above=0.)
-        self.detach_speed = config.getfloat('detach_speed',
-                                             self.travel_speed, above=0.)
-        self.dock_fixed_z = config.getboolean('dock_fixed_z', False)
-        self.allow_delayed_detach = config.getboolean('allow_delayed_detach',
-                                                       False)
-        self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
-                                                   above=0.)
+        self.position_endstop    = config.getfloat('z_offset')
+        self.x_offset            = config.getfloat('x_offset', 0.)
+        self.y_offset            = config.getfloat('y_offset', 0.)
+        self.speed               = config.getfloat('speed', 5.0, above=0.)
+        self.lift_speed          = config.getfloat('lift_speed',
+                                                   self.speed, above=0.)
+        self.dock_retries        = config.getint('dock_retries', 0)
+        self.auto_attach_detach  = config.getboolean('auto_attach_detach',
+                                                     True)
+        self.travel_speed        = config.getfloat('travel_speed',
+                                                   self.speed, above=0.)
+        self.attach_speed        = config.getfloat('attach_speed',
+                                                   self.travel_speed, above=0.)
+        self.detach_speed        = config.getfloat('detach_speed',
+                                                   self.travel_speed, above=0.)
+        self.sample_retract_dist = config.getfloat('sample_retract_dist',
+                                                   2., above=0.)
 
-        def parseCoord(name, expected_dims=3):
-            val = config.get(name, None)
-            error_msg = "Unable to parse {0} in {1}: {2}"
-            if not val:
-                return None
-            try:
-                vals = [float(x.strip()) for x in val.split(',')]
-            except Exception as e:
-                raise config.error(error_msg.format(name, self.name, str(e)))
-            supplied_dims = len(vals)
-            if not 2 <= supplied_dims <= expected_dims:
-                raise config.error(error_msg.format(name, self.name,
-                                   "Invalid number of coordinates"))
-            p = [None] * 3
-            p[:supplied_dims] = vals
-            return p
+        # Positions (approach, detach, etc)
+        self.approach_position = self._parse_coord(config, 'approach_position')
+        self.detach_position   = self._parse_coord(config, 'detach_position')
+        self.dock_position     = self._parse_coord(config, 'dock_position')
+        self.z_hop             = config.getfloat('z_hop', 0., above=0.)
 
-        self.approach_position = parseCoord('approach_position')
-        self.detach_position   = parseCoord('detach_position')
-        self.dock_position     = parseCoord('dock_position')
-        self.safe_z_position   = parseCoord('safe_z_position', 2)
+        self.dock_requires_z = (self.approach_position[2] is not None
+                                or self.dock_position[2] is not None)
 
         self.dock_angle, self.approach_distance = self._get_vector(
                                                         self.dock_position,
@@ -211,7 +159,7 @@ class DockableProbe:
                                                         self.dock_position,
                                                         self.detach_position)
 
-        #Pins
+        # Pins
         ppins = self.printer.lookup_object('pins')
         pin = config.get('pin')
         pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
@@ -227,87 +175,250 @@ class DockableProbe:
         self.query_endstop        = self.mcu_endstop.query_endstop
         self.finish_home_complete = self.wait_trigger_complete = None
 
+        # State
+        self.last_z = -9999
+        self.multi = MULTI_OFF
+        self._last_homed = None
+
         pstate = ProbeState(config, self)
         self.get_probe_state = pstate.get_probe_state
+        self.last_probe_state = PROBE_UNKNOWN
 
-        #Custom User Macros
-        gcode_macro = self.printer.load_object(config, 'gcode_macro')
-        self.pre_attach_gcode = gcode_macro.load_template(
-            config, 'pre_attach_gcode', '')
-        self.attach_gcode = gcode_macro.load_template(
-            config, 'attach_gcode', '')
-        self.post_attach_gcode = gcode_macro.load_template(
-            config, 'post_attach_gcode', '')
-        self.pre_detach_gcode = gcode_macro.load_template(
-            config, 'pre_detach_gcode', '')
-        self.detach_gcode = gcode_macro.load_template(
-            config, 'detach_gcode', '')
-        self.post_detach_gcode = gcode_macro.load_template(
-            config, 'post_detach_gcode', '')
+        self.probe_states = {
+            PROBE_ATTACHED: 'ATTACHED',
+            PROBE_DOCKED: 'DOCKED',
+            PROBE_UNKNOWN: 'UNKNOWN'
+        }
 
-        #Gcode Commands
+        # Gcode Commands
+        self.gcode.register_command('QUERY_DOCKABLE_PROBE',
+                                    self.cmd_QUERY_DOCKABLE_PROBE,
+                                    desc=self.cmd_QUERY_DOCKABLE_PROBE_help)
+
+        self.gcode.register_command('MOVE_TO_APPROACH_PROBE',
+                                    self.cmd_MOVE_TO_APPROACH_PROBE,
+                                    desc=self.cmd_MOVE_TO_APPROACH_PROBE_help)
+        self.gcode.register_command('MOVE_TO_DOCK_PROBE',
+                                    self.cmd_MOVE_TO_DOCK_PROBE,
+                                    desc=self.cmd_MOVE_TO_DOCK_PROBE_help)
+        self.gcode.register_command('MOVE_TO_EXTRACT_PROBE',
+                                    self.cmd_MOVE_TO_EXTRACT_PROBE,
+                                    desc=self.cmd_MOVE_TO_EXTRACT_PROBE_help)
+        self.gcode.register_command('MOVE_TO_INSERT_PROBE',
+                                    self.cmd_MOVE_TO_INSERT_PROBE,
+                                    desc=self.cmd_MOVE_TO_INSERT_PROBE_help)
+        self.gcode.register_command('MOVE_TO_DETACH_PROBE',
+                                    self.cmd_MOVE_TO_DETACH_PROBE,
+                                    desc=self.cmd_MOVE_TO_DETACH_PROBE_help)
+
+        self.gcode.register_command('SET_DOCKABLE_PROBE',
+                                    self.cmd_SET_DOCKABLE_PROBE,
+                                    desc=self.cmd_SET_DOCKABLE_PROBE_help)
         self.gcode.register_command('ATTACH_PROBE',
-                                    self.cmd_ATTACH_PROBE)
+                                    self.cmd_ATTACH_PROBE,
+                                    desc=self.cmd_ATTACH_PROBE_help)
         self.gcode.register_command('DETACH_PROBE',
-                                    self.cmd_DETACH_PROBE)
+                                    self.cmd_DETACH_PROBE,
+                                    desc=self.cmd_DETACH_PROBE_help)
 
-        #Event Handlers
+        # Event Handlers
         self.printer.register_event_handler('klippy:connect',
                                             self._handle_connect)
-        self.printer.register_event_handler('klippy:ready',
-                                            self._handle_ready)
-        self.printer.register_event_handler('homing:home_rails_begin',
-                                            self._handle_homing_rails_begin)
-        self.printer.register_event_handler('homing:home_rails_end',
-                                            self._handle_homing_rails_end)
+
+    # Parse a string coordinate representation from the config
+    # and return a list of numbers.
+    #
+    # e.g. "233, 10, 0" -> [233, 10, 0]
+    def _parse_coord(self, config, name, expected_dims=3):
+        val = config.get(name, None)
+        error_msg = "Unable to parse {0} in {1}: {2}"
+        if not val:
+            return None
+        try:
+            vals = [float(x.strip()) for x in val.split(',')]
+        except Exception as e:
+            raise config.error(error_msg.format(name, self.name, str(e)))
+        supplied_dims = len(vals)
+        if not 2 <= supplied_dims <= expected_dims:
+            raise config.error(error_msg.format(name, self.name,
+                                "Invalid number of coordinates"))
+        p = [None] * 3
+        p[:supplied_dims] = vals
+        return p
 
     def _build_config(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         for stepper in kin.get_steppers():
             if stepper.is_active_axis('z'):
                 self.add_stepper(stepper)
-        endstops = [es for rail in kin.rails
-                    for es, name in rail.get_endstops()]
-        if self in endstops and self.printer.lookup_object('safe_z_home', None):
-            e = ("{0}: cannot be used with safe_z_home if " +
-                "probe is used as z endstop")
-            raise self.printer.config_error(e.format(self.name))
+
     def _handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
-    def _handle_ready(self):
-        self.last_z = -9999
-        self.is_z_endstop = False
-        self.multi = MULTI_OFF
-        self._last_homed = None
-        self.init_pos = None
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        if not self.safe_z_position:
-            home_xy = [0,0]
-            for rail in kin.rails:
-                hi = rail.get_homing_info()
-                rmin, rmax = rail.get_range()
-                if hi.positive_dir:
-                    mid = (hi.position_endstop - rmin) *.5
-                else:
-                    mid = rmax * .5
-                for s in rail.get_steppers():
-                    a = s.get_name(short=True)
-                    if a == 'x':
-                        home_xy[0] = mid - self.x_offset
-                    if a == 'x':
-                        home_xy[1] = mid - self.y_offset
-                    if a == 'z':
-                        if hi.positive_dir:
-                            self.z_homes_positive = True
-                        else:
-                            self.z_homes_positive = False
-            self.safe_z_position = home_xy
+
+    #######################################################################
+    # GCode Commands
+    #######################################################################
+
+    cmd_QUERY_DOCKABLE_PROBE_help = ("Prints the current probe state, valid probe" +
+                                 " states are UNKNOWN, ATTACHED, and DOCKED")
+    def cmd_QUERY_DOCKABLE_PROBE(self, gcmd):
+        self.last_probe_state = self.get_probe_state()
+        state = self.probe_states[self.last_probe_state]
+
+        gcmd.respond_info('Probe Status: %s' % (state))
+
+    def get_status(self, curtime):
+        # Use last_'status' here to be consistent with QUERY_PROBE_'STATUS'.
+        return {
+            'last_status': self.last_probe_state,
+        }
+
+    cmd_MOVE_TO_APPROACH_PROBE_help = "Move close to the probe dock" \
+                                    "before attaching"
+    def cmd_MOVE_TO_APPROACH_PROBE(self, gcmd):
+        self._align_z()
+
+        if self._check_distance(dist=self.approach_distance):
+            self._align_to_vector(self.dock_angle)
+        else:
+            self._move_to_vector(self.dock_angle)
+
+        if len(self.approach_position) > 2:
+            self.toolhead.manual_move([None, None, self.approach_position[2]],
+                                      self.travel_speed)
+
+        self.toolhead.manual_move(
+            [self.approach_position[0], self.approach_position[1], None],
+             self.travel_speed)
+
+    cmd_MOVE_TO_DOCK_PROBE_help = "Move to connect the toolhead/dock" \
+                                "to the probe"
+    def cmd_MOVE_TO_DOCK_PROBE(self, gcmd):
+        if len(self.dock_position) > 2:
+            self.toolhead.manual_move([None, None, self.dock_position[2]],
+                                      self.attach_speed)
+
+        self.toolhead.manual_move(
+            [self.dock_position[0], self.dock_position[1], None],
+             self.attach_speed)
+
+    cmd_MOVE_TO_EXTRACT_PROBE_help = "Move away from the dock with the" \
+                                "probe attached"
+    def cmd_MOVE_TO_EXTRACT_PROBE(self, gcmd):
+        self.cmd_MOVE_TO_APPROACH_PROBE(gcmd)
+
+    cmd_MOVE_TO_INSERT_PROBE_help = "Move near the dock with the" \
+                                "probe attached before detaching"
+    def cmd_MOVE_TO_INSERT_PROBE(self, gcmd):
+        self.cmd_MOVE_TO_APPROACH_PROBE(gcmd)
+
+    cmd_MOVE_TO_DETACH_PROBE_help = "Move away from the dock to detach" \
+                                "the probe"
+    def cmd_MOVE_TO_DETACH_PROBE(self, gcmd):
+        if len(self.detach_position) > 2:
+            self.toolhead.manual_move([None, None, self.detach_position[2]],
+                                      self.detach_speed)
+
+        self.toolhead.manual_move(
+            [self.detach_position[0], self.detach_position[1], None],
+             self.detach_speed)
+
+    cmd_SET_DOCKABLE_PROBE_help = "Set probe parameters"
+    def cmd_SET_DOCKABLE_PROBE(self, gcmd):
+        auto = gcmd.get('AUTO_ATTACH_DETACH', None)
+        if auto is None:
+            return
+
+        if int(auto) == 1:
+            self.auto_attach_detach = True
+        else:
+            self.auto_attach_detach = False
+
+    cmd_ATTACH_PROBE_help = "Check probe status and attach probe using" \
+                            "the movement gcodes"
     def cmd_ATTACH_PROBE(self, gcmd):
         return_pos = self.toolhead.get_position()
         self.attach_probe(return_pos)
+
+    cmd_DETACH_PROBE_help = "Check probe status and detach probe using" \
+                            "the movement gcodes"
     def cmd_DETACH_PROBE(self, gcmd):
         return_pos = self.toolhead.get_position()
         self.detach_probe(return_pos)
+
+    def attach_probe(self, return_pos=None):
+        retry = 0
+        while (self.get_probe_state() != PROBE_ATTACHED
+               and retry < self.dock_retries + 1):
+            if self.get_probe_state() != PROBE_DOCKED:
+                raise self.printer.command_error(
+                    'Attach Probe: Probe not detected in dock, aborting')
+            # Call these gcodes as a script because we don't have enough
+            # structs/data to call the cmd_...() funcs and supply 'gcmd'.
+            # This method also has the advantage of calling user-written gcodes
+            # if they've been defined.
+            self.gcode.run_script_from_command("""
+                MOVE_TO_APPROACH_PROBE
+                MOVE_TO_DOCK_PROBE
+                MOVE_TO_EXTRACT_PROBE
+            """)
+
+            retry += 1
+
+        if self.get_probe_state() != PROBE_ATTACHED:
+            raise self.printer.command_error('Probe attach failed!')
+
+        if return_pos:
+            if not self._check_distance(return_pos, self.approach_distance):
+                self.toolhead.manual_move(
+                    [return_pos[0], return_pos[1], None],
+                    self.travel_speed)
+                # Do NOT return to the original Z position after attach
+                # as the probe might crash into the bed.
+
+    def detach_probe(self, return_pos=None):
+        retry = 0
+        while (self.get_probe_state() != PROBE_DOCKED
+               and retry < self.dock_retries + 1):
+            # Call these gcodes as a script because we don't have enough
+            # structs/data to call the cmd_...() funcs and supply 'gcmd'.
+            # This method also has the advantage of calling user-written gcodes
+            # if they've been defined.
+            self.gcode.run_script_from_command("""
+                MOVE_TO_INSERT_PROBE
+                MOVE_TO_DOCK_PROBE
+                MOVE_TO_DETACH_PROBE
+            """)
+
+            retry += 1
+
+        if self.get_probe_state() != PROBE_DOCKED:
+            raise self.printer.command_error('Probe detach failed!')
+
+        if return_pos:
+            if not self._check_distance(return_pos, self.detach_distance):
+                self.toolhead.manual_move(
+                    [return_pos[0], return_pos[1], None],
+                    self.travel_speed)
+                # Return to original Z position after detach as
+                # there's no chance of the probe crashing into the bed.
+                self.toolhead.manual_move(
+                    [None, None, return_pos[2]],
+                    self.travel_speed)
+
+    def auto_detach_probe(self, return_pos=None):
+        if self.get_probe_state() == PROBE_DOCKED:
+           return
+        if self.auto_attach_detach:
+            self.detach_probe(return_pos)
+
+    def auto_attach_probe(self, return_pos=None):
+        if self.get_probe_state() == PROBE_ATTACHED:
+           return
+        if not self.auto_attach_detach:
+            raise self.printer.command_error("Cannot probe, probe is not " \
+                                        "attached and auto-attach is disabled")
+        self.attach_probe(return_pos)
 
     #######################################################################
     # Functions for calculating points and moving the toolhead
@@ -375,176 +486,41 @@ class DockableProbe:
             curtime = self.printer.get_reactor().monotonic()
             homed_axes = self.toolhead.get_status(curtime)['homed_axes']
             self._last_homed = homed_axes
-        if self.dock_fixed_z:
-            dock_z = (self.dock_position[2] +
-                      self.position_endstop +
-                      self.sample_retract_dist)
-            tpos = self.toolhead.get_position()
+
+        if self.dock_requires_z:
+            self._align_z_required()
+
+        if self.z_hop > 0.0:
             if 'z' in self._last_homed:
-                if tpos[2] < dock_z:
-                    self.toolhead.set_position(tpos)
-                    self.toolhead.manual_move(
-                        [None, None, dock_z],
+                tpos = self.toolhead.get_position()
+                if tpos[2] < self.z_hop:
+                    self.toolhead.manual_move([None, None, self.z_hop],
                         self.lift_speed)
             else:
                 self._force_z_hop()
-        else:
-            if 'z' in self._last_homed:
-                self.toolhead.manual_move(
-                                        [None, None, self.dock_position[2]],
-                                        self.lift_speed)
-            else:
-                raise self.printer.command_error(
-                    "Cannot attach/detach probe, must home Z axis first")
+
+    def _align_z_required(self):
+        if 'z' not in self._last_homed:
+            raise self.printer.command_error(
+                "Cannot attach/detach probe, must home Z axis first")
+
+        self.toolhead.manual_move([None, None, self.approach_position[2]],
+                                self.lift_speed)
 
     # Hop z and return to un-homed state
     def _force_z_hop(self):
         this_z = self.toolhead.get_position()[2]
-        if self.last_z != this_z:
-            tpos = self.toolhead.get_position()
-            dock_z = self.dock_position[2] + self.position_endstop
-            self.toolhead.set_position([tpos[0], tpos[1], 0.0, tpos[3]],
-                                homing_axes=[2])
-            self.toolhead.manual_move(
-                [None, None, dock_z],
-                self.lift_speed)
-            kin = self.toolhead.get_kinematics()
-            kin.note_z_not_homed()
-            self.last_z = self.toolhead.get_position()[2]
+        if self.last_z == this_z:
+            return
 
-    # Attaching actions
-    def attach_probe(self, return_pos=None):
-        self.pre_attach_gcode.run_gcode_from_command()
-        if self.get_probe_state() == PROBE_DOCKED:
-            self._align_z()
-        if not return_pos:
-            return_pos = self.init_pos
-        if self._check_distance(dist=self.approach_distance):
-            self._align_to_vector(self.dock_angle)
-        retry = 0
-        while (self.get_probe_state() != PROBE_ATTACHED
-               and retry < self.dock_retries):
-            self._do_attach()
-            retry += 1
-        if self.get_probe_state() != PROBE_ATTACHED:
-            raise self.printer.command_error('Probe attach failed!')
-        self.post_attach_gcode.run_gcode_from_command()
-        if return_pos:
-            if not self._check_distance(return_pos, self.approach_distance):
-                self.toolhead.manual_move(
-                    [return_pos[0], return_pos[1], None],
-                    self.travel_speed)
-    def _do_attach(self):
-        if self.get_probe_state() != PROBE_DOCKED:
-            raise self.printer.command_error(
-                'Attach Probe: Probe not detected in dock, aborting')
-        if self._check_distance(dist=self.approach_distance):
-            self._align_to_vector(self.dock_angle)
-        else:
-            self._move_to_vector(self.dock_angle)
-        self.toolhead.manual_move(
-            [self.dock_position[0],self.dock_position[1], None],
-             self.attach_speed)
-        self.attach_gcode.run_gcode_from_command()
-        if self._check_distance(dist=self.approach_distance):
-            self._align_to_vector(self.dock_angle)
-        self.toolhead.manual_move(
-            [self.approach_position[0], self.approach_position[1], None],
-             self.travel_speed)
-
-    # Detaching actions
-    def detach_probe(self, return_pos=None):
-        self.pre_detach_gcode.run_gcode_from_command()
-        if self.get_probe_state() == PROBE_ATTACHED:
-            self._align_z()
-        self.toolhead.manual_move(
-            [self.approach_position[0], self.approach_position[1], None],
-             self.travel_speed)
-        retry = 0
-        while (self.get_probe_state() != PROBE_DOCKED
-               and retry < self.dock_retries):
-            self._do_detach()
-            retry += 1
-        if self._check_distance(dist=self.detach_distance):
-            self._align_to_vector(self.detach_angle)
-            self.toolhead.manual_move(
-                [self.detach_position[0], self.detach_position[1], None],
-                 self.travel_speed)
-        if self.get_probe_state() != PROBE_DOCKED:
-            raise self.printer.command_error('Probe detach failed!')
-        self.post_detach_gcode.run_gcode_from_command()
-        if return_pos:
-            if not self._check_distance(return_pos, self.detach_distance):
-                self.toolhead.manual_move(
-                    [return_pos[0], return_pos[1], None],
-                    self.travel_speed)
-    def _do_detach(self):
-        if self._check_distance(dist=self.detach_distance):
-            self._align_to_vector(self.dock_angle)
-        else:
-            self.toolhead.manual_move(
-                [self.approach_position[0], self.approach_position[1], None],
-                 self.travel_speed)
-        self.toolhead.manual_move(
-            [self.dock_position[0], self.dock_position[1], None],
-             self.attach_speed)
-        self.detach_gcode.run_gcode_from_command()
-        self.toolhead.manual_move(
-            [self.detach_position[0], self.detach_position[1], None],
-             self.travel_speed)
-
-    # Register a callback to detach the probe in the future if
-    # no pending probing actions are queued
-    def _delayed_detach(self):
-        if self.init_pos:
-            return_pos = self.init_pos
-        else:
-            return_pos = self.toolhead.get_position()
-        def reactor_bgfunc(print_time):
-            if self.multi == MULTI_OFF:
-                with self.gcode.get_mutex():
-                    self.detach_probe(return_pos)
-        def lookahead_bgfunc(print_time):
-            reactor = self.printer.get_reactor()
-            reactor.register_callback(
-                ( lambda et: reactor_bgfunc(print_time + PROBE_DETACH_DELAY )))
-        self.toolhead.register_lookahead_callback(lookahead_bgfunc)
-
-    #######################################################################
-    # Events handlers
-    #######################################################################
-    def _handle_homing_rails_begin(self, homing_state, rails):
-        homing_axes = [a for i, a in enumerate(['x','y','z'])
-                        if i in homing_state.get_axes()]
-        if self in [es for rail in rails for es, name in rail.get_endstops()]:
-            self.is_z_endstop = True
-
-        # Get homed axes now as they will report they are
-        # homed later even if they arent
-        curtime = self.printer.get_reactor().monotonic()
-        self._last_homed = self.toolhead.get_status(curtime)['homed_axes']
-        if self.get_probe_state() == PROBE_UNKNOWN:
-                self._force_z_hop()
-        if self.get_probe_state() == PROBE_ATTACHED:
-            # If X and Y endstop are within the dock location,
-            # Move out of the dock before attempting to home Z
-            if any(a in ['x','y'] for a in homing_axes):
-                self._force_z_hop()
-                if 'xy' in self._last_homed:
-                    if self._check_distance(self.dock_position,
-                                            self.approach_distance):
-                        self._align_to_vector(self.dock_angle)
-                        self._move_to_vector(self.dock_angle)
-            if 'z' in homing_axes:
-                if self.is_z_endstop:
-                    self._align_z()
-                else:
-                    if ('xy' in self._last_homed
-                        and not self.z_homes_positive):
-                        self.detach_probe(self.toolhead.get_position())
-    def _handle_homing_rails_end(self, homing_state, rails):
-        self.is_z_endstop = False
-        self._last_homed = None
+        tpos = self.toolhead.get_position()
+        self.toolhead.set_position([tpos[0], tpos[1], 0.0, tpos[3]],
+                            homing_axes=[2])
+        self.toolhead.manual_move([None, None, self.z_hop],
+            self.lift_speed)
+        kin = self.toolhead.get_kinematics()
+        kin.note_z_not_homed()
+        self.last_z = self.toolhead.get_position()[2]
 
     #######################################################################
     # Probe Wrappers
@@ -552,36 +528,26 @@ class DockableProbe:
 
     def multi_probe_begin(self):
         self.multi = MULTI_FIRST
-        if not self.init_pos:
-            self.init_pos = self.toolhead.get_position()
-        if not self._last_homed:
-            curtime = self.printer.get_reactor().monotonic()
-            self._last_homed = self.toolhead.get_status(curtime)['homed_axes']
-        if (self.is_z_endstop
-          and self.dock_fixed_z
-          and 'xy' in self._last_homed):
-            self.init_pos = self.safe_z_position
-        self.attach_probe()
+
     def multi_probe_end(self):
         self.multi = MULTI_OFF
-        pos = self.toolhead.get_position()
-        retract_z = (self.position_endstop + self.sample_retract_dist)
-        if pos[2] < retract_z:
-            self.toolhead.manual_move(
-                [None,
-                None,
-                retract_z],
-                self.lift_speed)
-        if self.allow_delayed_detach:
-            self._delayed_detach()
-        else:
-            self.detach_probe()
-        self.init_pos = None
+
+        return_pos = self.toolhead.get_position()
+        # Move away from the bed to ensure the probe isn't triggered,
+        # preventing detaching in the event there's no probe/dock sensor.
+        self.toolhead.manual_move([None, None, return_pos[2]+2], self.travel_speed)
+        self.auto_detach_probe(return_pos)
+
     def probe_prepare(self, hmove):
+        if self.multi == MULTI_OFF or self.multi == MULTI_FIRST:
+            return_pos = self.toolhead.get_position()
+            self.auto_attach_probe(return_pos)
         if self.multi == MULTI_FIRST:
             self.multi = MULTI_ON
+
     def probe_finish(self, hmove):
         self.wait_trigger_complete.wait()
+
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
         self.finish_home_complete = self.mcu_endstop.home_start(
@@ -589,8 +555,16 @@ class DockableProbe:
         r = self.printer.get_reactor()
         self.wait_trigger_complete = r.register_callback(self.wait_for_trigger)
         return self.finish_home_complete
+
     def wait_for_trigger(self, eventtime):
         self.finish_home_complete.wait()
+        if self.multi == MULTI_OFF:
+            return_pos = self.toolhead.get_position()
+            # Move away from the bed to ensure the probe isn't triggered,
+            # preventing detaching in the event there's no probe/dock sensor.
+            self.toolhead.manual_move([None, None, return_pos[2]+2], self.travel_speed)
+            self.auto_detach_probe(return_pos)
+
     def get_position_endstop(self):
         return self.position_endstop
 

--- a/klippy/extras/dockable_probe.py
+++ b/klippy/extras/dockable_probe.py
@@ -56,9 +56,12 @@ class ProbeState:
     def __init__(self, config, aProbe):
         self.printer = config.get_printer()
 
-        if (not config.fileconfig.has_option(config.section, 'check_open_attach')
-            and not config.fileconfig.has_option(config.section, 'probe_sense_pin')
-            and not config.fileconfig.has_option(config.section, 'dock_sense_pin')):
+        if (not config.fileconfig.has_option(config.section,
+                                             'check_open_attach')
+            and not config.fileconfig.has_option(config.section,
+                                               'probe_sense_pin')
+            and not config.fileconfig.has_option(config.section,
+                                               'dock_sense_pin')):
             raise self.printer.config_error(HINT_VERIFICATION_ERROR.format(
                 aProbe.name))
 
@@ -281,8 +284,8 @@ class DockableProbe:
     # GCode Commands
     #######################################################################
 
-    cmd_QUERY_DOCKABLE_PROBE_help = ("Prints the current probe state, valid probe" +
-                                 " states are UNKNOWN, ATTACHED, and DOCKED")
+    cmd_QUERY_DOCKABLE_PROBE_help = ("Prints the current probe state," +
+                " valid probe states are UNKNOWN, ATTACHED, and DOCKED")
     def cmd_QUERY_DOCKABLE_PROBE(self, gcmd):
         self.last_probe_state = self.get_probe_state()
         state = self.probe_states[self.last_probe_state]
@@ -557,7 +560,8 @@ class DockableProbe:
         return_pos = self.toolhead.get_position()
         # Move away from the bed to ensure the probe isn't triggered,
         # preventing detaching in the event there's no probe/dock sensor.
-        self.toolhead.manual_move([None, None, return_pos[2]+2], self.travel_speed)
+        self.toolhead.manual_move([None, None, return_pos[2]+2],
+                                  self.travel_speed)
         self.auto_detach_probe(return_pos)
 
     def probe_prepare(self, hmove):
@@ -584,7 +588,8 @@ class DockableProbe:
             return_pos = self.toolhead.get_position()
             # Move away from the bed to ensure the probe isn't triggered,
             # preventing detaching in the event there's no probe/dock sensor.
-            self.toolhead.manual_move([None, None, return_pos[2]+2], self.travel_speed)
+            self.toolhead.manual_move([None, None, return_pos[2]+2],
+                                      self.travel_speed)
             self.auto_detach_probe(return_pos)
 
     def get_position_endstop(self):


### PR DESCRIPTION
This is a redesign of the work done in #4328 to create a `[dockable_probe]` module to support Klicky-style probes that are physically detached most of the time from the toolhead.

## How we got here
The original PR has been sitting for a long time without attention and I took it upon myself to get it integrated into the main branch. Along the way I ended up simplifying the code and distilling it down to what is basically a handful of glorified movement commands (see the `MOVE_TO_*_PROBE` g-codes).

## Prior art
As mentioned, this is based on Mental's work but is significantly different. Rather than try to accommodate many different types of probe hardware and configurations, I targeted Klicky-style probes with fixed X/Y and fixed Z configurations. Other hardware and setups can override the movement g-codes where necessary to support their probes. See the `docs/Dockable_Probe.md` docs for setup examples.

## Testing
I've been running this code for about half a year on a bed slinger without issues (probe dock mounted Z 0). I put the code on a CoreXY today and successfully got it running there as well (probe dock mounted at fixed X, Y, used as virtual endstop for Z).

Back in Fall '22, I [posted on the Klipper Discourse about this code](https://klipper.discourse.group/t/reviving-the-dockable-probe/4256) and got help with wider tests and ironed out a couple bugs. There's been little chatter there until recently (a user with a very unique printer design) so I'm thinking it's been in the wild long enough to prove stable.

## Commits
I broke this down into three commits (rebased and squashed commits):

1. Everything Mental did on the original module (with potentially minor tweaks from me)
2. Everything I did in the rewrite, development followed the Discourse thread
3. A refactor commit to clarify/simplify the attachment verification methods

Let me know if this should be broken down in other ways.

## Finally

Thanks for your time and consideration! I know myself and others will be happy to have this feature native in Klipper.