### PR TITLE
make inverted belt path work with hybrid_corexy idex

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2084,6 +2084,8 @@ configuration.
 axis:
 #   The axis this extra carriage is on (either x or y). This parameter
 #   must be provided.
+invert_axis:
+#   Set to True in case you have a inverted belt path.
 #safe_distance:
 #   The minimum distance (in mm) to enforce between the dual and the primary
 #   carriages. If a G-Code command is executed that will bring the carriages

--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -20,6 +20,8 @@ class DualCarriages:
         self.dc = (rail_0, rail_1)
         self.saved_states = {}
         safe_dist = dc_config.getfloat('safe_distance', None, minval=0.)
+        invert_axis = dc_config.getboolean('invert_axis', False)
+        self.invert_axis = invert_axis
         if safe_dist is None:
             dc0_rail = rail_0.get_rail()
             dc1_rail = rail_1.get_rail()


### PR DESCRIPTION
This PR tries to fix an issue with an inverted belt path for hybrid_corexy Idex setups.

Thats the v-core idex belt path. It seems that it isnt possible atm to properly configure this situation with the current hybrid_corexy and dualcarriage implementation

![image](https://github.com/Klipper3d/klipper/assets/13624572/a6299105-22a8-4d10-bb3d-9e96285b643d)

If i configure the Toolhead stepper direction so that they move in the right direction, then they move diagonaly when moving just Y. If i invert the Y stepper direction then toolheads do move correctly in y, but then Y is inverted. Also tried to use mtor B for the X-carraige, same result.

Only way to make it somehow work is to put the dual carriage on the left side and the X carriage to the right side, but then i cant use Set Gcode offset anymore for the copy and mirror mode, only set kinematics helps then which results in a not working bed mesh leveling for the main toolhead

it would work if my toolheads would point into this direction
![image](https://github.com/Klipper3d/klipper/assets/13624572/12daacca-f80b-48b3-88f7-08a92599cabe)

i dont know a lot about kinematic coding in klipper, but this change seems to work very well from what i can say from my first tests.

would be nice if someone could have a look and tell me if there are any sideeffects i can face with this kind of change.

thanks