### PR TITLE
SAME70Q21 DWT init fix

### DIFF
--- a/src/generic/armcm_timer.c
+++ b/src/generic/armcm_timer.c
@@ -93,12 +93,18 @@ DECL_SHUTDOWN(timer_reset);
 void
 timer_init(void)
 {
+
     // Enable Debug Watchpoint and Trace (DWT) for its 32bit timer
+    #if CONFIG_MACH_SAME70
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 	DWT->LAR = 0xC5ACCE55; 
     DWT->CYCCNT = 0;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
+    #else
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+    DWT->CYCCNT = 0;
+    #endif
     // Schedule a recurring timer on fast cpus
     timer_reset();
 

--- a/src/generic/armcm_timer.c
+++ b/src/generic/armcm_timer.c
@@ -95,8 +95,9 @@ timer_init(void)
 {
     // Enable Debug Watchpoint and Trace (DWT) for its 32bit timer
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+	DWT->LAR = 0xC5ACCE55; 
     DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 
     // Schedule a recurring timer on fast cpus
     timer_reset();


### PR DESCRIPTION
Problem: With SAME70Q21->timer_read_time(void) always return with 0