### PR TITLE
Filament Sensors: Add switch_pin_state status variable

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -152,7 +152,6 @@ objects:
 - `switch_pin_state`: Returns True/False if the switch_pin digital
   input is logic 1/0
 
-
 ## filament_motion_sensor
 
 The following information is available in

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -149,6 +149,9 @@ objects:
 - `enabled`: Returns True if the switch sensor is currently enabled.
 - `filament_detected`: Returns True if the sensor is in a triggered
   state.
+- `switch_pin_state`: Returns True/False if the switch_pin digital
+  input is logic 1/0
+
 
 ## filament_motion_sensor
 
@@ -158,6 +161,8 @@ objects:
 - `enabled`: Returns True if the motion sensor is currently enabled.
 - `filament_detected`: Returns True if the sensor is in a triggered
   state.
+- `switch_pin_state`: Returns True/False if the switch_pin digital
+  input is logic 1/0
 
 ## firmware_retraction
 

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -69,6 +69,7 @@ class EncoderSensor:
     def encoder_event(self, eventtime, state):
         if self.extruder is not None:
             self._update_filament_runout_pos(eventtime)
+            self.runout_helper.switch_pin_state = state
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
             self.runout_helper.note_filament_present(True)

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -29,6 +29,7 @@ class RunoutHelper:
         self.min_event_systime = self.reactor.NEVER
         self.filament_present = False
         self.sensor_enabled = True
+        self.switch_pin_state = False
         # Register commands and event handlers
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.gcode.register_mux_command(
@@ -91,7 +92,8 @@ class RunoutHelper:
     def get_status(self, eventtime):
         return {
             "filament_detected": bool(self.filament_present),
-            "enabled": bool(self.sensor_enabled)}
+            "enabled": bool(self.sensor_enabled),
+            "switch_pin_state": bool(self.switch_pin_state)}
     cmd_QUERY_FILAMENT_SENSOR_help = "Query the status of the Filament Sensor"
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
         if self.filament_present:
@@ -112,6 +114,7 @@ class SwitchSensor:
         self.runout_helper = RunoutHelper(config)
         self.get_status = self.runout_helper.get_status
     def _button_handler(self, eventtime, state):
+        self.runout_helper.switch_pin_state = state
         self.runout_helper.note_filament_present(state)
 
 def load_config_prefix(config):


### PR DESCRIPTION
Added a switch_pin_state status variable to the RunoutHelper class. Variable state is modified by _button_handler() in SwitchSensor and encoder_event() in EncoderSensor.

This allows a macro to read the logic state of the switch_pin for filament_switch_sensor and filament_motion_sensor. In my case, I wanted this functionality in order to write a macro that tracks the motion of the filament during a purge in the START_PRINT macro. That way I can check if the extruder is working properly before the print starts. Checking filament extrusion during filament load or unload macros is also possible.