### PR TITLE
Toolhead: Use dict for step generation flush times.

### DIFF
--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -135,16 +135,13 @@ class InputShaper:
             is_sk = self._get_input_shaper_stepper_kinematics(s)
             if is_sk is None:
                 continue
-            old_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
             for shaper in self.shapers:
                 if shaper in failed_shapers:
                     continue
                 if not shaper.set_shaper_kinematics(is_sk):
                     failed_shapers.append(shaper)
             new_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
-            if old_delay != new_delay:
-                self.toolhead.note_step_generation_scan_time(new_delay,
-                                                             old_delay)
+            self.toolhead.note_step_generation_scan_time(self, new_delay)
         if failed_shapers:
             error = error or self.printer.command_error
             raise error("Failed to configure shaper(s) %s with given parameters"

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -70,15 +70,11 @@ class ExtruderStepper:
         self.stepper.set_trapq(extruder.get_trapq())
         self.motion_queue = extruder_name
     def _set_pressure_advance(self, pressure_advance, smooth_time):
-        old_smooth_time = self.pressure_advance_smooth_time
-        if not self.pressure_advance:
-            old_smooth_time = 0.
         new_smooth_time = smooth_time
         if not pressure_advance:
             new_smooth_time = 0.
         toolhead = self.printer.lookup_object("toolhead")
-        toolhead.note_step_generation_scan_time(new_smooth_time * .5,
-                                                old_delay=old_smooth_time * .5)
+        toolhead.note_step_generation_scan_time(self, new_smooth_time * .5)
         ffi_main, ffi_lib = chelper.get_ffi()
         espa = ffi_lib.extruder_set_pressure_advance
         espa(self.sk_extruder, pressure_advance, new_smooth_time)


### PR DESCRIPTION
Makes the API between toolhead and extruder, input shaper more robust, avoiding the need to track the old delay.