### PR TITLE
Improve support for python3.12 in configfile.py

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -217,7 +217,10 @@ class PrinterConfig:
         data = '\n'.join(buffer)
         del buffer[:]
         sbuffer = io.StringIO(data)
-        fileconfig.readfp(sbuffer, filename)
+        if sys.version_info.major >= 3:
+            fileconfig.read_file(sbuffer, filename)
+        else:
+            fileconfig.readfp(sbuffer, filename)
     def _resolve_include(self, source_filename, include_spec, fileconfig,
                          visited):
         dirname = os.path.dirname(source_filename)


### PR DESCRIPTION
It seems python3.12 has removed support for readfp() - use read_file() instead.

-Kevin