### PR TITLE
config: Improve Ultimaker default config

### DIFF
--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -31,7 +31,7 @@ step_pin: PC2
 dir_pin: !PC1
 enable_pin: !PC3
 microsteps: 16
-rotation_distance: 40
+rotation_distance: 16
 endstop_pin: ^!PA7
 position_endstop: 215
 position_max: 215
@@ -39,10 +39,11 @@ homing_speed: 20.0
 
 [extruder]
 step_pin: PL7
-dir_pin: PL6
+dir_pin: !PL6
 enable_pin: !PC0
 microsteps: 16
 rotation_distance: 33.500
+gear_ratio: 36:11
 nozzle_diameter: 0.400
 filament_diameter: 2.850
 heater_pin: PE4
@@ -58,10 +59,11 @@ max_temp: 275
 # Dual extruder support.
 #[extruder1]
 #step_pin: PL0
-#dir_pin: PL2
+#dir_pin: !PL2
 #enable_pin: !PL1
 #microsteps: 16
 #rotation_distance: 33.500
+#gear_ratio: 36:11
 #nozzle_diameter: 0.400
 #filament_diameter: 2.850
 #heater_pin: PE5
@@ -73,6 +75,14 @@ max_temp: 275
 #pid_Kd: 114
 #min_temp: 0
 #max_temp: 275
+
+[heater_fan nozzle_fan]
+pin: PJ6
+max_power: 1
+shutdown_speed: 0
+heater: extruder
+heater_temp: 50.0
+fan_speed: 0.6
 
 [heater_bed]
 heater_pin: PG5
@@ -125,3 +135,17 @@ scale: 2.000
 cycle_time: .000030
 hardware_pwm: True
 static_value: 1.250
+
+[display]
+lcd_type: ssd1306
+reset_pin: PE3
+menu_timeout: 60
+click_pin: ^!PD2
+encoder_pins: ^PG1, ^PG0
+encoder_steps_per_detent: 2
+
+[pca9632 wheel_leds]
+i2c_address: 96
+initial_RED: 1.0
+initial_GREEN: 1.0
+initial_BLUE: 1.0

--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -76,7 +76,7 @@ max_temp: 275
 #min_temp: 0
 #max_temp: 275
 
-[heater_fan nozzle_fan]
+[heater_fan heatbreak_cooling_fan]
 pin: PJ6
 max_power: 1
 shutdown_speed: 0


### PR DESCRIPTION
Hi! I have some changes to `config/generic-ultimaker-ultimainboard-v2.cfg`, to at least have better support for Ultimaker 2+:
- Added display and encoder wheel and LED support
- Fixed extruder gear ratio
- Added heatbreak fan

I have tested these on an Ultimaker 2+ and the only warnings that I get are related to missing configuration:
-  virtual_sdcard is not defined in config.
-  pause_resume is not defined in config.
-  gcode_macro pause is not defined in config.
-  gcode_macro resume is not defined in config.
-  gcode_macro cancel_print is not defined in config. 

If these features should be moved to their own file specifically for Ultimaker 2+, I can move them.