### PR TITLE
printer-anycubic-i3-mega-2017: drivers fan not turned on while moves without heating

### DIFF
--- a/config/printer-anycubic-i3-mega-2017.cfg
+++ b/config/printer-anycubic-i3-mega-2017.cfg
@@ -93,5 +93,5 @@ max_accel: 3000
 max_z_velocity: 10
 max_z_accel: 60
 
-[heater_fan stepstick_fan]
+[controller_fan drivers_fan]
 pin: PH4


### PR DESCRIPTION
Drivers/mainboard fan of Anycubic i3 Mega placed in [heater_fan ...] group. 
So it turned on only while heating but not while moves without heating.  
Mainboard/drivers fan must be in [controller_fan ...] group by default to prevent overheating.