### PR TITLE
Update printer-lulzbot-taz6-2017.cfg

### DIFF
--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -50,7 +50,7 @@ enable_pin: !PA4
 microsteps: 16
 gear_ratio: 48:9
 rotation_distance: 20.562
-nozzle_diameter: 0.400
+nozzle_diameter: 0.500
 filament_diameter: 2.920
 heater_pin: PH6
 sensor_type: ATC Semitec 104GT-2
@@ -70,7 +70,7 @@ min_extrude_temp: 140
 #enable_pin: !PA4
 #microsteps: 16
 #rotation_distance: 7.619
-#nozzle_diameter: 0.400
+#nozzle_diameter: 0.500
 #filament_diameter: 2.920
 #heater_pin: PH6
 #sensor_type: ATC Semitec 104GT-2


### PR DESCRIPTION
Stock nozzle sizes for Lulzbot TAZ6 are 0.5mm