### PR TITLE
Make TRSYNC_TIMEOUT configurable

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -280,9 +280,9 @@ class MCU_endstop:
         self._rest_ticks = rest_ticks
         reactor = self._mcu.get_printer().get_reactor()
         self._trigger_completion = reactor.completion()
-        expire_timeout = TRSYNC_TIMEOUT
+        expire_timeout = self._mcu.get_homing_trsync_timeout()
         if len(self._trsyncs) == 1:
-            expire_timeout = TRSYNC_SINGLE_MCU_TIMEOUT
+            expire_timeout = self._mcu.get_homing_trsync_single_mcu_timeout()
         for trsync in self._trsyncs:
             trsync.start(print_time, self._trigger_completion, expire_timeout)
         etrsync = self._trsyncs[0]
@@ -603,6 +603,11 @@ class MCU:
         ffi_main, self._ffi_lib = chelper.get_ffi()
         self._max_stepper_error = config.getfloat('max_stepper_error', 0.000025,
                                                   minval=0.)
+        self._homing_trsync_timeout = \
+            config.getfloat('homing_trsync_timeout', TRSYNC_TIMEOUT, minval=0.)
+        self._homing_trsync_single_mcu_timeout = \
+            config.getfloat('homing_trsync_single_mcu_timeout',
+                            TRSYNC_SINGLE_MCU_TIMEOUT, minval=0.)
         self._reserved_move_slots = 0
         self._stepqueues = []
         self._steppersync = None
@@ -859,6 +864,10 @@ class MCU:
         return int(time * self._mcu_freq)
     def get_max_stepper_error(self):
         return self._max_stepper_error
+    def get_homing_trsync_timeout(self):
+        return self._homing_trsync_timeout
+    def get_homing_trsync_single_mcu_timeout(self):
+        return self._homing_trsync_single_mcu_timeout
     # Wrapper functions
     def get_printer(self):
         return self._printer


### PR DESCRIPTION
I have a 5-toolhead printer, each toolhead is equipped with BTT SB2209 connected to the main mcu over canbus. Each has its own optical endstop (Voron Tap PCB) connected to the toolhead board. A little while ago I kept getting failed homing and following the solution in this post solved the issue for me: https://klipper.discourse.group/t/canbus-communication-timeout-while-homing-z/3741 (and similarly: https://github.com/bigtreetech/EBB/issues/3).

> Changed TRSYNC_TIMEOUT value in “/home/pi/klipper/klippy/mcu.py” file from 0.025 to 0.050, i.e. was “TRSYNC_TIMEOUT = 0.025”, and became “TRSYNC_TIMEOUT = 0.050”, and the error “Communication timeout during homing probe” disappeared

Seems like this timeout value is used only in the homing code in `home_start` which explains why there are no communication errors at any other time. I've been running a version of klipper with this local change for a while but I'd like to keep getting updates, so I'm opening this PR to make the timeout value configurable at the MCU level, and default to the old value since this seems to work fine for most boards.

I'm also open to writing alternative fixes, perhaps just doubling the timeout when the mcu is connected over canbus would be better?

