### PR TITLE
armcm: Add exception index and dummy heap for newlib 4.3+

### DIFF
--- a/src/generic/armcm_link.lds.S
+++ b/src/generic/armcm_link.lds.S
@@ -26,6 +26,12 @@ SECTIONS
         *(.rodata .rodata*)
     } > rom
 
+    .ARM.exidx : {
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+    } > rom
+
     . = ALIGN(4);
     _data_flash = .;
 
@@ -62,6 +68,23 @@ SECTIONS
     {
         . = . + CONFIG_STACK_SIZE;
         _stack_end = .;
+    } > ram
+
+    // Versions of newlib with libnosys require a heap end marker even
+    // in C freestanding mode. This creates a one byte heap.
+    // !! WARNING: The version of sbrk in libnosys does NOT check
+    // for the heap overrunning its allocation. Trying to expand the heap
+    // will have undefined behavior.
+    // Note: 'end' below refers to the initial end of the heap,
+    // while __heap_end__ refers to the last available address
+    .heap (NOLOAD) :
+    {
+        __heap_start__ = .;
+        end = __heap_start__;
+        _end = end;
+        __end = end;
+        __heap_end__ = .;
+        __HeapLimit = __heap_end__;
     } > ram
 
     /DISCARD/ : {


### PR DESCRIPTION
This commit adds entries to the armcm linker script to define a location for the exception index and a minimal heap.

This is to provide compat with newer versions of newlib, which will fail to compile if these sections are not defined.

This has been tested with newlib 4.3.0.20230120-2.3, gcc 13.2.1 20230803.

Example of failure before this commit:
```
builder@3099c959b7a9:~/klipper> cp /tmp/btt-octopus-stm32f429-canbridge-1m.config .config
builder@3099c959b7a9:~/klipper> make olddefconfig
  Creating symbolic link out/board
Loaded configuration '/home/builder/klipper/.config'
Configuration saved to '/home/builder/klipper/.config'
builder@3099c959b7a9:~/klipper> make
  Creating symbolic link out/board
  Building out/autoconf.h
  Compiling out/src/sched.o
  Compiling out/src/command.o
  Compiling out/src/basecmd.o
  Compiling out/src/debugcmds.o
  Compiling out/src/initial_pins.o
  Compiling out/src/gpiocmds.o
  Compiling out/src/stepper.o
  Compiling out/src/endstop.o
  Compiling out/src/trsync.o
  Compiling out/src/adccmds.o
  Compiling out/src/spicmds.o
  Compiling out/src/sdiocmds.o
  Compiling out/src/i2ccmds.o
  Compiling out/src/pwmcmds.o
  Compiling out/src/buttons.o
  Compiling out/src/tmcuart.o
  Compiling out/src/neopixel.o
  Compiling out/src/pulse_counter.o
  Compiling out/src/lcd_st7920.o
  Compiling out/src/lcd_hd44780.o
  Compiling out/src/spi_software.o
  Compiling out/src/i2c_software.o
  Compiling out/src/sensor_lis2dw.o
  Compiling out/src/thermocouple.o
  Compiling out/src/sensor_adxl345.o
  Compiling out/src/sensor_angle.o
  Compiling out/src/sensor_mpu9250.o
  Compiling out/src/stm32/watchdog.o
  Compiling out/src/stm32/gpio.o
  Compiling out/src/stm32/clockline.o
  Compiling out/src/stm32/dfu_reboot.o
  Compiling out/src/generic/crc16_ccitt.o
  Compiling out/src/generic/armcm_boot.o
  Compiling out/src/generic/armcm_irq.o
  Compiling out/src/generic/armcm_reset.o
  Compiling out/src/../lib/stm32f4/system_stm32f4xx.o
  Compiling out/src/stm32/stm32f4.o
  Compiling out/src/generic/armcm_timer.o
  Compiling out/src/stm32/gpioperiph.o
  Compiling out/src/stm32/adc.o
  Compiling out/src/stm32/i2c.o
  Compiling out/src/stm32/spi.o
  Compiling out/src/stm32/sdio.o
  Compiling out/src/stm32/usbotg.o
  Compiling out/src/generic/canserial.o
  Compiling out/src/../lib/fast-hash/fasthash.o
  Compiling out/src/stm32/can.o
  Compiling out/src/stm32/chipid.o
  Compiling out/src/generic/usb_canbus.o
  Compiling out/src/stm32/hard_pwm.o
  Building out/compile_time_request.o
Version: 5f990f93
  Preprocessing out/src/generic/armcm_link.ld
  Linking out/klipper.elf
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-closer.o): in function `_close_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/closer.c:47: warning: _close is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_getpid_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:83: warning: _getpid is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_kill_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:53: warning: _kill is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-lseekr.o): in function `_lseek_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/lseekr.c:49: warning: _lseek is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-readr.o): in function `_read_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/readr.c:49: warning: _read is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-writer.o): in function `_write_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/writer.c:49: warning: _write is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/thumb/v7e-m/nofp/libgcc.a(unwind-arm.o): in function `get_eit_entry':
/home/abuild/rpmbuild/BUILD/gcc-13.2.1+git7683/obj-x86_64-suse-linux/arm-none-eabi/thumb/v7e-m/nofp/libgcc/../../../../../../libgcc/unwind-arm-common.inc:366: undefined reference to `__exidx_start'
/usr/lib64/gcc/arm-none-eabi/13/ld: /home/abuild/rpmbuild/BUILD/gcc-13.2.1+git7683/obj-x86_64-suse-linux/arm-none-eabi/thumb/v7e-m/nofp/libgcc/../../../../../../libgcc/unwind-arm-common.inc:366: undefined reference to `__exidx_end'
collect2: error: ld returned 1 exit status
make: *** [Makefile:72: out/klipper.elf] Error 1
```

Example with this patch
```
builder@3099c959b7a9:~/klipper> cp /tmp/btt-octopus-stm32f429-canbridge-1m.config .config
builder@3099c959b7a9:~/klipper> make olddefconfig
  Creating symbolic link out/board
