### PR TITLE
Add support for BMP180 sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ out
 .config
 .config.old
 klippy/.version
-klippy/extras/bme280.py~

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 .config
 .config.old
 klippy/.version
+klippy/extras/bme280.py~

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2440,9 +2440,9 @@ sensor_pin:
 #   name in the above list.
 ```
 
-### BMP280/BME280/BME680 temperature sensor
+### BMP180/BMP280/BME280/BME680 temperature sensor
 
-BMP280/BME280/BME680 two wire interface (I2C) environmental sensors.
+BMP180/BMP280/BME280/BME680 two wire interface (I2C) environmental sensors.
 Note that these sensors are not intended for use with extruders and
 heater beds, but rather for monitoring ambient temperature (C),
 pressure (hPa), relative humidity and in case of the BME680 gas level.
@@ -2453,7 +2453,7 @@ temperature.
 ```
 sensor_type: BME280
 #i2c_address:
-#   Default is 118 (0x76). Some BME280 sensors have an address of 119
+#   Default is 118 (0x76). The BMP180 and some BME280 sensors have an address of 119
 #   (0x77).
 #i2c_mcu:
 #i2c_bus:

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -400,7 +400,8 @@ class BME280:
         self.write_register('CTRL_MEAS', meas)
 
         try:
-            time.sleep(0.005)
+            for i in range(94000):
+                pass
             data = self.read_register('REG_MSB', 3)
             UP = ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
         except Exception:

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -400,7 +400,7 @@ class BME280:
         try:
             self.reactor.pause(self.reactor.monotonic() + .01)
             data = self.read_register('REG_MSB', 3)
-            pressure_raw = \ 
+            pressure_raw = \
                 ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
         except Exception:
             logging.exception("BMP180: Error reading pressure")

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -400,7 +400,8 @@ class BME280:
         try:
             self.reactor.pause(self.reactor.monotonic() + .01)
             data = self.read_register('REG_MSB', 3)
-            pressure_raw = ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
+            pressure_raw = \ 
+                ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
         except Exception:
             logging.exception("BMP180: Error reading pressure")
             self.temp = self.pressure = .0

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
-# BMP180 sensor support by VAXXi <github@vaxxi.net>
+# BMP180 sensor support by VAXXi Popescu <github@vaxxi.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -240,8 +240,9 @@ class BME280:
         self.write_register('RESET', [RESET_CHIP_VALUE])
         self.reactor.pause(self.reactor.monotonic() + .5)
 
-        # Make sure non-volatile memory has been copied to registers, except BMP180 which has no status
+        # Make sure non-volatile memory has been copied to registers
         if self.chip_type != 'BMP180':
+            # BMP180 has no status register available
             status = self.read_register('STATUS', 1)[0]
             while status & STATUS_IM_UPDATE:
                 self.reactor.pause(self.reactor.monotonic() + .01)
@@ -403,7 +404,7 @@ class BME280:
         try:
             time.sleep(0.005)
             data = self.read_register('REG_MSB', 3)
-            UP = ( (data[0] << 16) | (data[1] << 8) | data[2] ) >> (8 - self.os_pres)
+            UP = ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
         except Exception:
             logging.exception("BMP180: Error reading pressure")
             self.temp = self.pressure = .0

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -8,7 +8,6 @@ from . import bus
 
 REPORT_TIME = .8
 BME280_CHIP_ADDR = 0x76
