### PR TITLE
Update flash_usb.py

### DIFF
--- a/scripts/flash_usb.py
+++ b/scripts/flash_usb.py
@@ -345,9 +345,10 @@ MCUTYPES = {
     'lpc176': flash_lpc176x, 'stm32f103': flash_stm32f1,
     'stm32f4': flash_stm32f4, 'stm32f042': flash_stm32f4,
     'stm32f070': flash_stm32f4, 'stm32f072': flash_stm32f4,
-    'stm32g0b1': flash_stm32f4, 'stm32f7': flash_stm32f4,
-    'stm32h7': flash_stm32f4, 'stm32l4': flash_stm32f4,
-    'stm32g4': flash_stm32f4, 'rp2040': flash_rp2040,
+    'stm32g0b1': flash_stm32f4, 'stm32g0b0': flash_stm32f4,
+    'stm32f7': flash_stm32f4, 'stm32h7': flash_stm32f4, 
+    'stm32l4': flash_stm32f4, 'stm32g4': flash_stm32f4, 
+    'rp2040': flash_rp2040,
 }
 
 


### PR DESCRIPTION
I have skr mini e3 v3 with stm32g0**b0** MCU, idk why, other e3 v3 boards i have are with stm32g0**b1**. 
To make ./scripts/flash-sdcard.sh work, a slight change was needed in the flash-usb.py file.