### PR TITLE
Simplification of host bulk sensor code

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -220,9 +220,9 @@ class ADXL345:
         self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("adxl345/dump_adxl345", "sensor", self.name,
-                                 self._handle_dump_adxl345)
+        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
+        self.api_dump.add_mux_endpoint("adxl345/dump_adxl345", "sensor",
+                                       self.name, {'header': hdr})
     def _build_config(self):
         cmdqueue = self.spi.get_command_queue()
         self.query_adxl345_cmd = self.mcu.lookup_command(
@@ -345,10 +345,6 @@ class ADXL345:
             self._start_measurements()
         else:
             self._finish_measurements()
-    def _handle_dump_adxl345(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
-        web_request.send({'header': hdr})
     def start_internal_client(self):
         cconn = self.api_dump.add_internal_client()
         return AccelQueryHelper(self.printer, cconn)

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, time, collections, multiprocessing, os
-from . import bus, motion_report, bulk_sensor
+from . import bus, bulk_sensor
 
 # ADXL345 registers
 REG_DEVID = 0x00
@@ -217,7 +217,7 @@ class ADXL345:
                                                           BYTES_PER_SAMPLE)
         self.last_error_count = 0
         # API server endpoints
-        self.api_dump = motion_report.APIDumpHelper(
+        self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
         wh = self.printer.lookup_object('webhooks')

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, time, collections, threading, multiprocessing, os
-from . import bus, motion_report
+from . import bus, motion_report, bulk_sensor
 
 # ADXL345 registers
 REG_DEVID = 0x00
@@ -173,58 +173,12 @@ class AccelCommandHelper:
         val = gcmd.get("VAL", minval=0, maxval=255, parser=lambda x: int(x, 0))
         self.chip.set_reg(reg, val)
 
-# Helper class for chip clock synchronization via linear regression
-class ClockSyncRegression:
-    def __init__(self, mcu, chip_clock_smooth, decay = 1. / 20.):
-        self.mcu = mcu
-        self.chip_clock_smooth = chip_clock_smooth
-        self.decay = decay
-        self.last_chip_clock = self.last_exp_mcu_clock = 0.
-        self.mcu_clock_avg = self.mcu_clock_variance = 0.
-        self.chip_clock_avg = self.chip_clock_covariance = 0.
-    def reset(self, mcu_clock, chip_clock):
-        self.mcu_clock_avg = self.last_mcu_clock = mcu_clock
-        self.chip_clock_avg = chip_clock
-        self.mcu_clock_variance = self.chip_clock_covariance = 0.
-        self.last_chip_clock = self.last_exp_mcu_clock = 0.
-    def update(self, mcu_clock, chip_clock):
-        # Update linear regression
-        decay = self.decay
-        diff_mcu_clock = mcu_clock - self.mcu_clock_avg
-        self.mcu_clock_avg += decay * diff_mcu_clock
-        self.mcu_clock_variance = (1. - decay) * (
-            self.mcu_clock_variance + diff_mcu_clock**2 * decay)
-        diff_chip_clock = chip_clock - self.chip_clock_avg
-        self.chip_clock_avg += decay * diff_chip_clock
-        self.chip_clock_covariance = (1. - decay) * (
-            self.chip_clock_covariance + diff_mcu_clock*diff_chip_clock*decay)
-    def set_last_chip_clock(self, chip_clock):
-        base_mcu, base_chip, inv_cfreq = self.get_clock_translation()
-        self.last_chip_clock = chip_clock
-        self.last_exp_mcu_clock = base_mcu + (chip_clock-base_chip) * inv_cfreq
-    def get_clock_translation(self):
-        inv_chip_freq = self.mcu_clock_variance / self.chip_clock_covariance
-        if not self.last_chip_clock:
-            return self.mcu_clock_avg, self.chip_clock_avg, inv_chip_freq
-        # Find mcu clock associated with future chip_clock
-        s_chip_clock = self.last_chip_clock + self.chip_clock_smooth
-        scdiff = s_chip_clock - self.chip_clock_avg
-        s_mcu_clock = self.mcu_clock_avg + scdiff * inv_chip_freq
-        # Calculate frequency to converge at future point
-        mdiff = s_mcu_clock - self.last_exp_mcu_clock
-        s_inv_chip_freq = mdiff / self.chip_clock_smooth
-        return self.last_exp_mcu_clock, self.last_chip_clock, s_inv_chip_freq
-    def get_time_translation(self):
-        base_mcu, base_chip, inv_cfreq = self.get_clock_translation()
-        clock_to_print_time = self.mcu.clock_to_print_time
-        base_time = clock_to_print_time(base_mcu)
-        inv_freq = clock_to_print_time(base_mcu + inv_cfreq) - base_time
-        return base_time, base_chip, inv_freq
-
 MIN_MSG_TIME = 0.100
 
 BYTES_PER_SAMPLE = 5
 SAMPLES_PER_BLOCK = 10
+
+API_UPDATES = 0.100
 
 # Printer class that controls ADXL345 chip
 class ADXL345:
@@ -259,10 +213,11 @@ class ADXL345:
         # Clock tracking
         self.last_sequence = self.max_query_duration = 0
         self.last_limit_count = self.last_error_count = 0
-        self.clock_sync = ClockSyncRegression(self.mcu, 640)
+        chip_smooth = self.data_rate * API_UPDATES * 2
+        self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
         # API server endpoints
         self.api_dump = motion_report.APIDumpHelper(
-            self.printer, self._api_update, self._api_startstop, 0.100)
+            self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
         wh = self.printer.lookup_object('webhooks')
         wh.register_mux_endpoint("adxl345/dump_adxl345", "sensor", self.name,

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -1,6 +1,6 @@
 # Support for reading acceleration data from an adxl345 chip
 #
-# Copyright (C) 2020-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020-2023  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, time, collections, multiprocessing, os
@@ -208,10 +208,11 @@ class ADXL345:
         mcu.register_config_callback(self._build_config)
         self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, "adxl345_data", oid)
         # Clock tracking
-        self.last_sequence = self.max_query_duration = 0
-        self.last_limit_count = self.last_error_count = 0
         chip_smooth = self.data_rate * API_UPDATES * 2
         self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
+        self.clock_updater = bulk_sensor.ChipClockUpdater(self.clock_sync,
+                                                          BYTES_PER_SAMPLE)
+        self.last_error_count = 0
         # API server endpoints
         self.api_dump = motion_report.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
@@ -250,7 +251,7 @@ class ADXL345:
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
-        last_sequence = self.last_sequence
+        last_sequence = self.clock_updater.get_last_sequence()
         time_base, chip_base, inv_freq = self.clock_sync.get_time_translation()
         # Process every message in raw_samples
         count = seq = 0
@@ -291,26 +292,7 @@ class ADXL345:
                 break
         else:
             raise self.printer.command_error("Unable to query adxl345 fifo")
-        mcu_clock = self.mcu.clock32_to_clock64(params['clock'])
-        seq_diff = (params['next_sequence'] - self.last_sequence) & 0xffff
-        self.last_sequence += seq_diff
-        buffered = params['buffered']
-        lc_diff = (params['limit_count'] - self.last_limit_count) & 0xffff
-        self.last_limit_count += lc_diff
-        duration = params['query_ticks']
-        if duration > self.max_query_duration:
-            # Skip measurement as a high query time could skew clock tracking
-            self.max_query_duration = max(2 * self.max_query_duration,
-                                          self.mcu.seconds_to_clock(.000005))
-            return
-        self.max_query_duration = 2 * duration
-        msg_count = (self.last_sequence * SAMPLES_PER_BLOCK
-                     + buffered // BYTES_PER_SAMPLE + fifo)
-        # The "chip clock" is the message counter plus .5 for average
-        # inaccuracy of query responses and plus .5 for assumed offset
-        # of adxl345 hw processing time.
-        chip_clock = msg_count + 1
-        self.clock_sync.update(mcu_clock + duration // 2, chip_clock)
+        self.clock_updater.update_clock(params)
     def _start_measurements(self):
         if self.is_measuring():
             return
@@ -340,12 +322,10 @@ class ADXL345:
                                     reqclock=reqclock)
         logging.info("ADXL345 starting '%s' measurements", self.name)
         # Initialize clock tracking
-        self.last_sequence = 0
-        self.last_limit_count = self.last_error_count = 0
-        self.clock_sync.reset(reqclock, 0)
-        self.max_query_duration = 1 << 31
+        self.clock_updater.note_start(reqclock)
         self._update_clock(minclock=reqclock)
-        self.max_query_duration = 1 << 31
+        self.clock_updater.clear_duration_filter()
+        self.last_error_count = 0
     def _finish_measurements(self):
         if not self.is_measuring():
             return
@@ -364,7 +344,7 @@ class ADXL345:
         if not samples:
             return {}
         return {'data': samples, 'errors': self.last_error_count,
-                'overflows': self.last_limit_count}
+                'overflows': self.clock_updater.get_last_limit_count()}
     def _api_startstop(self, is_start):
         if is_start:
             self._start_measurements()

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -187,7 +187,7 @@ MIN_MSG_TIME = 0.100
 BYTES_PER_SAMPLE = 5
 SAMPLES_PER_BLOCK = 10
 
-API_UPDATES = 0.100
+BATCH_UPDATES = 0.100
 
 # Printer class that controls ADXL345 chip
 class ADXL345:
@@ -211,18 +211,19 @@ class ADXL345:
         mcu.register_config_callback(self._build_config)
         self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, "adxl345_data", oid)
         # Clock tracking
-        chip_smooth = self.data_rate * API_UPDATES * 2
+        chip_smooth = self.data_rate * BATCH_UPDATES * 2
         self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
         self.clock_updater = bulk_sensor.ChipClockUpdater(self.clock_sync,
                                                           BYTES_PER_SAMPLE)
         self.last_error_count = 0
-        # API server endpoints
-        self.api_dump = bulk_sensor.APIDumpHelper(
-            self.printer, self._api_update, self._api_startstop, API_UPDATES)
+        # Process messages in batches
+        self.batch_bulk = bulk_sensor.BatchBulkHelper(
+            self.printer, self._process_batch,
+            self._start_measurements, self._finish_measurements, BATCH_UPDATES)
         self.name = config.get_name().split()[-1]
         hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
-        self.api_dump.add_mux_endpoint("adxl345/dump_adxl345", "sensor",
-                                       self.name, {'header': hdr})
+        self.batch_bulk.add_mux_endpoint("adxl345/dump_adxl345", "sensor",
+                                         self.name, {'header': hdr})
     def _build_config(self):
         cmdqueue = self.spi.get_command_queue()
         self.query_adxl345_cmd = self.mcu.lookup_command(
@@ -248,7 +249,10 @@ class ADXL345:
                     "This is generally indicative of connection problems "
                     "(e.g. faulty wiring) or a faulty adxl345 chip." % (
                         reg, val, stored_val))
-    # Measurement collection
+    def start_internal_client(self):
+        cconn = self.batch_bulk.add_internal_client()
+        return AccelQueryHelper(self.printer, cconn)
+    # Measurement decoding
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
@@ -294,6 +298,7 @@ class ADXL345:
         else:
             raise self.printer.command_error("Unable to query adxl345 fifo")
         self.clock_updater.update_clock(params)
+    # Start, stop, and process message batches
     def _start_measurements(self):
         # In case of miswiring, testing ADXL345 device ID prevents treating
         # noise or wrong signal as a correctly initialized device
@@ -329,8 +334,7 @@ class ADXL345:
         params = self.query_adxl345_end_cmd.send([self.oid, 0, 0])
         self.bulk_queue.clear_samples()
         logging.info("ADXL345 finished '%s' measurements", self.name)
-    # API interface
-    def _api_update(self, eventtime):
+    def _process_batch(self, eventtime):
         self._update_clock()
         raw_samples = self.bulk_queue.pull_samples()
         if not raw_samples:
@@ -340,14 +344,6 @@ class ADXL345:
             return {}
         return {'data': samples, 'errors': self.last_error_count,
                 'overflows': self.clock_updater.get_last_limit_count()}
-    def _api_startstop(self, is_start):
-        if is_start:
-            self._start_measurements()
-        else:
-            self._finish_measurements()
-    def start_internal_client(self):
-        cconn = self.api_dump.add_internal_client()
-        return AccelQueryHelper(self.printer, cconn)
 
 def load_config(config):
     return ADXL345(config)

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
-from . import bus, motion_report, bulk_sensor
+from . import bus, bulk_sensor
 
 MIN_MSG_TIME = 0.100
 TCODE_ERROR = 0xff
@@ -441,7 +441,7 @@ class Angle:
         mcu.register_config_callback(self._build_config)
         self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, "spi_angle_data", oid)
         # API server endpoints
