### PR TITLE
Update generic-bigtreetech-skr-3.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-3.cfg
+++ b/config/generic-bigtreetech-skr-3.cfg
@@ -33,7 +33,8 @@ step_pin: PE2
 dir_pin: PE3
 enable_pin: !PE0
 microsteps: 16
-rotation_distance: 40
+#8 for T8 LeadScrew or 40 for default belt
+rotation_distance: 8
 endstop_pin: ^PC0
 position_endstop: 0.5
 position_max: 200


### PR DESCRIPTION
Correcting the generic config to avoid problems when using regular T8 leadscrews on Z axis