### PR TITLE
Load all code into ram on the rp2040

### DIFF
--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -55,7 +55,7 @@ $(OUT)klipper.bin: $(OUT)klipper.elf
 	$(Q)$(OBJCOPY) -O binary $< $@
 
 rptarget-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)klipper.bin
-rplink-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)src/generic/armcm_link.ld
+rplink-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)src/rp2040/rp2040_link.ld
 
 # Set klipper.elf linker rules
 target-y += $(rptarget-y)

--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -17,6 +17,26 @@
 
 
 /****************************************************************
+ * Ram IRQ vector table
+ ****************************************************************/
+
+// Copy vector table to ram and activate it
+static void
+enable_ram_vectortable(void)
+{
+    // Symbols created by rp2040_link.lds.S linker script
+    extern uint32_t _ram_vectortable_start, _ram_vectortable_end;
+    extern uint32_t _text_vectortable_start;
+
+    uint32_t count = (&_ram_vectortable_end - &_ram_vectortable_start) * 4;
+    __builtin_memcpy(&_ram_vectortable_start, &_text_vectortable_start, count);
+    barrier();
+
+    SCB->VTOR = (uint32_t)&_ram_vectortable_start;
+}
+
+
+/****************************************************************
  * Bootloader
  ****************************************************************/
 
@@ -145,6 +165,7 @@ clock_setup(void)
 void
 armcm_main(void)
 {
+    enable_ram_vectortable();
     clock_setup();
     sched_main();
 }

--- a/src/rp2040/rp2040_link.lds.S
+++ b/src/rp2040/rp2040_link.lds.S
@@ -31,8 +31,7 @@ SECTIONS
         _text_vectortable_start = .;
         KEEP(*(.vector_table))
         _text_vectortable_end = .;
-        *(.text .text.*)
-        *(.rodata .rodata*)
+        *(.text.armcm_boot*)
     } > rom
 
     . = ALIGN(4);
@@ -42,7 +41,9 @@ SECTIONS
     {
         . = ALIGN(4);
         _data_start = .;
+        *(.text .text.*)
         *(.ramfunc .ramfunc.*);
+        *(.rodata .rodata*)
         *(.data .data.*);
         . = ALIGN(4);
         _data_end = .;

--- a/src/rp2040/rp2040_link.lds.S
+++ b/src/rp2040/rp2040_link.lds.S
@@ -37,6 +37,12 @@ SECTIONS
     . = ALIGN(4);
     _data_flash = .;
 
+    .ram_vectortable (NOLOAD) : {
+        _ram_vectortable_start = .;
+        . = . + ( _text_vectortable_end - _text_vectortable_start ) ;
+        _ram_vectortable_end = .;
+    } > ram
+
     .data : AT (_data_flash)
     {
         . = ALIGN(4);

--- a/src/rp2040/rp2040_link.lds.S
+++ b/src/rp2040/rp2040_link.lds.S
@@ -1,6 +1,6 @@
 // rp2040 linker script (based on armcm_link.lds.S and customized for stage2)
 //
-// Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2019-2024  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -9,9 +9,15 @@
 OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
 
+#if CONFIG_RP2040_HAVE_STAGE2
+  #define ROM_ORIGIN 0x10000000
+#else
+  #define ROM_ORIGIN CONFIG_FLASH_APPLICATION_ADDRESS
+#endif
+
 MEMORY
 {
-  rom (rx) : ORIGIN = 0x10000000 , LENGTH = CONFIG_FLASH_SIZE
+  rom (rx) : ORIGIN = ROM_ORIGIN , LENGTH = CONFIG_FLASH_SIZE
   ram (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_RAM_SIZE
 }
 
@@ -19,7 +25,9 @@ SECTIONS
 {
     .text : {
         . = ALIGN(4);
+#if CONFIG_RP2040_HAVE_STAGE2
         KEEP(*(.boot2))
+#endif
         _text_vectortable_start = .;
         KEEP(*(.vector_table))
         _text_vectortable_end = .;


### PR DESCRIPTION
There have been a few reports of instability on the rp2040 in code with strict timing requirements (eg, neopixels and tmcuart).  It is possible that rp2040 flash accesses are causing some timing instability.  Typically, all the active parts of the code would be fully loaded into the cache, and thus timing should not be variable.  However, it is possible that the initial cache load, or sporadic cache misses could lead to an issue.

This PR loads all of the code (along with the static data and irq vectortable) into ram on the rp2040.  With this PR, there should be few (if any) flash accesses after the initial code initialization.

Loading the rp2040 code into ram was previously proposed in PR #5889.

-Kevin