### PR TITLE
hall_filament_width_sensor: max filament diameter

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20231216: The `[hall_filament_width_sensor]` is changed to trigger filament runout
+when the thickness of the filament exceeds `max_diameter`. The maximum diameter
+defaults to `default_nominal_filament_diameter + max_difference`. See
+[[hall_filament_width_sensor] configuration
+reference](./Config_Reference.md#hall_filament_width_sensor) for more details.
+
 20231207: Several undocumented config parameters in the `[printer]`
 config section have been removed (the buffer_time_low,
 buffer_time_high, buffer_time_start, and move_flush_time parameters).

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4428,6 +4428,9 @@ adc2:
 #   command.
 #min_diameter: 1.0
 #   Minimal diameter for trigger virtual filament_switch_sensor.
+#max_diameter:
+#   Maximum diameter for triggering virtual filament_switch_sensor.
+#   The default is default_nominal_filament_diameter + max_difference.
 #use_current_dia_while_delay: False
 #   Use the current diameter instead of the nominal diameter while
 #   the measurement delay has not run through.

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -30,7 +30,8 @@ class HallFilamentWidthSensor:
                              - self.measurement_max_difference)
         self.diameter =self.nominal_filament_dia
         self.is_active =config.getboolean('enable', False)
-        self.runout_dia=config.getfloat('min_diameter', 1.0)
+        self.runout_dia_min=config.getfloat('min_diameter', 1.0)
+        self.runout_dia_max=config.getfloat('max_diameter', self.max_diameter)
         self.is_log =config.getboolean('logging', False)
         # Use the current diameter instead of nominal while the first
         # measurement isn't in place
@@ -125,7 +126,7 @@ class HallFilamentWidthSensor:
         self.update_filament_array(last_epos)
         # Check runout
         self.runout_helper.note_filament_present(
-            self.diameter > self.runout_dia)
+            self.runout_dia_min <= self.diameter <= self.runout_dia_max)
         # Does filament exists
         if self.diameter > 0.5:
             if len(self.filament_array) > 0:


### PR DESCRIPTION
Add support for maximum filament diameter to hall filament width sensor. If the diameter of the filament diameter is larger than the limit, the virtual runout sensor will trigger. The default value is set to maximum flow adjustment threshold to prevent oversized filament from clogging.