### PR TITLE
stm32g0: Disable internal pull-down resistors on UCPDx CCx pins, because klipper never uses UCPD

### DIFF
--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -162,6 +162,8 @@ bootloader_request(void)
 void
 armcm_main(void)
 {
+    // Disable internal pull-down resistors on UCPDx CCx pins
+    SYSCFG->CFGR1 |= (SYSCFG_CFGR1_UCPD1_STROBE | SYSCFG_CFGR1_UCPD2_STROBE);
     SCB->VTOR = (uint32_t)VectorTable;
 
     // Reset clock registers (in case bootloader has changed them)


### PR DESCRIPTION
According to https://www.st.com/resource/en/datasheet/stm32g0b1cb.pdf page 55.

![image](https://github.com/Klipper3d/klipper/assets/38851044/eba56f72-7bf3-484f-a862-38176e1e3717)
