### PR TITLE
avr: enable low-level menuconfig options for 328 and 328p

### DIFF
--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -11,7 +11,7 @@ config AVR_SELECT
     select HAVE_GPIO_I2C
     select HAVE_GPIO_HARD_PWM
     select HAVE_STRICT_TIMING
-    select HAVE_LIMITED_CODE_SIZE if MACH_atmega168
+    select HAVE_LIMITED_CODE_SIZE if MACH_atmega168 || MACH_atmega328 || MACH_atmega328p
 
 config BOARD_DIRECTORY
     string


### PR DESCRIPTION
Enable low-level menuconfig options for 328 and 328p

Signed-off-by: Andrei Kozhevnikov <coderusinbox@gmail.com>