-BMP180_CHIP_ADDR = 0x77
 
 BME280_REGS = {
     'RESET': 0xE0, 'CTRL_HUM': 0xF2,

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -2,11 +2,8 @@
 #
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
-# BMP180 sensor support by VAXXi Popescu <github@vaxxi.net>
-#
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-import time
 from . import bus
 
 REPORT_TIME = .8
@@ -390,7 +387,8 @@ class BME280:
         self.write_register('CTRL_MEAS', meas)
 
         try:
-            time.sleep(0.005)
+            for i in range(94000):
+                pass
             data = self.read_register('REG_MSB', 2)
             UT = (data[0] << 8) | data[1]
         except Exception:

--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -387,8 +387,7 @@ class BME280:
         self.write_register('CTRL_MEAS', meas)
 
         try:
-            for i in range(94000):
-                pass
+            self.reactor.pause(self.reactor.monotonic() + .01)
             data = self.read_register('REG_MSB', 2)
             UT = (data[0] << 8) | data[1]
         except Exception:
@@ -400,8 +399,7 @@ class BME280:
         self.write_register('CTRL_MEAS', meas)
 
         try:
-            for i in range(94000):
-                pass
+            self.reactor.pause(self.reactor.monotonic() + .01)
             data = self.read_register('REG_MSB', 3)
             UP = ((data[0] << 16)|(data[1] << 8)|data[2]) >> (8 - self.os_pres)
         except Exception:
@@ -531,33 +529,33 @@ class BME280:
 
     def _compensate_temp_bmp180(self, raw_temp):
         dig = self.dig
-        X1 = (raw_temp - dig['AC6']) * dig['AC5'] / 32768.
-        X2 = dig['MC'] * 2048 / (X1 + dig['MD'])
-        B5 = X1 + X2
-        self.t_fine = B5
-        return (B5 + 8)/16./10.
+        x1 = (raw_temp - dig['AC6']) * dig['AC5'] / 32768.
+        x2 = dig['MC'] * 2048 / (x1 + dig['MD'])
+        b5 = x1 + x2
+        self.t_fine = b5
+        return (b5 + 8)/16./10.
 
     def _compensate_pressure_bmp180(self, raw_pressure):
         dig = self.dig
-        B5 = self.t_fine
-        B6 = B5 - 4000
-        X1 = (dig['B2'] * (B6 * B6 / 4096)) / 2048
-        X2 = dig['AC2'] * B6 / 2048
-        X3 = X1 + X2
-        B3 = ((int(dig['AC1'] * 4 + X3) << self.os_pres) + 2) / 4
-        X1 = dig['AC3'] * B6 / 8192
-        X2 = (dig['B1'] * (B6 * B6 / 4096)) / 65536
-        X3 = ((X1 + X2) + 2) / 4
-        B4 = dig['AC4'] * (X3 + 32768) / 32768
-        B7 = (raw_pressure - B3) * (50000 >> self.os_pres)
-        if (B7 < 0x80000000):
-            p = (B7 * 2) / B4
+        b5 = self.t_fine
+        b6 = b5 - 4000
+        x1 = (dig['B2'] * (b6 * b6 / 4096)) / 2048
+        x2 = dig['AC2'] * b6 / 2048
+        x3 = x1 + x2
+        b3 = ((int(dig['AC1'] * 4 + x3) << self.os_pres) + 2) / 4
+        x1 = dig['AC3'] * b6 / 8192
+        x2 = (dig['B1'] * (b6 * b6 / 4096)) / 65536
+        X3 = ((x1 + x2) + 2) / 4
+        b4 = dig['AC4'] * (x3 + 32768) / 32768
+        b7 = (raw_pressure - b3) * (50000 >> self.os_pres)
+        if (b7 < 0x80000000):
+            p = (b7 * 2) / b4
         else:
-            p = (B7 / B4) * 2
-        X1 = (p / 256) * (p / 256)
-        X1 = (X1 * 3038) / 65536
-        X2 = (-7357 * p) / 65536
-        p = p + (X1 + X2 + 3791) / 16.
+            p = (b7 / b4) * 2
+        x1 = (p / 256) * (p / 256)
+        x1 = (x1 * 3038) / 65536
+        x2 = (-7357 * p) / 65536
+        p = p + (x1 + x2 + 3791) / 16.
         return p
 
     def read_id(self):


### PR DESCRIPTION
Add support for the older BMP180 sensor into the BMxx80 sensor category. Sensors supports oversampling for pressure only. No additional changes required to Mainsail, as it integrates into the existing display of temperature and humidity.

![image](https://github.com/Klipper3d/klipper/assets/9253744/54958c3a-34a1-4774-957c-dc07b4608572)
