### PR TITLE
filament_switch_sensor: add option to always execute gcode handlers

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4328,6 +4328,10 @@ more information.
 #   detected. See docs/Command_Templates.md for G-Code format. The
 #   default is not to run any G-Code commands, which disables insert
 #   detection.
+#run_always: False
+#  When false, runout_gcode is executed only during print, and
+#  insert_gcode only when out of print. Set to true to execute
+#  gcode handlers regardless of printing status. Default is False.
 #event_delay: 3.0
 #   The minimum amount of time in seconds to delay between events.
 #   Events triggered during this time period will be silently

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -23,6 +23,7 @@ class RunoutHelper:
         if config.get('insert_gcode', None) is not None:
             self.insert_gcode = gcode_macro.load_template(
                 config, 'insert_gcode')
+        self.run_always = config.getboolean('run_always', False)
         self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
         self.event_delay = config.getfloat('event_delay', 3., above=0.)
         # Internal state
@@ -74,14 +75,15 @@ class RunoutHelper:
         is_printing = idle_timeout.get_status(eventtime)["state"] == "Printing"
         # Perform filament action associated with status change (if any)
         if is_filament_present:
-            if not is_printing and self.insert_gcode is not None:
+            if ((not is_printing or self.run_always) and
+                    self.insert_gcode is not None):
                 # insert detected
                 self.min_event_systime = self.reactor.NEVER
                 logging.info(
                     "Filament Sensor %s: insert event detected, Time %.2f" %
                     (self.name, eventtime))
                 self.reactor.register_callback(self._insert_event_handler)
-        elif is_printing and self.runout_gcode is not None:
+        elif (is_printing or self.run_always) and self.runout_gcode is not None:
             # runout detected
             self.min_event_systime = self.reactor.NEVER
             logging.info(


### PR DESCRIPTION
Added `run_always` config option as a follow-up to the #6435.

I'm open for better name for the variable.