### PR TITLE
Resolve numpy errors w/ MEASURE_RESONANCES

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -207,7 +207,7 @@ software dependencies not installed by default. First, run on your Raspberry Pi
 the following commands:
 ```
 sudo apt update
-sudo apt install python3-numpy python3-matplotlib libatlas-base-dev
+sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-base
 ```
 
 Next, in order to install NumPy in the Klipper environment, run the command:


### PR DESCRIPTION
In lieu of issues like these: https://klipper.discourse.group/t/failed-to-import-numpy-module/4528/7

Supposedly, a recent version of Numpy changed the default implementation of BLAS from Atlas to OpenBLAS, causing the original documentation's installation of Atlas to be fruitless. The exact cause of what changed the default isn't clear to me as of now.

I added the `libopenblas-base` package which could be missing, causing the importing of numpy to fail when running MEASURE_RESONANCES or SHAPER_CALIBRATE commands. When it does fail on numpy because of this package, it was not very verbose about it.

I left the installation of Atlas in, because it doesn't seem to impact anything as of now. 

_For some reason, editing on Klipper3d/klipper submitted my patch branch on my fork of danger-klipper. Should be fine though, since there's no apparent other difference._