### PR TITLE
bed_mesh: Restore originally-saved profiles on BED_MESH_CLEAR

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -87,6 +87,7 @@ def parse_gcmd_coord(gcmd, name):
 class BedMesh:
     FADE_DISABLE = 0x7FFFFFFF
     def __init__(self, config):
+        self.name = config.get_name()
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
@@ -264,6 +265,13 @@ class BedMesh:
             gcmd.respond_info("Bed has not been probed")
     cmd_BED_MESH_CLEAR_help = "Clear the Mesh so no z-adjustment is made"
     def cmd_BED_MESH_CLEAR(self, gcmd):
+        # Remove the current bed mesh profile from the config file.
+        # We do this because BedMeshCalibrate.probe_finalize() updates
+        # the config file, which can lead to the wrong mesh being saved.
+        profile_name = self.pmgr.get_current_profile()
+        configfile = self.printer.lookup_object('configfile')
+        cfg_name = self.name + " " + profile_name
+        configfile.remove_section(cfg_name)
         self.set_mesh(None)
     cmd_BED_MESH_OFFSET_help = "Add X/Y offsets to the mesh lookup"
     def cmd_BED_MESH_OFFSET(self, gcmd):


### PR DESCRIPTION
BedMeshCalibrate.probe_finalize() updates the config file with the newly generated mesh data. That method is called during the completion of meshing. This means that every BED_MESH_CALIBRATE command updates the config file with new mesh data.

This can lead to mesh profiles being unintentionally overwritten. This can happen because BED_MESH_CLEAR does not restore the old mesh data in the config file. So, if a user runs the following commands:

   BED_MESH_CALIBRATE
   BED_MESH_CLEAR
   ...
   SAVE_CONFIG

the mesh will be saved despite the user having run BED_MESH_CLEAR.

Fortunately, the newly generated bedmesh is stored in a separate section of the config that holds pending changes. Therefore, all that is needed in order to avoid storing a bed mesh is to remove the section for the current profile, which removes it from the set of pending changes.