### PR TITLE
Fixes for STM32G4 devices

### DIFF
--- a/src/stm32/fdcan.c
+++ b/src/stm32/fdcan.c
@@ -162,10 +162,10 @@ canhw_set_filter(uint32_t id)
     can_filter(1, id);
     can_filter(2, id + 1);
 
-#if CONFIG_MACH_STM32G0
+#if CONFIG_MACH_STM32G0 || CONFIG_MACH_STM32G4
     SOC_CAN->RXGFC = ((id ? 3 : 1) << FDCAN_RXGFC_LSS_Pos
                       | 0x02 << FDCAN_RXGFC_ANFS_Pos);
-#elif CONFIG_MACH_STM32H7 || CONFIG_MAC_STM32G4
+#elif CONFIG_MACH_STM32H7
     uint32_t flssa = (uint32_t)MSG_RAM.FLS - SRAMCAN_BASE;
     SOC_CAN->SIDFC = flssa | ((id ? 3 : 1) << FDCAN_SIDFC_LSS_Pos);
     SOC_CAN->GFC = 0x02 << FDCAN_GFC_ANFS_Pos;
@@ -293,7 +293,7 @@ can_init(void)
 
     SOC_CAN->NBTP = btr;
 
-#if CONFIG_MACH_STM32H7 || CONFIG_MAC_STM32G4
+#if CONFIG_MACH_STM32H7
     /* Setup message RAM addresses */
     uint32_t f0sa = (uint32_t)MSG_RAM.RXF0 - SRAMCAN_BASE;
     SOC_CAN->RXF0C = f0sa | (ARRAY_SIZE(MSG_RAM.RXF0) << FDCAN_RXF0C_F0S_Pos);

--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -105,6 +105,9 @@ enable_clock_stm32g4(void)
         enable_pclock(CRS_BASE);
         CRS->CR |= CRS_CR_AUTOTRIMEN | CRS_CR_CEN;
     }
+
+    // Use PCLK for FDCAN
+    RCC->CCIPR = 2 << RCC_CCIPR_FDCANSEL_Pos;
 }
 
 // Main clock setup called at chip startup

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -240,9 +240,10 @@ gpio_adc_setup(uint32_t pin)
         // Enable ADC
         adc->ISR = ADC_ISR_ADRDY;
         adc->ISR; // Dummy read to make sure write is flushed
-        adc->CR |= ADC_CR_ADEN;
+        while (!(adc->CR & ADC_CR_ADEN))
+            adc->CR |= ADC_CR_ADEN;
         while (!(adc->ISR & ADC_ISR_ADRDY))
-           ;
+            ;
 
         // Set ADC clock cycles sample time for every channel
         uint32_t av = (aticks           | (aticks << 3)  | (aticks << 6)

--- a/src/stm32/usbfs.c
+++ b/src/stm32/usbfs.c
@@ -15,7 +15,7 @@
 #include "internal.h" // GPIO
 #include "sched.h" // DECL_INIT
 
-#if CONFIG_MACH_STM32F1 || CONFIG_MACH_STM32G4
+#if CONFIG_MACH_STM32F1
   // Transfer memory is accessed with 32bits, but contains only 16bits of data
   typedef volatile uint32_t epmword_t;
   #define WSIZE 2
@@ -25,6 +25,11 @@
   typedef volatile uint16_t epmword_t;
   #define WSIZE 2
   #define USBx_IRQn USB_IRQn
+#elif CONFIG_MACH_STM32G4
+  // Transfer memory is accessed with 16bits and contains 16bits of data
+  typedef volatile uint16_t epmword_t;
+  #define WSIZE 2
+  #define USBx_IRQn USB_LP_IRQn
 #elif CONFIG_MACH_STM32G0
   // Transfer memory is accessed with 32bits and contains 32bits of data
   typedef volatile uint32_t epmword_t;


### PR DESCRIPTION
The STM32G4 support never had USB or CAN tested, and changes to the STM32H7 ADC code in the meantime revealed a timing issue seen only as a small footnote in the reference manual.

Thanks to @mattthebaker for finding the USB issue first