### PR TITLE
tmc5160: Increase maximum current error check

### DIFF
--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -257,7 +257,7 @@ FieldFormatters.update({
 ######################################################################
 
 VREF = 0.325
-MAX_CURRENT = 3.000
+MAX_CURRENT = 10.000 # Maximum dependent on board, but 10 is safe sanity check
 
 class TMC5160CurrentHelper:
     def __init__(self, config, mcu_tmc):


### PR DESCRIPTION
It's possible to build and configure tmc5160 drivers with external mosfets that support more than 3 amps.  The actual maximum for tmc5160 drivers is dependent on how the board is wired and the mosfets used. Increase the error check to 10 amps.  This error checking is primarily intended to catch "obvious misconfigurations" (eg, specifying milli-amps instead of amps), and the new value of 10 amps should suffice for this task.

This is an alternative to #6381 (and #6093).

@bigtreetech - FYI.

-Kevin