### PR TITLE
controller_fan: add ability to watch temperature_sensors too

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2791,6 +2791,19 @@ watched component.
 #   is provided here, then the fan will be enabled when any of the given
 #   heaters/steppers are enabled. The default heater is "extruder", the
 #   default stepper is all of them.
+#temperature_sensors:
+#   A list of "temperature_sensor:target_temperature" pairs.
+#   When any of the defined temperature_sensors reaches it threshold, the
+#   fan will be enabled.
+#   For Example, "pi: 60" would enable the fan when the temperature_sensor
+#   "pi" reaches 60 degrees.
+#   The given exmaple would look like this:
+#   temperature_sensors:
+#     pi:60
+#     aanotherone:70
+#temperature_sensors_only:
+#   If set to True, this controller_fan will ONLY watch the given temperature_sensors
+#   and ignore any given heater/extruder. The default is False.
 ```
 
 ### [temperature_fan]

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -48,18 +48,23 @@ class ControllerFan:
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
-        self.last_speed = 0.0
+        self.last_speed = -1
 
         # get configured temperature_sensors as
         # ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))
         temperature_sensors_config = config.getlists(
-            "temperature_sensors", seps=(":", "\n"), count=2, default=[]
+            "temperature_sensors",
+            seps=(":", "\n"),
+            count=2,
+            default=[],
         )
+
         # parse given thresholds to floats
         self.temperature_sensors_config = [
             (
                 sensor[0],
                 float(sensor[1]),
+                # 12.4,
             )
             for sensor in temperature_sensors_config
         ]
@@ -161,7 +166,7 @@ class ControllerFan:
         return eventtime + 1.0
 
     def __check_fan_active(self, eventtime):
-        for sensor, threshold in self.temperature_sensors.items():
+        for _, (sensor, threshold) in self.temperature_sensors.items():
             current_temp, _ = sensor.get_temp(eventtime)
             if current_temp > threshold:
                 return True

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -27,7 +27,8 @@ class ControllerFan:
         self.last_on = self.idle_timeout
         self.last_speed = 0.
 
-        # get configured temperature_sensors as ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))
+        # get configured temperature_sensors as
+        # ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))
         temperature_sensors_config = config.getlists(
             "temperature_sensors",
             seps=(':', '\n'),
@@ -35,12 +36,18 @@ class ControllerFan:
             default=[]
         )
         # parse given thresholds to floats
-        self.temperature_sensors_config = [(sensor[0], float(sensor[1])) for sensor in temperature_sensors_config]
+        self.temperature_sensors_config = [
+            (sensor[0], float(sensor[1])) for sensor in temperature_sensors_config
+        ]
         self.temperature_sensors = dict()
-        self.temperature_sensors_only = config.getboolean("temperature_sensors_only", False)
+        self.temperature_sensors_only = config.getboolean(
+            "temperature_sensors_only",
+            False
+        )
         if self.temperature_sensors_only and len(self.temperature_sensors_config) <= 0:
             raise self.printer.config_error(
-                "If temperature_sensors_only is True, there have to have temperature_sensors been configured!"
+                "If temperature_sensors_only is True, "
+                "there have to have temperature_sensors been configured!"
             )
 
     def handle_connect(self):
@@ -66,8 +73,14 @@ class ControllerFan:
             )
 
     def __handle_connect_temperature_sensors():
-        all_temperature_sensor_module_names = [sensor[0] for sensor in self.printer.lookup_objects(module='temperature_sensor')]
-        all_temperature_sensor_names = [sensor.split(' ')[1] for sensor in all_temperature_sensor_module_names]
+        all_temperature_sensor_module_names = [
+            sensor[0] for sensor in self.printer.lookup_objects(
+                module='temperature_sensor'
+            )
+        ]
+        all_temperature_sensor_names = [
+            sensor.split(' ')[1] for sensor in all_temperature_sensor_module_names
+        ]
 
         for sensor_name, temperature_threshold in self.temperature_sensors_config:
             actual_configured_sensor = None

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -64,7 +64,6 @@ class ControllerFan:
             (
                 sensor[0],
                 float(sensor[1]),
-                # 12.4,
             )
             for sensor in temperature_sensors_config
         ]

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -7,45 +7,40 @@ from . import fan
 
 PIN_MIN_TIME = 0.100
 
+
 class ControllerFan:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
-        self.printer.register_event_handler("klippy:connect",
-                                            self.handle_connect)
+        self.printer.register_event_handler("klippy:connect", self.handle_connect)
         self.stepper_names = config.getlist("stepper", None)
-        self.stepper_enable = self.printer.load_object(config, 'stepper_enable')
-        self.printer.load_object(config, 'heaters')
+        self.stepper_enable = self.printer.load_object(config, "stepper_enable")
+        self.printer.load_object(config, "heaters")
         self.heaters = []
         self.fan = fan.Fan(config)
-        self.fan_speed = config.getfloat('fan_speed', default=1.,
-                                         minval=0., maxval=1.)
+        self.fan_speed = config.getfloat(
+            "fan_speed", default=1.0, minval=0.0, maxval=1.0
+        )
         self.idle_speed = config.getfloat(
-            'idle_speed', default=self.fan_speed, minval=0., maxval=1.)
+            "idle_speed", default=self.fan_speed, minval=0.0, maxval=1.0
+        )
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
-        self.last_speed = 0.
+        self.last_speed = 0.0
 
         # get configured temperature_sensors as
         # ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))
         temperature_sensors_config = config.getlists(
-            "temperature_sensors",
-            seps=(':', '\n'),
-            count=2,
-            default=[]
+            "temperature_sensors", seps=(":", "\n"), count=2, default=[]
         )
         # parse given thresholds to floats
         self.temperature_sensors_config = [
-            (
-                sensor[0],
-                float(sensor[1])
-            ) for sensor in temperature_sensors_config
+            (sensor[0], float(sensor[1])) for sensor in temperature_sensors_config
         ]
         self.temperature_sensors = dict()
         self.temperature_sensors_only = config.getboolean(
-            "temperature_sensors_only",
-            False
+            "temperature_sensors_only", False
         )
         if self.temperature_sensors_only and len(self.temperature_sensors_config) <= 0:
             raise self.printer.config_error(
@@ -58,11 +53,11 @@ class ControllerFan:
         self.__handle_connect_steppers()
         self.__handle_connect_temperature_sensors()
 
-    def __handle_connect_heaters():
-        pheaters = self.printer.lookup_object('heaters')
+    def __handle_connect_heaters(self):
+        pheaters = self.printer.lookup_object("heaters")
         self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
 
-    def __handle_connect_steppers():
+    def __handle_connect_steppers(self):
         all_steppers = self.stepper_enable.get_steppers()
         if self.stepper_names is None:
             self.stepper_names = all_steppers
@@ -75,45 +70,45 @@ class ControllerFan:
                 % (self.stepper_names, ", ".join(all_steppers))
             )
 
-    def __handle_connect_temperature_sensors():
+    def __handle_connect_temperature_sensors(self):
         all_temperature_sensor_module_names = [
-            sensor[0] for sensor in self.printer.lookup_objects(
-                module='temperature_sensor'
-            )
+            sensor[0]
+            for sensor in self.printer.lookup_objects(module="temperature_sensor")
         ]
         all_temperature_sensor_names = [
-            sensor.split(' ')[1] for sensor in all_temperature_sensor_module_names
+            sensor.split(" ")[1] for sensor in all_temperature_sensor_module_names
         ]
 
         for sensor_name, temperature_threshold in self.temperature_sensors_config:
             actual_configured_sensor = None
             try:
                 actual_configured_sensor = self.printer.lookup_object(
-                    'temperature_sensor ' + sensor_name.strip()
+                    "temperature_sensor " + sensor_name.strip()
                 )
             except Exception:
                 pass
 
             if actual_configured_sensor is None:
                 raise self.printer.config_error(
-                    "temperature_sensor '%s' is unknown, (valid sensors are: %s)"
+                    "temperature_sensor '%s' is unknown, "
+                    "(valid sensors are: %s)"
                     % (sensor_name, ", ".join(all_temperature_sensor_names))
                 )
 
             self.temperature_sensors[sensor_name] = (
                 actual_configured_sensor,
-                temperature_threshold
+                temperature_threshold,
             )
 
     def handle_ready(self):
         reactor = self.printer.get_reactor()
-        reactor.register_timer(self.callback, reactor.monotonic()+PIN_MIN_TIME)
+        reactor.register_timer(self.callback, reactor.monotonic() + PIN_MIN_TIME)
 
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)
 
     def callback(self, eventtime):
-        speed = 0.
+        speed = 0.0
         active = self.__check_fan_active(eventtime)
 
         if active:
@@ -129,9 +124,9 @@ class ControllerFan:
             print_time = self.fan.get_mcu().estimated_print_time(curtime)
             self.fan.set_speed(print_time + PIN_MIN_TIME, speed)
 
-        return eventtime + 1.
+        return eventtime + 1.0
 
-    def __check_fan_active(eventtime):
+    def __check_fan_active(self, eventtime):
         for sensor, threshold in self.temperature_sensors.items():
             current_temp, _ = sensor.get_temp(eventtime)
             if current_temp > threshold:
@@ -148,6 +143,7 @@ class ControllerFan:
             _, target_temp = heater.get_temp(eventtime)
             if target_temp:
                 return True
+
 
 def load_config_prefix(config):
     return ControllerFan(config)

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -11,18 +11,39 @@ PIN_MIN_TIME = 0.100
 class ControllerFan:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.printer.register_event_handler("klippy:ready", self.handle_ready)
-        self.printer.register_event_handler("klippy:connect", self.handle_connect)
-        self.stepper_names = config.getlist("stepper", None)
-        self.stepper_enable = self.printer.load_object(config, "stepper_enable")
-        self.printer.load_object(config, "heaters")
+        self.printer.register_event_handler(
+            "klippy:ready",
+            self.handle_ready,
+        )
+        self.printer.register_event_handler(
+            "klippy:connect",
+            self.handle_connect,
+        )
+        self.stepper_names = config.getlist(
+            "stepper",
+            None,
+        )
+        self.stepper_enable = self.printer.load_object(
+            config,
+            "stepper_enable",
+        )
+        self.printer.load_object(
+            config,
+            "heaters",
+        )
         self.heaters = []
         self.fan = fan.Fan(config)
         self.fan_speed = config.getfloat(
-            "fan_speed", default=1.0, minval=0.0, maxval=1.0
+            "fan_speed",
+            default=1.0,
+            minval=0.0,
+            maxval=1.0,
         )
         self.idle_speed = config.getfloat(
-            "idle_speed", default=self.fan_speed, minval=0.0, maxval=1.0
+            "idle_speed",
+            default=self.fan_speed,
+            minval=0.0,
+            maxval=1.0,
         )
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.heater_names = config.getlist("heater", ("extruder",))

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -37,7 +37,10 @@ class ControllerFan:
         )
         # parse given thresholds to floats
         self.temperature_sensors_config = [
-            (sensor[0], float(sensor[1])) for sensor in temperature_sensors_config
+            (
+                sensor[0],
+                float(sensor[1])
+            ) for sensor in temperature_sensors_config
         ]
         self.temperature_sensors = dict()
         self.temperature_sensors_only = config.getboolean(
@@ -111,7 +114,7 @@ class ControllerFan:
 
     def callback(self, eventtime):
         speed = 0.
-        active = self.__check_fan_active()
+        active = self.__check_fan_active(eventtime)
 
         if active:
             self.last_on = 0
@@ -128,7 +131,7 @@ class ControllerFan:
 
         return eventtime + 1.
 
-    def __check_fan_active():
+    def __check_fan_active(eventtime):
         for sensor, threshold in self.temperature_sensors.items():
             current_temp, _ = sensor.get_temp(eventtime)
             if current_temp > threshold:

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -48,7 +48,7 @@ class ControllerFan:
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
-        self.last_speed = -1
+        self.last_speed = 0.0
 
         # get configured temperature_sensors as
         # ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -26,46 +26,112 @@ class ControllerFan:
         self.heater_names = config.getlist("heater", ("extruder",))
         self.last_on = self.idle_timeout
         self.last_speed = 0.
+
+        # get configured temperature_sensors as ((str, str), (str, str)) => (("pi", "55"), ("spider", "77"))
+        temperature_sensors_config = config.getlists(
+            "temperature_sensors",
+            seps=(':', '\n'),
+            count=2,
+            default=[]
+        )
+        # parse given thresholds to floats
+        self.temperature_sensors_config = [(sensor[0], float(sensor[1])) for sensor in temperature_sensors_config]
+        self.temperature_sensors = dict()
+        self.temperature_sensors_only = config.getboolean("temperature_sensors_only", False)
+        if self.temperature_sensors_only and len(self.temperature_sensors_config) <= 0:
+            raise self.printer.config_error(
+                "If temperature_sensors_only is True, there have to have temperature_sensors been configured!"
+            )
+
     def handle_connect(self):
-        # Heater lookup
+        self.__handle_connect_heaters()
+        self.__handle_connect_steppers()
+        self.__handle_connect_temperature_sensors()
+
+    def __handle_connect_heaters():
         pheaters = self.printer.lookup_object('heaters')
         self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
-        # Stepper lookup
+
+    def __handle_connect_steppers():
         all_steppers = self.stepper_enable.get_steppers()
         if self.stepper_names is None:
             self.stepper_names = all_steppers
             return
+
         if not all(x in all_steppers for x in self.stepper_names):
             raise self.printer.config_error(
                 "One or more of these steppers are unknown: "
-                 "%s (valid steppers are: %s)"
-                % (self.stepper_names, ", ".join(all_steppers)))
+                "%s (valid steppers are: %s)"
+                % (self.stepper_names, ", ".join(all_steppers))
+            )
+
+    def __handle_connect_temperature_sensors():
+        all_temperature_sensor_module_names = [sensor[0] for sensor in self.printer.lookup_objects(module='temperature_sensor')]
+        all_temperature_sensor_names = [sensor.split(' ')[1] for sensor in all_temperature_sensor_module_names]
+
+        for sensor_name, temperature_threshold in self.temperature_sensors_config:
+            actual_configured_sensor = None
+            try:
+                actual_configured_sensor = self.printer.lookup_object(
+                    'temperature_sensor ' + sensor_name.strip()
+                )
+            except Exception:
+                pass
+
+            if actual_configured_sensor is None:
+                raise self.printer.config_error(
+                    "temperature_sensor '%s' is unknown, (valid sensors are: %s)"
+                    % (sensor_name, ", ".join(all_temperature_sensor_names))
+                )
+
+            self.temperature_sensors[sensor_name] = (
+                actual_configured_sensor,
+                temperature_threshold
+            )
+
     def handle_ready(self):
         reactor = self.printer.get_reactor()
         reactor.register_timer(self.callback, reactor.monotonic()+PIN_MIN_TIME)
+
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)
+
     def callback(self, eventtime):
         speed = 0.
-        active = False
-        for name in self.stepper_names:
-            active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()
-        for heater in self.heaters:
-            _, target_temp = heater.get_temp(eventtime)
-            if target_temp:
-                active = True
+        active = self.__check_fan_active()
+
         if active:
             self.last_on = 0
             speed = self.fan_speed
         elif self.last_on < self.idle_timeout:
             speed = self.idle_speed
             self.last_on += 1
+
         if speed != self.last_speed:
             self.last_speed = speed
             curtime = self.printer.get_reactor().monotonic()
             print_time = self.fan.get_mcu().estimated_print_time(curtime)
             self.fan.set_speed(print_time + PIN_MIN_TIME, speed)
+
         return eventtime + 1.
+
+    def __check_fan_active():
+        for sensor, threshold in self.temperature_sensors.items():
+            current_temp, _ = sensor.get_temp(eventtime)
+            if current_temp > threshold:
+                return True
+
+        if self.temperature_sensors_only:
+            return False
+
+        for stepper in self.stepper_names:
+            if self.stepper_enable.lookup_enable(stepper).is_motor_enabled():
+                return True
+
+        for heater in self.heaters:
+            _, target_temp = heater.get_temp(eventtime)
+            if target_temp:
+                return True
 
 def load_config_prefix(config):
     return ControllerFan(config)

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -57,13 +57,18 @@ class ControllerFan:
         )
         # parse given thresholds to floats
         self.temperature_sensors_config = [
-            (sensor[0], float(sensor[1])) for sensor in temperature_sensors_config
+            (
+                sensor[0],
+                float(sensor[1]),
+            )
+            for sensor in temperature_sensors_config
         ]
         self.temperature_sensors = dict()
         self.temperature_sensors_only = config.getboolean(
             "temperature_sensors_only", False
         )
-        if self.temperature_sensors_only and len(self.temperature_sensors_config) <= 0:
+        if (self.temperature_sensors_only and
+            len(self.temperature_sensors_config) <= 0):
             raise self.printer.config_error(
                 "If temperature_sensors_only is True, "
                 "there have to have temperature_sensors been configured!"
@@ -94,13 +99,18 @@ class ControllerFan:
     def __handle_connect_temperature_sensors(self):
         all_temperature_sensor_module_names = [
             sensor[0]
-            for sensor in self.printer.lookup_objects(module="temperature_sensor")
+            for sensor in self.printer.lookup_objects(
+                module="temperature_sensor",
+            )
         ]
         all_temperature_sensor_names = [
-            sensor.split(" ")[1] for sensor in all_temperature_sensor_module_names
+            sensor.split(" ")[1]
+            for sensor in all_temperature_sensor_module_names
         ]
 
-        for sensor_name, temperature_threshold in self.temperature_sensors_config:
+        # copy to local variable since the line would be to long =/
+        temperature_sensors_config = self.temperature_sensors_config
+        for sensor_name, temperature_threshold in temperature_sensors_config:
             actual_configured_sensor = None
             try:
                 actual_configured_sensor = self.printer.lookup_object(
@@ -123,7 +133,10 @@ class ControllerFan:
 
     def handle_ready(self):
         reactor = self.printer.get_reactor()
-        reactor.register_timer(self.callback, reactor.monotonic() + PIN_MIN_TIME)
+        reactor.register_timer(
+            self.callback,
+            reactor.monotonic() + PIN_MIN_TIME,
+        )
 
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)

--- a/test/klippy/controller_fan_multiple_temperature_sensors.config
+++ b/test/klippy/controller_fan_multiple_temperature_sensors.config
@@ -1,0 +1,95 @@
+
+
+[mcu]
+serial: /dev/ttyACM0
+
+
+[printer]
+kinematics: corexy
+max_velocity: 300
+max_accel: 7000
+max_z_velocity: 30
+max_z_accel: 350
+square_corner_velocity: 5.0
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+[extruder_stepper my_extra_stepper]
+extruder: extruder
+step_pin: PH5
+dir_pin: PH6
+enable_pin: !PB5
+microsteps: 16
+rotation_distance: 28.2
+
+
+[temperature_sensor pi]
+sensor_type: temperature_host
+min_temp: 10
+max_temp: 100
+
+
+[temperature_sensor spider]
+sensor_type: temperature_mcu
+min_temp: 10
+max_temp: 100
+
+
+[controller_fan combined_fan_for_electronics]
+pin: PB2
+kick_start_time: 0.5
+fan_speed: 0.30
+idle_timeout: 60
+temperature_sensors:
+    pi:55
+    spider:40
+    something:140
+temperature_sensors_only: True


### PR DESCRIPTION
I searched a way to have a fan controller that just watches one or more temperature sensors.. like host-temperature. since the enclosure fans of my voron are pretty loud.. and I noticed that most of the stuff is not getting hot at all.. so.. having this fan-controller work without the heater/extruder.. and just watch actual temperatures would be awesome! for my ears.. for the fans.. and hopefully for other guys out there ;)


I found this pretty old [PR](https://github.com/Klipper3d/klipper/pull/4341) from @mnigbur, which did not make it back then.. 


just pinging some of the guys who where active in the past in this thread.. @Ramalama2, @theopensourcerer, @meteyou, @edddeduck, @KevinOConnor

question: any chance to test it without running an actual machine? (in general, not for this one =))


To-Do:
- [x] adjust linting (its not linting, its a hand-written code checker :D)
- [x] test on machine

Signed-off-by: Sascha Ehlers <sascha@ehle.rs>