### PR TITLE
config: Update printer-sovol-sv06-2022.cfg to stock

### DIFF
--- a/config/printer-sovol-sv06-2022.cfg
+++ b/config/printer-sovol-sv06-2022.cfg
@@ -28,7 +28,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 position_endstop: 0
-position_max: 225
+position_max: 220
 homing_speed: 40
 homing_retract_dist: 0
 
@@ -50,7 +50,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 0
-position_max: 225
+position_max: 220
 homing_speed: 40
 homing_retract_dist: 0
 
@@ -72,7 +72,7 @@ microsteps: 16
 rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
 position_min: -4
-position_max: 261
+position_max: 250
 homing_speed: 4
 
 [tmc2209 stepper_z]


### PR DESCRIPTION
This printer is advertised as having a 220\*220\*250mm build volume.

Signed-off-by: Bassam Husain bassamanator.2cj4t@simplelogin.com