### PR TITLE
samc21: Fix CAN RAM base address

### DIFF
--- a/lib/README
+++ b/lib/README
@@ -24,7 +24,9 @@ version 1.0.56 (extracted on 20181220).
 The samc21 directory contains code from the
 Atmel.SAMC21_DFP.1.2.176.atpack zip file found at:
   http://packs.download.atmel.com/
-version 1.2.176 (extracted on 20230115).
+version 1.2.176 (extracted on 20230115). It has been modified to fix
+an incorrect base address for the CAN message ram. See samc21.patch
+for the modifications.
 
 The samd21 directory contains code from the
 Atmel.SAMD21_DFP.1.3.304.atpack zip file found at:

--- a/lib/samc21/samc21.patch
+++ b/lib/samc21/samc21.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/samc21/samc21/include/instance/can0.h b/lib/samc21/samc21/include/instance/can0.h
+index ffb7f796..4f04d555 100644
+--- a/lib/samc21/samc21/include/instance/can0.h
++++ b/lib/samc21/samc21/include/instance/can0.h
+@@ -133,7 +133,7 @@
+ #define CAN0_CLK_AHB_ID             8        // Index of AHB clock
+ #define CAN0_DMAC_ID_DEBUG          14       // DMA CAN Debug Req
+ #define CAN0_GCLK_ID                26       // Index of Generic Clock
+-#define CAN0_MSG_RAM_ADDR           0x200000000
++#define CAN0_MSG_RAM_ADDR           0x20000000
+ #define CAN0_QOS_RESET_VAL          2        // QOS reset value
+ 
+ #endif /* _SAMC21_CAN0_INSTANCE_ */
+diff --git a/lib/samc21/samc21/include/instance/can1.h b/lib/samc21/samc21/include/instance/can1.h
+index 484db284..eadd0b16 100644
+--- a/lib/samc21/samc21/include/instance/can1.h
++++ b/lib/samc21/samc21/include/instance/can1.h
+@@ -133,7 +133,7 @@
+ #define CAN1_CLK_AHB_ID             9        // Index of AHB clock
+ #define CAN1_DMAC_ID_DEBUG          15       // DMA CAN Debug Req
+ #define CAN1_GCLK_ID                27       // Index of Generic Clock
+-#define CAN1_MSG_RAM_ADDR           0x200000000
++#define CAN1_MSG_RAM_ADDR           0x20000000
+ #define CAN1_QOS_RESET_VAL          2        // QOS reset value
+ 
+ #endif /* _SAMC21_CAN1_INSTANCE_ */

--- a/lib/samc21/samc21/include/instance/can0.h
+++ b/lib/samc21/samc21/include/instance/can0.h
@@ -133,7 +133,7 @@
 #define CAN0_CLK_AHB_ID             8        // Index of AHB clock
 #define CAN0_DMAC_ID_DEBUG          14       // DMA CAN Debug Req
 #define CAN0_GCLK_ID                26       // Index of Generic Clock
-#define CAN0_MSG_RAM_ADDR           0x200000000
+#define CAN0_MSG_RAM_ADDR           0x20000000
 #define CAN0_QOS_RESET_VAL          2        // QOS reset value
 
 #endif /* _SAMC21_CAN0_INSTANCE_ */

--- a/lib/samc21/samc21/include/instance/can1.h
+++ b/lib/samc21/samc21/include/instance/can1.h
@@ -133,7 +133,7 @@
 #define CAN1_CLK_AHB_ID             9        // Index of AHB clock
 #define CAN1_DMAC_ID_DEBUG          15       // DMA CAN Debug Req
 #define CAN1_GCLK_ID                27       // Index of Generic Clock
-#define CAN1_MSG_RAM_ADDR           0x200000000
+#define CAN1_MSG_RAM_ADDR           0x20000000
 #define CAN1_QOS_RESET_VAL          2        // QOS reset value
 
 #endif /* _SAMC21_CAN1_INSTANCE_ */


### PR DESCRIPTION
Upstream header bug leads to clobbering of RXF0C and TXBC registers, causing severe memory corruption.

fdcan.c (and any other name applied to a Bosch M_CAN driver) on all targets should probably be modified to prevent such behaviour in future, but this will get SAM C21 up and running.