### PR TITLE
rp2040_flash: main.c: Fix the type when printing num_blocks

### DIFF
--- a/lib/rp2040_flash/main.c
+++ b/lib/rp2040_flash/main.c
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
         rc = 1;
         goto do_exit;
     }
-    fprintf(stderr, "Loaded UF2 image with %lu pages\n", image->num_blocks);
+    fprintf(stderr, "Loaded UF2 image with %zu pages\n", image->num_blocks);
 
     bool has_target = false;
     uint8_t target_bus = 0;


### PR DESCRIPTION
image->num_blocks is of type unsigned size_t thus unsigned int.

%lu specifies a type of long unsigned int. Thus resulting in compiler warning about type mismatch. Correct this by printing the value with a correct type.