### PR TITLE
Extend sermoon v1 configuration example

### DIFF
--- a/config/printer-creality-sermoonV1-2022.cfg
+++ b/config/printer-creality-sermoonV1-2022.cfg
@@ -94,6 +94,23 @@ pin: PC15
 # for more information.
 # pin: PB4
 
+[output_pin LED_pin]
+pin: PC14
+value: 0
+
+[filament_switch_sensor RunoutSensor]
+pause_on_runout: True
+runout_gcode: PAUSE
+insert_gcode: RESUME
+switch_pin: PA3
+
+# Sermoon V1 Pro has additional DoorSensor
+# [filament_switch_sensor DoorSensor]
+# pause_on_runout: True
+# runout_gcode: PAUSE
+# insert_gcode: RESUME
+# switch_pin: !PB14
+
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 restart_method: command


### PR DESCRIPTION
Repo has only core definition for the printer and missing filament sensors. This change adds both filament and optional door sensor. Idea is to stop printing when filament runs out or door being open.
LED pin added to the config to be able to turn LED light of the printer.