### PR TITLE
bed_screws: Reset on move error

### DIFF
--- a/klippy/extras/bed_screws.py
+++ b/klippy/extras/bed_screws.py
@@ -42,7 +42,12 @@ class BedScrews:
         self.current_screw = 0
         self.accepted_screws = 0
     def move(self, coord, speed):
-        self.printer.lookup_object('toolhead').manual_move(coord, speed)
+        try:
+            self.printer.lookup_object('toolhead').manual_move(coord, speed)
+        except self.printer.command_error as e:
+            self.unregister_commands()
+            self.reset()
+            raise
     def move_to_screw(self, state, screw):
         # Move up, over, and then down
         self.move((None, None, self.horizontal_move_z), self.lift_speed)


### PR DESCRIPTION
This is a follow up on [this issue](https://github.com/mainsail-crew/mainsail/issues/1624).

If the `stepper_x.position_max` or `stepper_y.position_max` values are smaller than those in the `bed_screws` entries, when one starts the `BED_SCREWS_ADJUST` tool, it will throw a "Move out of range" error, but the tool will be stuck in a running state, yet nothing works until we restart Klipper.

The fix here is to reset the state of the tool in case of error.