### PR TITLE
scripts: Added stm32f070 to mcus supported by flash_usb.py

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -344,8 +344,8 @@ MCUTYPES = {
     'samd': flash_atsamd, 'same5': flash_atsamd,
     'lpc176': flash_lpc176x, 'stm32f103': flash_stm32f1,
     'stm32f4': flash_stm32f4, 'stm32f042': flash_stm32f4,
-    'stm32f072': flash_stm32f4, 'stm32g0b1': flash_stm32f4,
-    'stm32f7': flash_stm32f4,
+    'stm32f070': flash_stm32f4, 'stm32f072': flash_stm32f4,
+    'stm32g0b1': flash_stm32f4, 'stm32f7': flash_stm32f4,
     'stm32h7': flash_stm32f4, 'stm32l4': flash_stm32f4,
     'stm32g4': flash_stm32f4, 'rp2040': flash_rp2040,
 }


### PR DESCRIPTION
Verified with an Monoprice Mini Select v2 using katapult.
