### PR TITLE
kinematics: Fix "Unable to infer active extruder stepper" errors.

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -69,6 +69,7 @@ class ExtruderStepper:
         self.stepper.set_position([extruder.last_position, 0., 0.])
         self.stepper.set_trapq(extruder.get_trapq())
         self.motion_queue = extruder_name
+        extruder.extruder_stepper = self
     def _set_pressure_advance(self, pressure_advance, smooth_time):
         old_smooth_time = self.pressure_advance_smooth_time
         if not self.pressure_advance:


### PR DESCRIPTION
# Background

x-in-1-out hotend configurations currently require naming the tool in the slicer and adding an extra `extruder=...` paramter to SET_PRESSURE_ADVANCE g-code. Failure to add the parameter results in *Unable to infer active extruder stepper* errors and aborted prints on the first tool change (at least with PrusaSlicer-like software).

As the error message states, there is an attempt to infer the value, but currently the value of printer.toolhead.extruder.extruder_stepper is _always_ the primary extruder_stepper (the one named "extruder").

This updates the sync_to_extruder method so the printer model is kept consistent with the currently active extruder_stepper by assigning it to the PrinterExtruder.