### PR TITLE
Normalising Fan PWM power

### DIFF
--- a/config/printer-artillery-sidewinder-x2-2022.cfg
+++ b/config/printer-artillery-sidewinder-x2-2022.cfg
@@ -76,15 +76,15 @@ max_temp: 130
 
 [fan]
 pin: PC8
-off_below: 0.1
+min_power: 0.1
 
 [heater_fan extruder]
 pin: PC7
-off_below: 0.2
+min_power: 0.2
 
 [controller_fan case]
 pin: PC6
-off_below: 0.3
+min_power: 0.3
 idle_speed: 0.0
 
 [temperature_sensor mainboard]

--- a/config/printer-geeetech-301-2019.cfg
+++ b/config/printer-geeetech-301-2019.cfg
@@ -127,7 +127,7 @@ heaters: extruder
 pin: multi_pin:extruder_fans
 heater: extruder
 max_power: 0.8
-off_below: 0.2
+min_power: 0.2
 shutdown_speed: 0
 
 [mcu]

--- a/config/printer-monoprice-select-mini-v2-2018.cfg
+++ b/config/printer-monoprice-select-mini-v2-2018.cfg
@@ -128,7 +128,7 @@ pin: PB8
 # chassis fan
 [controller_fan chassis_fan]
 pin: PB3
-off_below: 0.25
+min_power: 0.25
 
 [mcu]
 serial: /dev/ttyACM0

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,20 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230801: The setting `fan.off_bellow` has been changed to `fan.min_power`.
+However, this change will not affect users who do not utilize this setting.
+With this update, a PWM scaling has been introduced between `min_power` and
+`max_power`. Fans that require a higher `min_power` will now have access to
+their full "safe" power curve. By properly setting `min_power`, any fan
+(such as CPAP) should engage even at `M106 S1`. It's recommended to review
+your slicer/macros to adjust your fan speeds. Your previously designated 20%
+fan speed may no longer represent your lowest fan setting but will now
+correspond to an actual 20% fan speed.
+If you had previously set `max_power` to anything below 1.0 (default),
+it is advisable to recalibrate `min_power` and `kick_start_time` again, with
+the settings `min_power: 0` and `max_power: 1`.
+
+
 20230729: The exported status for `dual_carriage` is changed. Instead of
 exporting `mode` and `active_carriage`, the individual modes for each
 carriage are exported as `printer.dual_carriage.carriage_0` and

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2565,15 +2565,14 @@ Print cooling fan.
 pin:
 #   Output pin controlling the fan. This parameter must be provided.
 #max_power: 1.0
-#   The maximum power (expressed as a value from 0.0 to 1.0) that the
-#   pin may be set to. The value 1.0 allows the pin to be set fully
-#   enabled for extended periods, while a value of 0.5 would allow the
-#   pin to be enabled for no more than half the time. This setting may
-#   be used to limit the total power output (over extended periods) to
-#   the fan. If this value is less than 1.0 then fan speed requests
-#   will be scaled between zero and max_power (for example, if
-#   max_power is .9 and a fan speed of 80% is requested then the fan
-#   power will be set to 72%). The default is 1.0.
+#   The maximum power (0.0 to 1.0) that the pin may be set to. A value
+#   of 1.0 enables the pin fully for extended periods, while 0.5 allows
+#   it for no more than half the time. Use it to limit total power output
+#   (over extended periods) to the fan. This value is combined with
+#   min_power to scale fan speed. With `min_power` at 0.3 and
+#   `max_power` at 1.0, fan speed request scales between 0.3 (min_power)
+#   and 1.0 (max_power). Requesting 10% fan speed results in a value of
+#   0.37. Default is 1.0.
 #shutdown_speed: 0
 #   The desired fan speed (expressed as a value from 0.0 to 1.0) if
 #   the micro-controller software enters an error state. The default
