### PR TITLE
virtual_sdcard: Open file in utf-8 encoding

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -177,7 +177,7 @@ class VirtualSD:
             if fname not in flist:
                 fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
-            f = io.open(fname, 'r', newline='')
+            f = io.open(fname, 'r', newline='', encoding='utf-8')
             f.seek(0, os.SEEK_END)
             fsize = f.tell()
             f.seek(0)


### PR DESCRIPTION
When printing file with utf-8 comments in it, pause/resume breaks printing process, it tries to resume at wrong position, caused by utf-8 (or utf-16) characters byte size.

```
00:12:07  // Unknown command:"F30000"
00:12:40  // Unknown command:"Y109.644"
00:13:04  // Unknown command:"ERIMETER"
00:13:33  // Unknown command:"Y117.633"
00:14:17  // Unknown command:"Y107.81"
```

This simple PR fixes issue