### PR TITLE
Add a USB message queue to USB to CANbus bridge code

### DIFF
--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -244,9 +244,9 @@ usbcan_task(void)
 
         // Send any previous echo frames
         if (host_status) {
-            if (UsbCan.usb_send_busy)
+            if (UsbCan.notify_local || UsbCan.usb_send_busy)
                 // Don't send echo frame until other traffic is sent
-                return;
+                break;
             int ret = usb_send_bulk_in(gs, sizeof(*gs));
             if (ret < 0)
                 return;
@@ -281,6 +281,8 @@ canbus_send(struct canbus_msg *msg)
     int ret = send_frame(msg);
     if (ret < 0)
         goto retry_later;
+    if (UsbCan.notify_local && UsbCan.host_status)
+        canbus_notify_tx();
     UsbCan.notify_local = 0;
     return msg->dlc;
 retry_later:


### PR DESCRIPTION
The current Klipper USB to CANbus bridge code will stop reading messages from the USB bus if it becomes busy sending messages on the USB bus.  This was implemented as a flow control system to prevent bandwidth generated from host messages swamping message traffic received from the physical canbus.

Unfortunately, this flow control system has a notable performance impact.  The low-level USB hardware layer will keep sending messages until the device acknowledges them.  So, if the CANbus bridge code does not read USB messages, the retransmits continue to consume bandwidth - bandwidth that would be better utilized in sending messages from the device to the host.

This PR adds a small USB message queue to the USB to CANbus bridge code.  The Linux gs_usb driver will only send 10 pending packets before it pauses transmissions.  So, a small queue that stores these messages can help avoid low-level USB message resends.

This PR can notably improve the performance of the Klipper USB to CANbus bridge code.

-Kevin