### PR TITLE
stm32: enable 64KiB bootloader offset for all F4

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -288,7 +288,7 @@ choice
     config STM32_FLASH_START_C000
         bool "48KiB bootloader (MKS Robin Nano V3)" if MACH_STM32F4x5
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F446 || MACH_STM32F401
+        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F4
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader (HID Bootloader)" if MACH_STM32F103


### PR DESCRIPTION
Enables the 64KiB bootloader offset for the whole F4 family.