### PR TITLE
min_time setting in [fan] section

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2661,6 +2661,12 @@ pin:
 #   Time (in seconds) to run the fan at full speed when either first
 #   enabling or increasing it by more than 50% (helps get the fan
 #   spinning). The default is 0.100 seconds.
+#min_time: 0.1
+#   The minimum time in seconds during which the fan will execute the
+#   previous set speed value and not start executing the next one.
+#   The default is 0.100 seconds.
+#   The value can be changed downwards if the gcode contains a lot of
+#   fast fan speed changes.
 #off_below: 0.0
 #   The minimum input speed which will power the fan (expressed as a
 #   value from 0.0 to 1.0). When a speed lower than off_below is

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -5,8 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import pulse_counter
 
-FAN_MIN_TIME = 0.100
-
 class Fan:
     def __init__(self, config, default_shutdown_speed=0.):
         self.printer = config.get_printer()
@@ -18,6 +16,7 @@ class Fan:
                                                minval=0.)
         self.off_below = config.getfloat('off_below', default=0.,
                                          minval=0., maxval=1.)
+        self.min_time = config.getfloat('min_time', 0.1, above=0.)
         cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
         hardware_pwm = config.getboolean('hardware_pwm', False)
         shutdown_speed = config.getfloat(
@@ -51,7 +50,7 @@ class Fan:
         value = max(0., min(self.max_power, value * self.max_power))
         if value == self.last_fan_value:
             return
-        print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
+        print_time = max(self.last_fan_time + self.min_time, print_time)
         if self.enable_pin:
             if value > 0 and self.last_fan_value == 0:
                 self.enable_pin.set_digital(print_time, 1)


### PR DESCRIPTION
This PR is aimed at solving the problem with Dynamic fan speed on overhangs feature in Prusa Slicer. 
When this function is enabled on complex models, there are situations when the fan speed changes several times per second (sometimes these changes can occur up to hundreds of times per second if you print at really high accelerations). In such cases, klipper begins to accumulate a queue of fan speed changes, changing the speed much later than it is required and ignoring (postponing in a long queue) new commands. I saw the problem in the FAN_MIN_TIME parameter in fan.py . This parameter limits the number of fan speed changes to 10 times per second. 
I am not sure that this parameter can be removed, but it is quite possible to try to allow the user to set this parameter in the configuration file. 
I will also attach an [example](https://github.com/Klipper3d/klipper/files/12648484/test.zip) of an gcode, which causes fan spinning after the end of printing and ignore control comands for several minutes or until firmware restart.