### PR TITLE
docs: In Configuration Checks doc, missing ! in pin inversion example in Verify endstops

### DIFF
--- a/docs/Config_checks.md
+++ b/docs/Config_checks.md
@@ -67,7 +67,7 @@ The QUERY_ENDSTOPS command should report the endstop as "TRIGGERED".
 
 If the endstop appears inverted (it reports "open" when triggered and
 vice-versa) then add a "!" to the pin definition (for example,
-"endstop_pin: ^PA2"), or remove the "!" if there is already one
+"endstop_pin: ^!PA2"), or remove the "!" if there is already one
 present.
 
 If the endstop does not change at all then it generally indicates that


### PR DESCRIPTION
In the "Verify endstops" section there is an example of adding an exclamation point to the pin definition to invert its logic.  I believe the intention in the example is to keep the hardware pull-up ^ and follow it with ! to invert the pin logic, but the ! is missing.