### PR TITLE
Ender3S1 Stepper_Y limit

### DIFF
--- a/config/printer-creality-ender3-s1-2021.cfg
+++ b/config/printer-creality-ender3-s1-2021.cfg
@@ -38,8 +38,8 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PA6
 position_endstop: -8
-position_max: 238
-position_min: -13
+position_max: 223
+position_min: -10
 homing_speed: 50
 
 [stepper_z]
@@ -110,9 +110,9 @@ stow_on_each_sample: false
 
 [bed_mesh]
 speed: 120
-mesh_min: 10, 10
-mesh_max: 200, 194
-probe_count: 4,4
+mesh_min: 10, 20
+mesh_max: 200, 182
+probe_count: 5,5
 algorithm: bicubic
 
 [safe_z_home]


### PR DESCRIPTION
Fixed the Ender3 S1 crashing on the high end of the Y Axis

This necessitated an update to the bed mesh limits as well

I also changed from a 4x4 bed mesh to 5x5 as that is what i believe the original Ender 3 S1 uses, but I am not sure

Signed-off-by: Thomas Nykjær nykjaerthomas+github@gmail.com