### PR TITLE
fix: a typo in a document Bed Mesh

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -142,7 +142,7 @@ bicubic_tension: 0.2
   integer pair, and also may be specified a single integer that is applied
   to both axes.  In this example there are 4 segments along the X axis
   and 2 segments along the Y axis.  This evaluates to 8 interpolated
-  points along X, 6 interpolated points along Y, which results in a 13x8
+  points along X, 6 interpolated points along Y, which results in a 13x9
   mesh.  Note that if mesh_pps is set to 0 then mesh interpolation is
   disabled and the probed matrix will be sampled directly.
 


### PR DESCRIPTION
I found a typo in a document Bed_Mesh.md.

In the section Mesh Interpolation of Advanced Configuration, the meaning and the illustration shows 13x9 mesh however the text is 13x8.