### PR TITLE
Update Config_Reference.md - heater_fan wording

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2616,7 +2616,7 @@ whenever its associated heater is active. By default, a heater_fan has
 a shutdown_speed equal to max_power.
 
 ```
-[heater_fan my_nozzle_fan]
+[heater_fan heatbreak_cooling_fan]
 #pin:
 #max_power:
 #shutdown_speed:


### PR DESCRIPTION
The reference to my_nozzle_fan is misleading and could cause people to skip over the [fan] definition and assume this is the parts/print cooling fan. Alias changed to reflect heatbreak_cooling_fan as used in most configs that have a controllable hotend fan.

Thanks
James

Signed-off-by: James Hartley <james@hartleyns.com>