### PR TITLE
Apply 'strip' on the tool version string to remove any whitespace con…

### DIFF
--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -487,7 +487,7 @@ def tool_versions(tools):
     success = 0
     for tool in tools:
         # Extract first line from "tool --version" output
-        verstr = check_output("%s --version" % (tool,)).split('\n')[0]
+        verstr = check_output("%s --version" % (tool,)).split('\n')[0].strip()
         # Check if this tool looks like a binutils program
         isbinutils = 0
         if verstr.startswith('GNU '):


### PR DESCRIPTION
…trol characters that can generate erroneous code.

The 'tool_versions' function in buildcommands.py does not account for other whitespace control characters beside newline, ('\n'). In particular, compiling in Windows under the MSYS2 environment, the DOS-style line returns ('\r\n') output by the GNU tools break the correct generation of the compile_time_request.c module.