### PR TITLE
uc1701: x_offset and columns values added for uc1701 displays

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4030,6 +4030,11 @@ a0_pin:
 #contrast:
 #   The contrast to set. The value may range from 0 to 63 and the
 #   default is 40.
+#x_offset: 0
+#   Set the horizontal offset value on UC1701 displays. The value may
+#   range from 0 to 4 and the default is 0.
+#columns: 128
+#   Set the number of columns on UC1701 displays. The default is 128.
 ...
 ```
 

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -167,7 +167,9 @@ class ResetHelper:
 class UC1701(DisplayBase):
     def __init__(self, config):
         io = SPI4wire(config, "a0_pin")
-        DisplayBase.__init__(self, io)
+        x_offset = config.getint('x_offset', 0, minval=0, maxval=4)
+        columns = config.getint('columns', 128)
+        DisplayBase.__init__(self, io, columns=columns, x_offset=x_offset)
         self.contrast = config.getint('contrast', 40, minval=0, maxval=63)
         self.reset = ResetHelper(config.get("rst_pin", None), io.spi)
     def init(self):


### PR DESCRIPTION
Changing x_offset and columns in the printer.cfg allows to fix artifacts like shown on image. x_offset parameter shifts picture forward and columns parameter set to 132 clear point at end of line.
![image](https://github.com/Klipper3d/klipper/assets/91742261/5fcd0578-fb76-404e-9663-3bd2f000296c)
