### PR TITLE
Update Installation.md for shallow clone

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -54,7 +54,7 @@ ssh utility to connect to the Raspberry Pi (ssh pi@octopi -- password
 is "raspberry") and run the following commands:
 
 ```
-git clone https://github.com/Klipper3d/klipper
+git clone --depth 1 https://github.com/Klipper3d/klipper
 ./klipper/scripts/install-octopi.sh
 ```
 


### PR DESCRIPTION
Adding the `--depth 1` flag to the git clone command for shallow clone, as typical users do not need a full depth clone and this significantly improves installation time on embedded devices like the raspberry pi.