@@ -2593,18 +2592,14 @@ pin:
 #   Time (in seconds) to run the fan at full speed when either first
 #   enabling or increasing it by more than 50% (helps get the fan
 #   spinning). The default is 0.100 seconds.
-#off_below: 0.0
-#   The minimum input speed which will power the fan (expressed as a
-#   value from 0.0 to 1.0). When a speed lower than off_below is
-#   requested the fan will instead be turned off. This setting may be
-#   used to prevent fan stalls and to ensure kick starts are
-#   effective. The default is 0.0.
+#min_power: 0.0
+#   The minimum input power which will power the fan (expressed as a
+#   value from 0.0 to 1.0). The default is 0.0.
 #
-#   This setting should be recalibrated whenever max_power is adjusted.
-#   To calibrate this setting, start with off_below set to 0.0 and the
-#   fan spinning. Gradually lower the fan speed to determine the lowest
+#   To calibrate this setting, start with min_power=0 and max_power=1
+#   Gradually lower the fan speed to determine the lowest
 #   input speed which reliably drives the fan without stalls. Set
-#   off_below to the duty cycle corresponding to this value (for
+#   min_power to the duty cycle corresponding to this value (for
 #   example, 12% -> 0.12) or slightly higher.
 #tachometer_pin:
 #   Tachometer input pin for monitoring fan speed. A pullup is generally
@@ -2642,7 +2637,7 @@ a shutdown_speed equal to max_power.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
-#off_below:
+#min_power:
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
@@ -2679,7 +2674,7 @@ watched component.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
-#off_below:
+#min_power:
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
@@ -2725,7 +2720,7 @@ information.
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
-#off_below:
+#min_power:
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:
@@ -2783,7 +2778,7 @@ with the SET_FAN_SPEED [gcode command](G-Codes.md#fan_generic).
 #cycle_time:
 #hardware_pwm:
 #kick_start_time:
-#off_below:
+#min_power:
 #tachometer_pin:
 #tachometer_ppr:
 #tachometer_poll_interval:


### PR DESCRIPTION
What this does
---
It makes it possible to set 1% for a fan such as CPAP with a large off_below value and the fan will run at its lowest power at this setting

![image](https://github.com/Klipper3d/klipper/assets/16261998/116b3fa4-73e2-41d5-a0ac-30254f11bb32)

Why
---
Fans with quite high value for `off_below` (CPAP for example) are currently in klipper bit tricky to operate and people use several tricks either in slicer/gcode/macros to scale the values as requesting a 10% fan for cpap that might start at 16% or 30% gets ignored by klipper and fan stays off. When fan is properly configured in klipper and I request a fan to run at 1% of its speed I expect it to actually move, which is not the case currently. So the slicer/gcode needs to have a 'low level' knowledge of my hardware (when my fan actually will kick-in).

The value is actually currently partially scaled but between 0 and max_power. It's a bit odd.

How
---
This normalises the value between `off_below` and `max_power`.
When `off_below` would be set to `0.3` and max_power to `1.0`  a `10%` increment would have a value of `0.7` so requesting 10% of a fan will result in a value of `off_below + 0.7 = 0.37` and not `0.1` as it does currently which effectively has no effect.

Normalizing the value according to fan setting such that the CPAP and similar fans will kick in even at 1% so the whole range can be used in same fashion as with any other fan where `off_below=0`

Note
--

__These two notes bellow were addressed by renaming the parameter.__

~When testing this. Mainsail has a logic in place where they use `off_below` as a minimal setting for the fan using the fan slider, so setting the fan to say 2% will automatically set it to 30%
I will create a separate PR in Mainsail to remove this logic as it will no longer be needed.~

~After such update, users with `off_below > 0` who will not change their `M106` to lower the value will have their fans a bit louder, heh. They will generaly expect that their cpap might kick-in at around 16-30% so that's what they will have their lowest value set to in slicer and such. After the update it will be an actual 16-30% fan speed.~
