### PR TITLE
config: Fix sensorless homing for SV06 Plus

### DIFF
--- a/config/printer-sovol-sv06-plus-2023.cfg
+++ b/config/printer-sovol-sv06-plus-2023.cfg
@@ -39,7 +39,7 @@ uart_pin: PC1
 run_current: 0.860
 sense_resistor: 0.150
 uart_address: 3
-driver_SGTHRS: 81
+driver_SGTHRS: 86
 diag_pin: PA5
 
 [stepper_y]
@@ -59,7 +59,7 @@ uart_pin: PC0
 run_current: 0.900
 sense_resistor: 0.150
 uart_address: 3
-driver_SGTHRS: 82
+driver_SGTHRS: 110
 diag_pin: PA6
 
 [stepper_z]


### PR DESCRIPTION
In testing with a user on Discord we discovered the sensorless homing thresholds were out of line with what Sovol ships with Marlin. Updated printer-sovol-sv06-plus-2023.cfg to align with their settings.

Signed-off-by: Herb McNew <herb.mcnew@gmail.com>