### PR TITLE
hc32f460: Revert default clock back to 200MHz

### DIFF
--- a/src/hc32f460/Kconfig
+++ b/src/hc32f460/Kconfig
@@ -81,10 +81,10 @@ config STACK_SIZE
 
 choice "Clock Speed"
     prompt "Clock Speed"
-    config HC32F460_CLOCK_SPEED_168M
-        bool "168 MHz"
     config HC32F460_CLOCK_SPEED_200M
         bool "200 MHz"
+    config HC32F460_CLOCK_SPEED_168M
+        bool "168 MHz"
 endchoice
 
 config CLOCK_FREQ


### PR DESCRIPTION
Various build guides and documentation are based around the previous config default of 200MHz and don't instruct users to change this. The result of this is "timer to close" shutdown errors.

Change the default back to 200MHz to avoid nasty surprises.