### PR TITLE
probe: Use fixed speed for probe offset movement

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -263,7 +263,7 @@ class PrinterProbe:
         # Move the nozzle over the probe point
         curpos[0] += self.x_offset
         curpos[1] += self.y_offset
-        self._move(curpos, self.speed)
+        self._move(curpos, 50)
         # Start manual probe
         manual_probe.ManualProbeHelper(self.printer, gcmd,
                                        self.probe_calibrate_finalize)


### PR DESCRIPTION
Low calibration speed settings can be confusing to the user during a PROBE_CALIBRATE since the nozzle will move very slowly to the probe offset and any commands during that time are ignored. Introduce a setting for probe offset movement speed to circumvent this.