### PR TITLE
exclude_object: Fix use of deprecated gcmd.respond_error()

### DIFF
--- a/klippy/extras/exclude_object.py
+++ b/klippy/extras/exclude_object.py
@@ -234,7 +234,7 @@ class ExcludeObject:
 
         elif current:
             if not self.current_object:
-                gcmd.respond_error('There is no current object to cancel')
+                raise self.gcode.error('There is no current object to cancel')
 
             else:
                 self._exclude_object(self.current_object)


### PR DESCRIPTION
gcmd.respond_error() has been deprecated: https://github.com/Klipper3d/klipper/commit/61524542d20e50c4866836d6ed23ca03521ffb15

Signed-off-by: Andrei Ignat <andrei@ignat.se>