### PR TITLE
Simplify integer "upconversion" host code

### DIFF
--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -222,12 +222,11 @@ handle_message(struct serialqueue *sq, double eventtime, int len)
     pthread_mutex_lock(&sq->lock);
 
     // Calculate receive sequence number
-    uint64_t rseq = ((sq->receive_seq & ~MESSAGE_SEQ_MASK)
-                     | (sq->input_buf[MESSAGE_POS_SEQ] & MESSAGE_SEQ_MASK));
+    uint32_t rseq_delta = ((sq->input_buf[MESSAGE_POS_SEQ] - sq->receive_seq)
+                           & MESSAGE_SEQ_MASK);
+    uint64_t rseq = sq->receive_seq + rseq_delta;
     if (rseq != sq->receive_seq) {
         // New sequence number
-        if (rseq < sq->receive_seq)
-            rseq += MESSAGE_SEQ_MASK+1;
         if (rseq > sq->send_seq && sq->receive_seq != 1) {
             // An ack for a message not sent?  Out of order message?
             sq->bytes_invalid += len;

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -66,10 +66,8 @@ class ClockSync:
         self.queries_pending = 0
         # Extend clock to 64bit
         last_clock = self.last_clock
-        clock = (last_clock & ~0xffffffff) | params['clock']
-        if clock < last_clock:
-            clock += 0x100000000
-        self.last_clock = clock
+        clock_delta = (params['clock'] - last_clock) & 0xffffffff
+        self.last_clock = clock = last_clock + clock_delta
         # Check if this is the best round-trip-time seen so far
         sent_time = params['#sent_time']
         if not sent_time:
@@ -138,10 +136,9 @@ class ClockSync:
     # misc commands
     def clock32_to_clock64(self, clock32):
         last_clock = self.last_clock
-        clock_diff = (last_clock - clock32) & 0xffffffff
-        if clock_diff & 0x80000000:
-            return last_clock + 0x100000000 - clock_diff
-        return last_clock - clock_diff
+        clock_diff = (clock32 - last_clock) & 0xffffffff
+        clock_diff -= (clock_diff & 0x80000000) << 1
+        return last_clock + clock_diff
     def is_active(self):
         return self.queries_pending <= 4
     def dump_debug(self):

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -57,10 +57,9 @@ class MCU_buttons:
     def handle_buttons_state(self, params):
         # Expand the message ack_count from 8-bit
         ack_count = self.ack_count
-        ack_diff = (ack_count - params['ack_count']) & 0xff
-        if ack_diff & 0x80:
-            ack_diff -= 0x100
-        msg_ack_count = ack_count - ack_diff
+        ack_diff = (params['ack_count'] - ack_count) & 0xff
+        ack_diff -= (ack_diff & 0x80) << 1
+        msg_ack_count = ack_count + ack_diff
         # Determine new buttons
         buttons = bytearray(params['state'])
         new_count = msg_ack_count + len(buttons) - self.ack_count

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -118,9 +118,9 @@ class LIS2DW:
         count = seq = 0
         samples = [None] * (len(raw_samples) * SAMPLES_PER_BLOCK)
         for params in raw_samples:
-            seq_diff = (last_sequence - params['sequence']) & 0xffff
+            seq_diff = (params['sequence'] - last_sequence) & 0xffff
             seq_diff -= (seq_diff & 0x8000) << 1
-            seq = last_sequence - seq_diff
+            seq = last_sequence + seq_diff
             d = bytearray(params['data'])
             msg_cdiff = seq * SAMPLES_PER_BLOCK - chip_base
 
@@ -156,15 +156,11 @@ class LIS2DW:
         else:
             raise self.printer.command_error("Unable to query lis2dw fifo")
         mcu_clock = self.mcu.clock32_to_clock64(params['clock'])
-        sequence = (self.last_sequence & ~0xffff) | params['next_sequence']
-        if sequence < self.last_sequence:
-            sequence += 0x10000
-        self.last_sequence = sequence
+        seq_diff = (params['next_sequence'] - self.last_sequence) & 0xffff
+        self.last_sequence += seq_diff
         buffered = params['buffered']
-        limit_count = (self.last_limit_count & ~0xffff) | params['limit_count']
-        if limit_count < self.last_limit_count:
-            limit_count += 0x10000
-        self.last_limit_count = limit_count
+        lc_diff = (params['limit_count'] - self.last_limit_count) & 0xffff
+        self.last_limit_count += lc_diff
         duration = params['query_ticks']
         if duration > self.max_query_duration:
             # Skip measurement as a high query time could skew clock tracking
@@ -172,7 +168,7 @@ class LIS2DW:
                                           self.mcu.seconds_to_clock(.000005))
             return
         self.max_query_duration = 2 * duration
-        msg_count = (sequence * SAMPLES_PER_BLOCK
+        msg_count = (self.last_sequence * SAMPLES_PER_BLOCK
                      + buffered // BYTES_PER_SAMPLE + fifo)
         # The "chip clock" is the message counter plus .5 for average
         # inaccuracy of query responses and plus .5 for assumed offset

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -132,9 +132,9 @@ class MPU9250:
         count = seq = 0
         samples = [None] * (len(raw_samples) * SAMPLES_PER_BLOCK)
         for params in raw_samples:
-            seq_diff = (last_sequence - params['sequence']) & 0xffff
+            seq_diff = (params['sequence'] - last_sequence) & 0xffff
             seq_diff -= (seq_diff & 0x8000) << 1
-            seq = last_sequence - seq_diff
+            seq = last_sequence + seq_diff
             d = bytearray(params['data'])
             msg_cdiff = seq * SAMPLES_PER_BLOCK - chip_base
 
@@ -168,15 +168,11 @@ class MPU9250:
         else:
             raise self.printer.command_error("Unable to query mpu9250 fifo")
         mcu_clock = self.mcu.clock32_to_clock64(params['clock'])
-        sequence = (self.last_sequence & ~0xffff) | params['next_sequence']
-        if sequence < self.last_sequence:
-            sequence += 0x10000
-        self.last_sequence = sequence
+        seq_diff = (params['next_sequence'] - self.last_sequence) & 0xffff
+        self.last_sequence += seq_diff
         buffered = params['buffered']
-        limit_count = (self.last_limit_count & ~0xffff) | params['limit_count']
-        if limit_count < self.last_limit_count:
-            limit_count += 0x10000
-        self.last_limit_count = limit_count
+        lc_diff = (params['limit_count'] - self.last_limit_count) & 0xffff
+        self.last_limit_count += lc_diff
         duration = params['query_ticks']
         if duration > self.max_query_duration:
             # Skip measurement as a high query time could skew clock tracking
@@ -184,7 +180,7 @@ class MPU9250:
                                           self.mcu.seconds_to_clock(.000005))
             return
         self.max_query_duration = 2 * duration
-        msg_count = (sequence * SAMPLES_PER_BLOCK
+        msg_count = (self.last_sequence * SAMPLES_PER_BLOCK
                      + buffered // BYTES_PER_SAMPLE + fifo)
         # The "chip clock" is the message counter plus .5 for average
         # inaccuracy of query responses and plus .5 for assumed offset


### PR DESCRIPTION
Various parts of the host code will convert a 32bit (or 16bit or 4bit) counter from the mcu to an internal integer counter that does not overflow.  However, that code often implements that "upconversion" in slightly different ways.  That can be confusing.

This PR reworks the code to use the same general format for these conversions.  The general method often simplifies the code as well.

@garethky - fyi.

-Kevin