### PR TITLE
Added QuadBedLevel feature

### DIFF
--- a/klippy/extras/quad_bed_level.py
+++ b/klippy/extras/quad_bed_level.py
@@ -1,0 +1,136 @@
+# Mechanicaly conforms a moving bed to the bed with 4 Z steppers
+#
+# Copyright (C) 2018  Maks Zolin <mzolin@vorondesign.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import probe, z_tilt
+
+# Leveling code for XY rails that are controlled by Z steppers as in:
+#
+# Z stepper1 ----> O                             O <---- Z stepper2
+#                  | * <-- probe1   probe2 --> * |
+#                  |                             |
+#                  |                             | <--- Y2 rail
+#   Y1 rail -----> |                             |
+#                  |                             |
+#                  |=============================|
+#                  |            ^                |
+#                  |            |                |
+#                  |   X rail --/                |
+#                  |                             |
+#                  | * <-- probe0   probe3 --> * |
+# Z stepper0 ----> O                             O <---- Z stepper3
+
+class QuadBedLevel:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.retry_helper = z_tilt.RetryHelper(config,
+            "Possibly Z motor numbering is wrong")
+        self.max_adjust = config.getfloat("max_adjust", 4, above=0)
+        self.horizontal_move_z = config.getfloat("horizontal_move_z", 5.0)
+        self.probe_helper = probe.ProbePointsHelper(config, self.probe_finalize)
+        if len(self.probe_helper.probe_points) != 4:
+            raise config.error(
+                "Need exactly 4 probe points for quad_bed_level")
+        self.z_status = z_tilt.ZAdjustStatus(self.printer)
+        self.z_helper = z_tilt.ZAdjustHelper(config, 4)
+        self.bed_corners = config.getlists('bed_corners', parser=float,
+                                              seps=(',', '\n'), count=2)
+        if len(self.bed_corners) < 2:
+            raise config.error(
+                "quad_bed_level requires at least two bed_corners")
+        # Register QUAD_BED_LEVEL command
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command(
+            'QUAD_BED_LEVEL', self.cmd_QUAD_BED_LEVEL,
+            desc=self.cmd_QUAD_BED_LEVEL_help)
+    cmd_QUAD_BED_LEVEL_help = (
+        "Bend a bed to the shape of the gantry")
+    def cmd_QUAD_BED_LEVEL(self, gcmd):
+        self.z_status.reset()
+        self.retry_helper.start(gcmd)
+        self.probe_helper.start_probe(gcmd)
+    def probe_finalize(self, offsets, positions):
+        # Mirror our perspective so the adjustments make sense
+        # from the perspective of the bed
+        z_positions = [self.horizontal_move_z - p[2] for p in positions]
+        points_message = "Bed-relative probe points:\n%s\n" % (
+            " ".join(["%s: %.6f" % (z_id, z_positions[z_id])
+                for z_id in range(len(z_positions))]))
+        self.gcode.respond_info(points_message)
+        # Calculate slope along X axis between probe point 0 and 3
+        ppx0 = [positions[0][0] + offsets[0], z_positions[0]]
+        ppx3 = [positions[3][0] + offsets[0], z_positions[3]]
+        slope_x_pp03 = self.linefit(ppx0, ppx3)
+        # Calculate slope along X axis between probe point 1 and 2
+        ppx1 = [positions[1][0] + offsets[0], z_positions[1]]
+        ppx2 = [positions[2][0] + offsets[0], z_positions[2]]
+        slope_x_pp12 = self.linefit(ppx1, ppx2)
+        logging.info("quad_bed_level f1: %s, f2: %s"
+                     % (slope_x_pp03, slope_x_pp12))
+        # Calculate bed slope along Y axis between stepper 0 and 1
+        a1 = [positions[0][1] + offsets[1],
+              self.plot(slope_x_pp03, self.bed_corners[0][0])]
+        a2 = [positions[1][1] + offsets[1],
+              self.plot(slope_x_pp12, self.bed_corners[1][0])]
+        slope_y_s01 = self.linefit(a1, a2)
+        # Calculate bed slope along Y axis between stepper 2 and 3
+        b1 = [positions[3][1] + offsets[1],
+              self.plot(slope_x_pp03, self.bed_corners[3][0])]
+        b2 = [positions[2][1] + offsets[1],
+              self.plot(slope_x_pp12, self.bed_corners[2][0])]
+        slope_y_s32 = self.linefit(b1, b2)
+        logging.info("quad_bed_level af: %s, bf: %s"
+                     % (slope_y_s01, slope_y_s32))
+		# Calculate z height of each stepper
+        z_height = [0,0,0,0]
+        z_height[0] = (1) * self.plot(slope_y_s01, self.bed_corners[0][1])
+        z_height[1] = (1) * self.plot(slope_y_s01, self.bed_corners[1][1])
+        z_height[2] = (1) * self.plot(slope_y_s32, self.bed_corners[2][1])
+        z_height[3] = (1) * self.plot(slope_y_s32, self.bed_corners[3][1])
+
+        ainfo = zip(["z","z1","z2","z3"], z_height[0:4])
+        apos = " ".join(["%s: %06f" % (x) for x in ainfo])
+        self.gcode.respond_info("Actuator Positions:\n" + apos)
+
+        # take average height
+        z_ave = sum(z_height) / len(z_height)
+        self.gcode.respond_info("Average: %0.6f" % z_ave)
+        # adjust all steppers to the average height
+        z_adjust = []
+        for z in z_height:
+            z_adjust.append(z_ave - z)
+			
+        adjustinfo = zip(["z","z1","z2","z3"], z_adjust[0:4])
+        adjustpos = " ".join(["%s: %06f" % (x) for x in adjustinfo])
+
+        self.gcode.respond_info("Adjustment positions:\n" + adjustpos)
+
+        adjust_max = max(z_adjust)
+        if adjust_max > self.max_adjust:
+            raise self.gcode.error("Aborting quad_bed_level"
+                                   " required adjustment %0.6f"
+                                   " is greater than max_adjust %0.6f"
+                                   % (adjust_max, self.max_adjust))
+
+        speed = self.probe_helper.get_lift_speed()
+        self.z_helper.adjust_steppers(z_adjust, speed)
+        return self.z_status.check_retry_result(
+            self.retry_helper.check_retry(z_positions))
+
+    def linefit(self,p1,p2):
+        if p1[1] == p2[1]:
+            # Straight line
+            return 0,p1[1]
+        m = (p2[1] - p1[1])/(p2[0] - p1[0])
+        b = p1[1] - m * p1[0]
+        return m,b
+    def plot(self,f,x):
+        return f[0]*x + f[1]
+    def get_status(self, eventtime):
+        return self.z_status.get_status(eventtime)
+
+def load_config(config):
+    return QuadBedLevel(config)
+


