### PR TITLE
Add printer config for Anycubic Kobra Neo

### DIFF
--- a/config/printer-anycubic-kobra-neo-2022.cfg
+++ b/config/printer-anycubic-kobra-neo-2022.cfg
@@ -1,0 +1,141 @@
+# This file contains a configuration for the Anycubic Kobra Neo printer.
+#
+# See docs/Config_Reference.md for a description of parameters.
+#
+# To build the firmware, use the following configuration:
+#   - Micro-controller: Huada Semiconductor HC32F460
+#   - Communication interface: Serial (PA3 & PA2) - Anycubic
+#
+# Installation:
+#  1. Rename the klipper bin to `firmware.bin` and copy it to an SD Card.
+#  2. Power off the Printer, insert the SD Card and power it on.
+#  3. The the LCD will be stuck on the Firmware-update screen.
+#     Just Wait for 3-5 minutes to ensure the firmware is flashed.
+#  4. After waiting, shutdown the printer and remove the SD Card.
+
+[stepper_x]
+step_pin: PA12
+dir_pin: PA11
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 40
+endstop_pin: !PH2
+position_endstop: -8
+position_min:-8
+position_max: 220
+homing_speed: 70
+
+[stepper_y]
+step_pin: PA9
+dir_pin: PA8
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^!PC13
+position_endstop: -19
+position_min:-19
+position_max: 220
+homing_speed: 70
+
+[stepper_z]
+step_pin: PC7
+dir_pin: !PC6
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PC14
+position_endstop: 0
+position_min: -15
+position_max: 250
+homing_speed: 5
+
+[extruder]
+step_pin: PB15
+dir_pin: PB14
+enable_pin: !PA15
+microsteps: 16
+rotation_distance: 7.6987251
+max_extrude_only_distance: 101
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB8
+sensor_type: Generic 3950
+sensor_pin: PC3
+min_extrude_temp: 170
+min_temp: 0
+max_temp: 250
+control: pid
+pid_kp = 18.522
+pid_ki = 0.786
+pid_kd = 109.048
+
+
+[heater_bed]
+heater_pin: PB9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC1
+min_temp: 0
+max_temp: 120
+control: pid
+pid_kp = 60.954
+pid_ki = 0.991
+pid_kd = 937.171
+
+[bed_mesh]
+speed: 400
+horizontal_move_z: 7
+mesh_min: 32, 26
+mesh_max: 189, 189
+probe_count: 6, 6
+algorithm: lagrange
+
+[probe]
+pin: PA1
+x_offset: 37.5
+y_offset: -17
+z_offset: 0
+samples: 6
+samples_result: average
+samples_tolerance_retries: 7
+sample_retract_dist: 0.5
+speed: 2
+lift_speed: 10
+
+[bed_screws]
+screw1: 28, 24
+screw2: 192, 24
+screw3: 192, 190
+screw4: 28, 190
+
+[safe_z_home]
+home_xy_position: 0, 0
+speed: 5
+z_hop: 10
+z_hop_speed: 10
+
+[controller_fan controller_fan]
+pin: PB12
+
+[heater_fan extruder_fan]
+pin: PB13
+cycle_time: 0.000050
+
+[fan]
+pin: PB5
+cycle_time: 0.00005 #20kHz
+
+[output_pin enable_pin]
+pin: PB6
+static_value: 1
+    #This pin enables the bed, hotend, extruder fan, part fan.
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 600
+max_accel: 500
+max_z_velocity: 25
+max_z_accel: 25


### PR DESCRIPTION
Config: for Anycubic Kobra Neo.
It is almost the same as for Anycubic Kobra Go.