### PR TITLE
virtual_sdcard: reset file position and size to integer zero

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -119,7 +119,7 @@ class VirtualSD:
             self.current_file.close()
             self.current_file = None
             self.print_stats.note_cancel()
-        self.file_position = self.file_size = 0.
+        self.file_position = self.file_size = 0
     # G-Code commands
     def cmd_error(self, gcmd):
         raise gcmd.error("SD write not supported")
@@ -128,7 +128,7 @@ class VirtualSD:
             self.do_pause()
             self.current_file.close()
             self.current_file = None
-        self.file_position = self.file_size = 0.
+        self.file_position = self.file_size = 0
         self.print_stats.reset()
         self.printer.send_event("virtual_sdcard:reset_file")
     cmd_SDCARD_RESET_FILE_help = "Clears a loaded SD File. Stops the print "\


### PR DESCRIPTION
This is a fix to a minor bug which results in the `get_status()` reporting floating point values for `file_position` and `file_size` after a reset or cancel.   Some API clients expect the values in these fields to be integers, as reported in arksine/moonraker#673.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>

