### PR TITLE
config: Add Creality Ender 5 S1.

### DIFF
--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -1,23 +1,16 @@
-# !Ender-5 S1
+# Creality Ender 5 S1
+#
 # printer_size: 220x220x280
 # To use this config, during "make menuconfig" select the STM32F401
 # with a "64KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.
-
+#
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware
 # filename must end in ".bin" and must not match the last filename
 # that was flashed.
-
+#
 # See docs/Config_Reference.md for a description of parameters.
-
-[printer]
-kinematics: cartesian
-max_velocity: 300
-max_accel: 5000
-max_z_velocity: 10
-max_z_accel: 1000
-square_corner_velocity: 5.0
 
 [stepper_x]
 step_pin: PC2
@@ -26,7 +19,6 @@ enable_pin: !PC3
 rotation_distance: 40
 microsteps: 16
 endstop_pin: !PA5
-position_min: -5
 position_endstop: 220
 position_max: 222
 homing_speed: 80
@@ -38,9 +30,8 @@ enable_pin: !PC3
 rotation_distance: 40
 microsteps: 16
 endstop_pin: !PA6
-position_min: -2
 position_endstop: 220
-position_max: 225
+position_max: 220
 homing_speed: 80
 
 [stepper_z]
@@ -50,9 +41,8 @@ enable_pin: !PC3
 rotation_distance: 8
 microsteps: 16
 endstop_pin: probe:z_virtual_endstop
-position_min: -2
 position_max: 280
-homing_speed: 4
+homing_speed: 20
 second_homing_speed: 1
 homing_retract_dist: 2.0
 
@@ -65,15 +55,15 @@ microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
 max_extrude_cross_section: 5
-max_extrude_only_distance: 1000.0
+max_extrude_only_distance: 100.0
+pressure_advance: 0.075
 heater_pin: PA1
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC5
-# tuned for stock hardware with 210 degree Celsius target
-control = pid
-pid_kp = 22.698
-pid_ki = 1.363
-pid_kd = 94.481
+control = pid  # tuned for stock hardware with 210 degree Celsius target
+pid_kp = 20.749
+pid_ki = 1.064
+pid_kd = 101.153
 min_temp: 0
 max_temp: 305
 
@@ -81,84 +71,97 @@ max_temp: 305
 heater_pin: PA7
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC4
-# tuned for stock hardware with 60 degree Celsius target
-control = pid
-pid_kp = 59.663
-pid_ki = 0.476
-pid_kd = 1868.184
+control = pid  # tuned for stock hardware with 60 degree Celsius target
+pid_kp = 66.566
+pid_ki = 0.958
+pid_kd = 1155.761
 min_temp: 0
-max_temp: 15
+max_temp: 110
 
+# Part cooling fan
 [fan]
 pin: PA0
 kick_start_time: 0.5
 
-#set heatbreak fan runnig with temperature over 60
+# Hotend fan
+# set fan runnig when extruder temperature is over 60
 [heater_fan heatbreak_fan]
 pin: PC0
-max_power: 0.8
-shutdown_speed : 0
 heater:extruder
-heater_temp : 60
-fan_speed : 1.0
+heater_temp: 60
+fan_speed: 0.8
 
 [filament_switch_sensor filament_sensor]
 pause_on_runout: true
 switch_pin: ^!PC15
 
-#Stock CR Touch bed sensor
+# Stock CR Touch bed sensor
 [bltouch]
-sensor_pin: ^PC14       
+sensor_pin: ^PC14
 control_pin: PC13
 x_offset: -13
-y_offset: 27          
-speed: 20
-stow_on_each_sample: true    #Occasional bed crashes when false
+y_offset: 27
+speed: 10
+stow_on_each_sample: true    # Occasional bed crashes when false
 samples: 4
 sample_retract_dist: 2
-samples_result: average 
-
-[safe_z_home]
-home_xy_position:110, 55
-speed: 200
-z_hop: 10
-z_hop_speed: 10
+samples_result: average
+probe_with_touch_mode: true
 
 [bed_mesh]
 speed: 150
-mesh_min: 3,28         #need to handle head distance with bl_touch
+mesh_min: 3,28         # need to handle head distance with bl_touch
 mesh_max: 205,218
 mesh_pps: 3
 probe_count: 4,4
 fade_start: 1
 fade_end: 10
 fade_target: 0
-algorithm: bicubic
 
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[safe_z_home]
+home_xy_position: 110,55
+speed: 200
+z_hop: 10
+z_hop_speed: 10
+
+# Probe locations for x-axis twist measurement
 [axis_twist_compensation]
 calibrate_start_x: 3
 calibrate_end_x: 207
 calibrate_y: 110
 
+# Probe locations for assisted bed screw adjustment.
 [screws_tilt_adjust]
-screw1: 38, 6
+screw1: 38,6
 screw1_name: Front Left Screw
