### PR TITLE
Rework toolhead and move_queue flushing

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20231208: Several undocumented config parameters in the `[printer]`
+config section have been removed (the buffer_time_low,
+buffer_time_high, buffer_time_start, and move_flush_time parameters).
+
 20230826: If `safe_distance` is set or calculated to be 0 in `[dual_carriage]`,
 the carriages proximity checks will be disabled as per documentation. A user
 may wish to configure `safe_distance` explicitly to prevent accidental crashes

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -143,6 +143,8 @@ class PrinterOutputPin:
         self.mcu_pin.set_pwm(print_time, value)
         self.last_value = value
         self.last_print_time = print_time
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.note_kinematic_activity(print_time)
     cmd_SET_PIN_help = "Set the value of an output pin"
     def cmd_SET_PIN(self, gcmd):
         # Read requested value


### PR DESCRIPTION
This PR fixes "Timer too close" errors in the pwm_tool module when SET_PIN commands are issued while the toolhead is idle.  (And also likely fixes similar errors that may occur with "MANUAL_STEPPER SYNC=0" commands.)

Previously, the toolhead code would only manage flushing of the lookahead, kinematic, and mcu move_queues while the toolhead was in an active state.  Once the lookahead queue becomes empty, the toolhead would disable its internal flushing timers.  This PR reworks the toolhead code so that the its flush timer will stay active any time there is data in any of the kinematic queues, regardless of the lookahead state.

@Cirromulus , @dmbutyugin - FYI.

-Kevin