### PR TITLE
fan: Support multiple printer fans

### DIFF
--- a/config/sample-idex.cfg
+++ b/config/sample-idex.cfg
@@ -34,6 +34,10 @@ pid_Kd: 114
 min_temp: 0
 max_temp: 250
 
+# The definition for the part cooling fan for primary extruder
+[fan primary]
+pin: PH6
+
 # Helper script to park the carriage (called from T0 and T1 macros)
 [gcode_macro PARK_extruder]
 gcode:
@@ -47,6 +51,7 @@ gcode:
 gcode:
     PARK_{printer.toolhead.extruder}
     ACTIVATE_EXTRUDER EXTRUDER=extruder
+    ACTIVATE_FAN FAN=primary
     SET_DUAL_CARRIAGE CARRIAGE=0
     SET_GCODE_OFFSET Y=0
 
@@ -83,6 +88,10 @@ pid_Kd: 114
 min_temp: 0
 max_temp: 250
 
+# The definition for the part cooling fan for secondary extruder
+[fan secondary]
+pin: PH7
+
 [gcode_macro PARK_extruder1]
 gcode:
     SAVE_GCODE_STATE NAME=park1
@@ -94,6 +103,7 @@ gcode:
 gcode:
     PARK_{printer.toolhead.extruder}
     ACTIVATE_EXTRUDER EXTRUDER=extruder1
+    ACTIVATE_FAN FAN=secondary
     SET_DUAL_CARRIAGE CARRIAGE=1
     SET_GCODE_OFFSET Y=15
 
@@ -103,6 +113,7 @@ gcode:
     SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
     G1 X0
     ACTIVATE_EXTRUDER EXTRUDER=extruder
+    ACTIVATE_FAN FAN=primary,secondary
     SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
     G1 X100
     SET_DUAL_CARRIAGE CARRIAGE=1 MODE=COPY
@@ -114,6 +125,7 @@ gcode:
     SET_DUAL_CARRIAGE CARRIAGE=0 MODE=PRIMARY
     G1 X0
     ACTIVATE_EXTRUDER EXTRUDER=extruder
+    ACTIVATE_FAN FAN=primary,secondary
     SET_DUAL_CARRIAGE CARRIAGE=1 MODE=PRIMARY
     G1 X200
     SET_DUAL_CARRIAGE CARRIAGE=1 MODE=MIRROR

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2634,7 +2634,10 @@ sensor_type: temperature_combined
 
 ### [fan]
 
-Print cooling fan.
+Print cooling fan (one may define any number of sections with a
+"fan" prefix). Print cooling fan is controlled by M106/M107 gcodes.
+When multiple fans are defined, ACTIVATE_FAN [gcode command](G-Codes.md#fan)
+selects which fan is used for cooling.
 
 ```
 [fan]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -453,6 +453,17 @@ This command is deprecated and will be removed in the near future.
 #### SYNC_STEPPER_TO_EXTRUDER
 This command is deprecated and will be removed in the near future.
 
+### [fan]
+
+The following command is available when a
+[fan config section](Config_Reference.md#fan is enabled.
+
+#### ACTIVATE_FAN
+
+`ACTIVATE_FAN FAN=fan_name[,second_fan]` Selects the active printer fan that
+reacts to M106/M107 gcodes. Multiple fans can be selected simultaneously by
+a comma separated list. Current fan speed is transferred over to the new fan(s).
+
 ### [fan_generic]
 
 The following command is available when a

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -134,12 +134,17 @@ The following information is available for extruder_stepper objects (as well as
 
 The following information is available in
 [fan](Config_Reference.md#fan),
+[fan_generic](Config_Reference.md#fan_generic),
 [heater_fan some_name](Config_Reference.md#heater_fan) and
 [controller_fan some_name](Config_Reference.md#controller_fan)
 objects:
 - `speed`: The fan speed as a float between 0.0 and 1.0.
 - `rpm`: The measured fan speed in rotations per minute if the fan has
   a tachometer_pin defined.
+
+Additionally, [fan](Config_Reference.md#fan) also has:
+- `active`: If the fan is selected as the active fan via
+  [ACTIVATE_FAN](G-Codes.md#fan).
 
 ## filament_switch_sensor
 

--- a/test/klippy/fan.cfg
+++ b/test/klippy/fan.cfg
@@ -1,0 +1,48 @@
+# Test config for fan
+[fan]
+pin: PH6
+
+[fan fan2]
+pin: PH7
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200

--- a/test/klippy/fan.test
+++ b/test/klippy/fan.test
@@ -1,0 +1,14 @@
+# Test case for fan
+CONFIG fan.cfg
+DICTIONARY atmega2560.dict
+
+M106 S255
+M107
+
+ACTIVATE_FAN FAN=fan
+M106 S255
+ACTIVATE_FAN FAN=fan2
+M106 S128
+ACTIVATE_FAN FAN="fan,fan fan2"
+ACTIVATE_FAN FAN="fan, fan fan2"
+ACTIVATE_FAN FAN=fan


### PR DESCRIPTION
Allows to setup multiple printer fans.

Multi extruder setups can have separate part cooling fan for each extruder. This integrates support for that in core klipper, removing the need for every multi extruder config to override their macros.

But probably more importantly defines an endorsed way how multi fan setups should be controlled by the slicers.
