### PR TITLE
Makefile: Use C preprocessor from the target toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LD=$(CROSS_PREFIX)ld
 OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
-CPP=cpp
+CPP=$(CROSS_PREFIX)cpp
 PYTHON=python3
 
 # Source files


### PR DESCRIPTION
C preprocessor coming with the host toolchain may not understand the command-line syntax for preprocessing linker scripts.

Closes #6421