### PR TITLE
console.py: don't force usage of python2 in the shebang

### DIFF
--- a/klippy/console.py
+++ b/klippy/console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Script to implement a test console with firmware over serial port
 #
 # Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>


### PR DESCRIPTION
It seems that by now all parts of Klipper run fine on Python 3. Many systems (like MainsailOS) don't ship Python 2 anymore. On those systems simply running ./console.py fails due to the specific shebang.