### PR TITLE
atsamd: Optimize timer for samc21

### DIFF
--- a/src/atsamd/timer.c
+++ b/src/atsamd/timer.c
@@ -41,8 +41,8 @@ timer_read_time(void)
 {
 #if CONFIG_MACH_SAMC21
     TCp->COUNT32.CTRLBSET.reg |= TC_CTRLBSET_CMD(TC_CTRLBCLR_CMD_READSYNC_Val);
-    while (TCp->COUNT32.SYNCBUSY.reg & TC_SYNCBUSY_COUNT)
-        ;
+    TCp->COUNT32.COUNT.reg;
+    TCp->COUNT32.COUNT.reg;
 #endif
     return TCp->COUNT32.COUNT.reg;
 }


### PR DESCRIPTION
This optimizes the timer code for samc21. Tested by running single stepper benchmark as follows:
```
allocate_oids count=1
config_stepper oid=0 step_pin=PA27 dir_pin=PA28 invert_step=-1 step_pulse_ticks=0
finalize_config crc=0
SET ticks 97
reset_step_clock oid=0 clock={clock+freq}
set_next_step_dir oid=0 dir=0
queue_step oid=0 interval={ticks} count=60000 add=0
set_next_step_dir oid=0 dir=1
queue_step oid=0 interval=3000 count=1 add=0
```
Prior to this change, the minimum value for `ticks` was `99`. This change is marginally faster with a minimum `ticks` value of `97`. I'm not sure this optimization was worth it, but at least we know these values now. Notably, this is slower than the recorded benchmark for samd21, but that chip does not require syncing this field before a read.