### PR TITLE
Keep stepcompress move history relative to current time

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -60,7 +60,8 @@ defs_stepcompress = """
     void steppersync_free(struct steppersync *ss);
     void steppersync_set_time(struct steppersync *ss
         , double time_offset, double mcu_freq);
-    int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+    int steppersync_flush(struct steppersync *ss, uint64_t move_clock
+        , uint64_t clear_history_clock);
 """
 
 defs_itersolve = """
@@ -94,7 +95,8 @@ defs_trapq = """
         , double start_pos_x, double start_pos_y, double start_pos_z
         , double axes_r_x, double axes_r_y, double axes_r_z
         , double start_v, double cruise_v, double accel);
-    void trapq_finalize_moves(struct trapq *tq, double print_time);
+    void trapq_finalize_moves(struct trapq *tq, double print_time
+        , double clear_history_time);
     void trapq_set_position(struct trapq *tq, double print_time
         , double pos_x, double pos_y, double pos_z);
     int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -734,7 +734,7 @@ steppersync_set_time(struct steppersync *ss, double time_offset
 }
 
 // Expire the stepcompress history before the given clock time
-void __visible
+static void
 steppersync_history_expire(struct steppersync *ss, uint64_t end_clock)
 {
     int i;

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -54,8 +54,6 @@ struct step_move {
     int16_t add;
 };
 
-#define HISTORY_EXPIRE (30.0)
-
 struct history_steps {
     struct list_node node;
     uint64_t first_clock, last_clock;
@@ -292,6 +290,13 @@ free_history(struct stepcompress *sc, uint64_t end_clock)
     }
 }
 
+// Expire the stepcompress history older than the given clock
+static void
+stepcompress_history_expire(struct stepcompress *sc, uint64_t end_clock)
+{
+    free_history(sc, end_clock);
+}
+
 // Free memory associated with a 'stepcompress' object
 void __visible
 stepcompress_free(struct stepcompress *sc)
@@ -322,9 +327,6 @@ calc_last_step_print_time(struct stepcompress *sc)
 {
     double lsc = sc->last_step_clock;
     sc->last_step_print_time = sc->mcu_time_offset + (lsc - .5) / sc->mcu_freq;
-
-    if (lsc > sc->mcu_freq * HISTORY_EXPIRE)
-        free_history(sc, lsc - sc->mcu_freq * HISTORY_EXPIRE);
 }
 
 // Set the conversion rate of 'print_time' to mcu clock
@@ -731,6 +733,18 @@ steppersync_set_time(struct steppersync *ss, double time_offset
     }
 }
 
+// Expire the stepcompress history before the given clock time
+void __visible
+steppersync_history_expire(struct steppersync *ss, uint64_t end_clock)
+{
+    int i;
+    for (i = 0; i < ss->sc_num; i++)
+    {
+        struct stepcompress *sc = ss->sc_list[i];
+        stepcompress_history_expire(sc, end_clock);
+    }
+}
+
 // Implement a binary heap algorithm to track when the next available
 // 'struct move' in the mcu will be available
 static void
@@ -758,7 +772,8 @@ heap_replace(struct steppersync *ss, uint64_t req_clock)
 
 // Find and transmit any scheduled steps prior to the given 'move_clock'
 int __visible
-steppersync_flush(struct steppersync *ss, uint64_t move_clock)
+steppersync_flush(struct steppersync *ss, uint64_t move_clock
+                  , uint64_t clear_history_clock)
 {
     // Flush each stepcompress to the specified move_clock
     int i;
@@ -806,5 +821,7 @@ steppersync_flush(struct steppersync *ss, uint64_t move_clock)
     // Transmit commands
     if (!list_empty(&msgs))
         serialqueue_send_batch(ss->sq, ss->cq, &msgs);
+
+    steppersync_history_expire(ss, clear_history_clock);
     return 0;
 }

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -42,6 +42,7 @@ struct steppersync *steppersync_alloc(
 void steppersync_free(struct steppersync *ss);
 void steppersync_set_time(struct steppersync *ss, double time_offset
                           , double mcu_freq);
-int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+int steppersync_flush(struct steppersync *ss, uint64_t move_clock
+                      , uint64_t clear_history_clock);
 
 #endif // stepcompress.h

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -163,11 +163,10 @@ trapq_append(struct trapq *tq, double print_time
     }
 }
 
-#define HISTORY_EXPIRE (30.0)
-
 // Expire any moves older than `print_time` from the trapezoid velocity queue
 void __visible
