### PR TITLE
SDCard updates: added alias for BTT Octopus pro h723 v1.1 

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -166,6 +166,7 @@ BOARD_ALIASES = {
     'btt-octopus-f446-v1.1': BOARD_DEFS['btt-octopus-f446-v1'],
     'btt-octopus-pro-f429-v1.0': BOARD_DEFS['btt-octopus-f429-v1'],
     'btt-octopus-pro-f446-v1.0': BOARD_DEFS['btt-octopus-f446-v1'],
+    'btt-octopus-pro-h723-v1.1': BOARD_DEFS['btt-skr-3-h723'],
     'btt-skr-pro-v1.1': BOARD_DEFS['btt-skr-pro'],
     'btt-skr-pro-v1.2': BOARD_DEFS['btt-skr-pro'],
     'btt-gtr-v1': BOARD_DEFS['btt-gtr'],


### PR DESCRIPTION
SDCard updates

Added alias for Octopus pro h723 v1.1 for sdcard update script.
Signed-off-by: David Bucek [bucek.david@gmail.com](mailto:bucek.david@gmail.com)
