### PR TITLE
spi_flash: add support for fast SPI speeds

### DIFF
--- a/docs/SDCard_Updates.md
+++ b/docs/SDCard_Updates.md
@@ -48,7 +48,7 @@ All options can be viewed by the help screen:
 ./scripts/flash-sdcard.sh -h
 SD Card upload utility for Klipper
 
-usage: flash_sdcard.sh [-h] [-l] [-c] [-b <baud>] [-f <firmware>]
+usage: flash_sdcard.sh [-h] [-l] [-c] [-s] [-b <baud>] [-f <firmware>]
                        <device> <board>
 
 positional arguments:
@@ -59,6 +59,7 @@ optional arguments:
   -h              show this message
   -l              list available boards
   -c              run flash check/verify only (skip upload)
+  -s              use fast SPI speed (4MHz)
   -b <baud>       serial baud rate (default is 250000)
   -f <firmware>   path to klipper.bin
 ```
@@ -86,6 +87,25 @@ necessary to complete the flashing procedure, such as with bootloaders that
 use SDIO mode instead of SPI to access their SD Cards. (See Caveats below)
 But, it can also be used anytime to verify if the code flashed into the board
 matches the version in your build folder on any supported board.
+
+## Failure to Initialize
+
+Some SD cards may fail to initialize at the default SPI speed of 400KHz.  In
+this situation it is possible to use `-s` to drive the SPI peripheral at 4MHz.
+For example:
+
+```
+./scripts/flash-sdcard.sh -s /dev/ttyACM0 btt-skr-v1.3
+```
+
+If the device still fails to initialize then cause of the failure is
+unrelated to the speed and likely a result of one of the following
+conditions:
+
+- The SD card is improperly formatted.  Must be `fat` or `fat32`.
+- Attempt to initialize a card using the SPI interface that has already
+  been initialized over SDIO.
+- The SD card has failed or is corrupt.
 
 ## Caveats
 

--- a/scripts/flash-sdcard.sh
+++ b/scripts/flash-sdcard.sh
@@ -11,6 +11,7 @@ KLIPPER_DICT_DEFAULT="${SRCDIR}/out/klipper.dict"
 SPI_FLASH="${SRCDIR}/scripts/spi_flash/spi_flash.py"
 BAUD_ARG=""
 CHECK_ARG=""
+SPI_SPEED_ARG=""
 # Force script to exit if an error occurs
 set -e
 
@@ -18,7 +19,7 @@ print_help_message()
 {
     echo "SD Card upload utility for Klipper"
     echo
-    echo "usage: flash_sdcard.sh [-h] [-l] [-c] [-b <baud>] [-f <firmware>] [-d <dictionary>]"
+    echo "usage: flash_sdcard.sh [-h] [-l] [-c] [-s] [-b <baud>] [-f <firmware>] [-d <dictionary>]"
     echo "                       <device> <board>"
     echo
     echo "positional arguments:"
@@ -29,13 +30,14 @@ print_help_message()
     echo "  -h                show this message"
     echo "  -l                list available boards"
     echo "  -c                run flash check/verify only (skip upload)"
+    echo "  -s                use fast SPI speed (4MHz)"
     echo "  -b <baud>         serial baud rate (default is 250000)"
     echo "  -f <firmware>     path to klipper.bin"
     echo "  -d <dictionary>   path to klipper.dict for firmware validation"
 }
 
 # Parse command line "optional args"
-while getopts "hlcb:f:d:" arg; do
+while getopts "hlcsb:f:d:" arg; do
     case $arg in
         h)
             print_help_message
@@ -46,6 +48,7 @@ while getopts "hlcb:f:d:" arg; do
             exit 0
             ;;
         c) CHECK_ARG="-c";;
+        s) SPI_SPEED_ARG="-s";;
         b) BAUD_ARG="-b ${OPTARG}";;
         f) KLIPPER_BIN=$OPTARG;;
         d) KLIPPER_DICT=$OPTARG;;
@@ -85,4 +88,4 @@ fi
 
 # Run Script
 echo "Flashing ${KLIPPER_BIN} to ${DEVICE}"
-${KLIPPY_ENV} ${SPI_FLASH} ${CHECK_ARG} ${BAUD_ARG} ${KLIPPER_DICT} ${DEVICE} ${BOARD} ${KLIPPER_BIN}
+${KLIPPY_ENV} ${SPI_FLASH} ${CHECK_ARG} ${SPI_SPEED_ARG} ${BAUD_ARG} ${KLIPPER_DICT} ${DEVICE} ${BOARD} ${KLIPPER_BIN}

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -98,6 +98,7 @@ SPI_OID = 0
 SDIO_OID = 0
 SPI_MODE = 0
 SD_SPI_SPEED = 400000
+FAST_SD_SPI_SPEED = 4000000
 # MCU Command Constants
 RESET_CMD = "reset"
 GET_CFG_CMD = "get_config"
@@ -1303,6 +1304,9 @@ class MCUConnection:
     def _configure_mcu_spibus(self, printfunc=logging.info):
         # TODO: add commands for buttons?  Or perhaps an endstop?  We
         # just need to be able to query the status of the detect pin
+        fast_spi = self.board_config['fast_spi']
+        spi_speed = FAST_SD_SPI_SPEED if fast_spi else SD_SPI_SPEED
+        output_line("Requested SPI Clock Frequency: %d" % (spi_speed,))
         cs_pin = self.board_config['cs_pin'].upper()
         bus = self.board_config['spi_bus']
         bus_enums = self.enumerations.get(
@@ -1310,7 +1314,7 @@ class MCUConnection:
         pin_enums = self.enumerations.get('pin')
         if bus == "swspi":
             mcu_freq = self.clocksync.print_time_to_clock(1)
-            pulse_ticks = mcu_freq//SD_SPI_SPEED
+            pulse_ticks = mcu_freq//spi_speed
             cfgpins = self.board_config['spi_pins']
             pins = [p.strip().upper() for p in cfgpins.split(',') if p.strip()]
             pin_err_msg = "Invalid Software SPI Pins: %s" % (cfgpins,)
@@ -1323,13 +1327,13 @@ class MCUConnection:
                 SW_SPI_BUS_CMDS[0] % (SPI_OID, pins[0], pins[1], pins[2],
                                       SPI_MODE, pulse_ticks),
                 SW_SPI_BUS_CMDS[1] % (SPI_OID, pins[0], pins[1], pins[2],
-                                      SPI_MODE, SD_SPI_SPEED)
+                                      SPI_MODE, spi_speed)
             ]
         else:
             if bus not in bus_enums:
                 raise SPIFlashError("Invalid SPI Bus: %s" % (bus,))
             bus_cmds = [
-                SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, SD_SPI_SPEED),
+                SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, spi_speed),
             ]
         if cs_pin not in pin_enums:
             raise SPIFlashError("Invalid CS Pin: %s" % (cs_pin,))
@@ -1683,6 +1687,10 @@ def main():
         "-c","--check", action="store_true",
         help="Perform flash check/verify only")
     parser.add_argument(
+        "-s", "--fast-spi", action="store_true",
+        help="Use fast SPI speed (4MHz)"
+    )
+    parser.add_argument(
         "device", metavar="<device>", help="Device Serial Port")
     parser.add_argument(
         "board", metavar="<board>", help="Board Type")
@@ -1701,6 +1709,7 @@ def main():
     flash_args['klipper_bin_path'] = args.klipper_bin_path
     flash_args['klipper_dict_path'] = args.dict_path
     flash_args['verify_only'] = args.check
+    flash_args['fast_spi'] = args.fast_spi
     if args.check:
         # override board_defs setting when doing verify-only:
         flash_args['skip_verify'] = False

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -17,7 +17,6 @@ import traceback
 import json
 import board_defs
 import fatfs_lib
-import util
 import reactor
 import serialhdl
 import clocksync
@@ -1010,7 +1009,7 @@ class SDCardSDIO:
     def _send_command(self, cmd, args, wait=0):
         cmd_code = SD_COMMANDS[cmd]
         argument = 0
-        if isinstance(args, int) or isinstance(args, long):
+        if isinstance(args, int):
             argument = args & 0xFFFFFFFF
         elif isinstance(args, list) and len(args) == 4:
             argument = ((args[0] << 24) & 0xFF000000) | \


### PR DESCRIPTION
In PR #5450 we reduced the SPI clock to the 400KHz speed stated in the official SD Card specification.  At the time I did this because I discovered some cards failed to initialize at 4MHz.  That said, I thought the change could potentially affect other SD Cards, and based on feedback on Discourse it sounds like it has.  This PR adds an `-s` (fast_spi) option that will set the clock to 4MHz when enabled.

As of right now this is untested, I need to restore the original bootloader on some of my boards currently running Katapult.  I decided to create this now as a draft to get visibility for additional testers.   It would be appreciated if some users with working configurations can checkout this PR and verify that it doesn't introduce a regression.  When I am able to test and confirm that it works myself I will change the status of the PR.

In addition it would be good to have a tester experiencing the issue at 400KHz verify that running `flash-sdcard.sh -s` resolves the issue.