### PR TITLE
pid_calibrate: allowing TUNE_PID_DELTA to pass through gcode

### DIFF
--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -16,7 +16,7 @@ class PIDCalibrate:
     def cmd_PID_CALIBRATE(self, gcmd):
         heater_name = gcmd.get('HEATER')
         target = gcmd.get_float('TARGET')
-        tune_pid_delta = gcmd.get_float('TUNE_PID_DELTA', 5.0) 
+        tune_pid_delta = gcmd.get_float('TUNE_PID_DELTA', 5.0)
         write_file = gcmd.get_int('WRITE_FILE', 0)
         pheaters = self.printer.lookup_object('heaters')
         try:

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -40,7 +40,6 @@ class PIDCalibrate:
         Kp, Ki, Kd = calibrate.calc_final_pid()
         logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
         gcmd.respond_info(
-            "File had been changed."
             "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
             "The SAVE_CONFIG command will update the printer config file\n"
             "with these parameters and restart the printer." % (Kp, Ki, Kd))


### PR DESCRIPTION
I have utilized the Bambulab hotend paired with a 70W ceramic heater cartridge. After extensive testing, it became evident that this setup exhibited an exceptionally rapid temperature response. This led to an issue where the original delta value was too small, causing the temperature sensor to be unable to collect data quickly enough, resulting in suboptimal PID calibration parameters. By adjusting the delta value, significant improvements can be achieved in the effectiveness of the automatic calibration process.

Signed-off-by: Jaccob Hui <783739330@qq.com>
