### PR TITLE
Configurable timeout

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -58,6 +58,13 @@ serial:
 #   sending a Klipper command to the micro-controller so that it can
 #   reset itself. The default is 'arduino' if the micro-controller
 #   communicates over a serial port, 'command' otherwise.
+#trsync_timeout: 0.025
+#   Sync limit for multi-mcu homing in seconds. The default is 0.025.
+#   Should Klipper detect a communication issue between micro-controllers during
+#   multi-mcu homing then it will raise a "Communication timeout during homing"
+#   error.
+#trsync_single_mcu_timeout: 0.250
+#   Sync limit for single-mcu homing in seconds. The default is 0.250.
 ```
 
 ### [mcu my_extra_mcu]
@@ -71,7 +78,11 @@ pins such as "extra_mcu:ar9" may then be used elsewhere in the config
 
 ```
 [mcu my_extra_mcu]
-# See the "mcu" section for configuration parameters.
+#   See the "mcu" section for configuration parameters.
+#trsync_timeout:
+#   See the "mcu" section for details. The default is the setting of the "mcu"
+#trsync_single_mcu_timeout:
+#   See the "mcu" section for details. The default is the setting of the "mcu"
 ```
 
 ## Common kinematic settings


### PR DESCRIPTION
Make trsync_timeout and trsync_single_mcu_timeout configurable

Some people (including me) have (sometimes) issues with a multi mcu setup with a timeout during z-homing.
The default timeout is 25ms, in my case it just don't workout every time. Increasing the limit to 50ms fixes this issue for me entierly, but needs to be done by modifying the mcu.px file after every klipper update.
This PR makes the timeout configurable via the config while keeping the default values as is.

Signed-off-by: Michael Jäger michael@mjaeger.eu

PS
Yes I know the massiv thread for fixing can issues, None of the suggestions helped for me, I have no lost or retransmitted packages, ...