### PR TITLE
kin_shaper: minimal change to allow more shaper pulses

### DIFF
--- a/klippy/chelper/kin_shaper.c
+++ b/klippy/chelper/kin_shaper.c
@@ -22,7 +22,7 @@ struct shaper_pulses {
     int num_pulses;
     struct {
         double t, a;
-    } pulses[5];
+    } pulses[25];
 };
 
 // Shift pulses around 'mid-point' t=0 so that the input shaper is an identity


### PR DESCRIPTION
Hello everyone,

I am submitting this PR to introduce a minor change to the kin_shape.c code that should have no impact, with the primary goal of allowing the definition of shapers with a larger number of pulses.

The reason for this change comes from some work we are doing with a couple of Voron contributors: my [Shake&Tune module](https://github.com/Frix-x/klippain-shaketune) provides a way to measure vibrations at different speeds to get optimal settings for the slicer profiles. But we can also get some additional data from these measurements, like the main motor resonance. The idea is to add another input shaper filter to target this resonance and reduce its effect.

A first POC was done by using the `[input_shaper]` config targeting this motor resonance, and it resulted in generally lower motor noise, but it also removed the possibility to use IS for prints... So what we do now is to convolve our axis IS filter definition with a ZV filter targeting the motor resonance and define it using Dmitry's "custom" shaper in his edge branch. This method has already shown promising results on my test rig, significantly improving print quality by reducing VFAs and overall machine noise, even at high acceleration values, and also offering a bit more torque. These positive results have been replicated by some other users who have started to experiment with it.

However, the current problem is that I can't release a "plugin" very easily, since users would have to patch the kin_shaper.c file to increase the maximum number of pulses, causing their local repository to diverge from the main branch. This divergence is problematic in terms of the moonraker auto-update feature and would require reapplying the patch after every update, which is not really user-friendly...

As a side note, the choice of 25 pulses was made somewhat arbitrary. It was chosen to allow convolution of up to two instances of 3_hump_ei filters (each requiring 5 pulses), which should cover most cases. The current limit of 5 pulses only allows the use of two ZV filters at the same time, which I find quite limiting for general use, as most users will still want to run MZV, EI or the other standard filters... But 25 is not a fixed number and can be changed to whatever you prefer.

Finally, the whole motor filtering thing is a WIP and I'm not sure it's a good idea to integrate it into the main Klipper for now, but I'm really open to discussing it and how to do it properly. The only thing I need and that is included for now in this PR is the change from 5 to 25 max pulses in order to allow experimenting with it more easily with something like a Klipper extras plugin (that I may release in Shake&Tune).