### PR TITLE
Add process id, user id and group id to the info endpoint.

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -354,9 +354,14 @@ class WebHooks:
         state_message, state = self.printer.get_state_message()
         src_path = os.path.dirname(__file__)
         klipper_path = os.path.normpath(os.path.join(src_path, ".."))
-        response = {'state': state, 'state_message': state_message,
+        response = {'state': state,
+                    'state_message': state_message,
                     'hostname': socket.gethostname(),
-                    'klipper_path': klipper_path, 'python_path': sys.executable}
+                    'klipper_path': klipper_path,
+                    'python_path': sys.executable,
+                    'process_id': os.getpid(),
+                    'user_id': os.getuid(),
+                    'group_id': os.getgid()}
         start_args = self.printer.get_start_args()
         for sa in ['log_file', 'config_file', 'software_version', 'cpu_info']:
             response[sa] = start_args.get(sa)


### PR DESCRIPTION
Adding these three pieces of information to the info endpoint allows the system that connects to the klippy.sock to simply ask klipper these details. This avoids having to resort to less accurate methods. 

For example moonraker is checking the process that generated the socket itself. This works for the most time. However when using a socket proxy this fails.