### PR TITLE
Fix initial rp2040 SPI transfers

### DIFF
--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -89,8 +89,12 @@ void
 spi_prepare(struct spi_config config)
 {
     spi_hw_t *spi = config.spi;
+    if (spi->cr0 == config.cr0 && spi->cpsr == config.cpsr)
+        return;
+    spi->cr1 = 0;
     spi->cr0 = config.cr0;
     spi->cpsr = config.cpsr;
+    spi->cr1 = SPI_SSPCR1_SSE_BITS;
 }
 
 void


### PR DESCRIPTION
The rp2040 code was not initializing the SCLK line prior to the first SPI transfer.

This issue is likely the cause of common reports of `Invalid adxl345 id (got xx vs e5)` error on the first (and only first) adxl345 query.

@Sineos, @buzztiaan - FYI.

-Kevin