-trapq_finalize_moves(struct trapq *tq, double print_time)
+trapq_finalize_moves(struct trapq *tq, double print_time
+                     , double clear_history_time)
 {
     struct move *head_sentinel = list_first_entry(&tq->moves, struct move,node);
     struct move *tail_sentinel = list_last_entry(&tq->moves, struct move, node);
@@ -190,10 +189,9 @@ trapq_finalize_moves(struct trapq *tq, double print_time)
     if (list_empty(&tq->history))
         return;
     struct move *latest = list_first_entry(&tq->history, struct move, node);
-    double expire_time = latest->print_time + latest->move_t - HISTORY_EXPIRE;
     for (;;) {
         struct move *m = list_last_entry(&tq->history, struct move, node);
-        if (m == latest || m->print_time + m->move_t > expire_time)
+        if (m == latest || m->print_time + m->move_t > clear_history_time)
             break;
         list_del(&m->node);
         free(m);
@@ -206,7 +204,7 @@ trapq_set_position(struct trapq *tq, double print_time
                    , double pos_x, double pos_y, double pos_z)
 {
     // Flush all moves from trapq
-    trapq_finalize_moves(tq, NEVER_TIME);
+    trapq_finalize_moves(tq, NEVER_TIME, 0);
 
     // Prune any moves in the trapq history that were interrupted
     while (!list_empty(&tq->history)) {

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -204,7 +204,7 @@ trapq_set_position(struct trapq *tq, double print_time
                    , double pos_x, double pos_y, double pos_z)
 {
     // Flush all moves from trapq
-    trapq_finalize_moves(tq, NEVER_TIME, 0);
+    trapq_finalize_moves(tq, NEVER_TIME, NEVER_TIME);
 
     // Prune any moves in the trapq history that were interrupted
     while (!list_empty(&tq->history)) {

--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -204,7 +204,7 @@ trapq_set_position(struct trapq *tq, double print_time
                    , double pos_x, double pos_y, double pos_z)
 {
     // Flush all moves from trapq
-    trapq_finalize_moves(tq, NEVER_TIME, NEVER_TIME);
+    trapq_finalize_moves(tq, NEVER_TIME, 0);
 
     // Prune any moves in the trapq history that were interrupted
     while (!list_empty(&tq->history)) {

--- a/klippy/chelper/trapq.h
+++ b/klippy/chelper/trapq.h
@@ -43,7 +43,8 @@ void trapq_append(struct trapq *tq, double print_time
                   , double start_pos_x, double start_pos_y, double start_pos_z
                   , double axes_r_x, double axes_r_y, double axes_r_z
                   , double start_v, double cruise_v, double accel);
-void trapq_finalize_moves(struct trapq *tq, double print_time);
+void trapq_finalize_moves(struct trapq *tq, double print_time
+                          , double clear_history_time);
 void trapq_set_position(struct trapq *tq, double print_time
                         , double pos_x, double pos_y, double pos_z);
 int trapq_extract_old(struct trapq *tq, struct pull_move *p, int max

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -87,7 +87,7 @@ class ForceMove:
         print_time = print_time + accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
         self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
-                                  self.printer.get_reactor().NEVER)
+                                  print_time + 99999.9)
         stepper.set_trapq(prev_trapq)
         stepper.set_stepper_kinematics(prev_sk)
         toolhead.note_kinematic_activity(print_time)

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -86,7 +86,7 @@ class ForceMove:
                           0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time = print_time + accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
-        self.trapq_finalize_moves(self.trapq, print_time + 99999.9)
+        self.trapq_finalize_moves(self.trapq, print_time + 99999.9, 0)
         stepper.set_trapq(prev_trapq)
         stepper.set_stepper_kinematics(prev_sk)
         toolhead.note_kinematic_activity(print_time)

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -86,7 +86,8 @@ class ForceMove:
                           0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time = print_time + accel_t + cruise_t + accel_t
         stepper.generate_steps(print_time)
-        self.trapq_finalize_moves(self.trapq, print_time + 99999.9, 0)
+        self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
+                                  self.printer.get_reactor().NEVER)
         stepper.set_trapq(prev_trapq)
         stepper.set_stepper_kinematics(prev_sk)
         toolhead.note_kinematic_activity(print_time)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -67,7 +67,8 @@ class ManualStepper:
                           0., cruise_v, accel)
         self.next_cmd_time = self.next_cmd_time + accel_t + cruise_t + accel_t
         self.rail.generate_steps(self.next_cmd_time)
-        self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9, 0)
+        self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9,
+                                  self.printer.get_reactor().NEVER)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.note_kinematic_activity(self.next_cmd_time)
         if sync:

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -68,7 +68,7 @@ class ManualStepper:
         self.next_cmd_time = self.next_cmd_time + accel_t + cruise_t + accel_t
         self.rail.generate_steps(self.next_cmd_time)
         self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9,
-                                  self.printer.get_reactor().NEVER)
+                                  self.next_cmd_time + 99999.9)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.note_kinematic_activity(self.next_cmd_time)
         if sync:

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -67,7 +67,7 @@ class ManualStepper:
                           0., cruise_v, accel)
         self.next_cmd_time = self.next_cmd_time + accel_t + cruise_t + accel_t
         self.rail.generate_steps(self.next_cmd_time)
