### PR TITLE
Deprecate and remove support for uncommon options in output_pin

### DIFF
--- a/config/generic-mini-rambo.cfg
+++ b/config/generic-mini-rambo.cfg
@@ -84,7 +84,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.3
+value: 1.3
 
 [output_pin stepper_z_current]
 pin: PL4
@@ -92,7 +92,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.3
+value: 1.3
 
 [output_pin stepper_e_current]
 pin: PL5
@@ -100,7 +100,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.25
+value: 1.25
 
 [static_digital_output stepper_config]
 pins:

--- a/config/generic-ultimaker-ultimainboard-v2.cfg
+++ b/config/generic-ultimaker-ultimainboard-v2.cfg
@@ -97,7 +97,7 @@ max_z_accel: 30
 
 [output_pin case_light]
 pin: PH5
-static_value: 1.0
+value: 1.0
 
 # Motor current settings.
 [output_pin stepper_xy_current]
@@ -107,7 +107,7 @@ scale: 2.000
 # Max power setting.
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.200
+value: 1.200
 # Power adjustment setting.
 
 [output_pin stepper_z_current]
@@ -116,7 +116,7 @@ pwm: True
 scale: 2.000
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.200
+value: 1.200
 
 [output_pin stepper_e_current]
 pin: PL3
@@ -124,4 +124,4 @@ pwm: True
 scale: 2.000
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.250
+value: 1.250

--- a/config/printer-adimlab-2018.cfg
+++ b/config/printer-adimlab-2018.cfg
@@ -89,7 +89,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.3
+value: 1.3
 
 [output_pin stepper_z_current]
 pin: PL4
@@ -97,7 +97,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.3
+value: 1.3
 
 [output_pin stepper_e_current]
 pin: PL3
@@ -105,7 +105,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.25
+value: 1.25
 
 [display]
 lcd_type: st7920

--- a/config/printer-creality-cr30-2021.cfg
+++ b/config/printer-creality-cr30-2021.cfg
@@ -98,7 +98,6 @@ max_temp: 100
 
 [output_pin led]
 pin: PC14
-static_value: 0
 
 # Neopixel LED support
 # [neopixel led_neopixel]

--- a/config/printer-lulzbot-mini1-2016.cfg
+++ b/config/printer-lulzbot-mini1-2016.cfg
@@ -125,7 +125,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.300
+value: 1.300
 
 [output_pin stepper_z_current]
 pin: PL4
@@ -133,7 +133,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.630
+value: 1.630
 
 [output_pin stepper_e_current]
 pin: PL5
@@ -141,7 +141,7 @@ pwm: True
 scale: 2.0
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.250
+value: 1.250
 
 [static_digital_output stepper_config]
 # Microstepping pins

--- a/config/printer-wanhao-duplicator-6-2016.cfg
+++ b/config/printer-wanhao-duplicator-6-2016.cfg
@@ -86,7 +86,7 @@ pwm: True
 scale: 2.782
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.2
+value: 1.2
 
 [output_pin stepper_z_current]
 pin: PL4
@@ -94,7 +94,7 @@ pwm: True
 scale: 2.782
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.2
+value: 1.2
 
 [output_pin stepper_e_current]
 pin: PL3
@@ -102,7 +102,7 @@ pwm: True
 scale: 2.782
 cycle_time: .000030
 hardware_pwm: True
-static_value: 1.0
+value: 1.0
 
 [display]
 lcd_type: ssd1306

--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -61,12 +61,10 @@ gcode:
 #   P is the tone duration, S the tone frequency.
 # The frequency won't be pitch perfect.
 
-[output_pin BEEPER_pin]
+[pwm_cycle_time BEEPER_pin]
 pin: ar37
 #   Beeper pin. This parameter must be provided.
 #   ar37 is the default RAMPS/MKS pin.
