### PR TITLE
docs: Fix a typo in serial bootloader entry docs

### DIFF
--- a/docs/Bootloader_Entry.md
+++ b/docs/Bootloader_Entry.md
@@ -44,7 +44,7 @@ releasing `Ctrl`
 
 If a physical serial port is being used on the MCU (even if a USB serial adapter
 is being used to connect to it), sending the string
-`<SPACE><FS><SPACE>Request Serial Bootloader!!<SPACE>~`.
+`<SPACE><FS><SPACE>Request Serial Bootloader!!<SPACE>~` requests the bootloader.
 
 `<SPACE>` is an ASCII literal space, 0x20.
 


### PR DESCRIPTION
You always notice them after it's up there...