-screw2: 215, 6
+screw2: 215,6
 screw2_name: Front Right Screw
-screw3: 215, 175
+screw3: 215,175
 screw3_name: Rear Right Screw
-screw4: 38, 175
+screw4: 38,175
 screw4_name: Rear Left Screw
 horizontal_move_z: 5
-speed: 50
+speed: 100
 screw_thread: CW-M4
 
 [bed_screws]
-screw1: 25, 33
-screw2: 202, 33
-screw3: 202, 202
-screw4: 25, 202
+screw1: 25,25
+screw1_name: Front Left Screw
+screw2: 195,25
+screw2_name: Front Right Screw
+screw3: 195,195
+screw3_name: Rear Right Screw
+screw4: 25,195
+screw4_name: Rear Left Screw
 
-[mcu]
-serial:/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
-restart_method: command
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 5
+max_z_accel: 100
+square_corner_velocity: 5.0

--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -1,14 +1,14 @@
-# Creality Ender 5 S1
+# Creality Ender 5 S1 (HW version: CR4NS200141C13)
 #
 # printer_size: 220x220x280
 # To use this config, during "make menuconfig" select the STM32F401
 # with a "64KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.
 #
-# Flash this firmware by copying "out/klipper.bin" to a SD card and
-# turning on the printer with the card inserted. The firmware
-# filename must end in ".bin" and must not match the last filename
-# that was flashed.
+# Flash this firmware by creating a directory named "STM32F4_UPDATE"
+# on an SD card, copying the "out/klipper.bin" to it and then turn
+# on the printer with the card inserted. The firmware filename must
+# end in ".bin" and must not match the last filename that was flashed.
 #
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -126,7 +126,12 @@ speed: 200
 z_hop: 10
 z_hop_speed: 10
 
-# Probe locations for x-axis twist measurement
+# Many Ender 5 S1 printers appear to suffer from a slight twist
+# in the X axis.  This twist can be measured, and compensated for
+# using the AXIS_TWIST_COMPENSATION_CALIBRATE G-Code command.  See
+# https://www.klipper3d.org/Axis_Twist_Compensation.html for more
+# information.  This section provides the setup for this optional
+# calibration step.
 [axis_twist_compensation]
 calibrate_start_x: 3
 calibrate_end_x: 207

--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -121,7 +121,7 @@ serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 restart_method: command
 
 [safe_z_home]
-home_xy_position: 110,55
+home_xy_position: 123,83
 speed: 200
 z_hop: 10
 z_hop_speed: 10

--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -1,0 +1,164 @@
+# !Ender-5 S1
+# printer_size: 220x220x280
+# To use this config, during "make menuconfig" select the STM32F401
+# with a "64KiB bootloader" and serial (on USART1 PA10/PA9)
+# communication.
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning on the printer with the card inserted. The firmware
+# filename must end in ".bin" and must not match the last filename
+# that was flashed.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 5000
+max_z_velocity: 10
+max_z_accel: 1000
+square_corner_velocity: 5.0
+
+[stepper_x]
+step_pin: PC2
+dir_pin: !PB9
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: !PA5
+position_min: -5
+position_endstop: 220
+position_max: 222
+homing_speed: 80
+
+[stepper_y]
+step_pin: PB8
+dir_pin: !PB7
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: !PA6
+position_min: -2
+position_endstop: 220
+position_max: 225
+homing_speed: 80
+
+[stepper_z]
+step_pin: PB6
+dir_pin: PB5
+enable_pin: !PC3
+rotation_distance: 8
+microsteps: 16
+endstop_pin: probe:z_virtual_endstop
+position_min: -2
+position_max: 280
+homing_speed: 4
+second_homing_speed: 1
+homing_retract_dist: 2.0
+
+[extruder]
+step_pin: PB4
+dir_pin: PB3
+enable_pin: !PC3
+rotation_distance: 7.5
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+max_extrude_cross_section: 5
+max_extrude_only_distance: 1000.0
+heater_pin: PA1
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC5
+# tuned for stock hardware with 210 degree Celsius target
+control = pid
+pid_kp = 22.698
+pid_ki = 1.363
+pid_kd = 94.481
+min_temp: 0
+max_temp: 305
+
+[heater_bed]
+heater_pin: PA7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+# tuned for stock hardware with 60 degree Celsius target
+control = pid
+pid_kp = 59.663
+pid_ki = 0.476
+pid_kd = 1868.184
+min_temp: 0
+max_temp: 15
+
+[fan]
+pin: PA0
+kick_start_time: 0.5
+
+#set heatbreak fan runnig with temperature over 60
+[heater_fan heatbreak_fan]
+pin: PC0
+max_power: 0.8
+shutdown_speed : 0
+heater:extruder
+heater_temp : 60
+fan_speed : 1.0
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: true
+switch_pin: ^!PC15
+
+#Stock CR Touch bed sensor
+[bltouch]
+sensor_pin: ^PC14       
+control_pin: PC13
+x_offset: -13
+y_offset: 27          
+speed: 20
+stow_on_each_sample: true    #Occasional bed crashes when false
+samples: 4
+sample_retract_dist: 2
+samples_result: average 
+
+[safe_z_home]
+home_xy_position:110, 55
+speed: 200
+z_hop: 10
+z_hop_speed: 10
+
+[bed_mesh]
+speed: 150
+mesh_min: 3,28         #need to handle head distance with bl_touch
+mesh_max: 205,218
+mesh_pps: 3
+probe_count: 4,4
+fade_start: 1
+fade_end: 10
+fade_target: 0
+algorithm: bicubic
+
+[axis_twist_compensation]
+calibrate_start_x: 3
+calibrate_end_x: 207
+calibrate_y: 110
+
+[screws_tilt_adjust]
+screw1: 38, 6
+screw1_name: Front Left Screw
+screw2: 215, 6
+screw2_name: Front Right Screw
+screw3: 215, 175
+screw3_name: Rear Right Screw
+screw4: 38, 175
+screw4_name: Rear Left Screw
+horizontal_move_z: 5
+speed: 50
+screw_thread: CW-M4
+
+[bed_screws]
+screw1: 25, 33
+screw2: 202, 33
+screw3: 202, 202
+screw4: 25, 202
+
+[mcu]
+serial:/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command

