### PR TITLE
Sort SD card files by modification date

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -76,10 +76,15 @@ class VirtualSD:
             dname = self.sdcard_dirname
             try:
                 filenames = os.listdir(self.sdcard_dirname)
-                return [(fname, os.path.getsize(os.path.join(dname, fname)))
-                        for fname in sorted(filenames, key=lambda x: -os.path.getmtime(os.path.join(dname, x)))
+                return [
+                    (fname, os.path.getsize(os.path.join(dname, fname)))
+                        for fname in sorted(
+                    filenames,
+                    key=lambda x: -os.path.getmtime(os.path.join(dname, x))
+                    )
                         if not fname.startswith('.')
-                        and os.path.isfile((os.path.join(dname, fname)))]
+                        and os.path.isfile((os.path.join(dname, fname)))
+                        ]
             except:
                 logging.exception("virtual_sdcard get_file_list")
                 raise self.gcode.error("Unable to get file list")

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -71,7 +71,8 @@ class VirtualSD:
                     r_path = full_path[len(self.sdcard_dirname) + 1:]
                     size = os.path.getsize(full_path)
                     flist.append((r_path, size))
-            return sorted(flist, key=lambda f: -os.path.getmtime(f[0]))
+            return sorted(flist, key=lambda f: -os.path.getmtime(
+                os.path.join(self.sdcard_dirname, f[0])))
         else:
             dname = self.sdcard_dirname
             try:

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -71,13 +71,13 @@ class VirtualSD:
                     r_path = full_path[len(self.sdcard_dirname) + 1:]
                     size = os.path.getsize(full_path)
                     flist.append((r_path, size))
-            return sorted(flist, key=lambda f: f[0].lower())
+            return sorted(flist, key=lambda f: -os.path.getmtime(f[0]))
         else:
             dname = self.sdcard_dirname
             try:
                 filenames = os.listdir(self.sdcard_dirname)
                 return [(fname, os.path.getsize(os.path.join(dname, fname)))
-                        for fname in sorted(filenames, key=str.lower)
+                        for fname in sorted(filenames, key=lambda x: -os.path.getmtime(os.path.join(dname, x)))
                         if not fname.startswith('.')
                         and os.path.isfile((os.path.join(dname, fname)))]
             except:


### PR DESCRIPTION
Sort SD card files by modification date descending to make selecting files convenient on displays.

I have a display that just pulls files from sd card and displays them as is. But when my printer has dozens of files, or even more, it gets more and more frustrating to try to select the proper one. The suggested solution in this PR sorts the sd card contents by modification date to make it easier to select the right file, because usually users want to print the freshly sliced one.

Without this feature I can't treat the `[display]` as a solution that replaces mainsail or fluidd. Having as few as 10 files makes it pretty hard, if not impossible to navigate the desired file, especially if I sliced it without looking on the exact gcode name