### PR TITLE
Adding an adaptive horizontal_move_z setting for QUAD_GANTRY_LEVEL

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1181,6 +1181,15 @@ Where x is the 0, 0 point on the bed
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#adaptive_horizontal_move_z: false
+#   Whether to use an adaptive algorithm for horizontal_move_z.
+#   This can speed up QGL by allowing correction for significant skew
+#   on the first pass, and switching to a smaller value as the error
+#   decreases. The minimum for each pass is 4 times the error or the
+#   min_horizontal_move_z setting, whichever is greater.
+#min_horizontal_move_z:
+#   The minimum height for horizontal_move_z when using adaptive mode.
+#   The default is the same as horizontal_move_z for safety.
 #max_adjust: 4
 #   Safety limit if an adjustment greater than this value is requested
 #   quad_gantry_level will abort.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -382,6 +382,8 @@ class ProbePointsHelper:
         self.use_offsets = use_offsets
     def get_lift_speed(self):
         return self.lift_speed
+    def set_horizontal_move_z(self, hz):
+        self.horizontal_move_z = hz
     def _move_next(self):
         toolhead = self.printer.lookup_object('toolhead')
         # Lift toolhead
@@ -422,11 +424,13 @@ class ProbePointsHelper:
         # Perform automatic probing
         self.lift_speed = probe.get_lift_speed(gcmd)
         self.probe_offsets = probe.get_offsets()
-        if self.horizontal_move_z < self.probe_offsets[2]:
-            raise gcmd.error("horizontal_move_z can't be less than"
-                             " probe's z_offset")
         probe.multi_probe_begin()
         while 1:
+            # Check horizontal_move_z each probe in case the adaptive code
+            # has lowered it
+            if self.horizontal_move_z < self.probe_offsets[2]:
+                raise gcmd.error("horizontal_move_z can't be less than"
+                                 " probe's z_offset")
             done = self._move_next()
             if done:
                 break

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -106,6 +106,8 @@ class RetryHelper:
             self.increasing -= 1
         self.previous = error
         return self.increasing > 1
+    def get_previous_error(self):
+        return self.previous
     def check_retry(self, z_positions):
         if self.max_retries == 0:
             return


### PR DESCRIPTION
Adaptive horizontal_move_z allows the first Z height when starting QGL to be large, and then reduced to a smaller number (within the bounds of the error margin) for subsequent passes. This allows faster QGL with less z-hop between travels.