### PR TITLE
New pwm_tool module that supports mcu queing of pwm updates

### DIFF
--- a/config/sample-pwm-tool.cfg
+++ b/config/sample-pwm-tool.cfg
@@ -2,9 +2,8 @@
 # such as a laser or spindle.
 # See docs/Using_PWM_Tools.md for a more detailed description.
 
-[output_pin TOOL]
+[pwm_tool TOOL]
 pin: !ar9       # use your fan's pin number
-pwm: True
 hardware_pwm: True
 cycle_time: 0.001
 shutdown_value: 0
@@ -36,9 +35,9 @@ gcode:
 
 [menu __main __control __toolonoff]
 type: input
-enable: {'output_pin TOOL' in printer}
+enable: {'pwm_tool TOOL' in printer}
 name: Fan: {'ON ' if menu.input else 'OFF'}
-input: {printer['output_pin TOOL'].value}
+input: {printer['pwm_tool TOOL'].value}
 input_min: 0
 input_max: 1
 input_step: 1
@@ -47,9 +46,9 @@ gcode:
 
 [menu __main __control __toolspeed]
 type: input
-enable: {'output_pin TOOL' in printer}
+enable: {'pwm_tool TOOL' in printer}
 name: Tool speed: {'%3d' % (menu.input*100)}%