-        self.api_dump = motion_report.APIDumpHelper(
+        self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, 0.100)
         self.name = config.get_name().split()[1]
         wh = self.printer.lookup_object('webhooks')

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -444,9 +444,9 @@ class Angle:
         self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, 0.100)
         self.name = config.get_name().split()[1]
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("angle/dump_angle", "sensor", self.name,
-                                 self._handle_dump_angle)
+        api_resp = {'header': ('time', 'angle')}
+        self.api_dump.add_mux_endpoint("angle/dump_angle", "sensor", self.name,
+                                       api_resp)
     def _build_config(self):
         freq = self.mcu.seconds_to_clock(1.)
         while float(TCODE_ERROR << self.time_shift) / freq < 0.002:
@@ -553,10 +553,6 @@ class Angle:
             self._start_measurements()
         else:
             self._finish_measurements()
-    def _handle_dump_angle(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('time', 'angle')
-        web_request.send({'header': hdr})
     def start_internal_client(self):
         return self.api_dump.add_internal_client()
 

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -458,8 +458,6 @@ class Angle:
     def get_status(self, eventtime=None):
         return {'temperature': self.sensor_helper.last_temperature}
     # Measurement collection
-    def is_measuring(self):
-        return self.start_clock != 0
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below
         sample_ticks = self.sample_ticks
@@ -527,8 +525,6 @@ class Angle:
         return {'data': samples, 'errors': error_count,
                 'position_offset': offset}
     def _start_measurements(self):
-        if self.is_measuring():
-            return
         logging.info("Starting angle '%s' measurements", self.name)
         self.sensor_helper.start()
         # Start bulk reading
@@ -542,11 +538,8 @@ class Angle:
         self.query_spi_angle_cmd.send([self.oid, reqclock, rest_ticks,
                                        self.time_shift], reqclock=reqclock)
     def _finish_measurements(self):
-        if not self.is_measuring():
-            return
         # Halt bulk reading
         params = self.query_spi_angle_end_cmd.send([self.oid, 0, 0, 0])
-        self.start_clock = 0
         self.bulk_queue.clear_samples()
         self.sensor_helper.last_temperature = None
         logging.info("Stopped angle '%s' measurements", self.name)

--- a/klippy/extras/bulk_sensor.py
+++ b/klippy/extras/bulk_sensor.py
@@ -1,0 +1,53 @@
+# Tools for reading bulk sensor data from the mcu
+#
+# Copyright (C) 2020-2023  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+# Helper class for chip clock synchronization via linear regression
+class ClockSyncRegression:
+    def __init__(self, mcu, chip_clock_smooth, decay = 1. / 20.):
+        self.mcu = mcu
+        self.chip_clock_smooth = chip_clock_smooth
+        self.decay = decay
+        self.last_chip_clock = self.last_exp_mcu_clock = 0.
+        self.mcu_clock_avg = self.mcu_clock_variance = 0.
+        self.chip_clock_avg = self.chip_clock_covariance = 0.
+    def reset(self, mcu_clock, chip_clock):
+        self.mcu_clock_avg = self.last_mcu_clock = mcu_clock
+        self.chip_clock_avg = chip_clock
+        self.mcu_clock_variance = self.chip_clock_covariance = 0.
+        self.last_chip_clock = self.last_exp_mcu_clock = 0.
+    def update(self, mcu_clock, chip_clock):
+        # Update linear regression
+        decay = self.decay
+        diff_mcu_clock = mcu_clock - self.mcu_clock_avg
+        self.mcu_clock_avg += decay * diff_mcu_clock
+        self.mcu_clock_variance = (1. - decay) * (
+            self.mcu_clock_variance + diff_mcu_clock**2 * decay)
+        diff_chip_clock = chip_clock - self.chip_clock_avg
+        self.chip_clock_avg += decay * diff_chip_clock
+        self.chip_clock_covariance = (1. - decay) * (
+            self.chip_clock_covariance + diff_mcu_clock*diff_chip_clock*decay)
+    def set_last_chip_clock(self, chip_clock):
+        base_mcu, base_chip, inv_cfreq = self.get_clock_translation()
+        self.last_chip_clock = chip_clock
+        self.last_exp_mcu_clock = base_mcu + (chip_clock-base_chip) * inv_cfreq
+    def get_clock_translation(self):
+        inv_chip_freq = self.mcu_clock_variance / self.chip_clock_covariance
+        if not self.last_chip_clock:
+            return self.mcu_clock_avg, self.chip_clock_avg, inv_chip_freq
+        # Find mcu clock associated with future chip_clock
+        s_chip_clock = self.last_chip_clock + self.chip_clock_smooth
+        scdiff = s_chip_clock - self.chip_clock_avg
+        s_mcu_clock = self.mcu_clock_avg + scdiff * inv_chip_freq
+        # Calculate frequency to converge at future point
+        mdiff = s_mcu_clock - self.last_exp_mcu_clock
+        s_inv_chip_freq = mdiff / self.chip_clock_smooth
+        return self.last_exp_mcu_clock, self.last_chip_clock, s_inv_chip_freq
+    def get_time_translation(self):
+        base_mcu, base_chip, inv_cfreq = self.get_clock_translation()
+        clock_to_print_time = self.mcu.clock_to_print_time
+        base_time = clock_to_print_time(base_mcu)
+        inv_freq = clock_to_print_time(base_mcu + inv_cfreq) - base_time
+        return base_time, base_chip, inv_freq

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -42,12 +42,7 @@ class LIS2DW:
     def __init__(self, config):
         self.printer = config.get_printer()
         adxl345.AccelCommandHelper(config, self)
-        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
-              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
-        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
-        if any([a not in am for a in axes_map]):
-            raise config.error("Invalid lis2dw axes_map parameter")
-        self.axes_map = [am[a.strip()] for a in axes_map]
+        self.axes_map = adxl345.read_axes_map(config)
         self.data_rate = 1600
         # Setup mcu sensor_lis2dw bulk query code
         self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=5000000)

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -4,8 +4,8 @@
 # Copyright (C) 2020-2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, time, collections, threading, multiprocessing, os
