### PR TITLE
Clarify license requirements of low-level Klipper interfaces

### DIFF
--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -236,6 +236,15 @@ then the software will automatically attempt to load the python module
 klippy/extras/my_module.py . This module system is the preferred
 method for adding new functionality to Klipper.
 
+This Klipper "host module" system is an internal abstraction used to
+facilitate long-term code maintenance within Klipper. It is not an API
+for external code, nor is it a "plugin system". Also, note that
+Klipper uses the [GNU GPLv3 license](../COPYING). Any code utilizing
+the Klipper "host module" interface is also subject to the GNU GPLv3
+licensing requirements. See the Klipper [API Server](API_Server.md)
+documentation if interested in interacting with Klipper from external
+code.
+
 The easiest way to add a new module is to use an existing module as a
 reference - see **klippy/extras/servo.py** as an example.
 
@@ -366,6 +375,11 @@ Useful steps:
    [debugging documentation](Debugging.md) to convert this g-code file
    to micro-controller commands. This is useful to exercise corner
    cases and to check for regressions.
+
+Note that Klipper uses the [GNU GPLv3 license](../COPYING). The
+interface to kinematic code in Klipper is an internal abstraction, and
+any code utilizing that interface is also subject to the GNU GPLv3
+licensing requirements.
 
 ## Porting to a new micro-controller
 

--- a/docs/MCU_Commands.md
+++ b/docs/MCU_Commands.md
@@ -20,6 +20,14 @@ document) take a string value which is automatically converted to an
 integer value for the micro-controller. This is common with parameters
 named "pin" (or that have a suffix of "_pin").
 
+Note that Klipper uses the [GNU GPLv3 license](../COPYING). The
+Klipper host to micro-controller interface described here is an
+internal abstraction used to facilitate communication within the
+Klipper code. Any code utilizing this Klipper interface is also
+subject to the GNU GPLv3 licensing requirements. See the Klipper [API
+Server](API_Server.md) documentation if interested in interacting with
+Klipper from external code.
+
 ## Startup Commands
 
 It may be necessary to take certain one-time actions to configure the

--- a/docs/Protocol.md
+++ b/docs/Protocol.md
@@ -28,6 +28,14 @@ The goal of the protocol is to enable an error-free communication
 channel between the host and micro-controller that is low-latency,
 low-bandwidth, and low-complexity for the micro-controller.
 
+Note that Klipper uses the [GNU GPLv3 license](../COPYING). The
+Klipper host to micro-controller interface described here is an
+internal abstraction used to facilitate communication within the
+Klipper code. Any code utilizing this Klipper interface is also
+subject to the GNU GPLv3 licensing requirements. See the Klipper [API
+Server](API_Server.md) documentation if interested in interacting with
+Klipper from external code.
+
 ## Micro-controller Interface
 
 The Klipper transmission protocol can be thought of as a


### PR DESCRIPTION
This PR updates the documentation to make it clear that Klipper's low-level code abstractions are not licensing boundaries and any code using them is subject to the requirements of the GNU GPLv3 license.

This is not a change in licensing nor a change in behavior.  The Klipper low-level code abstractions have never been program boundaries nor licensing boundaries.  This update to the documentation just makes that a little more explicit.

-Kevin