### PR TITLE
ci: update & simplify docs contributing - docs: update + cosmetics

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ci_cache
         key: ${{ runner.os }}-build-${{ hashFiles('scripts/ci-install.sh') }}
@@ -21,7 +21,7 @@ jobs:
       run: ./scripts/ci-build.sh 2>&1
 
     - name: Upload micro-controller data dictionaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: data-dict
         path: ci_build/dict

--- a/.github/workflows/klipper3d-deploy.yaml
+++ b/.github/workflows/klipper3d-deploy.yaml
@@ -12,12 +12,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/_klipper3d/mkdocs-requirements.txt') }}

--- a/.github/workflows/klipper3d-deploy.yaml
+++ b/.github/workflows/klipper3d-deploy.yaml
@@ -1,4 +1,5 @@
 name: klipper3d deploy
+
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -8,11 +9,25 @@ on:
     paths:
       - docs/**
       - .github/workflows/klipper3d-deploy.yaml
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Documentation page deployment source branch (eg: "pr-docs")'
+        required: true
+        default: master
+
+# Required for the deployment to be able to upload to the "gh-pages" branch
+# (since the repo settings for default actions permission defaults to read only)
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
       - name: Setup python
         uses: actions/setup-python@v5
         with:

--- a/docs/Bootloader_Entry.md
+++ b/docs/Bootloader_Entry.md
@@ -21,7 +21,7 @@ Entering bootloader on <DEVICE>
 ```
 
 Where `<DEVICE>` is your serial device, such as
-`/dev/serial.by-id/usb-Klipper[...]` or `/dev/ttyACM0`
+`/dev/serial/by-id/usb-Klipper[...]` or `/dev/ttyACM0`
 
 Note that if this fails, no output will be printed, success is indicated by
 printing `Entering bootloader on <DEVICE>`.
@@ -34,7 +34,7 @@ picocom -b 1200 <DEVICE>
 ```
 
 Where `<DEVICE>` is your serial device, such as
-`/dev/serial.by-id/usb-Klipper[...]` or `/dev/ttyACM0`
+`/dev/serial/by-id/usb-Klipper[...]` or `/dev/ttyACM0`
 
 `<Ctrl-A><Ctrl-P>` means
 holding `Ctrl`, pressing and releasing `a`, pressing and releasing `p`, then
@@ -48,8 +48,7 @@ is being used to connect to it), sending the string
 
 `<SPACE>` is an ASCII literal space, 0x20.
 
-`<FS>` is the ASCII File Separator,
-0x1c.
+`<FS>` is the ASCII File Separator, 0x1c.
 
 Note that this is not a valid message as per the
 [MCU Protocol](Protocol.md#micro-controller-interface), but sync characters(`~`)
@@ -69,8 +68,7 @@ echo $'~ \x1c Request Serial Bootloader!! ~' >> /dev/<DEVICE>
 Where `<DEVICE>` is your serial port, such as `/dev/ttyS0`, or
 `/dev/serial/by-id/gpio-serial2`, and
 
-`<BAUD>` is the baud rate of the serial
-port, such as `115200`.
+`<BAUD>` is the baud rate of the serial port, such as `115200`.
 
 ### CANBUS
 

--- a/docs/Bootloader_Entry.md
+++ b/docs/Bootloader_Entry.md
@@ -83,7 +83,7 @@ This method also applies to devices operating in
 #### Katapult's flashtool.py
 
 ```shell
-python3 ./katapult/scripts/flashtool.py -i <CAN_IFACE> -u <UUID> -r
+python3 ~/katapult/scripts/flashtool.py -i <CAN_IFACE> -u <UUID> -r
 ```
 
 Where `<CAN_IFACE>` is the can interface to use. If using `can0`, both the `-i`
@@ -99,13 +99,12 @@ for information on finding the CAN UUID of your devices.
 
 When klipper receives one of the above bootloader requests:
 
-If Katapult (formerly known as CANBoot) is available, klipper will request that
-Katapult stay active on the next boot, then reset the MCU (therefore entering
-Katapult).
+If [Katapult (formerly known as CANBoot)](Bootloaders.md#katapult-bootloader-lpc176x-stm32-rp2040)
+is available, klipper will request that Katapult stay active on the next boot,
+then reset the MCU (therefore entering Katapult).
 
-If Katapult is not available, klipper will then try to enter a
-platform-specific bootloader, such as STM32's DFU
-mode([see note](#stm32-dfu-warning)).
+If Katapult is not available, klipper will then try to enter a platform-specific
+bootloader, such as STM32's DFU mode ([see note](#stm32-dfu-warning)).
 
 In short, Klipper will reboot to Katapult if installed, then a hardware specific
 bootloader if available.

--- a/docs/Bootloader_Entry.md
+++ b/docs/Bootloader_Entry.md
@@ -115,11 +115,16 @@ bootloader if available.
 For details about the specific bootloaders on various platforms see
 [Bootloaders](Bootloaders.md)
 
+---
+
 ## Notes
 
 ### STM32 DFU Warning
 
-Note that on some boards, like the Octopus Pro v1, entering DFU mode can cause
-undesired actions (such as powering the heater while in DFU mode). It is
-recommended to disconnect heaters, and otherwise prevent undesired operations
-when using DFU mode. Consult the documentation for your board for more details.
+!!! danger "STM32 DFU Warning"
+
+    Note that on some boards, like the Octopus Pro v1 or EBB36/42 v1.1, entering
+    DFU mode can cause undesired actions (such as powering the heater while in
+    DFU mode). It is recommended to disconnect heaters, and otherwise prevent
+    undesired operations when using DFU mode. Consult the documentation for your
+    board for more details.

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -277,7 +277,8 @@ the following chip config:
 source [find target/atsame5x.cfg]
 ```
 Obtain a bootloader - several bootloaders are available from
-[https://github.com/adafruit/uf2-samdx1/releases/latest](https://github.com/adafruit/uf2-samdx1/releases/latest). For example:
+[https://github.com/adafruit/uf2-samdx1/releases/latest](https://github.com/adafruit/uf2-samdx1/releases/latest).
+For example:
 ```
 wget 'https://github.com/adafruit/uf2-samdx1/releases/download/v3.7.0/bootloader-itsybitsy_m4-v3.7.0.bin'
 ```
@@ -344,9 +345,8 @@ while it is running). Alternatively, set the "boot 0" pin to low and
 ### STM32F103 with HID bootloader
 
 The [HID bootloader](https://github.com/Serasidis/STM32_HID_Bootloader) is a
-compact, driverless bootloader capable of flashing over USB. Also available
-is a [fork with builds specific to the SKR Mini E3 1.2](
-  https://github.com/Arksine/STM32_HID_Bootloader/releases/latest).
+compact, driverless bootloader capable of flashing over USB. Also available is a
+[fork with builds specific to the SKR Mini E3 1.2](https://github.com/Arksine/STM32_HID_Bootloader/releases/latest).
 
 For generic STM32F103 boards such as the blue pill it is possible to flash
 the bootloader via 3.3V serial using stm32flash as noted in the stm32duino
@@ -355,11 +355,10 @@ section above, substituting the file name for the desired hid bootloader binary
 
 It is not possible to use stm32flash for the SKR Mini E3 as the boot0 pin is
 tied directly to ground and not broken out via header pins.  It is recommended
-to use a STLink V2 with STM32Cubeprogrammer to flash the bootloader.   If you
+to use a STLink V2 with STM32Cubeprogrammer to flash the bootloader.  If you
 don't have access to a STLink it is also possible to use a
 [Raspberry Pi and OpenOCD](#running-openocd-on-the-raspberry-pi) with
 the following chip config:
-
 ```
 source [find target/stm32f1x.cfg]
 ```
@@ -412,7 +411,7 @@ make
 
 If the bootloader is running you can flash with something like:
 ```
-~/klipper/lib/hidflash/hid-flash ~/klipper/out/klipper.bin
+~/klipper/lib/hidflash/hid-flash out/klipper.bin
 ```
 alternatively, you can use `make flash` to flash klipper directly:
 ```
@@ -427,22 +426,22 @@ It may be necessary to manually enter the bootloader, this can be done by
 setting "boot 0" low and "boot 1" high.  On the SKR Mini E3 "Boot 1" is
 not available, so it may be done by setting pin PA2 low if you flashed
 "hid_btt_skr_mini_e3.bin".  This pin is labeled "TX0" on the TFT header in
-the SKR Mini E3's "PIN" document. There is a ground pin next to PA2
+the SKR Mini E3's "PIN" document.  There is a ground pin next to PA2
 which you can use to pull PA2 low.
 
 ### STM32F103/STM32F072 with MSC bootloader
 
-The [MSC bootloader](https://github.com/Telekatz/MSC-stm32f103-bootloader) is a driverless bootloader capable of flashing over USB.
+The [MSC bootloader](https://github.com/Telekatz/MSC-stm32f103-bootloader)
+is a driverless bootloader capable of flashing over USB.
 
 It is possible to flash the bootloader via 3.3V serial using stm32flash as noted
 in the stm32duino section above, substituting the file name for the desired
 MSC bootloader binary (ie: MSCboot-Bluepill.bin for the blue pill).
 
-For STM32F072 boards it is also possible to flash the bootloader over USB (via DFU)
-with something like:
-
+For STM32F072 boards it is also possible to flash the bootloader over USB
+(via DFU) with something like:
 ```
- dfu-util -d 0483:df11 -a 0 -R -D  MSCboot-STM32F072.bin -s0x08000000:leave
+dfu-util -d 0483:df11 -a 0 -R -D  MSCboot-STM32F072.bin -s 0x08000000:leave
 ```
 
 This bootloader uses 8KiB or 16KiB of flash space, see description of the bootloader
@@ -481,11 +480,11 @@ This should include all nodes currently in the bootloader.
 
 Once you have a UUID, you may upload firmware with following command:
 ```
-python3 flash_can.py -i can0 -f ~/klipper/out/klipper.bin -u aabbccddeeff
+python3 flash_can.py -i can0 -f out/klipper.bin -u aabbccddeeff
 ```
 
 Where `aabbccddeeff` is replaced by your UUID.  Note that the `-i` and `-f`
-options may be omitted, they default to `can0` and `~/klipper/out/klipper.bin`
+options may be omitted, they default to `can0` and `out/klipper.bin`
 respectively.
 
 When building Klipper for use with CanBoot, select the 8 KiB Bootloader option.
@@ -558,8 +557,8 @@ Begin by downloading and compiling the software (each step may take
 several minutes and the "make" step may take 30+ minutes):
 
 ```
-sudo apt-get update
-sudo apt-get install autoconf libtool telnet
+sudo apt update
+sudo apt install autoconf libtool telnet
 mkdir ~/openocd
 cd ~/openocd/
 git clone http://openocd.zylin.com/openocd

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -25,8 +25,47 @@ application.  This document is not an authoritative reference; it is
 intended as a collection of useful information that the Klipper
 developers have accumulated.
 
-## AVR micro-controllers
+## katapult bootloader (LPC176x, STM32, RP2040)
 
+The [katapult](https://github.com/Arksine/katapult) (formerly known as CANBoot)
+bootloader provides an option for uploading Klipper firmware over the CANBUS,
+Serial and USB. The bootloader itself is derived from Klipper's source code.
+Currently katapult supports the LPC176x, STM32, and RP2040.
+
+It is recommended to use a ST-Link Programmer to flash katapult, however it
+should be possible to flash using `stm32flash` on STM32F103 devices, and
+`dfu-util` on STM32F042/STM32F072 devices.  See the
+[STM32](#stm32f103-micro-controllers-blue-pill-devices) sections in this
+document for instructions on these flashing methods, substituting `katapult.bin`
+for the file name where appropriate. The linked katapult repository provides
+instructions for building the bootloader.
+
+The first time katapult has been flashed it should detect that no application
+is present and enter the bootloader.  If this doesn't occur it is possible to
+enter the bootloader by pressing the reset button twice in succession.
+
+The `flash_can.py` utility supplied in the `lib/canboot` folder may be used to
+upload Klipper firmware.  The device UUID is necessary to flash.  If you do not
+have a UUID it is possible to query nodes currently running the bootloader:
+``` shell
+python3 flash_can.py -q
+```
+
+This will return UUIDs for all connected nodes not currently assigned a UUID.
+This should include all nodes currently in the bootloader.
+
+Once you have a UUID, you may upload firmware with following command:
+``` shell
+python3 flash_can.py -i can0 -f ../../out/klipper.bin -u aabbccddeeff
+```
+
+Where `aabbccddeeff` is replaced by your UUID.  Note that the `-i` and `-f`
+options may be omitted, they default to `can0` and `../../out/klipper.bin`
+respectively.
+
+When building Klipper for use with katapult, select the 8 KiB Bootloader option.
+
+## AVR micro-controllers
 
 In general, the Arduino project is a good reference for bootloaders
 and flashing procedures on the 8-bit Atmel Atmega micro-controllers.
@@ -450,44 +489,6 @@ This bootloader uses 8KiB or 16KiB of flash space, see description of the bootlo
 The bootloader can be activated by pressing the reset button of the board twice.
 As soon as the bootloader is activated, the board appears as a USB flash drive
 onto which the klipper.bin file can be copied.
-
-### STM32F103/STM32F0x2 with CanBoot bootloader
-
-The [CanBoot](https://github.com/Arksine/CanBoot) bootloader provides an option
-for uploading Klipper firmware over the CANBUS.  The bootloader itself is
-derived from Klipper's source code.  Currently CanBoot supports the STM32F103,
-STM32F042, and STM32F072 models.
-
-It is recommended to use a ST-Link Programmer to flash CanBoot, however it
-should be possible to flash using `stm32flash` on STM32F103 devices, and
-`dfu-util` on STM32F042/STM32F072 devices.  See the previous sections in this
-document for instructions on these flashing methods, substituting `canboot.bin`
-for the file name where appropriate.  The CanBoot repository linked above provides
-instructions for building the bootloader.
-
-The first time CanBoot has been flashed it should detect that no application
-is present and enter the bootloader.  If this doesn't occur it is possible to
-enter the bootloader by pressing the reset button twice in succession.
-
-The `flash_can.py` utility supplied in the `lib/canboot` folder may be used to
-upload Klipper firmware.  The device UUID is necessary to flash.  If you do not
-have a UUID it is possible to query nodes currently running the bootloader:
-```
-python3 flash_can.py -q
-```
-This will return UUIDs for all connected nodes not currently assigned a UUID.
-This should include all nodes currently in the bootloader.
-
-Once you have a UUID, you may upload firmware with following command:
-```
-python3 flash_can.py -i can0 -f out/klipper.bin -u aabbccddeeff
-```
-
-Where `aabbccddeeff` is replaced by your UUID.  Note that the `-i` and `-f`
-options may be omitted, they default to `can0` and `out/klipper.bin`
-respectively.
-
-When building Klipper for use with CanBoot, select the 8 KiB Bootloader option.
 
 ## STM32F4 micro-controllers with DFU bootloader
 

--- a/docs/Bootloaders.md
+++ b/docs/Bootloaders.md
@@ -490,30 +490,11 @@ respectively.
 
 When building Klipper for use with CanBoot, select the 8 KiB Bootloader option.
 
-## STM32F4 micro-controllers (SKR Pro 1.1)
+## STM32F4 micro-controllers with DFU bootloader
 
 STM32F4 micro-controllers come equipped with a built-in system bootloader
 capable of flashing over USB (via DFU), 3.3V Serial, and various other
-methods (see STM Document AN2606 for more information).  Some
-STM32F4 boards, such as the SKR Pro 1.1, are not able to enter the DFU
-bootloader.  The HID bootloader is available for STM32F405/407
-based boards should the user prefer flashing over USB over using the sdcard.
-Note that you may need to configure and build a version specific to your
-board, a [build for the SKR Pro 1.1 is available here](
-  https://github.com/Arksine/STM32_HID_Bootloader/releases/latest).
-
-Unless your board is DFU capable the most accessible flashing method
-is likely via 3.3V serial, which follows the same procedure as
-[flashing the STM32F103 using stm32flash](#stm32f103-micro-controllers-blue-pill-devices).
-For example:
-```
-wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.5-beta/hid_bootloader_SKR_PRO.bin
-
-stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
-```
-
-This bootloader requires 16Kib of flash space on the STM32F4 (the application
-must be compiled with a start address of 16KiB).
+methods (see STM Document AN2606 for more information).
 
 As with the STM32F1, the STM32F4 uses the hid-flash tool to upload binaries to
 the MCU. See the instructions above for details on how to build and use
@@ -523,6 +504,30 @@ It may be necessary to manually enter the bootloader, this can be done by
 setting "boot 0" low, "boot 1" high and plugging in the device.  After
 programming is complete unplug the device and set "boot 1" back to low
 so the application will be loaded.
+
+### STM32F405/407 (SKR Pro 1.1)
+
+Some STM32F4 boards, such as the SKR Pro 1.1, are not able to enter the DFU
+bootloader.  The HID bootloader is available for STM32F405/407
+based boards should the user prefer flashing over USB over using the sdcard.
+
+Note that you may need to configure and build a version specific to your
+board, a [build for the SKR Pro 1.1 is available here](
+  https://github.com/Arksine/STM32_HID_Bootloader/releases/latest).
+
+Unless your board is DFU capable the most accessible flashing method
+is likely via 3.3V serial, which follows the same procedure as
+[flashing the STM32F103 using stm32flash](#stm32f103-micro-controllers-blue-pill-devices).
+
+For example:
+```
+wget https://github.com/Arksine/STM32_HID_Bootloader/releases/download/v0.7/hid_bootloader_SKR_PRO.bin
+
+stm32flash -w hid_bootloader_SKR_PRO.bin -v -g 0 /dev/ttyAMA0
+```
+
+This bootloader requires 16Kib of flash space on the STM32F4 (the application
+must be compiled with a start address of 16KiB).
 
 ## LPC176x micro-controllers (Smoothieboards)
 

--- a/docs/CANBUS_Troubleshooting.md
+++ b/docs/CANBUS_Troubleshooting.md
@@ -63,7 +63,7 @@ The Linux [can-utils](https://github.com/linux-can/can-utils) tool
 provides the capture software. It is typically installed on a machine
 by running:
 ```
-sudo apt-get update && sudo apt-get install can-utils
+sudo apt update && sudo apt install can-utils
 ```
 
 Once installed, one may obtain a capture of all CAN bus messages on an

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -105,8 +105,8 @@ The resulting files can be read and graphed using the `motan_graph.py`
 tool. To generate graphs on a Raspberry Pi, a one time step is
 necessary to install the "matplotlib" package:
 ```
-sudo apt-get update
-sudo apt-get install python-matplotlib
+sudo apt update
+sudo apt install python-matplotlib
 ```
 However, it may be more convenient to copy the data files to a desktop
 class machine along with the Python code in the `scripts/motan/`
@@ -159,8 +159,8 @@ To generate a graph, a one time step is necessary to install the
 "matplotlib" package:
 
 ```
-sudo apt-get update
-sudo apt-get install python-matplotlib
+sudo apt update
+sudo apt install python-matplotlib
 ```
 
 Then graphs can be produced with:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,33 +11,39 @@ See the [rotation distance document](Rotation_Distance.md).
 
 ## Where's my serial port?
 
-The general way to find a USB serial port is to run `ls
-/dev/serial/by-id/*` from an ssh terminal on the host machine. It will
-likely produce output similar to the following:
+The general way to find a USB serial port is to run
+``` shell
+ls /dev/serial/by-id/*
 ```
+from an ssh terminal on the host machine. It will
+likely produce output similar to the following:
+``` shell
 /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
 
-The name found in the above command is stable and it is possible to
-use it in the config file and while flashing the micro-controller
-code. For example, a flash command might look similar to:
-```
+The name found in the above command is stable and it is possible to use
+it in the config file and while flashing the micro-controller code.
+For example, a flash command might look similar to:
+``` shell
 sudo service klipper stop
 make flash FLASH_DEVICE=/dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 sudo service klipper start
 ```
 and the updated config might look like:
-```
+``` yaml
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB2.0-Serial-if00-port0
 ```
 
-Be sure to copy-and-paste the name from the "ls" command that you ran
+Be sure to copy-and-paste the name from the "`ls`" command that you ran
 above as the name will be different for each printer.
 
 If you are using multiple micro-controllers and they do not have
 unique ids (common on boards with a CH340 USB chip) then follow the
-directions above using the command `ls /dev/serial/by-path/*` instead.
+directions above using the command `` instead.
+``` shell
+ls /dev/serial/by-path/*
+```
 
 ## When the micro-controller restarts the device changes to /dev/ttyUSB1
 
@@ -64,9 +70,9 @@ will need to manually flash. See if there is a config file in the
 [config directory](../config) with specific instructions for flashing
 the device. Also, check the board manufacturer's documentation to see
 if it describes how to flash the device. Finally, it may be possible
-to manually flash the device using tools such as "avrdude" or
-"bossac" - see the [bootloader document](Bootloaders.md) for
-additional information.
+to manually flash the device using tools such as "avrdude",
+"bossac", "dfu-util" or "stm32flash" - see the
+[bootloader document](Bootloaders.md) for additional information.
 
 ## How do I change the serial baud rate?
 
@@ -82,7 +88,7 @@ flashed to the micro-controller. The Klipper printer.cfg file will
 also need to be updated to match that baud rate (see the
 [config reference](Config_Reference.md#mcu) for details).  For
 example:
-```
+``` yaml
 [mcu]
 baud: 250000
 ```
@@ -144,13 +150,13 @@ package.
 It is possible to run multiple instances of the Klipper host software,
 but doing so requires Linux admin knowledge. The Klipper installation
 scripts ultimately cause the following Unix command to be run:
-```
+``` shell
 ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer.cfg -l /tmp/klippy.log
 ```
 One can run multiple instances of the above command as long as each
 instance has its own printer config file, its own log file, and its
 own pseudo-tty. For example:
-```
+``` shell
 ~/klippy-env/bin/python ~/klipper/klippy/klippy.py ~/printer2.cfg -l /tmp/klippy2.log -I /tmp/printer2
 ```
 
@@ -176,7 +182,7 @@ can be configured to use "/tmp/printer" for the printer serial port.
 The code does this to reduce the chance of accidentally commanding the
 head into the bed or a wall. Once the printer is homed the software
 attempts to verify each move is within the position_min/max defined in
-the config file. If the motors are disabled (via an M84 or M18
+the config file. If the motors are disabled (via an `M84` or `M18`
 command) then the motors will need to be homed again prior to
 movement.
 
@@ -190,8 +196,9 @@ the desired movement to the "custom g-code" section of your slicer.
 
 If the printer requires some additional movement as part of the homing
 process itself (or fundamentally does not have a homing process) then
-consider using a safe_z_home or homing_override section in the config
-file. If you need to move a stepper for diagnostic or debugging
+consider using a [safe_z_home](Config_Reference.html#safe_z_home) or
+[homing_override](Config_Reference.html#homing_override) section in the
+config file. If you need to move a stepper for diagnostic or debugging
 purposes then consider adding a force_move section to the config
 file. See [config reference](Config_Reference.md#customized_homing)
 for further details on these options.
@@ -210,26 +217,28 @@ information.
 
 ## I converted my config from Marlin and the X/Y axes work fine, but I just get a screeching noise when homing the Z axis
 
-Short answer: First, make sure you have verified the stepper
-configuration as described in the
-[config check document](Config_checks.md). If the problem persists,
-try reducing the max_z_velocity setting in the printer config.
+Short answer:<br>
+First, make sure you have verified the stepper configuration as
+described in the [config check document](Config_checks.md). If the
+problem persists, try reducing the max_z_velocity setting in the
+printer config.
 
-Long answer: In practice Marlin can typically only step at a rate of
-around 10000 steps per second. If it is requested to move at a speed
-that would require a higher step rate then Marlin will generally just
-step as fast as it can. Klipper is able to achieve much higher step
-rates, but the stepper motor may not have sufficient torque to move at
-a higher speed. So, for a Z axis with a high gearing ratio or high
-microsteps setting the actual obtainable max_z_velocity may be smaller
-than what is configured in Marlin.
+Long answer:<br>
+In practice Marlin can typically only step at a rate of around 10000
+steps per second. If it is requested to move at a speed that would
+require a higher step rate then Marlin will generally just step as fast
+as it can. Klipper is able to achieve much higher step rates, but the
+stepper motor may not have sufficient torque to move at a higher speed.
+So, for a Z axis with a high gearing ratio or high microsteps setting
+the actual obtainable max_z_velocity may be smaller than what is
+configured in Marlin.
 
 ## My TMC motor driver turns off in the middle of a print
 
 If using the TMC2208 (or TMC2224) driver in "standalone mode" then
 make sure to use the
-[latest version of Klipper](#how-do-i-upgrade-to-the-latest-software). A
-workaround for a TMC2208 "stealthchop" driver problem was added to
+[latest version of Klipper](#how-do-i-upgrade-to-the-latest-software).
+A workaround for a TMC2208 "stealthchop" driver problem was added to
 Klipper in mid-March of 2020.
 
 ## I keep getting random "Lost communication with MCU" errors
@@ -291,7 +300,8 @@ seconds. If the micro-controller does not receive a confirmation every
 off all heaters and stepper motors.
 
 See the "config_digital_out" command in the
-[MCU commands](MCU_Commands.md) document for further details.
+[MCU commands](MCU_Commands.md#common-micro-controller-objects)
+document for further details.
 
 In addition, the micro-controller software is configured with a
 minimum and maximum temperature range for each heater at startup (see
@@ -307,7 +317,8 @@ details.
 
 ## How do I convert a Marlin pin number to a Klipper pin name?
 
-Short answer: A mapping is available in the
+Short answer:<br>
+A mapping is available in the
 [sample-aliases.cfg](../config/sample-aliases.cfg) file. Use that file
 as a guide to finding the actual micro-controller pin names. (It is
 also possible to copy the relevant
@@ -319,7 +330,8 @@ the sample-aliases.cfg file uses pin names that start with the prefix
 and the prefix "analog" instead of "A" (eg, Arduino pin `A14` is
 Klipper alias `analog14`).
 
-Long answer: Klipper uses the standard pin names defined by the
+Long answer:<br>
+Klipper uses the standard pin names defined by the
 micro-controller. On the Atmega chips these hardware pins have names
 like `PA4`, `PC7`, or `PD2`.
 
@@ -338,30 +350,31 @@ names defined by the micro-controller.
 
 It depends on the type of device and type of pin:
 
-ADC pins (or Analog pins): For thermistors and similar "analog"
-sensors, the device must be wired to an "analog" or "ADC" capable pin
-on the micro-controller. If you configure Klipper to use a pin that is
-not analog capable, Klipper will report a "Not a valid ADC pin" error.
+- ADC pins (or Analog pins): For thermistors and similar "analog"
+  sensors, the device must be wired to an "analog" or "ADC" capable pin
+  on the micro-controller. If you configure Klipper to use a pin that
+  is not analog capable, Klipper will report a "Not a valid ADC pin"
+  error.
 
-PWM pins (or Timer pins): Klipper does not use hardware PWM by default
-for any device. So, in general, one may wire heaters, fans, and
-similar devices to any general purpose IO pin. However, fans and
-output_pin devices may be optionally configured to use `hardware_pwm:
-True`, in which case the micro-controller must support hardware PWM on
-the pin (otherwise, Klipper will report a "Not a valid PWM pin"
-error).
+- PWM pins (or Timer pins): Klipper does not use hardware PWM by
+  default for any device. So, in general, one may wire heaters, fans,
+  and similar devices to any general purpose IO pin. However, fans and
+  output_pin devices may be optionally configured to use `hardware_pwm:
+   True`, in which case the micro-controller must support hardware PWM
+  on the pin (otherwise, Klipper will report a "Not a valid PWM pin"
+  error).
 
-IRQ pins (or Interrupt pins): Klipper does not use hardware interrupts
-on IO pins, so it is never necessary to wire a device to one of these
-micro-controller pins.
+- IRQ pins (or Interrupt pins): Klipper does not use hardware interrupts
+  on IO pins, so it is never necessary to wire a device to one of these
+  micro-controller pins.
 
-SPI pins: When using hardware SPI it is necessary to wire the pins to
-the micro-controller's SPI capable pins. However, most devices can be
-configured to use "software SPI", in which case any general purpose IO
-pins may be used.
+- SPI pins: When using hardware SPI it is necessary to wire the pins to
+  the micro-controller's SPI capable pins. However, most devices can be
+  configured to use "software SPI", in which case any general purpose IO
+  pins may be used.
 
-I2C pins: When using I2C it is necessary to wire the pins to the
-micro-controller's I2C capable pins.
+- I2C pins: When using I2C it is necessary to wire the pins to the
+  micro-controller's I2C capable pins.
 
 Other devices may be wired to any general purpose IO pin. For example,
 steppers, heaters, fans, Z probes, servos, LEDs, common hd44780/st7920
@@ -370,12 +383,12 @@ general purpose IO pin.
 
 ## How do I cancel an M109/M190 "wait for temperature" request?
 
-Navigate to the OctoPrint terminal tab and issue an M112 command in
-the terminal box. The M112 command will cause Klipper to enter into a
+Navigate to the OctoPrint terminal tab and issue an `M112` command in
+the terminal box. The `M112` command will cause Klipper to enter into a
 "shutdown" state, and it will cause OctoPrint to disconnect from
 Klipper. Navigate to the OctoPrint connection area and click on
 "Connect" to cause OctoPrint to reconnect. Navigate back to the
-terminal tab and issue a FIRMWARE_RESTART command to clear the Klipper
+terminal tab and issue a `FIRMWARE_RESTART` command to clear the Klipper
 error state.  After completing this sequence, the previous heating
 request will be canceled and a new print may be started.
 
@@ -394,28 +407,28 @@ Note that endstop switches themselves tend to trigger at slightly
 different positions, so a difference of a couple of microsteps is
 likely the result of endstop inaccuracies. A stepper motor itself can
 only lose steps in increments of 4 full steps. (So, if one is using 16
-microsteps, then a lost step on the stepper would result in the "mcu:"
+microsteps, then a lost step on the stepper would result in the `mcu:`
 step counter being off by a multiple of 64 microsteps.)
 
 ## Why does Klipper report errors? I lost my print!
 
-Short answer: We want to know if our printers detect a problem so that
-the underlying issue can be fixed and we can obtain great quality
-prints. We definitely do not want our printers to silently produce low
-quality prints.
+Short answer:<br>
+We want to know if our printers detect a problem so that the underlying
+issue can be fixed and we can obtain great quality prints. We definitely
+do not want our printers to silently produce low quality prints.
 
-Long answer: Klipper has been engineered to automatically workaround
-many transient problems. For example, it automatically detects
-communication errors and will retransmit; it schedules actions in
-advance and buffers commands at multiple layers to enable precise
-timing even with intermittent interference. However, should the
-software detect an error that it can not recover from, if it is
-commanded to take an invalid action, or if it detects it is hopelessly
-unable to perform its commanded task, then Klipper will report an
-error. In these situations there is a high risk of producing a
-low-quality print (or worse). It is hoped that alerting the user will
-empower them to fix the underlying issue and improve the overall
-quality of their prints.
+Long answer:<br>
+Klipper has been engineered to automatically workaround many transient
+problems. For example, it automatically detects communication errors and
+will retransmit; it schedules actions in advance and buffers commands at
+multiple layers to enable precise timing even with intermittent
+interference. However, should the software detect an error that it can
+not recover from, if it is commanded to take an invalid action, or if it
+detects it is hopelessly unable to perform its commanded task, then
+Klipper will report an error. In these situations there is a high risk
+of producing a low-quality print (or worse). It is hoped that alerting
+the user will empower them to fix the underlying issue and improve the
+overall quality of their prints.
 
 There are some related questions: Why doesn't Klipper pause the print
 instead? Report a warning instead? Check for errors before the print?
@@ -438,16 +451,15 @@ prior to upgrading.
 When ready to upgrade, the general method is to ssh into the Raspberry
 Pi and run:
 
-```
+``` shell
 cd ~/klipper
 git pull
 ~/klipper/scripts/install-octopi.sh
 ```
 
-Then one can recompile and flash the micro-controller code. For
-example:
-
-```
+Then one can recompile and flash the micro-controller code.
+For example:
+``` shell
 make menuconfig
 make clean
 make
@@ -460,7 +472,7 @@ sudo service klipper start
 However, it's often the case that only the host software changes. In
 this case, one can update and restart just the host software with:
 
-```
+``` shell
 cd ~/klipper
 git pull
 sudo service klipper restart
@@ -474,19 +486,19 @@ If any errors persist then double check the
 [config changes](Config_Changes.md) document, as you may need to
 modify the printer configuration.
 
-Note that the RESTART and FIRMWARE_RESTART g-code commands do not load
-new software - the above "sudo service klipper restart" and "make
-flash" commands are needed for a software change to take effect.
+Note that the `RESTART` and `FIRMWARE_RESTART` g-code commands do not
+load new software - the above `sudo service klipper restart` and
+`make flash` commands are needed for a software change to take effect.
 
 ## How do I uninstall Klipper?
 
-On the firmware end, nothing special needs to happen. Just follow the
-flashing directions for the new firmware.
+On the firmware end, nothing special needs to happen.
+Just follow the flashing directions for the new firmware.
 
 On the raspberry pi end, an uninstall script is available in
-[scripts/klipper-uninstall.sh](../scripts/klipper-uninstall.sh). For
-example:
-```
+[scripts/klipper-uninstall.sh](../scripts/klipper-uninstall.sh).
+For example:
+``` shell
 sudo ~/klipper/scripts/klipper-uninstall.sh
 rm -rf ~/klippy-env ~/klipper
 ```

--- a/docs/RPi_microcontroller.md
+++ b/docs/RPi_microcontroller.md
@@ -91,7 +91,7 @@ _Linux GPIO character device_ to verify the configuration.
 To install the _Linux GPIO character device - binary_ on a debian
 based distro like octopi run:
 ```
-sudo apt-get install gpiod
+sudo apt install gpiod
 ```
 
 To check available gpiochip run:

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -54,14 +54,14 @@ theme:
     repo: fontawesome/brands/github
     alternate: material/web
   features:
-      #- navigation.tabs
-      #- navigation.expand
-      - navigation.top
-      # if enabled, the TOC doesn't work for some pages
-      # - toc.integrate
-      - search.suggest
-      - search.highlight
-      - search.share
+    #- navigation.tabs
+    #- navigation.expand
+    - navigation.top
+    # if enabled, the TOC doesn't work for some pages
+    # - toc.integrate
+    - search.suggest
+    - search.highlight
+    - search.share
   language: en
 extra_css:
   - _klipper3d/css/extra.css

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -17,10 +17,13 @@ markdown_extensions:
   - toc:
       permalink: True
       toc_depth: 6
+  - admonition
   - attr_list
   - mdx_partial_gfm
   - mdx_truly_sane_lists
   - mdx_breakless_lists
+  - pymdownx.details
+  - pymdownx.superfences
 plugins:
   search:
     lang: en


### PR DESCRIPTION
My start focus was to update all sites regarding the CanBoot -> katapult transition.
Stuff I catched on the lines/pages I fixed too.

Changed site can be viewed here: https://docgalaxyblock.github.io/klipper
_Note: It looks like some cometic customization stuff got not applied_

I stopped my work today since the used mkdocs-material version is not uptodate and the official mkdocs-material docs differ a bit.
Will try to update mkdocs-material without breaking anything and then update more pages.

Greetings
Doc