### PR TITLE
Update printer-creality-ender5-2019.cfg to add instructions for silent boards

### DIFF
--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -1,10 +1,12 @@
 # This file contains common pin mappings for the 2019 Creality
 # Ender 5. To use this config, the firmware should be compiled for the
-# AVR atmega1284p.
+# AVR atmega1284p. This also works for the v1.1.5 silent boards.
 
 # Note, a number of Melzi boards are shipped with a bootloader that
 # requires the following command to flash the board:
 #  avrdude -p atmega1284p -c arduino -b 57600 -P /dev/ttyUSB0 -U out/klipper.elf.hex
+# For v1.1.5 silent boards, the following command is used:
+#  avrdude -p atmega1284p -c arduino -P /dev/ttyUSB0 -b 115200 -U flash:w:out/klipper.elf.hex
 # If the above command does not work and "make flash" does not work
 # then one may need to flash a bootloader to the board - see the
 # Klipper docs/Bootloaders.md file for more information.
@@ -80,6 +82,8 @@ pin: PB4
 
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
+# Silent boards tend to have the exact same serial ID, except without USB2.0, using USB instead.
+# e.g. /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 
 [printer]
 kinematics: cartesian

--- a/config/printer-creality-ender5-2019.cfg
+++ b/config/printer-creality-ender5-2019.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for the 2019 Creality
 # Ender 5. To use this config, the firmware should be compiled for the
-# AVR atmega1284p. This also works for the v1.1.5 silent boards.
+# AVR atmega1284p. This also works for the v1.1.5 silent boards. 
 
 # Note, a number of Melzi boards are shipped with a bootloader that
 # requires the following command to flash the board:


### PR DESCRIPTION
Recently tested on my ender 5 pro that came from creality with a v1.1.5 board. Works.