### PR TITLE
Improved/fixed scripts/install-arch.sh

### DIFF
--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -25,7 +25,7 @@ install_packages()
 
     # Install desired packages
      report_status "Installing packages..."
-     sudo pacman -S ${PKGLIST}
+     sudo pacman --needed -S ${PKGLIST}
      $AURCLIENT build ${AURLIST}
 }
 

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -11,7 +11,7 @@ KLIPPER_GROUP=$KLIPPER_USER
 install_packages()
 {
     # Packages for python cffi
-    PKGLIST="python2-virtualenv libffi base-devel"
+    PKGLIST="python-virtualenv libffi base-devel"
     # kconfig requirements
     PKGLIST="${PKGLIST} ncurses"
     # hub-ctrl


### PR DESCRIPTION
- python2-virtualenv package does not exist anymore
- prevents reinstalling of already satisfied packages
- more dynamic aur package install
- reduced footprint (no requirement to manually install pamac aur before)

Tested on:
Linux Voron 5.15.2-1 #1 SMP PREEMPT Sun Jul 2 23:54:37 +07 2023 riscv64 GNU/Linux