### PR TITLE
Config: Update Octopus Max EZ for wrong bltouch pins

### DIFF
--- a/config/generic-bigtreetech-octopus-max-ez.cfg
+++ b/config/generic-bigtreetech-octopus-max-ez.cfg
@@ -304,8 +304,8 @@ aliases:
 # See the sample-lcd.cfg file for definitions of common LCD displays.
 
 #[bltouch]
-#sensor_pin: PB14
-#control_pin: PB15
+#sensor_pin: ^PB15
+#control_pin: PB14
 
 # Proximity switch
 #[probe]


### PR DESCRIPTION
It has been discovered on the discord by the user Pizn that the bltouch pins are swapped in this config and don't include the ^ pull on the sensor pin.

This has been tested and confirmed by the user.

Thanks
James

Signed-off-by: James Hartley <james@hartleyns.com>