### PR TITLE
[WIP] Add basic for GPIO extension for RP2040

### DIFF
--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -47,6 +47,21 @@ config STACK_SIZE
     int
     default 512
 
+config GPIO_EXTENSION
+    bool "expend GPIO via 74HC595 chip"
+    default false
+
+config GPIO_EXTENSION_NUM
+    int "Number of 74HC595 chips" if GPIO_EXTENSION
+    default 1
+
+config GPIO_EXTENSION_SPI
+    int "GPIO Extension SPI port" if GPIO_EXTENSION
+    default 0
+
+config GPIO_EXTENSION_CS
+    int "GPIO Extension GPIO Pin" if GPIO_EXTENSION
+    default 21
 
 ######################################################################
 # Bootloader options

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -5,8 +5,12 @@ CROSS_PREFIX=arm-none-eabi-
 
 dirs-y += src/rp2040 src/generic lib/rp2040/elf2uf2 lib/fast-hash lib/can2040
 
+CFLAGS-$(CONFIG_GPIO_EXTENSION) = -DGPIO_EXTENSION -DGPIO_EXTENSION_NUM=$(CONFIG_GPIO_EXTENSION_NUM)
+CFLAGS-$(CONFIG_GPIO_EXTENSION) += -DGPIO_EXTENSION_CS=$(CONFIG_GPIO_EXTENSION_CS) -DGPIO_EXTENSION_SPI=$(CONFIG_GPIO_EXTENSION_SPI)
+
+
 CFLAGS += -mcpu=cortex-m0plus -mthumb -Ilib/cmsis-core
-CFLAGS += -Ilib/rp2040 -Ilib/rp2040/cmsis_include -Ilib/fast-hash -Ilib/can2040
+CFLAGS += -Ilib/rp2040 -Ilib/rp2040/cmsis_include -Ilib/fast-hash -Ilib/can2040 $(CFLAGS-y)
 
 # Add source files
 src-y += rp2040/main.c rp2040/watchdog.c rp2040/gpio.c

--- a/src/rp2040/gpio.c
+++ b/src/rp2040/gpio.c
@@ -20,6 +20,9 @@
  ****************************************************************/
 
 DECL_ENUMERATION_RANGE("pin", "gpio0", 0, 30);
+#ifdef GPIO_EXTENSION
+DECL_ENUMERATION_RANGE("pin", "gpio_ext", 31, 31 + GPIO_EXTENSION_NUM * 8);
+#endif
 
 // Set the mode and extended function of a pin
 void


### PR DESCRIPTION
Plan to add support using 74HC595 to add 8/16/etc output only GPIO to RP2040 to solve RP2040 shortage of IO pins. The PR doesn't include the actual code yet. like to get early feedback while working on hardware prototype.