### PR TITLE
gcode: expose status with available commands

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -168,6 +168,12 @@ The following information is available in the
   module. These settings may differ from the config file if a
   `SET_RETRACTION` command alters them.
 
+## gcode
+
+The following information is available in the `gcode` object:
+- `commands`: Returns a list of all currently available commands. For each
+  command, if a help string is defined it will also be provided.
+
 ## gcode_button
 
 The following information is available in

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -104,6 +104,7 @@ class GCodeDispatch:
         self.ready_gcode_handlers = {}
         self.mux_commands = {}
         self.gcode_help = {}
+        self.status_commands = {}
         # Register commands needed before config file is loaded
         handlers = ['M110', 'M112', 'M115',
                     'RESTART', 'FIRMWARE_RESTART', 'ECHO', 'STATUS', 'HELP']
@@ -126,6 +127,7 @@ class GCodeDispatch:
                 del self.ready_gcode_handlers[cmd]
             if cmd in self.base_gcode_handlers:
                 del self.base_gcode_handlers[cmd]
+            self._build_status_commands()
             return old_cmd
         if cmd in self.ready_gcode_handlers:
             raise self.printer.config_error(
@@ -138,6 +140,7 @@ class GCodeDispatch:
             self.base_gcode_handlers[cmd] = func
         if desc is not None:
             self.gcode_help[cmd] = desc
+        self._build_status_commands()
     def register_mux_command(self, cmd, key, value, func, desc=None):
         prev = self.mux_commands.get(cmd)
         if prev is None:
@@ -156,6 +159,14 @@ class GCodeDispatch:
         prev_values[value] = func
     def get_command_help(self):
         return dict(self.gcode_help)
+    def get_status(self, eventtime):
+        return {'commands': self.status_commands}
+    def _build_status_commands(self):
+        commands = {cmd: {} for cmd in self.gcode_handlers}
+        for cmd in self.gcode_help:
+            if cmd in commands:
+                commands[cmd]['help'] = self.gcode_help[cmd]
+        self.status_commands = commands
     def register_output_handler(self, cb):
         self.output_callbacks.append(cb)
     def _handle_shutdown(self):
@@ -163,12 +174,14 @@ class GCodeDispatch:
             return
         self.is_printer_ready = False
         self.gcode_handlers = self.base_gcode_handlers
+        self._build_status_commands()
         self._respond_state("Shutdown")
     def _handle_disconnect(self):
         self._respond_state("Disconnect")
     def _handle_ready(self):
         self.is_printer_ready = True
         self.gcode_handlers = self.ready_gcode_handlers
+        self._build_status_commands()
         self._respond_state("Ready")
     # Parse input into commands
     args_r = re.compile('([A-Z_]+|[A-Z*/])')


### PR DESCRIPTION
This exposes a new `gcode` status object, with a list of the currently available commands:

![image](https://github.com/Klipper3d/klipper/assets/85504/1d9aa729-c0c8-4d3f-969e-362963ccc797)

It currently exposes the `commands` (all currently available commands in Klipper), and for each command, if the help text is available, it will also be included.

I understand that we already have the [gcode/help](https://www.klipper3d.org/API_Server.html#gcodehelp) endpoint, but this works on a pull, whereas status updates are pushed to the client.