-pwm: True
-#   A piezo beeper needs a PWM signal, a DC buzzer doesn't.
 value: 0
 #   Silent at power on, set to 1 if active low.
 shutdown_value: 0

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240123: The output_pin SET_PIN CYCLE_TIME parameter has been
+removed. Use the new
+[pwm_cycle_time](Config_Reference.md#pwm_cycle_time) module if it is
+necessary to dynamically change a pwm pin's cycle time.
+
 20240123: The output_pin `maximum_mcu_duration` parameter is
 deprecated. Use a [pwm_tool config section](Config_Reference.md#pwm_tool)
 instead. The option will be removed in the near future.

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240123: The output_pin `maximum_mcu_duration` parameter is
+deprecated. Use a [pwm_tool config section](Config_Reference.md#pwm_tool)
+instead. The option will be removed in the near future.
+
 20240123: The output_pin `static_value` parameter is deprecated.
 Replace with `value` and `shutdown_value` parameters.  The option will
 be removed in the near future.

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240123: The output_pin `static_value` parameter is deprecated.
+Replace with `value` and `shutdown_value` parameters.  The option will
+be removed in the near future.
+
 20231216: The `[hall_filament_width_sensor]` is changed to trigger filament runout
 when the thickness of the filament exceeds `max_diameter`. The maximum diameter
 defaults to `default_nominal_filament_diameter + max_difference`. See

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3096,11 +3096,6 @@ pin:
 #   If this is true, the value fields should be between 0 and 1; if it
 #   is false the value fields should be either 0 or 1. The default is
 #   False.
-#static_value:
-#   If this is set, then the pin is assigned to this value at startup
-#   and the pin can not be changed during runtime. A static pin uses
-#   slightly less ram in the micro-controller. The default is to use
-#   runtime configuration of pins.
 #value:
 #   The value to initially set the pin to during MCU configuration.
 #   The default is 0 (for low voltage).
@@ -3133,6 +3128,8 @@ pin:
 #   then the 'value' parameter can be specified using the desired
 #   amperage for the stepper. The default is to not scale the 'value'
 #   parameter.
+#static_value:
+#   This option is deprecated and should no longer be specified.
 ```
 
 ### [pwm_tool]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3153,6 +3153,24 @@ pin:
 #   See the "output_pin" section for the definition of these parameters.
 ```
 
+### [pwm_cycle_time]
+
+Run-time configurable output pins with dynamic pwm cycle timing (one
+may define any number of sections with an "pwm_cycle_time" prefix).
+Pins configured here will be setup as output pins and one may modify
+them at run-time using "SET_PIN PIN=my_pin VALUE=.1 CYCLE_TIME=0.100"
+type extended [g-code commands](G-Codes.md#pwm_cycle_time).
+
+```
+[pwm_cycle_time my_pin]
+pin:
+#value:
+#shutdown_value:
+#cycle_time: 0.100
+#scale:
+#   See the "output_pin" section for information on these parameters.
+```
+
 ### [static_digital_output]
 
 Statically configured digital output pins (one may define any number

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3102,13 +3102,6 @@ pin:
 #shutdown_value:
 #   The value to set the pin to on an MCU shutdown event. The default
 #   is 0 (for low voltage).
-#maximum_mcu_duration:
-#   The maximum duration a non-shutdown value may be driven by the MCU
-#   without an acknowledge from the host.
-#   If host can not keep up with an update, the MCU will shutdown
-#   and set all pins to their respective shutdown values.
-#   Default: 0 (disabled)
-#   Usual values are around 5 seconds.
 #cycle_time: 0.100
 #   The amount of time (in seconds) per PWM cycle. It is recommended
 #   this be 10 milliseconds or greater when using software based PWM.
@@ -3128,8 +3121,9 @@ pin:
 #   then the 'value' parameter can be specified using the desired
 #   amperage for the stepper. The default is to not scale the 'value'
 #   parameter.
+#maximum_mcu_duration:
 #static_value:
-#   This option is deprecated and should no longer be specified.
+#   These options are deprecated and should no longer be specified.
 ```
 
 ### [pwm_tool]
@@ -3144,9 +3138,15 @@ extended [g-code commands](G-Codes.md#output_pin).
 [pwm_tool my_tool]
 pin:
 #   The pin to configure as an output. This parameter must be provided.
+#maximum_mcu_duration:
+#   The maximum duration a non-shutdown value may be driven by the MCU
+#   without an acknowledge from the host.
+#   If host can not keep up with an update, the MCU will shutdown
+#   and set all pins to their respective shutdown values.
+#   Default: 0 (disabled)
+#   Usual values are around 5 seconds.
 #value:
 #shutdown_value:
-#maximum_mcu_duration:
 #cycle_time: 0.100
 #hardware_pwm: False
 #scale:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -839,17 +839,10 @@ The following command is available when an
 enabled.
 
 #### SET_PIN
-`SET_PIN PIN=config_name VALUE=<value> [CYCLE_TIME=<cycle_time>]`: Set
-the pin to the given output `VALUE`. VALUE should be 0 or 1 for
-"digital" output pins. For PWM pins, set to a value between 0.0 and
-1.0, or between 0.0 and `scale` if a scale is configured in the
-output_pin config section.
-
-Some pins (currently only "soft PWM" pins) support setting an explicit
-cycle time using the CYCLE_TIME parameter (specified in seconds). Note
-that the CYCLE_TIME parameter is not stored between SET_PIN commands
-(any SET_PIN command without an explicit CYCLE_TIME parameter will use
-the `cycle_time` specified in the output_pin config section).
+`SET_PIN PIN=config_name VALUE=<value>`: Set the pin to the given
+output `VALUE`. VALUE should be 0 or 1 for "digital" output pins. For
+PWM pins, set to a value between 0.0 and 1.0, or between 0.0 and
+`scale` if a scale is configured in the output_pin config section.
 
 ### [palette2]
 
@@ -977,6 +970,21 @@ direction as well as Z.
 babystepping), and subtract if from the probe's z_offset.  This acts
 to take a frequently used babystepping value, and "make it permanent".
 Requires a `SAVE_CONFIG` to take effect.
+
+### [pwm_cycle_time]
+
+The following command is available when a
+[pwm_cycle_time config section](Config_Reference.md#pwm_cycle_time)
+is enabled.
+
+#### SET_PIN
+`SET_PIN PIN=config_name VALUE=<value> [CYCLE_TIME=<cycle_time>]`:
+This command works similarly to [output_pin](#output_pin) SET_PIN
+commands. The command here supports setting an explicit cycle time
+using the CYCLE_TIME parameter (specified in seconds). Note that the
+CYCLE_TIME parameter is not stored between SET_PIN commands (any
+SET_PIN command without an explicit CYCLE_TIME parameter will use the
+`cycle_time` specified in the pwm_cycle_time config section).
 
 ### [query_adc]
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -374,6 +374,13 @@ is defined):
   template expansion, the PROBE (or similar) command must be run prior
   to the macro containing this reference.
 
+## pwm_cycle_time
+
+The following information is available in
+[pwm_cycle_time some_name](Config_Reference.md#pwm_cycle_time)
+objects:
+- `value`: The "value" of the pin, as set by a `SET_PIN` command.
+
 ## quad_gantry_level
 
 The following information is available in the `quad_gantry_level` object

--- a/klippy/extras/multi_pin.py
+++ b/klippy/extras/multi_pin.py
@@ -46,9 +46,9 @@ class PrinterMultiPin:
     def set_digital(self, print_time, value):
         for mcu_pin in self.mcu_pins:
             mcu_pin.set_digital(print_time, value)
-    def set_pwm(self, print_time, value, cycle_time=None):
+    def set_pwm(self, print_time, value):
         for mcu_pin in self.mcu_pins:
-            mcu_pin.set_pwm(print_time, value, cycle_time)
+            mcu_pin.set_pwm(print_time, value)
 
 def load_config_prefix(config):
     return PrinterMultiPin(config)

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -36,6 +36,7 @@ class PrinterOutputPin:
                                            maxval=MAX_SCHEDULE_TIME)
         self.mcu_pin.setup_max_duration(max_mcu_duration)
         if max_mcu_duration:
+            config.deprecate('maximum_mcu_duration')
             self.resend_interval = max_mcu_duration - RESEND_HOST_TIME
         # Determine start and shutdown values
         static_value = config.getfloat('static_value', None,

--- a/klippy/extras/pwm_cycle_time.py
+++ b/klippy/extras/pwm_cycle_time.py
@@ -1,0 +1,123 @@
+# Handle pwm output pins with variable frequency
+#
+# Copyright (C) 2017-2023  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+PIN_MIN_TIME = 0.100
+MAX_SCHEDULE_TIME = 5.0
+
+class MCU_pwm_cycle:
+    def __init__(self, pin_params, cycle_time, start_value, shutdown_value):
+        self._mcu = pin_params['chip']
+        self._cycle_time = cycle_time
+        self._oid = None
+        self._mcu.register_config_callback(self._build_config)
+        self._pin = pin_params['pin']
+        self._invert = pin_params['invert']
+        if self._invert:
+            start_value = 1. - start_value
+            shutdown_value = 1. - shutdown_value
+        self._start_value = max(0., min(1., start_value))
+        self._shutdown_value = max(0., min(1., shutdown_value))
+        self._last_clock = self._cycle_ticks = 0
+        self._set_cmd = self._set_cycle_ticks = None
+    def _build_config(self):
+        cmd_queue = self._mcu.alloc_command_queue()
+        curtime = self._mcu.get_printer().get_reactor().monotonic()
+        printtime = self._mcu.estimated_print_time(curtime)
+        self._last_clock = self._mcu.print_time_to_clock(printtime + 0.200)
+        cycle_ticks = self._mcu.seconds_to_clock(self._cycle_time)
+        if self._shutdown_value not in [0., 1.]:
+            raise self._mcu.get_printer().config_error(
+                "shutdown value must be 0.0 or 1.0 on soft pwm")
+        if cycle_ticks >= 1<<31:
+            raise self._mcu.get_printer().config_error(
+                "PWM pin cycle time too large")
+        self._mcu.request_move_queue_slot()
+        self._oid = self._mcu.create_oid()
+        self._mcu.add_config_cmd(
+            "config_digital_out oid=%d pin=%s value=%d"
+            " default_value=%d max_duration=%d"
+            % (self._oid, self._pin, self._start_value >= 1.0,
+               self._shutdown_value >= 0.5, 0))
+        self._mcu.add_config_cmd(
+            "set_digital_out_pwm_cycle oid=%d cycle_ticks=%d"
+            % (self._oid, cycle_ticks))
+        self._cycle_ticks = cycle_ticks
+        svalue = int(self._start_value * cycle_ticks + 0.5)
+        self._mcu.add_config_cmd(
+            "queue_digital_out oid=%d clock=%d on_ticks=%d"
+            % (self._oid, self._last_clock, svalue), is_init=True)
+        self._set_cmd = self._mcu.lookup_command(
+            "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue)
+        self._set_cycle_ticks = self._mcu.lookup_command(
+            "set_digital_out_pwm_cycle oid=%c cycle_ticks=%u", cq=cmd_queue)
+    def set_pwm_cycle(self, print_time, value, cycle_time):
+        clock = self._mcu.print_time_to_clock(print_time)
+        minclock = self._last_clock
+        # Send updated cycle_time if necessary
+        cycle_ticks = self._mcu.seconds_to_clock(cycle_time)
+        if cycle_ticks != self._cycle_ticks:
+            if cycle_ticks >= 1<<31:
+                raise self._mcu.get_printer().command_error(
+                    "PWM cycle time too large")
+            self._set_cycle_ticks.send([self._oid, cycle_ticks],
+                                       minclock=minclock, reqclock=clock)
+            self._cycle_ticks = cycle_ticks
+        # Send pwm update
+        if self._invert:
+            value = 1. - value
+        v = int(max(0., min(1., value)) * float(self._cycle_ticks) + 0.5)
+        self._set_cmd.send([self._oid, clock, v],
+                           minclock=self._last_clock, reqclock=clock)
+        self._last_clock = clock
+
+class PrinterOutputPWMCycle:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.last_print_time = 0.
+        cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
+                                     maxval=MAX_SCHEDULE_TIME)
+        self.last_cycle_time = self.default_cycle_time = cycle_time
+        # Determine start and shutdown values
+        self.scale = config.getfloat('scale', 1., above=0.)
+        self.last_value = config.getfloat(
+            'value', 0., minval=0., maxval=self.scale) / self.scale
+        self.shutdown_value = config.getfloat(
+            'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
+        # Create pwm pin object
+        ppins = self.printer.lookup_object('pins')
+        pin_params = ppins.lookup_pin(config.get('pin'), can_invert=True)
+        self.mcu_pin = MCU_pwm_cycle(pin_params, cycle_time,
+                                     self.last_value, self.shutdown_value)
+        # Register commands
+        pin_name = config.get_name().split()[1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("SET_PIN", "PIN", pin_name,
+                                   self.cmd_SET_PIN,
+                                   desc=self.cmd_SET_PIN_help)
+    def get_status(self, eventtime):
+        return {'value': self.last_value}
+    def _set_pin(self, print_time, value, cycle_time):
+        if value == self.last_value and cycle_time == self.last_cycle_time:
+            return
+        print_time = max(print_time, self.last_print_time + PIN_MIN_TIME)
+        self.mcu_pin.set_pwm_cycle(print_time, value, cycle_time)
+        self.last_value = value
+        self.last_cycle_time = cycle_time
+        self.last_print_time = print_time
+    cmd_SET_PIN_help = "Set the value of an output pin"
+    def cmd_SET_PIN(self, gcmd):
+        # Read requested value
+        value = gcmd.get_float('VALUE', minval=0., maxval=self.scale)
+        value /= self.scale
+        cycle_time = gcmd.get_float('CYCLE_TIME', self.default_cycle_time,
+                                    above=0., maxval=MAX_SCHEDULE_TIME)
+        # Obtain print_time and apply requested settings
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_lookahead_callback(
+            lambda print_time: self._set_pin(print_time, value, cycle_time))
+
+def load_config_prefix(config):
+    return PrinterOutputPWMCycle(config)

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -67,7 +67,7 @@ class pca9685_pwm:
         cmd_queue = self._mcu.alloc_command_queue()
         self._set_cmd = self._mcu.lookup_command(
             "queue_pca9685_out oid=%c clock=%u value=%hu", cq=cmd_queue)
-    def set_pwm(self, print_time, value, cycle_time=None):
+    def set_pwm(self, print_time, value):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._invert:
             value = 1. - value

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -30,7 +30,6 @@ class pca9685_pwm:
         self._invert = pin_params['invert']
         self._start_value = self._shutdown_value = float(self._invert)
         self._is_enable = not not self._start_value
-        self._is_static = False
         self._last_clock = 0
         self._pwm_max = 0.
         self._set_cmd = None
@@ -44,28 +43,18 @@ class pca9685_pwm:
         if cycle_time != self._cycle_time:
             logging.info("Ignoring pca9685 cycle time of %.6f (using %.6f)",
                          cycle_time, self._cycle_time)
-    def setup_start_value(self, start_value, shutdown_value, is_static=False):
-        if is_static and start_value != shutdown_value:
-            raise pins.error("Static pin can not have shutdown value")
+    def setup_start_value(self, start_value, shutdown_value):
         if self._invert:
             start_value = 1. - start_value
             shutdown_value = 1. - shutdown_value
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
-        self._is_static = is_static
         self._replicape.note_pwm_start_value(
             self._channel, self._start_value, self._shutdown_value)
         self._is_enable = not not self._start_value
     def _build_config(self):
         self._pwm_max = self._mcu.get_constant_float("PCA9685_MAX")
         cycle_ticks = self._mcu.seconds_to_clock(self._cycle_time)
-        if self._is_static:
-            self._mcu.add_config_cmd(
-                "set_pca9685_out bus=%d addr=%d channel=%d"
-                " cycle_ticks=%d value=%d" % (
-                    self._bus, self._address, self._channel,
-                    cycle_ticks, self._start_value * self._pwm_max))
-            return
         self._mcu.request_move_queue_slot()
         self._oid = self._mcu.create_oid()
         self._mcu.add_config_cmd(

--- a/klippy/extras/static_digital_output.py
+++ b/klippy/extras/static_digital_output.py
@@ -10,8 +10,10 @@ class PrinterStaticDigitalOut:
         ppins = printer.lookup_object('pins')
         pin_list = config.getlist('pins')
         for pin_desc in pin_list:
-            mcu_pin = ppins.setup_pin('digital_out', pin_desc)
-            mcu_pin.setup_start_value(1, 1, True)
+            pin_params = ppins.lookup_pin(pin_desc, can_invert=True)
+            mcu = pin_params['chip']
+            mcu.add_config_cmd("set_digital_out pin=%s value=%d"
+                               % (pin_params['pin'], not pin_params['invert']))
 
 def load_config_prefix(config):
     return PrinterStaticDigitalOut(config)

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -104,7 +104,6 @@ class SX1509_digital_out(object):
         self._invert = pin_params['invert']
         self._mcu.register_config_callback(self._build_config)
         self._start_value = self._shutdown_value = self._invert
-        self._is_static = False
         self._max_duration = 2.
         self._set_cmd = self._clear_cmd = None
         # Set direction to output
@@ -116,12 +115,9 @@ class SX1509_digital_out(object):
         return self._mcu
     def setup_max_duration(self, max_duration):
         self._max_duration = max_duration
-    def setup_start_value(self, start_value, shutdown_value, is_static=False):
-        if is_static and start_value != shutdown_value:
-            raise pins.error("Static pin can not have shutdown value")
+    def setup_start_value(self, start_value, shutdown_value):
         self._start_value = (not not start_value) ^ self._invert
         self._shutdown_value = self._invert
-        self._is_static = is_static
         # We need to set the start value here so the register is
         # updated before the SX1509 class writes it.
         if self._start_value:
@@ -148,7 +144,6 @@ class SX1509_pwm(object):
         self._invert = pin_params['invert']
         self._mcu.register_config_callback(self._build_config)
         self._start_value = self._shutdown_value = float(self._invert)
-        self._is_static = False
         self._max_duration = 2.
         self._hardware_pwm = False
         self._pwm_max = 0.
@@ -182,15 +177,12 @@ class SX1509_pwm(object):
     def setup_cycle_time(self, cycle_time, hardware_pwm=False):
         self._cycle_time = cycle_time
         self._hardware_pwm = hardware_pwm
-    def setup_start_value(self, start_value, shutdown_value, is_static=False):
-        if is_static and start_value != shutdown_value:
-            raise pins.error("Static pin can not have shutdown value")
+    def setup_start_value(self, start_value, shutdown_value):
         if self._invert:
             start_value = 1. - start_value
             shutdown_value = 1. - shutdown_value
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
-        self._is_static = is_static
     def set_pwm(self, print_time, value, cycle_time=None):
         self._sx1509.set_register(self._i_on_reg, ~int(255 * value)
                                   if not self._invert

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -183,7 +183,7 @@ class SX1509_pwm(object):
             shutdown_value = 1. - shutdown_value
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
-    def set_pwm(self, print_time, value, cycle_time=None):
+    def set_pwm(self, print_time, value):
         self._sx1509.set_register(self._i_on_reg, ~int(255 * value)
                                   if not self._invert
                                   else int(255 * value) & 0xFF)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -381,9 +381,9 @@ class MCU_pwm:
         self._pin = pin_params['pin']
         self._invert = pin_params['invert']
         self._start_value = self._shutdown_value = float(self._invert)
-        self._last_clock = self._last_cycle_ticks = 0
+        self._last_clock = 0
         self._pwm_max = 0.
-        self._set_cmd = self._set_cycle_ticks = None
+        self._set_cmd = None
     def get_mcu(self):
         return self._mcu
     def setup_max_duration(self, max_duration):
@@ -441,40 +441,21 @@ class MCU_pwm:
         self._mcu.add_config_cmd(
             "set_digital_out_pwm_cycle oid=%d cycle_ticks=%d"
             % (self._oid, cycle_ticks))
-        self._last_cycle_ticks = cycle_ticks
+        self._pwm_max = float(cycle_ticks)
         svalue = int(self._start_value * cycle_ticks + 0.5)
         self._mcu.add_config_cmd(
             "queue_digital_out oid=%d clock=%d on_ticks=%d"
             % (self._oid, self._last_clock, svalue), is_init=True)
         self._set_cmd = self._mcu.lookup_command(
             "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue)
-        self._set_cycle_ticks = self._mcu.lookup_command(
-            "set_digital_out_pwm_cycle oid=%c cycle_ticks=%u", cq=cmd_queue)
-    def set_pwm(self, print_time, value, cycle_time=None):
-        clock = self._mcu.print_time_to_clock(print_time)
-        minclock = self._last_clock
-        self._last_clock = clock
+    def set_pwm(self, print_time, value):
         if self._invert:
             value = 1. - value
-        if self._hardware_pwm:
-            v = int(max(0., min(1., value)) * self._pwm_max + 0.5)
-            self._set_cmd.send([self._oid, clock, v],
-                               minclock=minclock, reqclock=clock)
-            return
-        # Soft pwm update
-        if cycle_time is None:
-            cycle_time = self._cycle_time
-        cycle_ticks = self._mcu.seconds_to_clock(cycle_time)
-        if cycle_ticks != self._last_cycle_ticks:
-            if cycle_ticks >= 1<<31:
-                raise self._mcu.get_printer().command_error(
-                    "PWM cycle time too large")
-            self._set_cycle_ticks.send([self._oid, cycle_ticks],
-                                       minclock=minclock, reqclock=clock)
-            self._last_cycle_ticks = cycle_ticks
-        on_ticks = int(max(0., min(1., value)) * float(cycle_ticks) + 0.5)
-        self._set_cmd.send([self._oid, clock, on_ticks],
-                           minclock=minclock, reqclock=clock)
+        v = int(max(0., min(1., value)) * self._pwm_max + 0.5)
+        clock = self._mcu.print_time_to_clock(print_time)
+        self._set_cmd.send([self._oid, clock, v],
+                           minclock=self._last_clock, reqclock=clock)
+        self._last_clock = clock
 
 class MCU_adc:
     def __init__(self, mcu, pin_params):

--- a/test/klippy/pwm.cfg
+++ b/test/klippy/pwm.cfg
@@ -5,6 +5,12 @@ value: 0
 shutdown_value: 0
 cycle_time: 0.01
 
+[pwm_cycle_time cycle_pwm_pin]
+pin: PH7
+value: 0
+shutdown_value: 0
+cycle_time: 0.01
+
 [output_pin hard_pwm_pin]
 pin: PH6
 pwm: True

--- a/test/klippy/pwm.test
+++ b/test/klippy/pwm.test
@@ -16,18 +16,24 @@ SET_PIN PIN=soft_pwm_pin VALUE=0
 SET_PIN PIN=soft_pwm_pin VALUE=0.5
 SET_PIN PIN=soft_pwm_pin VALUE=1
 
+# Soft PWM with dynamic cycle time
+# Test basic on off
+SET_PIN PIN=cycle_pwm_pin VALUE=0
+SET_PIN PIN=cycle_pwm_pin VALUE=0.5
+SET_PIN PIN=cycle_pwm_pin VALUE=1
+
 # Test cycle time
-SET_PIN PIN=soft_pwm_pin VALUE=0 CYCLE_TIME=0.1
-SET_PIN PIN=soft_pwm_pin VALUE=1 CYCLE_TIME=0.5
-SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=0.001
-SET_PIN PIN=soft_pwm_pin VALUE=0.75 CYCLE_TIME=0.01
-SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=1
+SET_PIN PIN=cycle_pwm_pin VALUE=0 CYCLE_TIME=0.1
+SET_PIN PIN=cycle_pwm_pin VALUE=1 CYCLE_TIME=0.5
+SET_PIN PIN=cycle_pwm_pin VALUE=0.5 CYCLE_TIME=0.001
+SET_PIN PIN=cycle_pwm_pin VALUE=0.75 CYCLE_TIME=0.01
+SET_PIN PIN=cycle_pwm_pin VALUE=0.5 CYCLE_TIME=1
 
 # Test duplicate values
-SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
-SET_PIN PIN=soft_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
-SET_PIN PIN=soft_pwm_pin VALUE=0.75 CYCLE_TIME=0.5
-SET_PIN PIN=soft_pwm_pin VALUE=0.75 CYCLE_TIME=0.75
+SET_PIN PIN=cycle_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
+SET_PIN PIN=cycle_pwm_pin VALUE=0.5 CYCLE_TIME=0.5
+SET_PIN PIN=cycle_pwm_pin VALUE=0.75 CYCLE_TIME=0.5
+SET_PIN PIN=cycle_pwm_pin VALUE=0.75 CYCLE_TIME=0.75
 
 # PWM tool
 # Basic test


### PR DESCRIPTION
Over the last few years the `output_pin` module has gained a handful of options that have made it harder to maintain the the low-level backend code.  This PR simplifies the output_pin module.  The main changes are:
1. The `static_value` parameter is deprecated.  This option has little impact - it only saves a few bytes in the micro-controller.  Going forward it is simple enough to just not specify it.
2. The `maximum_mcu_duration` parameter is deprecated.  The `pwm_tool` module is a better choice for tools that require this capability.  It should be straight forward for users to change their configs from `[output_pin mypin]` to `[pwm_tool mypin]`.
3. The `SET_PIN CYCLE_TIME=x` g-code command for `[output_pin mypin]` config sections has been removed.  Users can convert to a new `[pwm_cycle_time mypin]` config as a replacement.  This change is setup to take effect immediately (no deprecation period).

This is the last PR as part of the `pwm_tool` series of changes (eg, #6369, #6410, #6420).

@Cirromulus - fyi.

-Kevin