-from . import bus, motion_report, adxl345
+import logging, time, threading, multiprocessing, os
+from . import bus, motion_report, adxl345, bulk_sensor
 
 # LIS2DW registers
 REG_LIS2DW_WHO_AM_I_ADDR = 0x0F
@@ -30,13 +30,12 @@ LIS2DW_DEV_ID = 0x44
 FREEFALL_ACCEL = 9.80665
 SCALE = FREEFALL_ACCEL * 1.952 / 4
 
-Accel_Measurement = collections.namedtuple(
-    'Accel_Measurement', ('time', 'accel_x', 'accel_y', 'accel_z'))
-
 MIN_MSG_TIME = 0.100
 
 BYTES_PER_SAMPLE = 6
 SAMPLES_PER_BLOCK = 8
+
+API_UPDATES = 0.100
 
 # Printer class that controls LIS2DW chip
 class LIS2DW:
@@ -69,10 +68,11 @@ class LIS2DW:
         # Clock tracking
         self.last_sequence = self.max_query_duration = 0
         self.last_limit_count = self.last_error_count = 0
-        self.clock_sync = adxl345.ClockSyncRegression(self.mcu, 640)
+        chip_smooth = self.data_rate * API_UPDATES * 2
+        self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
         # API server endpoints
         self.api_dump = motion_report.APIDumpHelper(
-            self.printer, self._api_update, self._api_startstop, 0.100)
+            self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
         wh = self.printer.lookup_object('webhooks')
         wh.register_mux_endpoint("lis2dw/dump_lis2dw", "sensor", self.name,

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -97,8 +97,9 @@ class LIS2DW:
                     "(e.g. faulty wiring) or a faulty lis2dw chip." % (
                         reg, val, stored_val))
     def start_internal_client(self):
