### PR TITLE
Update Rotation_Distance.md

### DIFF
--- a/docs/Rotation_Distance.md
+++ b/docs/Rotation_Distance.md
@@ -72,7 +72,7 @@ Then use the following procedure to "measure and trim":
    `<subsequent_mark_distance>`. Then calculate:
    `actual_extrude_distance = <initial_mark_distance> - <subsequent_mark_distance>`
 5. Calculate rotation_distance as:
-   `rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / <requested_extrude_distance>`
+   `rotation_distance = <previous_rotation_distance> * <requested_extrude_distance> / <actual_extrude_distance>`
    Round the new rotation_distance to three decimal places.
 
 If the actual_extrude_distance differs from requested_extrude_distance


### PR DESCRIPTION
The formula to calculate [Rotation distance](https://www.klipper3d.org/Rotation_Distance.html) for extruders seems to have the variables swapped.

Old formula
`rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / <requested_extrude_distance>`

Corrected formula
`rotation_distance = <previous_rotation_distance> * <requested_extrude_distance> / <actual_extrude_distance>`