### PR TITLE
adxl345: Add I2C support to the ADXL345 accelerometer implementation

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1631,8 +1631,15 @@ specify an explicit name (eg, [adxl345 my_chip_name]).
 
 ```
 [adxl345]
+#i2c_mcu:
+#i2c_bus:
+#i2c_software_scl_pin:
+#i2c_software_sda_pin:
+#i2c_speed: 400000
+#   See the "common I2C settings" section for a description of the
+#   above parameters. The default "i2c_speed" is 400000.
 cs_pin:
-#   The SPI enable pin for the sensor. This parameter must be provided.
+#   The SPI enable pin for the sensor. This parameter must be provided if using SPI communication.
 #spi_speed: 5000000
 #   The SPI speed (in hz) to use when communicating with the chip.
 #   The default is 5000000.

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -1,20 +1,15 @@
 # Measuring Resonances
 
-Klipper has built-in support for the ADXL345, MPU-9250 and LIS2DW compatible
-accelerometers which can be used to measure resonance frequencies of the printer
-for different axes, and auto-tune [input shapers](Resonance_Compensation.md) to
-compensate for resonances. Note that using accelerometers requires some
-soldering and crimping. The ADXL345/LIS2DW can be connected to the SPI interface
-of a Raspberry Pi or MCU board (it needs to be reasonably fast). The MPU family can
-be connected to the I2C interface of a Raspberry Pi directly, or to an I2C
-interface of an MCU board that supports 400kbit/s *fast mode* in Klipper.
+Klipper has built-in support for the ADXL345, MPU-9250, and LIS2DW compatible accelerometers, which can be used for measuring the resonance frequencies of a printer's different axes and automatically tuning [input shapers](Resonance_Compensation.md) to compensate for resonances. Note that using accelerometers may require some soldering and crimping skills.
+
+The ADXL345 and LIS2DW can be connected via the SPI interface to a (reasonably fast) Raspberry Pi or MCU board. The MPU family should be connected through the I2C interface of a Raspberry Pi directly or to an MCU board's I2C interface that supports 400kbit/s *fast mode* in Klipper. While not typically recommended, the ADXL345 can now also be used with the I2C interface in *fast mode*, if no other options are available.
 
 When sourcing accelerometers, be aware that there are a variety of different PCB
 board designs and different clones of them. If it is going to be connected to a
 5V printer MCU ensure it has a voltage regulator and level shifters.
 
 For ADXL345s/LIS2DWs, make sure that the board supports SPI mode (a small number of
-boards appear to be hard-configured for I2C by pulling SDO to GND).
+boards appear to be hard-configured for I2C by pulling SDO to GND). While Klipper supports using the ADXL345 with the I2C interface, it is not recommended, because the slower bus can cause issues.
 
 For MPU-9250/MPU-9255/MPU-6515/MPU-6050/MPU-6500s there are also a variety of
 board designs and clones with different I2C pull-up resistors which will need
@@ -113,6 +108,10 @@ makes 5V dangerous for your RPi.
 Wiring diagrams for some of the ADXL345 boards:
 
 ![ADXL345-Pico](img/adxl345-pico.png)
+
+##### Alternative Wiring for I2C
+
+The wiring should be done similar to the MPU series.
 
 ### I2C Accelerometers
 
@@ -236,7 +235,11 @@ Add the following to the printer.cfg file:
 serial: /tmp/klipper_host_mcu
 
 [adxl345]
+# Using SPI:
 cs_pin: rpi:None
+# Alternatively using I2C:
+# i2c_mcu: rpi
+# i2c_bus: i2c.1
 
 [resonance_tester]
 accel_chip: adxl345
@@ -282,8 +285,12 @@ now add an `adxl.cfg` file with the following settings:
 serial: /dev/serial/by-id/usb-Klipper_rp2040_<mySerial>
 
 [adxl345]
+# Using SPI:
 cs_pin: adxl:gpio1
 spi_bus: spi0a
+# Alternatively using I2C:
+# i2c_mcu: adxl
+# i2c_bus: i2c0a
 axes_map: x,z,y
 
 [resonance_tester]

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -202,13 +202,13 @@ class ADXL345:
         self.data_rate = config.getint('rate', 3200)
         if self.data_rate not in QUERY_RATES:
             raise config.error("Invalid rate parameter: %d" % (self.data_rate,))
-        
+
         # Check if i2c or spi is used
-        if (config.get('i2c_bus', None) is None and 
+        if (config.get('i2c_bus', None) is None and
             config.get('i2c_software_scl_pin', None) is None):
             self.bus_type = 'spi'
-            self.spi = bus.MCU_SPI_from_config(config, 
-                                               3, 
+            self.spi = bus.MCU_SPI_from_config(config,
+                                               3,
                                                default_speed=5000000)
             self.mcu = mcu = self.spi.get_mcu()
             self.oid = oid = mcu.create_oid()
@@ -227,7 +227,7 @@ class ADXL345:
                            % (self.oid, self.i2c.get_oid()))
             self.mcu.add_config_cmd("query_adxl345_i2c oid=%d rest_ticks=0"
                             % (self.oid,), on_restart=True)
-            
+
         # Setup mcu sensor_adxl345 bulk query code
         self.query_adxl345_cmd = None
         mcu.register_config_callback(self._build_config)
@@ -252,13 +252,15 @@ class ADXL345:
             self.query_adxl345_cmd = self.mcu.lookup_command(
                 "query_adxl345 oid=%c rest_ticks=%u", cq=cmdqueue)
             self.clock_updater.setup_query_command(
-                self.mcu, "query_adxl345_status oid=%c", oid=self.oid, cq=cmdqueue)
+                self.mcu, "query_adxl345_status oid=%c",
+                oid=self.oid, cq=cmdqueue)
         else:
             cmdqueue = self.i2c.get_command_queue()
             self.query_adxl345_cmd = self.mcu.lookup_command(
                 "query_adxl345_i2c oid=%c rest_ticks=%u", cq=cmdqueue)
             self.clock_updater.setup_query_command(
-                self.mcu, "query_adxl345_i2c_status oid=%c", oid=self.oid, cq=cmdqueue)
+                self.mcu, "query_adxl345_i2c_status oid=%c",
+                oid=self.oid, cq=cmdqueue)
     def read_reg(self, reg):
         if self.bus_type == 'spi':
             params = self.spi.spi_transfer([reg | REG_MOD_READ, 0x00])

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ src-$(CONFIG_WANT_SOFTWARE_SPI) += spi_software.c
 src-$(CONFIG_WANT_SOFTWARE_I2C) += i2c_software.c
 sensors-src-$(CONFIG_HAVE_GPIO_SPI) := thermocouple.c sensor_adxl345.c \
     sensor_angle.c
-sensors-src-$(CONFIG_HAVE_GPIO_I2C) += sensor_mpu9250.c
+sensors-src-$(CONFIG_HAVE_GPIO_I2C) += sensor_mpu9250.c sensor_adxl345_i2c.c
 src-$(CONFIG_WANT_SENSORS) += $(sensors-src-y)
 src-$(CONFIG_WANT_LIS2DW) += sensor_lis2dw.c
 src-$(CONFIG_NEED_SENSOR_BULK) += sensor_bulk.c

--- a/src/sensor_adxl345_i2c.c
+++ b/src/sensor_adxl345_i2c.c
@@ -1,0 +1,151 @@
+// Support for gathering acceleration data from ADXL345 chip using I2C
+//
+// Copyright (C) 2020-2023  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2024       Endrik Einberg <endrik@endrik.dev>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // memcpy
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
+#include "basecmd.h" // oid_alloc
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_TASK
+#include "sensor_bulk.h" // sensor_bulk_report
+#include "board/gpio.h" // i2c_read
+#include "i2ccmds.h" // i2cdev_oid_lookup
+
+// Definitions for ADXL345 chip registers
+#define AR_DATAX0      0x32 // Data register for X-Axis
+#define AR_FIFO_STATUS 0x39 // FIFO status register
+#define SET_FIFO_CTL   0x90 // FIFO control register
+#define BYTES_PER_SAMPLE 5  // Bytes per accelerometer sample
+
+// Struct to store ADXL345 data and configuration
+struct adxl345_i2c {
+    struct timer timer; // Timer for scheduling reads
+    uint32_t rest_ticks; // Ticks to rest between reads
+    struct i2cdev_s *i2c; // I2C device pointer
+    uint16_t fifo_entries; // FIFO entries available
+    uint8_t flags; // Status flags
+    struct sensor_bulk sb; // Sensor bulk data storage
+};
+
+// Flag definitions
+enum {
+    AX_PENDING = 1 << 0, // Data read pending flag
+};
+
+static struct task_wake adxl345_i2c_wake; // Task wake-up management
+
+// Event handler to wake up the adxl345_task periodically
+static uint_fast8_t adxl345_i2c_event(struct timer *timer) {
+    struct adxl345_i2c *ax2 = container_of(timer, struct adxl345_i2c, timer);
+    ax2->flags |= AX_PENDING;
+    sched_wake_task(&adxl345_i2c_wake);
+    return SF_DONE;
+}
+
+// Initialize ADXL345 sensor configuration
+void command_config_adxl345_i2c(uint32_t *args) {
+    struct adxl345_i2c *ax2 = oid_alloc(args[0], command_config_adxl345_i2c, sizeof(*ax2));
+    ax2->timer.func = adxl345_i2c_event;
+    ax2->i2c = i2cdev_oid_lookup(args[1]);
+}
+DECL_COMMAND(command_config_adxl345_i2c, "config_adxl345_i2c oid=%c i2c_oid=%c");
+
+// Reschedules the timer for the next data read
+static void adxl_i2c_reschedule_timer(struct adxl345_i2c *ax2) {
+    irq_disable();
+    ax2->timer.waketime = timer_read_time() + ax2->rest_ticks;
+    sched_add_timer(&ax2->timer);
+    irq_enable();
+}
+
+// Queries accelerometer data and handles errors
+static void adxl_i2c_query(struct adxl345_i2c *ax2, uint8_t oid) {
+    uint8_t reg = AR_DATAX0; // Start register for accelerometer data
+    uint8_t data[8]; // Buffer for reading data
+    i2c_read(ax2->i2c->i2c_config, 1, &reg, sizeof(data), data);
+    ax2->fifo_entries = data[7] & ~0x80; // Mask off trigger bit from FIFO status
+
+    uint8_t *d = &ax2->sb.data[ax2->sb.data_count];
+    
+    // Check for data errors before processing
+    if (((data[1] & 0xf0) && (data[1] & 0xf0) != 0xf0)
+        || ((data[3] & 0xf0) && (data[3] & 0xf0) != 0xf0)
+        || ((data[5] & 0xf0) && (data[5] & 0xf0) != 0xf0)
+        || (data[6] != SET_FIFO_CTL) || (ax2->fifo_entries > 32)) {
+        // Fill with error code and reset FIFO entries
+        memset(d, 0xff, BYTES_PER_SAMPLE); 
+        ax2->fifo_entries = 0;
+    } else {
+        // Process and store valid X, Y, Z readings
+        d[0] = data[0]; // X low
+        d[1] = data[2]; // Y low
+        d[2] = data[4]; // Z low
+        d[3] = (data[1] & 0x1f) | (data[5] << 5); // X high and Z high
+        d[4] = (data[3] & 0x1f) | ((data[5] << 2) & 0x60); // Y high and Z high
+    }
+
+    ax2->sb.data_count += BYTES_PER_SAMPLE;
+    if (ax2->sb.data_count + BYTES_PER_SAMPLE > ARRAY_SIZE(ax2->sb.data))
+        sensor_bulk_report(&ax2->sb, oid);
+    
+    // Manage FIFO data and reschedule as needed
+    if (ax2->fifo_entries >= 31)
+        ax2->sb.possible_overflows++;
+    if (ax2->fifo_entries > 1) {
+        sched_wake_task(&adxl345_i2c_wake);
+    } else {
+        ax2->flags &= ~AX_PENDING;
+        adxl_i2c_reschedule_timer(ax2);
+    }
+}
+
+// Start or stop data queries for ADXL345
+void command_query_adxl345_i2c(uint32_t *args) {
+    struct adxl345_i2c *ax2 = oid_lookup(args[0], command_config_adxl345_i2c);
+
+    sched_del_timer(&ax2->timer);
+    ax2->flags = 0;
+    if (!args[1])
+        return; // Stop measurements
+
+    // Begin new measurement cycle
+    ax2->rest_ticks = args[1];
+    sensor_bulk_reset(&ax2->sb);
+    adxl_i2c_reschedule_timer(ax2);
+}
+DECL_COMMAND(command_query_adxl345_i2c, "query_adxl345_i2c oid=%c rest_ticks=%u");
+
+// Query the status of the ADXL345 sensor
+void command_query_adxl345_i2c_status(uint32_t *args) {
+    struct adxl345_i2c *ax2 = oid_lookup(args[0], command_config_adxl345_i2c);
+    uint8_t msg[1] = { AR_FIFO_STATUS };
+
+    uint32_t time1 = timer_read_time();
+    uint8_t fifo_status_msg;
+    i2c_read(ax2->i2c->i2c_config, 1, msg, 1, &fifo_status_msg);
+    uint32_t time2 = timer_read_time();
+
+    uint_fast8_t fifo_status = fifo_status_msg & ~0x80; // Mask off trigger bit
+    if (fifo_status > 32)
+        return; // Error in query, no response sent
+    
+    sensor_bulk_status(&ax2->sb, args[0], time1, time2 - time1, fifo_status * BYTES_PER_SAMPLE);
+}
+DECL_COMMAND(command_query_adxl345_i2c_status, "query_adxl345_i2c_status oid=%c");
+
+// Task to handle ADXL345 data queries
+void adxl345_i2c_task(void) {
+    if (!sched_check_wake(&adxl345_i2c_wake))
+        return;
+    uint8_t oid;
+    struct adxl345_i2c *ax2;
+    foreach_oid(oid, ax2, command_config_adxl345_i2c) {
+        if (ax2->flags & AX_PENDING)
+            adxl_i2c_query(ax2, oid);
+    }
+}
+DECL_TASK(adxl345_i2c_task);


### PR DESCRIPTION
Hello,

The purpose of this pull request is to allow others with the same issues as me to use their accelerometers without hardware modding. Namely the issue I had was that my board from Seeed Studio, the [Grove - ADXL345 - 3-Axis Digital Accelerometer(±16g)](https://www.seeedstudio.com/Grove-3-Axis-Digital-Accelerometer-16g.html), was hardwired to use I2C with a trace below the ADXL345 chip itself (between CS and Vin). As I do not own a hot air station, I wanted to avoid desoldering this chip as much as possible. Turns out what I wanted was possible, as the ADXL345 chip supports 400 kHz I2C communication, which is already supported by Klipper in the MPU series.

I changed the ADXL345 Klippy Python code to detect I2C or SPI bus usage from the config, modifying the communication behaviour accordingly. I also implemented a new sensor_adxl345_i2c.c driver, because the code changes were much larger in this case and it is easier to configure the Makefile this way (to include only if I2C is supported on a given MCU). 

I have tested this on my own printer and both I2C and SPI (on another board) work properly. I do not think there is a big risk in breaking any existing functionality, because the added Python code uses basic if statements, where the SPI cases include previously existing code.

I admit the documentation of this addition could be vastly improved, but I think it is currently usable for someone already tinkering with accelerometers using a manual setup (vs a KUSBA or something). I sadly currently lack the time to improve it. Still, I felt it's important to get this change out there so nobody ends up buying another board unnecessarily or maybe breaking one trying to get SPI to work (or maybe even wasting their time trying to do this).