--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -98,6 +98,7 @@ sensor_pin: ^PC14
 control_pin: PC13
 x_offset: -13
 y_offset: 27
+z_offset: 2.0
 speed: 10
 stow_on_each_sample: true    # Occasional bed crashes when false
 samples: 4

--- a/config/printer-creality-ender5-s1-2023.cfg
+++ b/config/printer-creality-ender5-s1-2023.cfg
@@ -54,16 +54,13 @@ rotation_distance: 7.5
 microsteps: 16
 nozzle_diameter: 0.400
 filament_diameter: 1.750
-max_extrude_cross_section: 5
-max_extrude_only_distance: 100.0
-pressure_advance: 0.075
 heater_pin: PA1
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC5
-control = pid  # tuned for stock hardware with 210 degree Celsius target
-pid_kp = 20.749
-pid_ki = 1.064
-pid_kd = 101.153
+control: pid  # tuned for stock hardware with 210 degree Celsius target
+pid_kp: 20.749
+pid_ki: 1.064
+pid_kd: 101.153
 min_temp: 0
 max_temp: 305
 
@@ -71,10 +68,10 @@ max_temp: 305
 heater_pin: PA7
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC4
-control = pid  # tuned for stock hardware with 60 degree Celsius target
-pid_kp = 66.566
-pid_ki = 0.958
-pid_kd = 1155.761
+control: pid  # tuned for stock hardware with 60 degree Celsius target
+pid_kp: 66.566
+pid_ki: 0.958
+pid_kd: 1155.761
 min_temp: 0
 max_temp: 110
 

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -207,7 +207,6 @@ CONFIG ../../config/printer-artillery-sidewinder-x2-2022.cfg
 CONFIG ../../config/printer-creality-ender5-s1-2023.cfg
 CONFIG ../../config/printer-elegoo-neptune3-pro-2023.cfg
 
-
 # Printers using the stm32f405
 DICTIONARY stm32f405.dict
 CONFIG ../../config/generic-mellow-fly-gemini-v1.cfg

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -204,7 +204,9 @@ CONFIG ../../config/printer-voxelab-aquila-2021.cfg
 DICTIONARY stm32f401.dict
 CONFIG ../../config/generic-fysetc-cheetah-v2.0.cfg
 CONFIG ../../config/printer-artillery-sidewinder-x2-2022.cfg
+CONFIG ../../config/printer-creality-ender5-s1-2023.cfg
 CONFIG ../../config/printer-elegoo-neptune3-pro-2023.cfg
+
 
 # Printers using the stm32f405
 DICTIONARY stm32f405.dict


### PR DESCRIPTION
My first GitHub submission....

From the main commit:

> printer-creality-ender5-s1-2023: New default config file for the Creality Ender 5 S1.
> 
> Creality released the Ender 5 S1 model in November of 2022.  It
> has enough hardware differences from the previous models that
> that the existing Ender 5 configs are not compatible.  This
> configuration is based on one provided by Creality that was then
> tweaked and modified.  I have been using these values (plus some
> additional entries) for about 6 months with no issues.
> 
> I have tidied up the file per the Example_Configs document,
> although I admit I may have missed something.  I'm happy to make
> or accept any required changes.
> 

All IP rights assigned to the Klipper3D project and development team.

Signed-off-by: Brian Greenberg <grnbrg@grnbrg.org>