### PR TITLE
fix virtual SD file position count

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -258,7 +258,7 @@ class VirtualSD:
             # Dispatch command
             self.cmd_from_sd = True
             line = lines.pop()
-            next_file_position = self.file_position + len(line) + 1
+            next_file_position = self.file_position + len(line.encode()) + 1
             self.next_file_position = next_file_position
             try:
                 self.gcode.run_script(line)


### PR DESCRIPTION
The resume process begins at `self.current_file.seek(self.file_position)`, where `self.file_position` represents a byte-length offset. However, `file_position` is incremented by `len(line)`, which corresponds to the string length. If there are any UTF-8 characters preceding the 'PAUSE' command, the resumed file position must be set before the occurrence of 'PAUSE'.

To address this issue, replacing the string length with the byte length is sufficient. 