### PR TITLE
Multiple config - change wording for heater fan

### DIFF
--- a/config/generic-fysetc-f6.cfg
+++ b/config/generic-fysetc-f6.cfg
@@ -78,7 +78,7 @@ max_temp: 130
 pin: PL5
 
 #fan for hotend FAN1
-#[heater_fan my_nozzle_fan]
+#[heater_fan heatbreak_cooling_fan]
 #pin: PL4
 #shutdown_speed: 1
 

--- a/config/generic-fysetc-s6-v2.cfg
+++ b/config/generic-fysetc-s6-v2.cfg
@@ -80,7 +80,7 @@ max_temp: 130
 pin: PB0
 
 #fan for hotend FAN1
-#[heater_fan my_nozzle_fan]
+#[heater_fan heatbreak_cooling_fan]
 #pin: PB1
 #shutdown_speed: 1
 

--- a/config/generic-fysetc-s6.cfg
+++ b/config/generic-fysetc-s6.cfg
@@ -80,7 +80,7 @@ max_temp: 130
 pin: PB0
 
 #fan for hotend FAN1
-#[heater_fan my_nozzle_fan]
+#[heater_fan heatbreak_cooling_fan]
 #pin: PB1
 #shutdown_speed: 1
 

--- a/config/generic-fysetc-spider.cfg
+++ b/config/generic-fysetc-spider.cfg
@@ -91,7 +91,7 @@ max_temp: 130
 pin: PB0
 
 #fan for hotend FAN1
-#[heater_fan my_nozzle_fan]
+#[heater_fan heatbreak_cooling_fan]
 #pin: PB1
 #shutdown_speed: 1
 

--- a/config/printer-tevo-flash-2018.cfg
+++ b/config/printer-tevo-flash-2018.cfg
@@ -78,7 +78,7 @@ pid_Kd: 698.838
 min_temp: 0
 max_temp: 70
 
-[heater_fan my_nozzle_fan]
+[heater_fan heatbreak_cooling_fan]
 pin: PH4
 
 [fan]


### PR DESCRIPTION
The reference to `my_nozzle_fan` in these configs could be confusing and misleading, leading users to think it is the parts/print cooling fan, changed to heatbreak_cooling_fan as used in other configs.

Thanks
James