### PR TITLE
probe: use the x coordinates from the correct toolhead after probing with dual carriage

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -122,6 +122,10 @@ class PrinterProbe:
         pos[2] = self.z_position
         try:
             epos = phoming.probing_move(self.mcu_probe, pos, speed)
+            # cache the current xy position in case of a IDEX
+            if self.printer.lookup_object('dual_carriage') is not None:
+                epos[0] = pos[0]
+                epos[1] = pos[1]
         except self.printer.command_error as e:
             reason = str(e)
             if "Timeout during endstop homing" in reason:
@@ -136,6 +140,9 @@ class PrinterProbe:
                 axis_twist_compensation.get_z_compensation_value(pos))
         # add z compensation to probe position
         epos[2] += z_compensation
+        # set the toolhead to the cached xy position in case of a IDEX
+        if self.printer.lookup_object('dual_carriage') is not None:
+            toolhead.set_position(epos)
         self.gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
                                 % (epos[0], epos[1], epos[2]))
         return epos[:3]


### PR DESCRIPTION
After probing with the dual_carriage activated, klipper sets the x coordinate to the x pos of the x carriage.

This pr fixes that and lets you probe with any of the toolheads

this is just for the `PROBE` g-code command, there is a similar issue after z-homing, but more complex

Signed-off-by: Helge Magnus Keck [HelgeKeck@hotmail.com](mailto:HelgeKeck@hotmail.com)