### PR TITLE
feat: Add configurable i2c timeout

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4722,4 +4722,8 @@ via the `i2c_speed` parameter. All other Klipper micro-controllers use a
 #   The Klipper implementation on most micro-controllers is hard-coded
 #   to 100000 and changing this value has no effect. The default is
 #   100000. Linux, RP2040 and ATmega support 400000.
+#i2c_timeout:
+#   The time in microseconds after which a i2c timeout occurs. Defaults
+#   to 5000 (5ms). Some architectures like Linux do not support this, in
+#   which case the value is ignored.
 ```

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -142,7 +142,7 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
 
 # Helper code for working with devices connected to an MCU via an I2C bus
 class MCU_I2C:
-    def __init__(self, mcu, bus, addr, speed, sw_pins=None):
+    def __init__(self, mcu, bus, addr, speed, timeout, sw_pins=None):
         self.mcu = mcu
         self.bus = bus
         self.i2c_address = addr
@@ -156,8 +156,8 @@ class MCU_I2C:
                 % (self.oid, sw_pins[0], sw_pins[1], speed, addr))
         else:
             self.config_fmt = (
-                "i2c_set_bus oid=%d i2c_bus=%%s rate=%d address=%d"
-                % (self.oid, speed, addr))
+                "i2c_set_bus oid=%d i2c_bus=%%s rate=%d address=%d timeout=%d"
+                % (self.oid, speed, addr, timeout))
         self.cmd_queue = self.mcu.alloc_command_queue()
         self.mcu.register_config_callback(self.build_config)
         self.i2c_write_cmd = self.i2c_read_cmd = self.i2c_modify_bits_cmd = None
@@ -213,6 +213,7 @@ def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
     printer = config.get_printer()
     i2c_mcu = mcu.get_printer_mcu(printer, config.get('i2c_mcu', 'mcu'))
     speed = config.getint('i2c_speed', default_speed, minval=100000)
+    timeout = config.getint('i2c_timeout', 5000, minval=0, maxval=65535)
     if default_addr is None:
         addr = config.getint('i2c_address', minval=0, maxval=127)
     else:
@@ -230,7 +231,7 @@ def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
         bus = config.get('i2c_bus', None)
         sw_pins = None
     # Create MCU_I2C object
-    return MCU_I2C(i2c_mcu, bus, addr, speed, sw_pins)
+    return MCU_I2C(i2c_mcu, bus, addr, speed, timeout, sw_pins)
 
 
 ######################################################################

--- a/src/atsam/gpio.h
+++ b/src/atsam/gpio.h
@@ -50,7 +50,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/atsam/gpio.h
+++ b/src/atsam/gpio.h
@@ -47,9 +47,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *twi;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/atsam/i2c.c
+++ b/src/atsam/i2c.c
@@ -116,21 +116,21 @@ addr_to_u32(uint8_t addr_len, uint8_t *addr)
 }
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     if (bus >= ARRAY_SIZE(twi_bus)  || rate > 400000)
         shutdown("Invalid i2c_setup parameters!");
     Twi *p_twi = twi_bus[bus].dev;
     init_pins(bus);
     i2c_init(bus, rate);
-    return (struct i2c_config){ .twi=p_twi, .addr=addr};
+    return (struct i2c_config){ .twi=p_twi, .addr=addr, .timeout=timeout };
 }
 
 void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
     Twi *p_twi = config.twi;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
     uint32_t status, bytes_to_send = write_len;
     p_twi->TWI_MMR = TWI_MMR_DADR(config.addr);
     for (;;) {
@@ -157,7 +157,7 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
     Twi *p_twi = config.twi;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
     uint32_t status, bytes_to_send = read_len;
     uint8_t stop = 0;
     p_twi->TWI_MMR = 0;

--- a/src/atsamd/gpio.h
+++ b/src/atsamd/gpio.h
@@ -51,7 +51,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/atsamd/gpio.h
+++ b/src/atsamd/gpio.h
@@ -48,9 +48,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *si;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/atsamd/i2c.c
+++ b/src/atsamd/i2c.c
@@ -41,13 +41,13 @@ i2c_init(uint32_t bus, SercomI2cm *si)
 }
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     Sercom *sercom = sercom_enable_pclock(bus);
     sercom_i2c_pins(bus);
     SercomI2cm *si = &sercom->I2CM;
     i2c_init(bus, si);
-    return (struct i2c_config){ .si=si, .addr=addr<<1 };
+    return (struct i2c_config){ .si=si, .addr=addr<<1, .timeout=timeout };
 }
 
 static void

--- a/src/avr/gpio.h
+++ b/src/avr/gpio.h
@@ -50,7 +50,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/avr/gpio.h
+++ b/src/avr/gpio.h
@@ -47,9 +47,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 
 struct i2c_config {
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -28,7 +28,7 @@ DECL_CONSTANT_STR("BUS_PINS_twi", "PD0,PD1");
 #endif
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     if (bus)
         shutdown("Unsupported i2c bus");
@@ -48,7 +48,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         // Enable interface
         TWCR = (1<<TWEN);
     }
-    return (struct i2c_config){ .addr=addr<<1 };
+    return (struct i2c_config){ .addr=addr<<1, .timeout=timeout };
 }
 
 static void
@@ -97,7 +97,7 @@ i2c_stop(uint32_t timeout)
 void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     i2c_start(timeout);
     i2c_send_byte(config.addr, timeout);
@@ -110,7 +110,7 @@ void
 i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
     i2c_start(timeout);
     i2c_send_byte(config.addr, timeout);
     while (reg_len--)

--- a/src/hc32f460/gpio.h
+++ b/src/hc32f460/gpio.h
@@ -52,9 +52,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *i2c;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/hc32f460/gpio.h
+++ b/src/hc32f460/gpio.h
@@ -55,7 +55,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -36,11 +36,11 @@ command_i2c_set_bus(uint32_t *args)
 {
     uint8_t addr = args[3] & 0x7f;
     struct i2cdev_s *i2c = i2cdev_oid_lookup(args[0]);
-    i2c->i2c_config = i2c_setup(args[1], args[2], addr);
+    i2c->i2c_config = i2c_setup(args[1], args[2], addr, args[4]);
     i2c->flags |= IF_HARDWARE;
 }
 DECL_COMMAND(command_i2c_set_bus,
-             "i2c_set_bus oid=%c i2c_bus=%u rate=%u address=%u");
+             "i2c_set_bus oid=%c i2c_bus=%u rate=%u address=%u timeout=%u");
 
 void
 i2cdev_set_software_bus(struct i2cdev_s *i2c, struct i2c_software *is)

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -49,7 +49,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -46,9 +46,11 @@ void gpio_pwm_write(struct gpio_pwm g, uint16_t val);
 struct i2c_config {
     int fd;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -73,7 +73,7 @@ fail:
 }
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     // Note:  The rate is set by the kernel driver, for a Raspberry Pi this
     // is done with the following setting in /boot/config.txt:
@@ -81,7 +81,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     // dtparam=i2c_baudrate=<rate>
 
     int fd = i2c_open(bus, addr);
-    return (struct i2c_config){.fd=fd, .addr=addr};
+    return (struct i2c_config){.fd=fd, .addr=addr, .timeout=timeout};
 }
 
 void

--- a/src/lpc176x/gpio.h
+++ b/src/lpc176x/gpio.h
@@ -48,9 +48,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *i2c;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/lpc176x/i2c.c
+++ b/src/lpc176x/i2c.c
@@ -37,7 +37,7 @@ enum {
 };
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     if (bus >= ARRAY_SIZE(i2c_bus))
         shutdown("Invalid i2c bus");
@@ -64,7 +64,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         i2c->I2CONSET = IF_ENA;
     }
 
-    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1 };
+    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1, .timeout=timeout };
 }
 
 static void
@@ -126,7 +126,7 @@ void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
     LPC_I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     i2c_start(i2c, timeout);
     i2c_send_byte(i2c, config.addr, timeout);
@@ -140,7 +140,7 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
     LPC_I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
     uint8_t addr = config.addr | 0x01;
 
     if (reg_len != 0) {

--- a/src/rp2040/gpio.h
+++ b/src/rp2040/gpio.h
@@ -50,7 +50,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/rp2040/gpio.h
+++ b/src/rp2040/gpio.h
@@ -47,9 +47,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *i2c;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/rp2040/i2c.c
+++ b/src/rp2040/i2c.c
@@ -68,7 +68,7 @@ static const struct i2c_info i2c_bus[] = {
 };
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     if (bus > ARRAY_SIZE(i2c_bus))
         shutdown("Invalid i2c bus");
@@ -115,7 +115,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
                         I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_BITS);
     }
 
-    return (struct i2c_config){ .i2c=info->i2c, .addr=addr };
+    return (struct i2c_config){ .i2c=info->i2c, .addr=addr, .timeout=timeout };
 }
 
 static void
@@ -193,7 +193,7 @@ void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
     i2c_hw_t *i2c = (i2c_hw_t*)config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     i2c_start(i2c, config.addr);
     i2c_do_write(i2c, config.addr, write_len, write, 1, timeout);
@@ -205,7 +205,7 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
     i2c_hw_t *i2c = (i2c_hw_t*)config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     i2c_start(i2c, config.addr);
     if (reg_len != 0)

--- a/src/stm32/gpio.h
+++ b/src/stm32/gpio.h
@@ -51,7 +51,7 @@ struct i2c_config {
     uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr,
                             uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg

--- a/src/stm32/gpio.h
+++ b/src/stm32/gpio.h
@@ -48,9 +48,11 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *i2c;
     uint8_t addr;
+    uint16_t timeout;
 };
 
-struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
+struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, 
+                            uint16_t timeout);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -62,7 +62,7 @@ i2c_busy_errata(uint8_t scl_pin, uint8_t sda_pin)
 }
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     // Lookup requested i2c bus
     if (bus >= ARRAY_SIZE(i2c_bus))
@@ -87,7 +87,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         i2c->CR1 = I2C_CR1_PE;
     }
 
-    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1 };
+    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1, .timeout=timeout };
 }
 
 static uint32_t
@@ -151,7 +151,7 @@ void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     i2c_start(i2c, config.addr, write_len, timeout);
     while (write_len--)
@@ -164,7 +164,7 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
     uint8_t addr = config.addr | 0x01;
 
     if (reg_len) {

--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -124,7 +124,7 @@ static const struct i2c_info i2c_bus[] = {
 };
 
 struct i2c_config
-i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
+i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr, uint16_t timeout)
 {
     // Lookup requested i2c bus
     if (bus >= ARRAY_SIZE(i2c_bus))
@@ -147,7 +147,7 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         i2c->CR1 = I2C_CR1_PE;
     }
 
-    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1 };
+    return (struct i2c_config){ .i2c=i2c, .addr=addr<<1, .timeout=timeout };
 }
 
 static uint32_t
@@ -166,7 +166,7 @@ void
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     // Send start and address
     i2c->CR2 = (I2C_CR2_START | config.addr | (write_len << I2C_CR2_NBYTES_Pos)
@@ -183,7 +183,7 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(config.timeout);
 
     // Send start, address, reg
     i2c->CR2 = (I2C_CR2_START | config.addr |


### PR DESCRIPTION
I am playing around with a custom sensor which I query using I2C. The sensor runs off a rp2040 which acts as the I2C target in this case. I wrote the code in CircuitPython for convenience, unfortunately my logic analyser shows the response time from the rp2040 to a read request is routinely in the 4ms to 6ms range which trips Klipper's hardcoded I2C timeout.

In this PR I made the timeout configurable in klippy and added the `i2c_timeout` config option which defaults to `5000` (the formerly hardcoded timeout value).