### PR TITLE
heaters: adds temperature monitors

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -245,6 +245,11 @@ object is available if any heater is defined):
   temperature sensors by their full config section names,
   e.g. `["extruder", "heater_bed", "heater_generic my_custom_heater",
   "temperature_sensor electronics_temp"]`.
+- `available_monitors`: Returns a list of all currently available
+  temperature monitors by their full config section names,
+  e.g. `["tmc2240 stepper_x"]`.  While a temperature sensor is always
+  available to read, a temperature monitor may not be available and
+  will return null in such case.
 
 ## idle_timeout
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -230,6 +230,7 @@ class PrinterHeaters:
         self.gcode_id_to_sensor = {}
         self.available_heaters = []
         self.available_sensors = []
+        self.available_monitors = []
         self.has_started = self.have_load_sensors = False
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.printer.register_event_handler("gcode:request_restart",
@@ -293,9 +294,12 @@ class PrinterHeaters:
             raise self.printer.config_error(
                 "G-Code sensor id %s already registered" % (gcode_id,))
         self.gcode_id_to_sensor[gcode_id] = psensor
+    def register_monitor(self, config):
+        self.available_monitors.append(config.get_name())
     def get_status(self, eventtime):
         return {'available_heaters': self.available_heaters,
-                'available_sensors': self.available_sensors}
+                'available_sensors': self.available_sensors,
+                'available_monitors': self.available_monitors}
     def turn_off_all_heaters(self, print_time=0.):
         for heater in self.heaters.values():
             heater.set_temp(0.)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -125,6 +125,9 @@ class TMCErrorCheck:
         # Setup for temperature query
         self.adc_temp = None
         self.adc_temp_reg = self.fields.lookup_register("adc_temp")
+        if self.adc_temp_reg is not None:
+            pheaters = self.printer.load_object(config, 'heaters')
+            pheaters.register_monitor(config)
     def _query_register(self, reg_info, try_clear=False):
         last_value, reg_name, mask, err_mask, cs_actual_mask = reg_info
         cleared_flags = 0


### PR DESCRIPTION
(This is a follow up on #6145 and discussion on PR #6205 and #6210)

This PR adds a new `available_monitors` entry to the `heaters` status object.

This allows the `TMC2240` to register itself as a temperature monitor so that Moonraker can then read the temperature and store the history data and provide it to the frontends.