-        self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9)
+        self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9, 0)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.note_kinematic_activity(self.next_cmd_time)
         if sync:

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -211,8 +211,8 @@ class PrinterExtruder:
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
-    def update_move_time(self, flush_time):
-        self.trapq_finalize_moves(self.trapq, flush_time)
+    def update_move_time(self, flush_time, clear_history_time):
+        self.trapq_finalize_moves(self.trapq, flush_time, clear_history_time)
     def get_status(self, eventtime):
         sts = self.heater.get_status(eventtime)
         sts['can_extrude'] = self.heater.can_extrude
@@ -313,7 +313,7 @@ class PrinterExtruder:
 class DummyExtruder:
     def __init__(self, printer):
         self.printer = printer
-    def update_move_time(self, flush_time):
+    def update_move_time(self, flush_time, clear_history_time):
         pass
     def check_move(self, move):
         raise move.move_error("Extrude when no extruder present")

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -955,7 +955,7 @@ class MCU:
         self._reserved_move_slots += 1
     def register_flush_callback(self, callback):
         self._flush_callbacks.append(callback)
-    def flush_moves(self, print_time):
+    def flush_moves(self, print_time, clear_history_time):
         if self._steppersync is None:
             return
         clock = self.print_time_to_clock(print_time)
@@ -963,7 +963,10 @@ class MCU:
             return
         for cb in self._flush_callbacks:
             cb(print_time, clock)
-        ret = self._ffi_lib.steppersync_flush(self._steppersync, clock)
+        clear_history_clock = \
+            max(0, self._clocksync.get_clock(clear_history_time))
+        ret = self._ffi_lib.steppersync_flush(self._steppersync, clock,
+                                              clear_history_clock)
         if ret:
             raise error("Internal error in MCU '%s' stepcompress"
                         % (self._name,))

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -964,7 +964,7 @@ class MCU:
         for cb in self._flush_callbacks:
             cb(print_time, clock)
         clear_history_clock = \
-            max(0, self._clocksync.get_clock(clear_history_time))
+            max(0, self.print_time_to_clock(clear_history_time))
         ret = self._ffi_lib.steppersync_flush(self._steppersync, clock,
                                               clear_history_clock)
         if ret:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -525,9 +525,8 @@ class ToolHead:
             self.move_queue.flush()
         except DripModeEndSignal as e:
             self.move_queue.reset()
-            clear_history_time = self.reactor.monotonic() - MOVE_HISTORY_EXPIRE
             self.trapq_finalize_moves(self.trapq, self.reactor.NEVER,
-                                      clear_history_time)
+                                      self.reactor.NEVER)
         # Exit "Drip" state
         self.reactor.update_timer(self.flush_timer, self.reactor.NOW)
         self.flush_step_generation()

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -290,7 +290,8 @@ class ToolHead:
         for sg in self.step_generators:
             sg(sg_flush_time)
         self.last_sg_flush_time = sg_flush_time
-        clear_history_time = self.reactor.monotonic() - MOVE_HISTORY_EXPIRE
+        clear_history_time = self.mcu.estimated_print_time(
+            self.reactor.monotonic() - MOVE_HISTORY_EXPIRE)
         # Free trapq entries that are no longer needed
         free_time = sg_flush_time - self.kin_flush_delay
         self.trapq_finalize_moves(self.trapq, free_time, clear_history_time)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -525,8 +525,7 @@ class ToolHead:
             self.move_queue.flush()
         except DripModeEndSignal as e:
             self.move_queue.reset()
-            self.trapq_finalize_moves(self.trapq, self.reactor.NEVER,
-                                      self.reactor.NEVER)
+            self.trapq_finalize_moves(self.trapq, self.reactor.NEVER, 0)
         # Exit "Drip" state
         self.reactor.update_timer(self.flush_timer, self.reactor.NOW)
         self.flush_step_generation()


### PR DESCRIPTION
Currently the stepcompress history is removed as soon as it's older than 30 seconds before the furthest move in the stepcompress queue. If the furthest move is long and will end more than 30 seconds in the future, then the stepcompress history will return a "future" stepper position rather than a past position.

I found this issue while trying to graph the output of `extruder.find_past_position(print_time)` with a 45mm move at 1.33mm/s, which puts it around 33.8 seconds, and it would give me a graph like this one:

![image](https://github.com/Klipper3d/klipper/assets/2053039/40c391c4-46b9-42d7-8f72-282ba1e59276)

Note the purple line (the expected extruder position) is constant for the first ~4 seconds of the move rather than providing the expected stepper position. With this fix applied, the graph is as expected:

![image](https://github.com/Klipper3d/klipper/assets/2053039/23dcac5a-ab91-4c8a-bee5-cd9c9aaf2cc4)

This was reported, for example, in: https://klipper.discourse.group/t/filament-sensor-triggers-on-long-g0-e-command/3771. It's hard to track real world problems which can be caused by flushing the history too early but I've personally observed false positives with my BTT SFS v1 which might be related t this. I have a 350mm printer so long moves on top/bottom layers are to be expected when printing large parts at slow speeds, as we do with the first layer and the top infill.