### PR TITLE
Update printer-sovol-sv06-plus-2023.cfg

### DIFF
--- a/config/printer-sovol-sv06-plus-2023.cfg
+++ b/config/printer-sovol-sv06-plus-2023.cfg
@@ -119,6 +119,9 @@ pid_kd: 637.30
 min_temp: 0
 max_temp: 130
 
+[verify_heater heater_bed]
+heating_gain: 1
+
 [fan]
 pin: PA0
 


### PR DESCRIPTION
Added verify_heater configuration for heat bed, as Klipper's default setting for this will otherwise lead to print-aborting "verify_heater" errors due to the SV06+ bed being slightly slower to gain heat than the rate that Klipper expects by default

The default expects a minimum bed heat increase of 2°C per minute which the SV06+ doesn't always manage, especially if any heat adjustment is made during a print while the extruder is demanding more current - attempting to go from 100°C to 110° during a polycarbonate print for example is likely to cause a print failure

This config change reduces the enforced minimum rate of heat bed temperature increase to 1°C per minute, preventing "verify_heater" errors due to slow heat gain 