### PR TITLE
Extruder: Allow gaps in extruder numbering.

### DIFF
--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -261,7 +261,7 @@ class PrinterMotionReport:
                 ename = "extruder"
             extruder = self.printer.lookup_object(ename, None)
             if extruder is None:
-                break
+                continue
             etrapq = extruder.get_trapq()
             self.trapqs[ename] = DumpTrapQ(self.printer, ename, etrapq)
         # Populate 'trapq' and 'steppers' in get_status result

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -335,6 +335,6 @@ def add_printer_objects(config):
         if i:
             section = 'extruder%d' % (i,)
         if not config.has_section(section):
-            break
+            continue
         pe = PrinterExtruder(config.getsection(section), i)
         printer.add_object(section, pe)


### PR DESCRIPTION
When an extruder is not available, IE, it's broken or otherwise, the strict incremental numbering makes it cumbersome to reconfigure the printer.

This allows gaps in the extruder numbering.
The only downside I can see is slight extra work on printer startup. That should amount to <1ms of real life latency.