### PR TITLE
bed_mesh: support for Z in BED_MESH_OFFSET

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -542,11 +542,19 @@ This gcode may be used to clear the internal mesh state.
 
 ### Apply X/Y offsets
 
-`BED_MESH_OFFSET [X=<value>] [Y=<value>]`
+`BED_MESH_OFFSET [X=<value>] [Y=<value>] [ZFADE=<value>]`
 
 This is useful for printers with multiple independent extruders, as an offset
 is necessary to produce correct Z adjustment after a tool change.  Offsets
 should be specified relative to the primary extruder.  That is, a positive
 X offset should be specified if the secondary extruder is mounted to the
-right of the primary extruder, and a positive Y offset should be specified
-if the secondary extruder is mounted "behind" the primary extruder.
+right of the primary extruder, a positive Y offset should be specified
+if the secondary extruder is mounted "behind" the primary extruder, and
+a positive ZFADE offset should be specified if the secondary extruder's
+nozzle is above the primary extruder's.
+
+Note that a ZFADE offset does *NOT* directly apply additional adjustment.  It
+is intended to compensate for a `gcode offset` when [mesh fade](#mesh-fade)
+is enabled.  For example, if a secondary extruder is higher than the primary
+and needs a negative gcode offset, ie: `SET_GCODE_OFFSET Z=-.2`, it can be
+accounted for in `bed_mesh` with `BED_MESH_OFFSET ZFADE=.2`.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -184,10 +184,12 @@ SAVE_CONFIG gcode must be run to make the changes to persistent memory
 permanent.
 
 #### BED_MESH_OFFSET
-`BED_MESH_OFFSET [X=<value>] [Y=<value>]`: Applies X and/or Y offsets
-to the mesh lookup. This is useful for printers with independent
-extruders, as an offset is necessary to produce correct Z adjustment
-after a tool change.
+`BED_MESH_OFFSET [X=<value>] [Y=<value>] [ZFADE=<value]`: Applies X, Y,
+and/or ZFADE offsets to the mesh lookup. This is useful for printers with
+independent extruders, as an offset is necessary to produce correct Z
+adjustment after a tool change.  Note that a ZFADE offset does not apply
+additional z-adjustment directly, it is used to correct the `fade`
+calculation when a `gcode offset` has been applied to the Z axis.
 
 ### [bed_screws]
 


### PR DESCRIPTION
This adds a "Z" parameter to `BED_MESH_OFFSET` that is used to account for changes in `gcode offset` on the Z axis when calculating fade.  Without this, changing a tool that is offset on Z will cause jumps in the fade calculation.  This likely makes fade unusable for multi-tool printers.

This addition does not add any additional adjustment on the z-axis, so it cannot be used to replace `SET_GCODE_OFFSET`, and instead must be used to complement it.  Like `X` and `Y`, the `Z` offset should be relative to the primary extruder.  If a secondary extruder's nozzle is higher than the primary extruder by .2mm, then `BED_MESH_OFFSET Z=.2` is the correct setting.  Presumably this would come after `SET_GCODE_OFFSET Z=-.2`.   I believe this is consistent across all axes, but if it isn't I am open to changing the behavior.

This will need to be tested by some individuals with multiple tools, as I am unable to do so.
