### PR TITLE
Rename shadowed mcu variable in loop

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -147,9 +147,9 @@ class Printer:
         host_version = self.start_args['software_version']
         msg_update = []
         msg_updated = []
-        for mcu_name, mcu in self.lookup_objects('mcu'):
+        for mcu_name, mcu_obj in self.lookup_objects('mcu'):
             try:
-                mcu_version = mcu.get_status()['mcu_version']
+                mcu_version = mcu_obj.get_status()['mcu_version']
             except:
                 logging.exception("Unable to retrieve mcu_version from mcu")
                 continue


### PR DESCRIPTION
`mcu` var clashes with the `mcu` module import as reported by flake8:

`klippy/klippy.py:150:23: F402 import 'mcu' from line 9 shadowed by loop variable`