### PR TITLE
Default to no additional temperature smoothing

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20230820: The heater `smooth_time` now defaults to not perform any
+additional temperature smoothing. To return to the previous behavior
+of one second smoothing, set `smooth_time: 1.0` in the heater config
+section.
+
 20230810: The flash-sdcard.sh script now supports both variants of the
 Bigtreetech SKR-3, STM32H743 and STM32H723. For this, the original tag
 of btt-skr-3 now has changed to be either btt-skr-3-h743 or btt-skr-3-h723.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -798,10 +798,10 @@ sensor_pin:
 #   The resistance (in ohms) of the pullup attached to the thermistor.
 #   This parameter is only valid when the sensor is a thermistor. The
 #   default is 4700 ohms.
-#smooth_time: 1.0
+#smooth_time:
 #   A time value (in seconds) over which temperature measurements will
 #   be smoothed to reduce the impact of measurement noise. The default
-#   is 1 seconds.
+#   is to not perform any additional temperature smoothing.
 control:
 #   Control algorithm (either pid or watermark). This parameter must
 #   be provided.

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -34,7 +34,8 @@ class Heater:
                          is not None)
         self.can_extrude = self.min_extrude_temp <= 0. or is_fileoutput
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
-        self.smooth_time = config.getfloat('smooth_time', 1., above=0.)
+        self.smooth_time = config.getfloat('smooth_time', self.pwm_delay,
+                                           above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
         self.lock = threading.Lock()
         self.last_temp = self.smoothed_temp = self.target_temp = 0.


### PR DESCRIPTION
The default for heater `smooth_time` used to be 2 seconds; it was reduced to 1 second on 20210903.  This PR would further change that default to not perform any extra temperature smoothing.

Klipper already has a relatively slow response time of 300ms for heater updates.  We've seen in the past that additional "smoothing" time can result in worse PID stability (which was why the default was originally reduced from 2 seconds).  I suspect that no additional smoothing may be a better overall default for most printers.  That is, I suspect most printers today don't need extra smoothing and could benefit from a more responsive pid.

In particular, many printers today have stable temperature circuits.  Also, regardless of the `smooth_time` setting, Klipper already averages 8 measurements on every reported sample.  So, in effect, there is already some "smoothing" even with no extra `smooth_time` set.

Comments?

@rext3d , @dans98 - fyi.

-Kevin

P.S.  This is a followup to PR #4646 .