### PR TITLE
Limit maximum temperature in MAX31865.calc_adc() to melting point of platinum

### DIFF
--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -320,6 +320,7 @@ class MAX31865(SensorBase):
     def calc_adc(self, temp):
         # Calculate relative resistance via Callendar-Van Dusen formula:
         #  resistance = rtd_nominal_r * (1 + CVD_A * temp + CVD_B * temp**2)
+        temp = min(temp, 1768.3)  # Melting point of platinum
         R_div_nominal = 1. + CVD_A * temp + CVD_B * temp * temp
         adc = int(R_div_nominal / self.adc_to_resist_div_nominal + 0.5)
         adc = max(0, min(MAX31865_ADC_MAX, adc))

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -323,7 +323,7 @@ class MAX31865(SensorBase):
         temp = min(temp, 1768.3)  # Melting point of platinum
         R_div_nominal = 1. + CVD_A * temp + CVD_B * temp * temp
         adc = int(R_div_nominal / self.adc_to_resist_div_nominal + 0.5)
-        adc = max(0, min(MAX31865_ADC_MAX, adc))
+        adc = max(0, min(MAX31865_ADC_MAX - 1, adc))
         adc = adc << 1 # Add fault bit
         return adc
     def build_spi_init(self, config):


### PR DESCRIPTION
Limit the maximum temperature in MAX31865.calc_adc() to the melting point of platinum. Above this temperature the Callendar-Van Dusen formula does not make sense. The default value for max_temp is 9999999.9 and at this temperature the result of this formula is negative. This sets max_sample_value to 0 which causes the mcu to shutdown.

Discourse topic: https://klipper.discourse.group/t/max31865-min-value-and-max-value-not-set/10029
