### PR TITLE
feature: shutdown klipper when fan failure

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,9 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240102: If any fan tachometer is configured but no speed signal is received,
+now Klipper will shutdown to avoid any hardware damage.
+
 20231216: The `[hall_filament_width_sensor]` is changed to trigger filament runout
 when the thickness of the filament exceeds `max_diameter`. The maximum diameter
 defaults to `default_nominal_filament_diameter + max_difference`. See

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2693,6 +2693,8 @@ pin:
 #tachometer_pin:
 #   Tachometer input pin for monitoring fan speed. A pullup is generally
 #   required. This parameter is optional.
+#   If tachometer is configured but no speed signal received,
+#   klipper will shutdown to avoid any hardware damage
 #tachometer_ppr: 2
 #   When tachometer_pin is specified, this is the number of pulses per
 #   revolution of the tachometer signal. For a BLDC fan this is


### PR DESCRIPTION
Shutdown Klipper when tachometer cannot receive the speed signal

Tachometer only reads the fan speed (maybe displayed in some places) for now, Monitoring fan speed and turning off printer when fan fails helps avoid hardware damage and additional looses

code has been tested on my printer and everything works fine.

related pr: https://github.com/Klipper3d/klipper/pull/6364

PS: English is not my native language, please ignore any grammar issues, and I would be very pleased if you point out my issue.

Signed-off-by: Dayong Wang <wuyoutech@gmail.com>
