### PR TITLE
Update LIS2DW example to match current BTT documentation

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -314,8 +314,11 @@ Restart Klipper via the `RESTART` command.
 serial: /dev/serial/by-id/usb-Klipper_rp2040_<mySerial>
 
 [lis2dw]
-cs_pin: lis:gpio1
-spi_bus: spi0a
+cs_pin: lis:gpio9
+#spi_bus: spi0a
+spi_software_sclk_pin: lis:gpio10
+spi_software_mosi_pin: lis:gpio11
+spi_software_miso_pin: lis:gpio8
 axes_map: x,z,y
 
 [resonance_tester]


### PR DESCRIPTION
As found while testing my own BTT S2DW board, the klipper doc example was using wrong pins (and method?).