### PR TITLE
config: Kingroon KP3S stepper will go to the right direction

### DIFF
--- a/config/printer-kingroon-kp3s-2020.cfg
+++ b/config/printer-kingroon-kp3s-2020.cfg
@@ -18,7 +18,7 @@
 
 [stepper_x]
 step_pin: PE3
-dir_pin: !PE2
+dir_pin: PE2
 enable_pin: !PE4
 microsteps: 32
 rotation_distance: 40
@@ -29,7 +29,7 @@ homing_speed: 50
 
 [stepper_y]
 step_pin: PE0
-dir_pin: !PB9
+dir_pin: PB9
 enable_pin: !PE1
 microsteps: 32
 rotation_distance: 40
@@ -40,7 +40,7 @@ homing_speed: 50
 
 [stepper_z]
 step_pin: PB5
-dir_pin: PB4
+dir_pin: !PB4
 enable_pin: !PB8
 microsteps: 32
 rotation_distance: 8


### PR DESCRIPTION
With the default configuration, the home position was ser in the wrong direction. 

Please check the [Kingroon KP3S configuration file](https://github.com/nehilo/Klipper-KingRoon-Printers/blob/main/KP3S_Configuration/stepper.cfg) and [Kingroon KP3S howto page](https://kingroon.com/blogs/3d-print-101/how-to-prepare-klipper-firmware-for-kingroon-kp3s-using-fluiddpi) for more details