### PR TITLE
motan: Added norm2 and smooth analyzers

### DIFF
--- a/scripts/motan/analyzers.py
+++ b/scripts/motan/analyzers.py
@@ -105,6 +105,59 @@ class GenIntegral:
         return data
 AHandlers["integral"] = GenIntegral
 
+# Calculate a pointwise 2-norm of several datasets (e.g. compute velocity or
+# accel from its x, y,... components)
+class GenNorm2:
+    ParametersMin = 2
+    ParametersMax = 3
+    DataSets = [
+        ('norm2(<dataset1>,<dataset2>)',
+         'pointwise 2-norm of dataset1 and dataset2'),
+        ('norm2(<dataset1>,<dataset2>,<dataset3>)',
+         'pointwise 2-norm of 3 datasets'),
+    ]
+    def __init__(self, amanager, name_parts):
+        self.amanager = amanager
+        self.datasets = []
+        self.datasets.append(name_parts[1])
+        self.datasets.append(name_parts[2])
+        if len(name_parts) == 4:
+            self.datasets.append(name_parts[3])
+        for dataset in self.datasets:
+            amanager.setup_dataset(dataset)
+    def get_label(self):
+        label = self.amanager.get_label(self.datasets[0])
+        units = label['units']
+        datas = ['position', 'velocity', 'acceleration']
+        data_name = ''
+        for d in datas:
+            if d in label['label']:
+                data_name = d
+                break
+        lname = ''
+        for d in self.datasets:
+            l = self.amanager.get_label(d)['label']
+            for r in datas:
+                l = l.replace(r, '').strip()
+            if lname:
+                lname += '+'
+            lname += l
+        lname += ' ' + data_name + ' norm2'
+        return {'label': lname, 'units': units}
+    def generate_data(self):
+        seg_time = self.amanager.get_segment_time()
+        data = []
+        for dataset in self.datasets:
+            data.append(self.amanager.get_datasets()[dataset])
+        res = [0.] * len(data[0])
+        for i in range(len(data[0])):
+            norm2 = 0.
+            for dataset in data:
+                norm2 += dataset[i] * dataset[i]
+            res[i] = math.sqrt(norm2)
+        return res
+AHandlers["norm2"] = GenNorm2
+
 # Calculate a kinematic stepper position from the toolhead requested position
 class GenKinematicPosition:
     ParametersMin = ParametersMax = 1

--- a/scripts/motan/analyzers.py
+++ b/scripts/motan/analyzers.py
@@ -158,6 +158,44 @@ class GenNorm2:
         return res
 AHandlers["norm2"] = GenNorm2
 
+class GenSmoothed:
+    ParametersMin = 1
+    ParametersMax = 2
+    DataSets = [
+        ('smooth(<dataset>)', 'Generate moving weighted average of a dataset'),
+        ('smooth(<dataset>,<smooth_time>)',
+         'Generate moving weighted average of a dataset with a given'
+         ' smoothing time that defines the window size'),
+    ]
+    def __init__(self, amanager, name_parts):
+        self.amanager = amanager
+        self.source = name_parts[1]
+        amanager.setup_dataset(self.source)
+        self.smooth_time = 0.01
+        if len(name_parts) > 2:
+            self.smooth_time = float(name_parts[2])
+    def get_label(self):
+        label = self.amanager.get_label(self.source)
+        return {'label': 'Smoothed ' + label['label'], 'units': label['units']}
+    def generate_data(self):
+        seg_time = self.amanager.get_segment_time()
+        src = self.amanager.get_datasets()[self.source]
+        n = len(src)
+        data = [0.] * n
+        hst = 0.5 * self.smooth_time
+        seg_half_len = round(hst / seg_time)
+        inv_norm = 1. / sum([min(k + 1, seg_half_len + seg_half_len - k)
+                             for k in range(2 * seg_half_len)])
+        for i in range(n):
+            j = max(0, i - seg_half_len)
+            je = min(n, i + seg_half_len)
+            avg_val = 0.
+            for k, v in enumerate(src[j:je]):
+                avg_val += v * min(k + 1, seg_half_len + seg_half_len - k)
+            data[i] = avg_val * inv_norm
+        return data
+AHandlers["smooth"] = GenSmoothed
+
 # Calculate a kinematic stepper position from the toolhead requested position
 class GenKinematicPosition:
     ParametersMin = ParametersMax = 1


### PR DESCRIPTION
These two analyzers are useful, in my opinion, for various analyses of the motion data, e.g. as

- `["norm2(derivative(stepq(stepper_x)),derivative(stepq(stepper_y)))"]` to find the commanded toolhead velocity in XY plane from its X and Y steppers velocities;
- `["smooth(adxl345(hotend,x))","smooth(adxl345(bed,y))"]` to plot the smoothed accelerometer readings to eliminate high-frequency noise from the data.