-input: {printer['output_pin TOOL'].value}
+input: {printer['pwm_tool TOOL'].value}
 input_min: 0
 input_max: 1
 input_step: 0.01

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3127,6 +3127,26 @@ pin:
 #   parameter.
 ```
 
+### [pwm_tool]
+
+Pulse width modulation digital output pins capable of high speed
+updates (one may define any number of sections with an "output_pin"
+prefix). Pins configured here will be setup as output pins and one may
+modify them at run-time using "SET_PIN PIN=my_pin VALUE=.1" type
+extended [g-code commands](G-Codes.md#output_pin).
+
+```
+[pwm_tool my_tool]
+pin:
+#   The pin to configure as an output. This parameter must be provided.
+#value:
+#shutdown_value:
+#cycle_time: 0.100
+#hardware_pwm: False
+#scale:
+#   See the "output_pin" section for the definition of these parameters.
+```
+
 ### [static_digital_output]
 
 Statically configured digital output pins (one may define any number

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -834,7 +834,8 @@ commands to manage the LED's color settings).
 ### [output_pin]
 
 The following command is available when an
-[output_pin config section](Config_Reference.md#output_pin) is
+[output_pin config section](Config_Reference.md#output_pin) or
+[pwm_tool config section](Config_Reference.md#pwm_tool) is
 enabled.
 
 #### SET_PIN

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -318,7 +318,8 @@ is defined):
 ## output_pin
 
 The following information is available in
-[output_pin some_name](Config_Reference.md#output_pin) objects:
+[output_pin some_name](Config_Reference.md#output_pin) and
+[pwm_tool some_name](Config_Reference.md#pwm_tool) objects:
 - `value`: The "value" of the pin, as set by a `SET_PIN` command.
 
 ## palette2

--- a/docs/Using_PWM_Tools.md
+++ b/docs/Using_PWM_Tools.md
@@ -1,7 +1,7 @@
 # Using PWM tools
 
 This document describes how to setup a PWM-controlled laser or spindle
-using `output_pin` and some macros.
+using `pwm_tool` and some macros.
 
 ## How does it work?
 
@@ -25,14 +25,6 @@ Also, you should configure a safety timeout,
 so that when your host or MCU encounters an error, the tool will stop.
 
 For an example configuration, see [config/sample-pwm-tool.cfg](/config/sample-pwm-tool.cfg).
-
-## Current Limitations
-
-There is a limitation of how frequent PWM updates may occur.
-While being very precise, a PWM update may only occur every 0.1 seconds,
-rendering it almost useless for raster engraving.
-However, there exists an [experimental branch](https://github.com/Cirromulus/klipper/tree/laser_tool) with its own tradeoffs.
-In long term, it is planned to add this functionality to main-line klipper.
 
 ## Commands
 

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -49,6 +49,8 @@ defs_stepcompress = """
         , uint64_t clock);
     int stepcompress_queue_msg(struct stepcompress *sc
         , uint32_t *data, int len);
+    int stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
+        , uint32_t *data, int len);
     int stepcompress_extract_old(struct stepcompress *sc
         , struct pull_history_steps *p, int max
         , uint64_t start_clock, uint64_t end_clock);

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -623,6 +623,21 @@ stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len)
     return 0;
 }
 
+// Queue an mcu command that will consume space in the mcu move queue
+int __visible
+stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
+                          , uint32_t *data, int len)
+{
+    int ret = stepcompress_flush(sc, UINT64_MAX);
+    if (ret)
+        return ret;
+
+    struct queue_message *qm = message_alloc_and_encode(data, len);
+    qm->min_clock = qm->req_clock = req_clock;
+    list_add_tail(&qm->node, &sc->msg_queue);
+    return 0;
+}
+
 // Return history of queue_step commands
 int __visible
 stepcompress_extract_old(struct stepcompress *sc, struct pull_history_steps *p

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -29,6 +29,8 @@ int stepcompress_set_last_position(struct stepcompress *sc, uint64_t clock
 int64_t stepcompress_find_past_position(struct stepcompress *sc
                                         , uint64_t clock);
 int stepcompress_queue_msg(struct stepcompress *sc, uint32_t *data, int len);
+int stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
+                              , uint32_t *data, int len);
 int stepcompress_extract_old(struct stepcompress *sc
                              , struct pull_history_steps *p, int max
                              , uint64_t start_clock, uint64_t end_clock);

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -1,0 +1,157 @@
+# Queued PWM gpio output
+#
+# Copyright (C) 2017-2023  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import chelper
+
+PIN_MIN_TIME = 0.100
+MAX_SCHEDULE_TIME = 5.0
+
+class error(Exception):
+    pass
+
+class MCU_queued_pwm:
+    def __init__(self, pin_params):
+        self._mcu = pin_params['chip']
+        self._hardware_pwm = False
+        self._cycle_time = 0.100
+        self._max_duration = 2.
+        self._oid = self._mcu.create_oid()
+        ffi_main, ffi_lib = chelper.get_ffi()
+        self._stepqueue = ffi_main.gc(ffi_lib.stepcompress_alloc(self._oid),
+                                      ffi_lib.stepcompress_free)
+        self._mcu.register_stepqueue(self._stepqueue)
+        self._stepcompress_queue_mq_msg = ffi_lib.stepcompress_queue_mq_msg
+        self._mcu.register_config_callback(self._build_config)
+        self._pin = pin_params['pin']
+        self._invert = pin_params['invert']
+        self._start_value = self._shutdown_value = float(self._invert)
+        self._last_clock = self._cycle_ticks = 0
+        self._pwm_max = 0.
+        self._set_cmd_tag = None
+    def get_mcu(self):
+        return self._mcu
+    def setup_max_duration(self, max_duration):
+        self._max_duration = max_duration
+    def setup_cycle_time(self, cycle_time, hardware_pwm=False):
+        self._cycle_time = cycle_time
+        self._hardware_pwm = hardware_pwm
+    def setup_start_value(self, start_value, shutdown_value):
+        if self._invert:
+            start_value = 1. - start_value
+            shutdown_value = 1. - shutdown_value
+        self._start_value = max(0., min(1., start_value))
+        self._shutdown_value = max(0., min(1., shutdown_value))
+    def _build_config(self):
+        if self._max_duration and self._start_value != self._shutdown_value:
+            raise pins.error("Pin with max duration must have start"
+                             " value equal to shutdown value")
+        cmd_queue = self._mcu.alloc_command_queue()
+        curtime = self._mcu.get_printer().get_reactor().monotonic()
+        printtime = self._mcu.estimated_print_time(curtime)
+        self._last_clock = self._mcu.print_time_to_clock(printtime + 0.200)
+        cycle_ticks = self._mcu.seconds_to_clock(self._cycle_time)
+        mdur_ticks = self._mcu.seconds_to_clock(self._max_duration)
+        if mdur_ticks >= 1<<31:
+            raise pins.error("PWM pin max duration too large")
+        if self._hardware_pwm:
+            self._pwm_max = self._mcu.get_constant_float("PWM_MAX")
+            self._mcu.add_config_cmd(
+                "config_pwm_out oid=%d pin=%s cycle_ticks=%d value=%d"
+                " default_value=%d max_duration=%d"
+                % (self._oid, self._pin, cycle_ticks,
+                   self._start_value * self._pwm_max,
+                   self._shutdown_value * self._pwm_max, mdur_ticks))
+            svalue = int(self._start_value * self._pwm_max + 0.5)
+            self._mcu.add_config_cmd("queue_pwm_out oid=%d clock=%d value=%d"
+                                     % (self._oid, self._last_clock, svalue),
+                                     on_restart=True)
+            self._set_cmd_tag = self._mcu.lookup_command(
+                "queue_pwm_out oid=%c clock=%u value=%hu",
+                cq=cmd_queue).get_command_tag()
+            return
+        # Software PWM
+        if self._shutdown_value not in [0., 1.]:
+            raise pins.error("shutdown value must be 0.0 or 1.0 on soft pwm")
+        if cycle_ticks >= 1<<31:
+            raise pins.error("PWM pin cycle time too large")
+        self._mcu.add_config_cmd(
+            "config_digital_out oid=%d pin=%s value=%d"
+            " default_value=%d max_duration=%d"
+            % (self._oid, self._pin, self._start_value >= 1.0,
+               self._shutdown_value >= 0.5, mdur_ticks))
+        self._mcu.add_config_cmd(
+            "set_digital_out_pwm_cycle oid=%d cycle_ticks=%d"
+            % (self._oid, cycle_ticks))
+        self._cycle_ticks = cycle_ticks
+        svalue = int(self._start_value * cycle_ticks + 0.5)
+        self._mcu.add_config_cmd(
+            "queue_digital_out oid=%d clock=%d on_ticks=%d"
+            % (self._oid, self._last_clock, svalue), is_init=True)
+        self._set_cmd_tag = self._mcu.lookup_command(
+            "queue_digital_out oid=%c clock=%u on_ticks=%u",
+            cq=cmd_queue).get_command_tag()
+    def set_pwm(self, print_time, value):
+        clock = self._mcu.print_time_to_clock(print_time)
+        minclock = self._last_clock
+        self._last_clock = clock
+        if self._invert:
+            value = 1. - value
+        max_count = self._cycle_ticks
+        if self._hardware_pwm:
+            max_count = self._pwm_max
+        v = int(max(0., min(1., value)) * max_count + 0.5)
+        data = (self._set_cmd_tag, self._oid, clock & 0xffffffff, v)
+        ret = self._stepcompress_queue_mq_msg(self._stepqueue, clock,
+                                              data, len(data))
+        if ret:
+            raise error("Internal error in stepcompress")
+
+class PrinterOutputPin:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        ppins = self.printer.lookup_object('pins')
+        # Determine pin type
+        pin_params = ppins.lookup_pin(config.get('pin'), can_invert=True)
+        self.mcu_pin = MCU_queued_pwm(pin_params)
+        cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
+                                     maxval=MAX_SCHEDULE_TIME)
+        hardware_pwm = config.getboolean('hardware_pwm', False)
+        self.mcu_pin.setup_cycle_time(cycle_time, hardware_pwm)
+        self.scale = config.getfloat('scale', 1., above=0.)
+        self.last_print_time = 0.
+        self.mcu_pin.setup_max_duration(0.)
+        # Determine start and shutdown values
+        self.last_value = config.getfloat(
+            'value', 0., minval=0., maxval=self.scale) / self.scale
+        self.shutdown_value = config.getfloat(
+            'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
+        self.mcu_pin.setup_start_value(self.last_value, self.shutdown_value)
+        # Register commands
+        pin_name = config.get_name().split()[1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("SET_PIN", "PIN", pin_name,
+                                   self.cmd_SET_PIN,
+                                   desc=self.cmd_SET_PIN_help)
+    def get_status(self, eventtime):
+        return {'value': self.last_value}
+    def _set_pin(self, print_time, value):
+        if value == self.last_value:
+            return
+        print_time = max(print_time, self.last_print_time)
+        self.mcu_pin.set_pwm(print_time, value)
+        self.last_value = value
+        self.last_print_time = print_time
+    cmd_SET_PIN_help = "Set the value of an output pin"
+    def cmd_SET_PIN(self, gcmd):
+        # Read requested value
+        value = gcmd.get_float('VALUE', minval=0., maxval=self.scale)
+        value /= self.scale
+        # Obtain print_time and apply requested settings
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_lookahead_callback(
+            lambda print_time: self._set_pin(print_time, value))
+
+def load_config_prefix(config):
+    return PrinterOutputPin(config)

--- a/test/klippy/pwm.cfg
+++ b/test/klippy/pwm.cfg
@@ -13,6 +13,12 @@ value: 0
 shutdown_value: 0
 cycle_time: 0.01
 
+[pwm_tool test_pwm_tool]
+pin: PH4
+value: 0
+shutdown_value: 0
+cycle_time: 0.01
+
 [mcu]
 serial: /dev/ttyACM0
 

--- a/test/klippy/pwm.test
+++ b/test/klippy/pwm.test
@@ -28,3 +28,11 @@ SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
 SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
 SET_PIN PIN=soft_pwm_pin VALUE=0.75 CYCLE_TIME=0.5
 SET_PIN PIN=soft_pwm_pin VALUE=0.75 CYCLE_TIME=0.75
+
+# PWM tool
+# Basic test
+SET_PIN PIN=test_pwm_tool VALUE=0
+SET_PIN PIN=test_pwm_tool VALUE=0.5
+SET_PIN PIN=test_pwm_tool VALUE=0.5
+SET_PIN PIN=test_pwm_tool VALUE=0.25
+SET_PIN PIN=test_pwm_tool VALUE=1


### PR DESCRIPTION
This is an alternative implementation for #4128.  The goal is to support fine grained control of spindles, lasers, and similar tools that are controlled by PWM input.  The current `output_pin` module requires that each pin update have a minimum duration of 100ms, which is often not sufficient for these tools.  This PR introduces a new `pwm_tool` module capable of queuing PWM updates in the micro-controller and is therefore capable of much higher update rates.

This differs from #4128 in the implementation.  I'm leery that some of the low-level changes in #4128 may introduce a regression.  This PR makes only a few changes outside of the new pwm_tool.py code.  That is, the implementation here is mostly isolated to the new module and is therefore unlikely to introduce a regression to any users not using this module.

Unfortunately, I do not have a good setup to test this module.  Feedback is appreciated.

@Cirromulus - FYI.

-Kevin