### PR TITLE
Added package selection for HC32F460

### DIFF
--- a/src/hc32f460/Kconfig
+++ b/src/hc32f460/Kconfig
@@ -15,6 +15,14 @@ config BOARD_DIRECTORY
     string
     default "hc32f460"
 
+choice "MCU Package"
+    prompt "Number of pins"
+    config HC32F460_PINS_64
+        bool "64"
+    config HC32F460_PINS_100
+        bool "100"
+endchoice
+
 
 ######################################################################
 # Communication interface

--- a/src/hc32f460/gpio.c
+++ b/src/hc32f460/gpio.c
@@ -18,7 +18,12 @@
 DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 16);
 DECL_ENUMERATION_RANGE("pin", "PB0", GPIO('B', 0), 16);
 DECL_ENUMERATION_RANGE("pin", "PC0", GPIO('C', 0), 16);
+#if CONFIG_HC32F460_PINS_100
+DECL_ENUMERATION_RANGE("pin", "PD0", GPIO('D', 0), 16);
+DECL_ENUMERATION_RANGE("pin", "PE0", GPIO('E', 0), 16);
+#else
 DECL_ENUMERATION_RANGE("pin", "PD2", GPIO('D', 2), 1);
+#endif
 DECL_ENUMERATION_RANGE("pin", "PH2", PortH * 16 + 2, 1);    // H: special case
 
 

--- a/src/hc32f460/hard_pwm.c
+++ b/src/hc32f460/hard_pwm.c
@@ -75,6 +75,24 @@ static const struct gpio_pwm_info pwm_mapping[] = {
     {GPIO('C',14), 4, TimeraCh5},
     {GPIO('C',15), 4, TimeraCh6},
     {GPIO('D', 2), 2, TimeraCh4},
+#if CONFIG_HC32F460_PINS_100
+    {GPIO('D',12), 4, TimeraCh1},
+    {GPIO('D',13), 4, TimeraCh2},
+    {GPIO('D',14), 4, TimeraCh3},
+    {GPIO('D',15), 4, TimeraCh4},
+    {GPIO('E', 2), 3, TimeraCh5},
+    {GPIO('E', 3), 3, TimeraCh6},
+    {GPIO('E', 4), 3, TimeraCh7},
+    {GPIO('E', 5), 3, TimeraCh8},
+    {GPIO('E', 8), 1, TimeraCh5},
+    {GPIO('E', 9), 1, TimeraCh1},
+    {GPIO('E',10), 1, TimeraCh6},
+    {GPIO('E',11), 1, TimeraCh2},
+    {GPIO('E',12), 1, TimeraCh7},
+    {GPIO('E',13), 1, TimeraCh3},
+    {GPIO('E',14), 1, TimeraCh4},
+    {GPIO('E',15), 1, TimeraCh8},
+#endif
 };
 
 


### PR DESCRIPTION
HC32F460-PETB has a 100 pin package that is used on Tenlog 32bit boards (and possibly others).
The default configuration is set to 64 pins.