### PR TITLE
tmc: Query latest value during _init_registers()

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -262,7 +262,8 @@ class TMCCommandHelper:
                                    desc=self.cmd_SET_TMC_CURRENT_help)
     def _init_registers(self, print_time=None):
         # Send registers
-        for reg_name, val in self.fields.registers.items():
+        for reg_name in list(self.fields.registers.keys()):
+            val = self.fields.registers[reg_name] # Val may change during loop
             self.mcu_tmc.set_register(reg_name, val, print_time)
     cmd_INIT_TMC_help = "Initialize TMC stepper driver registers"
     def cmd_INIT_TMC(self, gcmd):


### PR DESCRIPTION
The set_register() code may block, and it therefore may be possible that the loop in _init_registers() could occur in parallel with other updates.  That could result in a "OrderedDict mutated during iteration" error.

Avoid the error by querying the latest value during each iteration of the loop.

Error reported at https://klipper.discourse.group/t/unhandled-exception-during-run-z-hop/11580 and https://klipper.discourse.group/t/sensorless-homing-x-returns-unhandled-exception-during-run/9844

-Kevin