### PR DESCRIPTION
New function for moving beds with 4 independent moving z axes.
It's based/derived on quad_bed_level but its task is to flatten the level the bed by moving the individual axes.

I did several successfull tests and this feature is able to flatten/level beds of any shapes like ones with a hyperbolic parabola effect (potato chip).

Some examples:
Bed before:
![image](https://github.com/Klipper3d/klipper/assets/6054234/6e70143e-1bcb-4b05-9229-556d52a4edaa)

Bed after 3 iterations of leveling (took ~6min)
![image](https://github.com/Klipper3d/klipper/assets/6054234/6dd55666-3e55-409b-8fba-b2b74d37d6b6)

Here is the console output during a quad_bed_level:
```
16:24:52
Retries: 3/5 Probed points range: 0.006000 tolerance: 0.010000
16:24:49
Making the following Z adjustments:
stepper_z = -0.003839
stepper_z1 = 0.001486
stepper_z2 = 0.003822
stepper_z3 = -0.001469
16:24:49
Adjustment positions:
z: -0.003839 z1: 0.001486 z2: 0.003822 z3: -0.001469
16:24:49
Average: 16.647960
16:24:49
Actuator Positions:
z: 16.651799 z1: 16.646474 z2: 16.644138 z3: 16.649429
16:24:49
Bed-relative probe points:
0: 16.651242 1: 16.646742 2: 16.645242 3: 16.649742
16:24:49
probe at 540.000,60.000 is z=3.350258
16:24:36
probe at 540.000,600.000 is z=3.354758
16:24:23
probe at 50.000,600.000 is z=3.353258
16:24:10
probe at 50.000,60.000 is z=3.348758
16:24:01
Retries: 2/5 Probed points range: 0.029000 tolerance: 0.010000
16:23:58
Making the following Z adjustments:
stepper_z = 0.027657
stepper_z1 = -0.018258
stepper_z2 = -0.000115
stepper_z3 = -0.009283
16:23:58
Adjustment positions:
z: 0.027657 z1: -0.018258 z2: -0.000115 z3: -0.009283
16:23:58
Average: 16.648247
16:23:57
Actuator Positions:
z: 16.620591 z1: 16.666506 z2: 16.648362 z3: 16.657531
16:23:57
Bed-relative probe points:
0: 16.628740 1: 16.657740 2: 16.651240 3: 16.651740
16:23:57
probe at 540.000,60.000 is z=3.348260
16:23:44
probe at 540.000,600.000 is z=3.348760
16:23:32
probe at 50.000,600.000 is z=3.342260
16:23:19
probe at 50.000,60.000 is z=3.371260
16:23:10
Retries: 1/5 Probed points range: 0.121000 tolerance: 0.010000
16:23:06
Making the following Z adjustments:
stepper_z = 0.089295
stepper_z1 = -0.095760
stepper_z2 = 0.010195
stepper_z3 = -0.003730
16:23:06
Adjustment positions:
z: 0.089295 z1: -0.095760 z2: 0.010195 z3: -0.003730
16:23:06
Average: 16.649476
16:23:06
Actuator Positions:
z: 16.560181 z1: 16.745237 z2: 16.639282 z3: 16.653206
16:23:06
Bed-relative probe points:
0: 16.581330 1: 16.702330 2: 16.653330 3: 16.638830
16:23:06
probe at 540.000,60.000 is z=3.361170
16:22:53
probe at 540.000,600.000 is z=3.346670
16:22:40
probe at 50.000,600.000 is z=3.297670
16:22:27
probe at 50.000,60.000 is z=3.418670
16:22:18
Retries: 0/5 Probed points range: 1.017500 tolerance: 0.010000
16:22:14
Making the following Z adjustments:
stepper_z = 0.269584
stepper_z1 = -1.088170
stepper_z2 = 0.395465
stepper_z3 = 0.423121
16:22:14
Adjustment positions:
z: 0.269584 z1: -1.088170 z2: 0.395465 z3: 0.423121
16:22:14
Average: 16.643972
16:22:14
Actuator Positions:
z: 16.374388 z1: 17.732142 z2: 16.248507 z3: 16.220851
16:22:14
Bed-relative probe points:
0: 16.354000 1: 17.265000 2: 16.447000 3: 16.247500
16:22:14
probe at 540.000,60.000 is z=3.752500
16:22:01
probe at 540.000,600.000 is z=3.553000
16:21:48
probe at 50.000,600.000 is z=2.735000
16:21:35
probe at 50.000,60.000 is z=3.646000
16:21:29
quad_bed_level
```

It started from `points range: 1.017500 `
after 3 iterations it went down to `points range: 0.006000`

Configuration is similar to "[quad_gantry_level]"

So the section would look like this:

```
[quad_bed_level]
#bed_corners:
# X/Y coordinates describing the location of each bed "pivot point".
# These points beeing measured from the coordinates of the nozzle
# This parameter must be provided
#points:
# X/Y coordinates of each probe point during a Quad_bed_level command.
# The location is measured from the nozzle coordinates, so make sure to adjust the coordinate according to the probe offset
#speed: 150
#   The speed (in mm/s) of non-probing moves during the calibration.
#   The default is 50.
#horizontal_move_z: 30
#   The height (in mm) that the head should be commanded to move to
#   just prior to starting a probe operation. The default is 5.
#max_adjust: 7
#   Safety limit if an adjustment greater than this value is requested
#   quad_gantry_level will abort.
#retries: 5
#   Number of times to retry if the probed points aren't within
#   tolerance.
#retry_tolerance: 0.010
#   If retries are enabled then retry if largest and smallest probed
#   points differ more than retry_tolerance.
```