### PR TITLE
Replace deprecated logger.warn with logger.warning

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -172,16 +172,16 @@ class PrinterConfig:
             autosave_data = data[pos + len(AUTOSAVE_HEADER):].strip()
         # Check for errors and strip line prefixes
         if "\n#*# " in regular_data:
-            logging.warn("Can't read autosave from config file"
-                         " - autosave state corrupted")
+            logging.warning("Can't read autosave from config file"
+                            " - autosave state corrupted")
             return data, ""
         out = [""]
         for line in autosave_data.split('\n'):
             if ((not line.startswith("#*#")
                  or (len(line) >= 4 and not line.startswith("#*# ")))
                 and autosave_data):
-                logging.warn("Can't read autosave from config file"
-                             " - modifications after header")
+                logging.warning("Can't read autosave from config file"
+                                " - modifications after header")
                 return data, ""
             out.append(line[4:])
         out.append("")

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -95,8 +95,8 @@ class LinearVoltage:
         for temp, volt in params:
             adc = (volt - voltage_offset) / adc_voltage
             if adc < 0. or adc > 1.:
-                logging.warn("Ignoring adc sample %.3f/%.3f in heater %s",
-                             temp, volt, config.get_name())
+                logging.warning("Ignoring adc sample %.3f/%.3f in heater %s",
+                                temp, volt, config.get_name())
                 continue
             samples.append((adc, temp))
         try:

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -126,7 +126,7 @@ class HTU21D:
         rdevId |= response[1]
         checksum = response[2]
         if self._chekCRC8(rdevId) != checksum:
-            logging.warn("htu21d: Reading deviceId !Checksum error!")
+            logging.warning("htu21d: Reading deviceId !Checksum error!")
         rdevId = rdevId >> 8
         deviceId_list = list(
             filter(
@@ -135,10 +135,10 @@ class HTU21D:
         if len(deviceId_list) != 0:
             logging.info("htu21d: Found Device Type %s" % deviceId_list[0])
         else:
-            logging.warn("htu21d: Unknown Device ID %#x " % rdevId)
+            logging.warning("htu21d: Unknown Device ID %#x " % rdevId)
 
-        if(self.deviceId != deviceId_list[0]):
-            logging.warn(
+        if self.deviceId != deviceId_list[0]:
+            logging.warning(
                 "htu21d: Found device %s. Forcing to type %s as config.",
                  deviceId_list[0],self.deviceId)
 
@@ -169,7 +169,7 @@ class HTU21D:
             rtemp  = response[0] << 8
             rtemp |= response[1]
             if self._chekCRC8(rtemp) != response[2]:
-                logging.warn("htu21d: Checksum error on Temperature reading!")
+                logging.warning("htu21d: Checksum error on Temperature reading!")
             else:
                 self.temp = (0.002681 * float(rtemp) - 46.85)
                 logging.debug("htu21d: Temperature %.2f " % self.temp)
@@ -190,7 +190,7 @@ class HTU21D:
             rhumid = response[0] << 8
             rhumid|= response[1]
             if self._chekCRC8(rhumid) != response[2]:
-                logging.warn("htu21d: Checksum error on Humidity reading!")
+                logging.warning("htu21d: Checksum error on Humidity reading!")
             else:
                 #clear status bits,
                 # humidity always returns xxxxxx10 in the LSB field

--- a/klippy/extras/htu21d.py
+++ b/klippy/extras/htu21d.py
@@ -169,7 +169,9 @@ class HTU21D:
             rtemp  = response[0] << 8
             rtemp |= response[1]
             if self._chekCRC8(rtemp) != response[2]:
-                logging.warning("htu21d: Checksum error on Temperature reading!")
+                logging.warning(
+                    "htu21d: Checksum error on Temperature reading!"
+                )
             else:
                 self.temp = (0.002681 * float(rtemp) - 46.85)
                 logging.debug("htu21d: Temperature %.2f " % self.temp)

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -62,7 +62,7 @@ class SensorBase:
         last_read_time  = self.mcu.clock_to_print_time(last_read_clock)
         self._callback(last_read_time, temp)
     def report_fault(self, msg):
-        logging.warn(msg)
+        logging.warning(msg)
 
 
 ######################################################################

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -33,7 +33,7 @@ class Thermistor:
                    / (ln3_r12 - ln3_r13 * ln_r12 / ln_r13))
         if self.c3 <= 0.:
             beta = ln_r13 / inv_t13
-            logging.warn("Using thermistor beta %.3f in heater %s", beta, name)
+            logging.warning("Using thermistor beta %.3f in heater %s", beta, name)
             self.setup_coefficients_beta(t1, r1, beta)
             return
         self.c2 = (inv_t12 - self.c3 * ln3_r12) / ln_r12

--- a/klippy/extras/thermistor.py
+++ b/klippy/extras/thermistor.py
@@ -33,7 +33,8 @@ class Thermistor:
                    / (ln3_r12 - ln3_r13 * ln_r12 / ln_r13))
         if self.c3 <= 0.:
             beta = ln_r13 / inv_t13
-            logging.warning("Using thermistor beta %.3f in heater %s", beta, name)
+            logging.warning("Using thermistor beta %.3f in heater %s",
+                            beta, name)
             self.setup_coefficients_beta(t1, r1, beta)
             return
         self.c2 = (inv_t12 - self.c3 * ln3_r12) / ln_r12

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -137,8 +137,8 @@ class SerialReader:
                                         bustype='socketcan')
                 bus.send(set_id_msg)
             except (can.CanError, os.error) as e:
-                logging.warn("%sUnable to open CAN port: %s",
-                             self.warn_prefix, e)
+                logging.warning("%sUnable to open CAN port: %s",
+                                self.warn_prefix, e)
                 self.reactor.pause(self.reactor.monotonic() + 5.)
                 continue
             bus.close = bus.shutdown # XXX


### PR DESCRIPTION
the `logger.warn` alias will be removed in upcoming Python 3.13. Changes are compatible with Python >= 2.7.