-        cconn = self.bulk_batch.add_internal_client()
-        return adxl345.AccelQueryHelper(self.printer, cconn)
+        aqh = adxl345.AccelQueryHelper(self.printer)
+        self.batch_bulk.add_client(aqh.handle_batch)
+        return aqh
     # Measurement decoding
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-from . import bus, motion_report, adxl345, bulk_sensor
+from . import bus, adxl345, bulk_sensor
 
 # LIS2DW registers
 REG_LIS2DW_WHO_AM_I_ADDR = 0x0F
@@ -63,7 +63,7 @@ class LIS2DW:
                                                           BYTES_PER_SAMPLE)
         self.last_error_count = 0
         # API server endpoints
-        self.api_dump = motion_report.APIDumpHelper(
+        self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
         wh = self.printer.lookup_object('webhooks')

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -66,9 +66,9 @@ class LIS2DW:
         self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("lis2dw/dump_lis2dw", "sensor", self.name,
-                                 self._handle_dump_lis2dw)
+        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
+        self.api_dump.add_mux_endpoint("lis2dw/dump_lis2dw", "sensor",
+                                       self.name, {'header': hdr})
 
     def _build_config(self):
         cmdqueue = self.spi.get_command_queue()
@@ -193,10 +193,6 @@ class LIS2DW:
             self._start_measurements()
         else:
             self._finish_measurements()
-    def _handle_dump_lis2dw(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
-        web_request.send({'header': hdr})
     def start_internal_client(self):
         cconn = self.api_dump.add_internal_client()
         return adxl345.AccelQueryHelper(self.printer, cconn)

--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -14,9 +14,9 @@ class DumpStepper:
         self.mcu_stepper = mcu_stepper
         self.last_api_clock = 0
         self.api_dump = bulk_sensor.APIDumpHelper(printer, self._api_update)
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("motion_report/dump_stepper", "name",
-                                 mcu_stepper.get_name(), self._add_api_client)
+        api_resp = {'header': ('interval', 'count', 'add')}
+        self.api_dump.add_mux_endpoint("motion_report/dump_stepper", "name",
+                                       mcu_stepper.get_name(), api_resp)
     def get_step_queue(self, start_clock, end_clock):
         mcu_stepper = self.mcu_stepper
         res = []
@@ -62,10 +62,6 @@ class DumpStepper:
                 "start_mcu_position": mcu_pos, "step_distance": step_dist,
                 "first_clock": first_clock, "first_step_time": first_time,
                 "last_clock": last_clock, "last_step_time": last_time}
-    def _add_api_client(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('interval', 'count', 'add')
-        web_request.send({'header': hdr})
 
 NEVER_TIME = 9999999999999999.
 
@@ -77,9 +73,10 @@ class DumpTrapQ:
         self.trapq = trapq
         self.last_api_msg = (0., 0.)
         self.api_dump = bulk_sensor.APIDumpHelper(printer, self._api_update)
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("motion_report/dump_trapq", "name", name,
-                                 self._add_api_client)
+        api_resp = {'header': ('time', 'duration', 'start_velocity',
+                               'acceleration', 'start_position', 'direction')}
+        self.api_dump.add_mux_endpoint("motion_report/dump_trapq", "name", name,
+                                       api_resp)
     def extract_trapq(self, start_time, end_time):
         ffi_main, ffi_lib = chelper.get_ffi()
         res = []
@@ -130,11 +127,6 @@ class DumpTrapQ:
             return {}
         self.last_api_msg = d[-1]
         return {"data": d}
-    def _add_api_client(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('time', 'duration', 'start_velocity', 'acceleration',
-               'start_position', 'direction')
-        web_request.send({'header': hdr})
 
 STATUS_REFRESH_TIME = 0.250
 

--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -5,99 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 import chelper
-
-API_UPDATE_INTERVAL = 0.500
-
-# Helper to periodically transmit data to a set of API clients
-class APIDumpHelper:
-    def __init__(self, printer, data_cb, startstop_cb=None,
-                 update_interval=API_UPDATE_INTERVAL):
-        self.printer = printer
-        self.data_cb = data_cb
-        if startstop_cb is None:
-            startstop_cb = (lambda is_start: None)
-        self.startstop_cb = startstop_cb
-        self.is_started = False
-        self.update_interval = update_interval
-        self.update_timer = None
-        self.clients = {}
-    def _stop(self):
-        self.clients.clear()
-        reactor = self.printer.get_reactor()
-        reactor.unregister_timer(self.update_timer)
-        self.update_timer = None
-        if not self.is_started:
-            return reactor.NEVER
-        try:
-            self.startstop_cb(False)
-        except self.printer.command_error as e:
-            logging.exception("API Dump Helper stop callback error")
-            self.clients.clear()
-        self.is_started = False
-        if self.clients:
-            # New client started while in process of stopping
-            self._start()
-        return reactor.NEVER
-    def _start(self):
-        if self.is_started:
-            return
-        self.is_started = True
-        try:
-            self.startstop_cb(True)
-        except self.printer.command_error as e:
-            logging.exception("API Dump Helper start callback error")
-            self.is_started = False
-            self.clients.clear()
-            raise
-        reactor = self.printer.get_reactor()
-        systime = reactor.monotonic()
-        waketime = systime + self.update_interval
-        self.update_timer = reactor.register_timer(self._update, waketime)
-    def add_client(self, web_request):
-        cconn = web_request.get_client_connection()
-        template = web_request.get_dict('response_template', {})
-        self.clients[cconn] = template
-        self._start()
-    def add_internal_client(self):
-        cconn = InternalDumpClient()
-        self.clients[cconn] = {}
-        self._start()
-        return cconn
-    def _update(self, eventtime):
-        try:
-            msg = self.data_cb(eventtime)
-        except self.printer.command_error as e:
-            logging.exception("API Dump Helper data callback error")
-            return self._stop()
-        if not msg:
-            return eventtime + self.update_interval
-        for cconn, template in list(self.clients.items()):
-            if cconn.is_closed():
-                del self.clients[cconn]
-                if not self.clients:
-                    return self._stop()
-                continue
-            tmp = dict(template)
-            tmp['params'] = msg
-            cconn.send(tmp)
-        return eventtime + self.update_interval
-
-# An "internal webhooks" wrapper for using APIDumpHelper internally
-class InternalDumpClient:
-    def __init__(self):
-        self.msgs = []
-        self.is_done = False
-    def get_messages(self):
-        return self.msgs
-    def finalize(self):
-        self.is_done = True
-    def is_closed(self):
-        return self.is_done
-    def send(self, msg):
-        self.msgs.append(msg)
-        if len(self.msgs) >= 10000:
-            # Avoid filling up memory with too many samples
-            self.finalize()
+from . import bulk_sensor
 
 # Extract stepper queue_step messages
 class DumpStepper:
@@ -105,7 +13,7 @@ class DumpStepper:
         self.printer = printer
         self.mcu_stepper = mcu_stepper
         self.last_api_clock = 0
-        self.api_dump = APIDumpHelper(printer, self._api_update)
+        self.api_dump = bulk_sensor.APIDumpHelper(printer, self._api_update)
         wh = self.printer.lookup_object('webhooks')
         wh.register_mux_endpoint("motion_report/dump_stepper", "name",
                                  mcu_stepper.get_name(), self._add_api_client)
@@ -168,7 +76,7 @@ class DumpTrapQ:
         self.name = name
         self.trapq = trapq
         self.last_api_msg = (0., 0.)
-        self.api_dump = APIDumpHelper(printer, self._api_update)
+        self.api_dump = bulk_sensor.APIDumpHelper(printer, self._api_update)
         wh = self.printer.lookup_object('webhooks')
         wh.register_mux_endpoint("motion_report/dump_trapq", "name", name,
                                  self._add_api_client)

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -109,8 +109,9 @@ class MPU9250:
     def set_reg(self, reg, val, minclock=0):
         self.i2c.i2c_write([reg, val & 0xFF], minclock=minclock)
     def start_internal_client(self):
-        cconn = self.batch_bulk.add_internal_client()
-        return adxl345.AccelQueryHelper(self.printer, cconn)
+        aqh = adxl345.AccelQueryHelper(self.printer)
+        self.batch_bulk.add_client(aqh.handle_batch)
+        return aqh
     # Measurement decoding
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -59,12 +59,7 @@ class MPU9250:
     def __init__(self, config):
         self.printer = config.get_printer()
         adxl345.AccelCommandHelper(config, self)
-        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
-              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
-        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
-        if any([a not in am for a in axes_map]):
-            raise config.error("Invalid mpu9250 axes_map parameter")
-        self.axes_map = [am[a.strip()] for a in axes_map]
+        self.axes_map = adxl345.read_axes_map(config)
         self.data_rate = config.getint('rate', 4000)
         if self.data_rate not in SAMPLE_RATE_DIVS:
             raise config.error("Invalid rate parameter: %d" % (self.data_rate,))

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -83,9 +83,9 @@ class MPU9250:
         self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
-        wh = self.printer.lookup_object('webhooks')
-        wh.register_mux_endpoint("mpu9250/dump_mpu9250", "sensor", self.name,
-                                 self._handle_dump_mpu9250)
+        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
+        self.api_dump.add_mux_endpoint("mpu9250/dump_mpu9250", "sensor",
+                                       self.name, {'header': hdr})
     def _build_config(self):
         cmdqueue = self.i2c.get_command_queue()
         self.mcu.add_config_cmd("config_mpu9250 oid=%d i2c_oid=%d"
@@ -207,10 +207,6 @@ class MPU9250:
             self._start_measurements()
         else:
             self._finish_measurements()
-    def _handle_dump_mpu9250(self, web_request):
-        self.api_dump.add_client(web_request)
-        hdr = ('time', 'x_acceleration', 'y_acceleration', 'z_acceleration')
-        web_request.send({'header': hdr})
     def start_internal_client(self):
         cconn = self.api_dump.add_internal_client()
         return adxl345.AccelQueryHelper(self.printer, cconn)

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -80,10 +80,11 @@ class MPU9250:
         mcu.register_config_callback(self._build_config)
         self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, "mpu9250_data", oid)
         # Clock tracking
-        self.last_sequence = self.max_query_duration = 0
-        self.last_limit_count = self.last_error_count = 0
         chip_smooth = self.data_rate * API_UPDATES * 2
         self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
+        self.clock_updater = bulk_sensor.ChipClockUpdater(self.clock_sync,
+                                                          BYTES_PER_SAMPLE)
+        self.last_error_count = 0
         # API server endpoints
         self.api_dump = motion_report.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
@@ -120,7 +121,7 @@ class MPU9250:
     def _extract_samples(self, raw_samples):
         # Load variables to optimize inner loop below
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
-        last_sequence = self.last_sequence
+        last_sequence = self.clock_updater.get_last_sequence()
         time_base, chip_base, inv_freq = self.clock_sync.get_time_translation()
         # Process every message in raw_samples
         count = seq = 0
@@ -152,35 +153,9 @@ class MPU9250:
         return samples
 
     def _update_clock(self, minclock=0):
-        # Query current state
-        for retry in range(5):
-            params = self.query_mpu9250_status_cmd.send([self.oid],
-                                                        minclock=minclock)
-            fifo = params['fifo'] & 0x1fff
-            if fifo <= FIFO_SIZE:
-                break
-        else:
-            raise self.printer.command_error("Unable to query mpu9250 fifo")
-        mcu_clock = self.mcu.clock32_to_clock64(params['clock'])
-        seq_diff = (params['next_sequence'] - self.last_sequence) & 0xffff
-        self.last_sequence += seq_diff
-        buffered = params['buffered']
-        lc_diff = (params['limit_count'] - self.last_limit_count) & 0xffff
-        self.last_limit_count += lc_diff
-        duration = params['query_ticks']
-        if duration > self.max_query_duration:
-            # Skip measurement as a high query time could skew clock tracking
-            self.max_query_duration = max(2 * self.max_query_duration,
-                                          self.mcu.seconds_to_clock(.000005))
-            return
-        self.max_query_duration = 2 * duration
-        msg_count = (self.last_sequence * SAMPLES_PER_BLOCK
-                     + buffered // BYTES_PER_SAMPLE + fifo)
-        # The "chip clock" is the message counter plus .5 for average
-        # inaccuracy of query responses and plus .5 for assumed offset
-        # of mpu9250 hw processing time.
-        chip_clock = msg_count + 1
-        self.clock_sync.update(mcu_clock + duration // 2, chip_clock)
+        params = self.query_mpu9250_status_cmd.send([self.oid],
+                                                    minclock=minclock)
+        self.clock_updater.update_clock(params)
     def _start_measurements(self):
         if self.is_measuring():
             return
@@ -215,12 +190,10 @@ class MPU9250:
                                     reqclock=reqclock)
         logging.info("MPU9250 starting '%s' measurements", self.name)
         # Initialize clock tracking
-        self.last_sequence = 0
-        self.last_limit_count = self.last_error_count = 0
-        self.clock_sync.reset(reqclock, 0)
-        self.max_query_duration = 1 << 31
+        self.clock_updater.note_start(reqclock)
         self._update_clock(minclock=reqclock)
-        self.max_query_duration = 1 << 31
+        self.clock_updater.clear_duration_filter()
+        self.last_error_count = 0
     def _finish_measurements(self):
         if not self.is_measuring():
             return
@@ -242,7 +215,7 @@ class MPU9250:
         if not samples:
             return {}
         return {'data': samples, 'errors': self.last_error_count,
-                'overflows': self.last_limit_count}
+                'overflows': self.clock_updater.get_last_limit_count()}
     def _api_startstop(self, is_start):
         if is_start:
             self._start_measurements()

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -5,7 +5,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, time
-from . import bus, motion_report, adxl345, bulk_sensor
+from . import bus, adxl345, bulk_sensor
 
 MPU9250_ADDR =      0x68
 
@@ -80,7 +80,7 @@ class MPU9250:
                                                           BYTES_PER_SAMPLE)
         self.last_error_count = 0
         # API server endpoints
-        self.api_dump = motion_report.APIDumpHelper(
+        self.api_dump = bulk_sensor.APIDumpHelper(
             self.printer, self._api_update, self._api_startstop, API_UPDATES)
         self.name = config.get_name().split()[-1]
         wh = self.printer.lookup_object('webhooks')


### PR DESCRIPTION
This PR introduces new klippy/extras/bulk_sensor.py code and is intended to simplify the existing adxl345.py, mpu9250.py, lis2dw.py, and angle.py code.  This PR is an internal rework and should not produce a user noticeable change.

The existing host "bulk sensor" modules have a lot of duplicate code.  This makes it harder to maintain these modules, and makes it harder to add new "bulk sensors".  The goal of this PR is to move much of the low-level message handling code to bulk_sensor.py and to keep the per-chip modules focused just on chip specific logic.  Ideally this will make it easier to add future "bulk sensors".

This PR will also facilitate refactoring of the mcu code.  MCU code changes will require users to reflash their MCUs, so I'll plan on introducing those changes in a separate PR.

@garethky - FYI.

-Kevin