### PR TITLE
Make MCU Protocol mismatch error message more specific

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -166,8 +166,8 @@ class Printer:
         msg = ["MCU Protocol error",
                message_protocol_error1,
                "Your Klipper version is: %s" % (host_version,),
-               "MCU(s) which should be updated:"]
-        msg += msg_update + ["Up-to-date MCU(s):"] + msg_updated
+               "MCU(s) reporting a different version:"]
+        msg += msg_update + ["MCU(s) reporting the same version:"] + msg_updated
         msg += [message_protocol_error2, str(e)]
         return "\n".join(msg)
     def _connect(self, eventtime):


### PR DESCRIPTION
There is a good chance that an "MCU Protocol Error" may not require all MCUs to be updated, but the current error message seems to indicate that all MCUs that don't exactly match the current version should be updated.  That may be misleading.  Try to word the message to be a little more precise.

There is a risk this message may be more confusing for users, in that it doesn't explicitly state which MCUs to update.

@meteyou , @Drachenkaetzchen - FYI.

-Kevin