### PR TITLE
Add grouping for LEDs for use as separate chain on a single gpio

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3017,6 +3017,26 @@ PCA9632 LED support. The PCA9632 is used on the FlashForge Dreamer.
 #   See the "led" section for information on these parameters.
 ```
 
+### [led_group]
+
+Groups LEDs together into LED groups, which then can be used like any LED
+chain.
+
+```
+[led_group my_group]
+#leds:
+#   A list of LEDs to put in the group. Every chain in a new line with the chain
+#   name, optionally followed by the index range in brackets. Ranges can be
+#   combined by separating them with a comma. Example:
+#   my_neopixel (2-4,6-7,10)
+#   combined by separating them with a comma. LEDs are indexed in the order they
+#   are configured. Example:
+#   my_neopixelw (2-4,6-7,10)
+#   my_neopixel
+#   my_dotstar
+#   for use, simply add led_group:my_neopixel when you use it
+```
+
 ## Additional servos, buttons, and other pins
 
 ### [servo]

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -94,8 +94,14 @@ class PrinterLED:
     def setup_helper(self, config, update_func, led_count=1):
         led_helper = LEDHelper(config, update_func, led_count)
         name = config.get_name().split()[-1]
+        if name in self.led_helpers:
+            raise config.error("LED name '%s' is not unique." % (name,))
         self.led_helpers[name] = led_helper
         return led_helper
+    def lookup_led_helper(self, name):
+        if name in self.led_helpers:
+            return self.led_helpers[name]
+        raise config.error("Unknown LED '%s'" % (name,))
     def _activate_timer(self):
         if self.render_timer is not None or not self.active_templates:
             return

--- a/klippy/extras/led_group.py
+++ b/klippy/extras/led_group.py
@@ -1,0 +1,72 @@
+# Support for LED groups
+#
+# Copyright (C) 2022 Julian Schill <j.schill@web.de>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+class PrinterLEDGroup:
+    def __init__(self, config):
+        self.config = config
+        self.printer = config.get_printer()
+        self.config_leds = config.get('leds')
+        self.printer_led = self.printer.lookup_object('led')
+        self.config_chains = self.config_leds.split('\n')
+        self.leds=[]
+        self.led_helpers=[]
+        self.printer.register_event_handler('klippy:connect',
+                                                self._handle_connect)
+
+    def _handle_connect(self):
+        for chain in self.config_chains:
+            chain = chain.strip()
+            parms = [parameter.strip() for parameter in chain.split()
+                        if parameter.strip()]
+            if parms:
+                led_helper = self.printer_led.lookup_led_helper(parms[0])
+                led_count = led_helper.get_led_count()
+                led_indices = ''.join(parms[1:]).strip('()').split(',')
+                for led in led_indices:
+                    if led:
+                        if '-' in led:
+                            start, stop = map(int,led.split('-'))
+                            if start > led_count or stop > led_count or \
+                                start < 1 or stop < 1:
+                                raise self.printer.config_error(
+                                    "LED index out of range for '%s' in '%s'"
+                                        % (parms[0],parms[1],))
+                            if stop == start:
+                                led_list = [start-1]
+                            elif stop > start:
+                                led_list = list(range(start-1, stop))
+                            else:
+                                led_list = list(reversed(range(stop-1, start)))
+                            for i in led_list:
+                                self.leds.append((led_helper, int(i)))
+                        else:
+                            i = int(led)
+                            if i > led_count or i < 1:
+                                raise self.printer.config_error(
+                                    "LED index out of range for '%s' in '%s'"
+                                        % (parms[0],parms[1],))
+                            self.leds.append((led_helper, (int(i)-1)))
+                    else:
+                        for i in range(led_count):
+                            self.leds.append((led_helper, int(i)))
+                if led_helper not in self.led_helpers:
+                    self.led_helpers.append(led_helper)
+        self.ledCount = len(self.leds)
+
+        pled = self.printer.load_object(self.config, "led")
+        self.led_helper = pled.setup_helper(self.config, self.update_leds,
+                                                self.ledCount)
+
+    def update_leds(self, led_state, print_time):
+        for i, (led_helper, index) in enumerate(self.leds):
+            led_helper.set_color(index+1, led_state[i])
+        for led_helper in self.led_helpers:
+            led_helper.check_transmit(print_time)
+
+    def get_status(self, eventtime=None):
+        return self.led_helper.get_status(eventtime)
+
+def load_config_prefix(config):
+    return PrinterLEDGroup(config)


### PR DESCRIPTION
I reused the code made by [julianschill](https://github.com/julianschill) one year ago on this pull request https://github.com/Klipper3d/klipper/pull/5788 and correct something [KevinOConnor](https://github.com/KevinOConnor) say about `raise self.printer.config_error()` maybe now the pull request by accepted.

for the short description made by [julianschill](https://github.com/julianschill) 

> This adds the functionality to create groups of LEDs to either separate a chain or combine multiple chains to one big LED chain.


Configuration made by me and use on my BLV MGN Cube:
```
[neopixel _status_panel]
pin: PD3
chain_count: 48
color_order: GRB
initial_RED: 0.0
initial_GREEN: 0.0
initial_BLUE: 0.0

[led_group status_panel1]
leds:
  _status_panel (1-16)

[led_group status_panel2]
leds:
  _status_panel (17-32)

[led_group status_panel3]
leds:
  _status_panel (33-48)
```

I use this script https://github.com/Elenedeath/klipper-neopixel to have a working panel with 3 different information on it. this is a little video to show it in action https://www.youtube.com/watch?v=7i_VIg28kKw


this is my start gcode:
```
  M117 Heating bed...
  _NEOPIXEL_DISPLAY LED=status_panel3 TYPE=bed_temp MODE=progress NUMBERS=16
  M190 S{params.BED_TEMP|default(printer.heater_bed.target, true)  }; wait for bed to heat up
  M117 Heating extruder...
  _NEOPIXEL_DISPLAY LED=status_panel2 TYPE=extruder_temp MODE=progress NUMBERS=16
  M109 S{params.EXTRUDER_TEMP|default(printer.extruder.target, true) }; wait for extruder to heat up
  M117 Printing...
  _NEOPIXEL_DISPLAY LED=status_panel1 TYPE=print_percent MODE=progress NUMBERS=16
```

and i can chain another neopixel without the need to specific another gpio for it, only need a new group.

on this example, i have status_panel1 for print_percent, status_panel2 for extruder_temp and status_panel3 for bed_temp

Signed-off-by: Brochard Pierre <elenedeath@gmail.com>
