### PR TITLE
heater_fan: Add Heater Fan Self Check Logic

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2707,6 +2707,11 @@ a shutdown_speed equal to max_power.
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
 #   will be set to when its associated heater is enabled. The default
 #   is 1.0
+#min_rpm: 0
+#   The minimum expected fan speed in RPM. Klipper shuts down if the 
+#   fan is enabled but fan RPM reading from the tachometer is below 
+#   this value. This parameter is optional but tachometer_pin must 
+#   be specified for this parameter to be valid.
 ```
 
 ### [controller_fan]

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -24,7 +24,8 @@ class PrinterHeaterFan:
         self.max_err = 3
         self.min_rpm = config.getint("min_rpm", 0, minval=0)
         if self.min_rpm > 0 and self.fan.tachometer._freq_counter is None:
-            raise config.error("'tachometer_pin' must be specified before enabling `min_rpm`")
+            raise config.error(
+                "'tachometer_pin' must be specified before enabling `min_rpm`")
     def handle_ready(self):
         pheaters = self.printer.lookup_object('heaters')
         self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
@@ -58,8 +59,8 @@ class PrinterHeaterFan:
         if has_err:
             self.num_err += 1
             if self.num_err > self.max_err:
-                msg = "'%s' spinning below minimum safe speed of %d rev/min" % (
-                    self.name, self.min_rpm)
+                msg = "'%s' spinning below minimum safe speed of %d rev/min" 
+                    % (self.name, self.min_rpm)
                 logging.error(msg)
                 self.printer.invoke_shutdown(msg)
                 return self.printer.get_reactor().NEVER

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -6,6 +6,7 @@
 from . import fan
 
 PIN_MIN_TIME = 0.100
+SAFETY_CHECK_INIT_TIME = 3.
 
 class PrinterHeaterFan:
     def __init__(self, config):
@@ -18,11 +19,20 @@ class PrinterHeaterFan:
         self.fan = fan.Fan(config, default_shutdown_speed=1.)
         self.fan_speed = config.getfloat("fan_speed", 1., minval=0., maxval=1.)
         self.last_speed = 0.
+        self.name = config.get_name().split()[-1]
+        self.num_err = 0
+        self.max_err = 3
+        self.min_rpm = config.getint("min_rpm", 0, minval=0)
+        if self.min_rpm > 0 and self.fan.tachometer._freq_counter is None:
+            raise config.error("'tachometer_pin' must be specified before enabling `min_rpm`")
     def handle_ready(self):
         pheaters = self.printer.lookup_object('heaters')
         self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
         reactor = self.printer.get_reactor()
         reactor.register_timer(self.callback, reactor.monotonic()+PIN_MIN_TIME)
+        if self.min_rpm > 0:
+            reactor.register_timer(
+                self.fan_check, reactor.monotonic()+SAFETY_CHECK_INIT_TIME)
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)
     def callback(self, eventtime):
@@ -37,6 +47,25 @@ class PrinterHeaterFan:
             print_time = self.fan.get_mcu().estimated_print_time(curtime)
             self.fan.set_speed(print_time + PIN_MIN_TIME, speed)
         return eventtime + 1.
+    def fan_check(self, eventtime):
+        rpm = self.fan.tachometer.get_status(eventtime)['rpm']
+        has_err = False
+        if rpm is not None:
+            for heater in self.heaters:
+                current_temp, target_temp = heater.get_temp(eventtime)
+                if current_temp > self.heater_temp and rpm < self.min_rpm:
+                    has_err = True
+        if has_err:
+            self.num_err += 1
+            if self.num_err > self.max_err:
+                msg = "'%s' spinning below minimum safe speed of %d rev/min" % (
+                    self.name, self.min_rpm)
+                logging.error(msg)
+                self.printer.invoke_shutdown(msg)
+                return self.printer.get_reactor().NEVER
+        else:
+            self.num_err = 0
+        return eventtime + 1.5
 
 def load_config_prefix(config):
     return PrinterHeaterFan(config)


### PR DESCRIPTION
Add a simple self-check functionality to heater_fans with tachometer signal.

### Why do we want this?   

This functionality is especially useful for hotend fans, which when they fail can result in some quite catastophic consequences for the hotend and surrounding parts.

### Configuration   

The user simply adds configurations related to fan tachometer (tachometer_pin, tachometer_ppr) and one additional configuration:
`min_rpm`, which specifies the minimum expected RPM of the fan when it is enabled. When fan speed is detected to be below the minimum RPM. then klipper shutsdown with an error. By default, min_rpm is 0 and thus the self-test functionality is not enabled.

### Code description  

- **Initialization**, the heater_fan module checks for `min_rpm` config, and sets it to the specified value. A config error is thrown if tachometer configuration is not specified by the user but `min_rpm` is. 
- **Event handler**, a `fan_check()` event handler is created if `min_rpm` is enabled. This event handler is first called 3 sec after startup and every 1.5 sec afterwards.
- **Self-check logic**, the main logic for fan self-check is implemented in `fan_check()` which is called periodically. Each time `fan_check` is called the current fan speed and it's related heater temperature is read. If heater temp is above `heater_temp` and current fan speed is lower than `min_rpm`, the error counter is incremented; otherwise the error counter is reset to zero. An error is thrown if the error counter reaches 4 and klipper is shutdown. 
