### PR TITLE
scripts: Support both H743 and H723 BTT SKR3 boards sdflash

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230810: The flash-sdcard.sh script now supports both variants of the
+Bigtreetech SKR-3, STM32H743 and STM32H723. For this, the original tag
+of btt-skr-3 now has changed to be either btt-skr-3-h743 or btt-skr-3-h723.
+
 20230729: The exported status for `dual_carriage` is changed. Instead of
 exporting `mode` and `active_carriage`, the individual modes for each
 carriage are exported as `printer.dual_carriage.carriage_0` and

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -87,8 +87,15 @@ BOARD_DEFS = {
         'spi_bus': 'spi3a',
         'cs_pin': 'PA15'
     },
-    'btt-skr-3': {
+    'btt-skr-3-h743': {
         'mcu': 'stm32h743xx',
+        'spi_bus': 'swspi',
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': 'PC11',
+        'skip_verify': True
+    },
+    'btt-skr-3-h723': {
+        'mcu': 'stm32h723xx',
         'spi_bus': 'swspi',
         'spi_pins': "PC8,PD2,PC12",
         'cs_pin': 'PC11',


### PR DESCRIPTION
BigTreeTech is shipping the SKR-3 Controller Board now with the STM32H723 micro in addition to the existing STM32H743 version.

This adds the H723 target to the spi-flash script and renames the existing H743 variant to be consistent with other entries and disambiguate between the two.
