### PR TITLE
tmc: Adding UART interface support to tmc2240

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3362,6 +3362,7 @@ the name of the corresponding stepper config section (for example,
 
 ```
 [tmc2240 stepper_x]
+interface: spi
 cs_pin:
 #   The pin corresponding to the TMC2240 chip select line. This pin
 #   will be set to low at the start of SPI messages and raised to high
@@ -3472,6 +3473,23 @@ run_current:
 #   "sensorless homing". (Be sure to also set driver_SGT to an
 #   appropriate sensitivity value.) The default is to not enable
 #   sensorless homing.
+```
+
+### [tmc2240] UART
+
+Configure a TMC2240 stepper motor driver via UART. To use this
+feature, define a config section with a "tmc2240" prefix followed by
+the name of the corresponding stepper config section (for example,
+"[tmc2240 stepper_x]").
+
+See the [TMC2240 config reference](Config_Reference.html#tmc2240) for additional
+configuration fields.
+
+```
+[tmc2240 stepper_x]
+interface: uart
+uart_pin: 
+#diag_pin:
 ```
 
 ### [tmc5160]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3355,7 +3355,7 @@ run_current:
 
 ### [tmc2240]
 
-Configure a TMC2240 stepper motor driver via SPI bus. To use this
+Configure a TMC2240 stepper motor driver via SPI bus or UART. To use this
 feature, define a config section with a "tmc2240" prefix followed by
 the name of the corresponding stepper config section (for example,
 "[tmc2240 stepper_x]").
@@ -3374,6 +3374,9 @@ cs_pin:
 #spi_software_miso_pin:
 #   See the "common SPI settings" section for a description of the
 #   above parameters.
+#uart_pin:
+#   The pin connected to the TMC2240 DIAG1/SW line. If this parameter
+#   is provided UART communication is used rather then SPI.
 #chain_position:
 #chain_length:
 #   These parameters configure an SPI daisy chain. The two parameters
@@ -3473,23 +3476,6 @@ run_current:
 #   "sensorless homing". (Be sure to also set driver_SGT to an
 #   appropriate sensitivity value.) The default is to not enable
 #   sensorless homing.
-```
-
-### [tmc2240] UART
-
-Configure a TMC2240 stepper motor driver via UART. To use this
-feature, define a config section with a "tmc2240" prefix followed by
-the name of the corresponding stepper config section (for example,
-"[tmc2240 stepper_x]").
-
-See the [TMC2240 config reference](Config_Reference.html#tmc2240) for additional
-configuration fields.
-
-```
-[tmc2240 stepper_x]
-interface: uart
-uart_pin:
-#diag_pin:
 ```
 
 ### [tmc5160]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3362,7 +3362,6 @@ the name of the corresponding stepper config section (for example,
 
 ```
 [tmc2240 stepper_x]
-interface: spi
 cs_pin:
 #   The pin corresponding to the TMC2240 chip select line. This pin
 #   will be set to low at the start of SPI messages and raised to high

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3488,7 +3488,7 @@ configuration fields.
 ```
 [tmc2240 stepper_x]
 interface: uart
-uart_pin: 
+uart_pin:
 #diag_pin:
 ```
 

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -5,9 +5,13 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-from . import bus, tmc, tmc2130
+from . import bus, tmc, tmc2130, tmc_uart
 
 TMC_FREQUENCY=12500000.
+
+COMMUNICATION_INTERFACE = {
+    'spi': 'spi', 'uart': 'uart'
+}
 
 Registers = {
     "GCONF":            0x00,
@@ -343,8 +347,17 @@ class TMC2240:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
-                                           TMC_FREQUENCY)
+        interface = config.getchoice('interface',
+                                     COMMUNICATION_INTERFACE,
+                                     'spi')
+        if interface == 'spi':
+            # Use SPI bus for communication
+            self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
+                                             TMC_FREQUENCY)
+        elif interface == 'uart':
+            # use UART for communication
+            self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields,
+                                               3, TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -9,10 +9,6 @@ from . import bus, tmc, tmc2130, tmc_uart
 
 TMC_FREQUENCY=12500000.
 
-COMMUNICATION_INTERFACE = {
-    'spi': 'spi', 'uart': 'uart'
-}
-
 Registers = {
     "GCONF":            0x00,
     "GSTAT":            0x01,
@@ -347,17 +343,14 @@ class TMC2240:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        interface = config.getchoice('interface',
-                                     COMMUNICATION_INTERFACE,
-                                     'spi')
-        if interface == 'spi':
-            # Use SPI bus for communication
-            self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
-                                             TMC_FREQUENCY)
-        elif interface == 'uart':
+        if config.get("uart_pin", None) is not None:
             # use UART for communication
             self.mcu_tmc = tmc_uart.MCU_TMC_uart(config, Registers, self.fields,
-                                               3, TMC_FREQUENCY)
+                                                 3, TMC_FREQUENCY)
+        else:
+            # Use SPI bus for communication
+            self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
+                                               TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands


### PR DESCRIPTION
Adding UART communication option for tmc2240 driver chips, which support both spi and uart. To achieve this a new config field has been added `interface` with the options `spi` (default/fallback) and `uart`.

The code is tested by atleast 3 users on a new upcoming board, which uses UART on the 2240 drivers to save mcu pins.

Signed-off-by:  Christoph Frei <fryakatkop@gmail.com>