### PR TITLE
fan: Support multiple part fans

### DIFF
--- a/config/sample-idex.cfg
+++ b/config/sample-idex.cfg
@@ -34,6 +34,10 @@ pid_Kd: 114
 min_temp: 0
 max_temp: 250
 
+# The definition for the part cooling fan for primary extruder
+[fan]
+pin: PH6
+
 # Helper script to park the carriage (called from T0 and T1 macros)
 [gcode_macro PARK_extruder]
 gcode:
@@ -47,6 +51,7 @@ gcode:
 gcode:
     PARK_{printer.toolhead.extruder}
     ACTIVATE_EXTRUDER EXTRUDER=extruder
+    ACTIVATE_FAN FAN=fan
     SET_DUAL_CARRIAGE CARRIAGE=0
     SET_GCODE_OFFSET Y=0
 
@@ -81,6 +86,10 @@ pid_Kd: 114
 min_temp: 0
 max_temp: 250
 
+# The definition for the part cooling fan for secondary extruder
+[fan secondary]
+pin: PH7
+
 [gcode_macro PARK_extruder1]
 gcode:
     SAVE_GCODE_STATE NAME=park1
@@ -92,5 +101,6 @@ gcode:
 gcode:
     PARK_{printer.toolhead.extruder}
     ACTIVATE_EXTRUDER EXTRUDER=extruder1
+    ACTIVATE_FAN FAN='fan secondary'
     SET_DUAL_CARRIAGE CARRIAGE=1
     SET_GCODE_OFFSET Y=15

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2539,7 +2539,13 @@ serial_no:
 
 ### [fan]
 
-Print cooling fan.
+Print cooling fan, controlled by M106/M107 gcodes.
+One may define any number of sections with a
+"fan" prefix.  Fan with no prefix is the default.
+ACTIVATE_FAN [gcode command](G-Codes.md#fan) can be used
+to select another fan to be the print cooling fan.
+When not active, can be manually controlled
+with the SET_FAN_SPEED [gcode command](G-Codes.md#fan_generic).
 
 ```
 [fan]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -429,6 +429,18 @@ This command is deprecated and will be removed in the near future.
 #### SYNC_STEPPER_TO_EXTRUDER
 This command is deprecated and will be removed in the near future.
 
+### [fan]
+
+The following command is available when a
+[fan config section](Config_Reference.md#fan is
+enabled.
+
+#### ACTIVATE_FAN
+
+`ACTIVATE_FAN FAN=config_name` Selects the active printer fan that reacts to
+M106/M107 gcodes. Current fan speed is transferred over to the new fan.
+Nameless [fan] is active by default.
+
 ### [fan_generic]
 
 The following command is available when a
@@ -438,6 +450,8 @@ enabled.
 #### SET_FAN_SPEED
 `SET_FAN_SPEED FAN=config_name SPEED=<speed>` This command sets the
 speed of a fan. "speed" must be between 0.0 and 1.0.
+
+Can also be used with non-active [fan] entries.
 
 ### [filament_switch_sensor]
 

--- a/klippy/extras/fan_generic.py
+++ b/klippy/extras/fan_generic.py
@@ -5,24 +5,8 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import fan
 
-class PrinterFanGeneric:
-    cmd_SET_FAN_SPEED_help = "Sets the speed of a fan"
-    def __init__(self, config):
-        self.printer = config.get_printer()
-        self.fan = fan.Fan(config, default_shutdown_speed=0.)
-        self.fan_name = config.get_name().split()[-1]
-
-        gcode = self.printer.lookup_object("gcode")
-        gcode.register_mux_command("SET_FAN_SPEED", "FAN",
-                                   self.fan_name,
-                                   self.cmd_SET_FAN_SPEED,
-                                   desc=self.cmd_SET_FAN_SPEED_help)
-
-    def get_status(self, eventtime):
-        return self.fan.get_status(eventtime)
-    def cmd_SET_FAN_SPEED(self, gcmd):
-        speed = gcmd.get_float('SPEED', 0.)
-        self.fan.set_speed_from_command(speed)
-
 def load_config_prefix(config):
-    return PrinterFanGeneric(config)
+    instance = fan.FanControllable(config)
+    # Support for suffix only name. The full name is already registered in init.
+    instance.register_cmds_for_name(instance.name[len('fan_generic '):])
+    return instance

--- a/klippy/extras/printer_fan.py
+++ b/klippy/extras/printer_fan.py
@@ -1,0 +1,47 @@
+# Support for toolchnagers
+#
+# Copyright (C) 2023 Viesturs Zarins <viesturz@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+# Main printer fan.
+# Handles M106 M107 and routes to the active generic fan.
+class PrinterFan:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.active_fan = None
+        self.requested_speed = None
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command("M106", self.cmd_M106)
+        gcode.register_command("M107", self.cmd_M107)
+
+    def status(self, eventtime):
+        return {'fan': self.active_fan.name if self.active_fan else None,
+                'speed': self.requested_speed}
+
+    def get_fan(self):
+        return self.activate_fan
+
+    def activate_fan(self, fan):
+        # Set new active fan and move the set speed to that fan.
+        if self.active_fan == fan:
+            return
+        if self.active_fan and self.requested_speed is not None:
+            self.active_fan.set_speed_from_command(0.)
+        self.active_fan = fan
+        if self.active_fan and self.requested_speed is not None:
+            self.active_fan.set_speed_from_command(self.requested_speed)
+
+    def cmd_M106(self, gcmd):
+        # Set fan speed
+        self.requested_speed = gcmd.get_float('S', 255., minval=0.) / 255.
+        if self.active_fan:
+            self.active_fan.set_speed_from_command(self.requested_speed)
+    def cmd_M107(self, gcmd):
+        # Turn fan off
+        self.requested_speed = 0.
+        if self.active_fan:
+            self.active_fan.set_speed_from_command(self.requested_speed)
+
+def load_config(config):
+    return PrinterFan(config)


### PR DESCRIPTION
Multi extruder setups can have separate part cooling fan for each extruder. This change allows runtime switching between fans using ACTIVATE_FAN command, similar to ACTIVATE_EXTRUDER.

The fix is to essentially make [fan] the same as [fan_generic] and use ACTIVATE_FAN to specifcy which fan is the printer fan. Inactive printer fans may be manually controlled using existing  SET_FAN_SPEED command.

This helps primarliy with PrusaSlicer gcode, that just emits M106 S110; T1; when changing tools. Making emulation with macros quite complex.