Loaded configuration '/home/builder/klipper/.config'
Configuration saved to '/home/builder/klipper/.config'
builder@3099c959b7a9:~/klipper> make
  Creating symbolic link out/board
  Building out/autoconf.h
  Compiling out/src/sched.o
  Compiling out/src/command.o
  Compiling out/src/basecmd.o
  Compiling out/src/debugcmds.o
  Compiling out/src/initial_pins.o
  Compiling out/src/gpiocmds.o
  Compiling out/src/stepper.o
  Compiling out/src/endstop.o
  Compiling out/src/trsync.o
  Compiling out/src/adccmds.o
  Compiling out/src/spicmds.o
  Compiling out/src/sdiocmds.o
  Compiling out/src/i2ccmds.o
  Compiling out/src/pwmcmds.o
  Compiling out/src/buttons.o
  Compiling out/src/tmcuart.o
  Compiling out/src/neopixel.o
  Compiling out/src/pulse_counter.o
  Compiling out/src/lcd_st7920.o
  Compiling out/src/lcd_hd44780.o
  Compiling out/src/spi_software.o
  Compiling out/src/i2c_software.o
  Compiling out/src/sensor_lis2dw.o
  Compiling out/src/thermocouple.o
  Compiling out/src/sensor_adxl345.o
  Compiling out/src/sensor_angle.o
  Compiling out/src/sensor_mpu9250.o
  Compiling out/src/stm32/watchdog.o
  Compiling out/src/stm32/gpio.o
  Compiling out/src/stm32/clockline.o
  Compiling out/src/stm32/dfu_reboot.o
  Compiling out/src/generic/crc16_ccitt.o
  Compiling out/src/generic/armcm_boot.o
  Compiling out/src/generic/armcm_irq.o
  Compiling out/src/generic/armcm_reset.o
  Compiling out/src/../lib/stm32f4/system_stm32f4xx.o
  Compiling out/src/stm32/stm32f4.o
  Compiling out/src/generic/armcm_timer.o
  Compiling out/src/stm32/gpioperiph.o
  Compiling out/src/stm32/adc.o
  Compiling out/src/stm32/i2c.o
  Compiling out/src/stm32/spi.o
  Compiling out/src/stm32/sdio.o
  Compiling out/src/stm32/usbotg.o
  Compiling out/src/generic/canserial.o
  Compiling out/src/../lib/fast-hash/fasthash.o
  Compiling out/src/stm32/can.o
  Compiling out/src/stm32/chipid.o
  Compiling out/src/generic/usb_canbus.o
  Compiling out/src/stm32/hard_pwm.o
  Building out/compile_time_request.o
Version: aa0d199b3
  Preprocessing out/src/generic/armcm_link.ld
  Linking out/klipper.elf
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-closer.o): in function `_close_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/closer.c:47: warning: _close is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_getpid_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:83: warning: _getpid is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_kill_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:53: warning: _kill is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-lseekr.o): in function `_lseek_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/lseekr.c:49: warning: _lseek is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-readr.o): in function `_read_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/readr.c:49: warning: _read is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-writer.o): in function `_write_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/writer.c:49: warning: _write is not implemented and will always fail
lto-wrapper: warning: using serial compilation of 5 LTRANS jobs
lto-wrapper: note: see the '-flto' option documentation for more information
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-closer.o): in function `_close_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/closer.c:47: warning: _close is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_getpid_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:83: warning: _getpid is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-signalr.o): in function `_kill_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/signalr.c:53: warning: _kill is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-lseekr.o): in function `_lseek_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/lseekr.c:49: warning: _lseek is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-readr.o): in function `_read_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/readr.c:49: warning: _read is not implemented and will always fail
/usr/lib64/gcc/arm-none-eabi/13/ld: /usr/lib64/gcc/arm-none-eabi/13/../../../../arm-none-eabi/lib/thumb/v7e-m/nofp/libg_nano.a(libc_a-writer.o): in function `_write_r':
/home/abuild/rpmbuild/BUILD/newlib-4.3.0.20230120/build-nano-dir/arm-none-eabi/thumb/v7e-m/nofp/newlib/../../../../../../newlib/libc/reent/writer.c:49: warning: _write is not implemented and will always fail
  Creating hex file out/klipper.bin
```

Config here: https://github.com/Laikulo/Klipper-firmware/blob/main/factory-configs/btt-octopus-stm32f429-canbridge-1m.config

I also ran a test build in an ubuntu (jammy) container with the -ci scripts, but one of the avr configurations failes both with and without this patch due to code space limitations. However, I confirmed that the config I used above also compiles successfully on ubuntu with newlib 3.3.0-1.3
