### PR TITLE
Remove previously deprecated features

### DIFF
--- a/config/printer-geeetech-301-2019.cfg
+++ b/config/printer-geeetech-301-2019.cfg
@@ -71,25 +71,21 @@ pid_Kp: 39
 pid_Ki: 2
 pid_Kd: 210
 
-[extruder1]
+[extruder_stepper e1]
+extruder:
 step_pin: PA0
 dir_pin: !PB6
 enable_pin: !PA1
 microsteps: 16
 rotation_distance: 32
-nozzle_diameter: 0.4
-filament_diameter: 1.75
-shared_heater: extruder
 
-[extruder2]
+[extruder_stepper e2]
+extruder:
 step_pin: PB2
 dir_pin: !PB11
 enable_pin: !PC4
 microsteps: 16
 rotation_distance: 32
-nozzle_diameter: 0.4
-filament_diameter: 1.75
-shared_heater: extruder
 
 [heater_bed]
 heater_pin: PB1

--- a/config/printer-modix-big60-2020.cfg
+++ b/config/printer-modix-big60-2020.cfg
@@ -199,7 +199,6 @@ algorithm: bicubic
 bicubic_tension: 0.15
 fade_start: 0.5
 fade_end: 2.5
-relative_reference_index: 60
 
 [bed_screws]
 screw1: 0,0

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,14 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240215: Several deprecated features have been removed. Using "NTC
+100K beta 3950" as a thermistor name has been removed (deprecated on
+20211110). The `SYNC_STEPPER_TO_EXTRUDER` and
+`SET_EXTRUDER_STEP_DISTANCE` commands have been removed, and the
+extruder `shared_heater` config option has been removed (deprecated on
+20220210). The bed_mesh `relative_reference_index` option has been
+removed (deprecated on 20230619).
+
 20240123: The output_pin SET_PIN CYCLE_TIME parameter has been
 removed. Use the new
 [pwm_cycle_time](Config_Reference.md#pwm_cycle_time) module if it is

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -979,13 +979,6 @@ Visual Examples:
 #   where Z = 0.  When this option is specified the mesh will be offset
 #   so that zero Z adjustment occurs at this location.  The default is
 #   no zero reference.
-#relative_reference_index:
-#   **DEPRECATED, use the "zero_reference_position" option**
-#   The legacy option superceded by the "zero reference position".
-#   Rather than a coordinate this option takes an integer "index" that
-#   refers to the location of one of the generated points. It is recommended
-#   to use the "zero_reference_position" instead of this option for new
-#   configurations. The default is no relative reference index.
 #faulty_region_1_min:
 #faulty_region_1_max:
 #   Optional points that define a faulty region.  See docs/Bed_Mesh.md

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -449,12 +449,6 @@ MOTION_QUEUE (as defined in an [extruder](Config_Reference.md#extruder)
 config section). If MOTION_QUEUE is an empty string then the stepper
 will be desynchronized from all extruder movement.
 
-#### SET_EXTRUDER_STEP_DISTANCE
-This command is deprecated and will be removed in the near future.
-
-#### SYNC_STEPPER_TO_EXTRUDER
-This command is deprecated and will be removed in the near future.
-
 ### [fan_generic]
 
 The following command is available when a

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -281,8 +281,6 @@ class PrinterHeaters:
         if sensor_type not in self.sensor_factories:
             raise self.printer.config_error(
                 "Unknown temperature sensor '%s'" % (sensor_type,))
-        if sensor_type == 'NTC 100K beta 3950':
-            config.deprecate('sensor_type', 'NTC 100K beta 3950')
         return self.sensor_factories[sensor_type](config)
     def register_sensor(self, config, psensor, gcode_id=None):
         self.available_sensors.append(config.get_name())

--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -102,12 +102,6 @@ temperature1: 25
 resistance1: 100000
 beta: 3974
 
-# Definition inherent from name. This sensor is deprecated!
-[thermistor NTC 100K beta 3950]
-temperature1: 25
-resistance1: 100000
-beta: 3950
-
 # Definition from description of Marlin "thermistor 75"
 [thermistor NTC 100K MGB18-104F39050L32]
 temperature1: 25


### PR DESCRIPTION
This PR removes features that we have previously deprecated.  I'll look to make this change in about a month.  Details are in the PR:

Several deprecated features have been removed. Using "NTC 100K beta 3950" as a thermistor name has been removed (deprecated on 20211110). The `SYNC_STEPPER_TO_EXTRUDER` and `SET_EXTRUDER_STEP_DISTANCE` commands have been removed, and the extruder `shared_heater` config option has been removed (deprecated on 20220210). The bed_mesh `relative_reference_index` option has been removed (deprecated on 20230619).

-Kevin