### PR TITLE
virtual_sdcard: Add an option to sort by date

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1465,6 +1465,10 @@ path:
 #   be provided.
 #on_error_gcode:
 #   A list of G-Code commands to execute when an error is reported.
+#recent_first: False
+#   Set to True to sort the files with modified date in reverse, so the
+#   most recently uploaded one is at the top. Otherwise they are
+#   sorted alphabetically. The default is False.
 
 ```
 

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -17,6 +17,7 @@ class VirtualSD:
         self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
         self.current_file = None
         self.file_position = self.file_size = 0
+        self.recent_first = config.get("recent_first", False)
         # Print Stat Tracking
         self.print_stats = self.printer.load_object(config, 'print_stats')
         # Work timer
@@ -76,8 +77,14 @@ class VirtualSD:
             dname = self.sdcard_dirname
             try:
                 filenames = os.listdir(self.sdcard_dirname)
+                if self.recent_first:
+                    filenames.sort(
+                        key=lambda f: os.path.getmtime(os.path.join(dname, f)),
+                        reverse=True)
+                else:
+                    filenames.sort(key=str.lower)
                 return [(fname, os.path.getsize(os.path.join(dname, fname)))
-                        for fname in sorted(filenames, key=str.lower)
+                        for fname in filenames
                         if not fname.startswith('.')
                         and os.path.isfile((os.path.join(dname, fname)))]
             except:


### PR DESCRIPTION
Added an option to sort the files with modified date in reverse, 
so the most recently uploaded one is at the top.

It should be useful for many LCD screen users so that they can 
easily reprint the latest file when they are at the printer.
Especially if there are a lot of g-code files or not named properly.