### PR TITLE
doc: Add required dependency to run numpy with python3 on RPI

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -207,7 +207,7 @@ software dependencies not installed by default. First, run on your Raspberry Pi
 the following commands:
 ```
 sudo apt update
-sudo apt install python3-numpy python3-matplotlib libatlas-base-dev
+sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-base
 ```
 
 Next, in order to install NumPy in the Klipper environment, run the command:


### PR DESCRIPTION
When installing klipper using python3, I hit an issue when setting up numpy. Following the provided documentation leads to the following error when running `TEST_RESONANCES AXIS=X`

> Failed to import `numpy` module, make sure it was installed via `~/klippy-env/bin/pip install` (refer to docs/Measuring_Resonances.md for more details).

Attempting to import numpy through the virtualenv leads to the error:

```
~/klippy-env/bin/python3
Python 3.9.2 (default, Mar 12 2021, 04:06:34)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy
Traceback (most recent call last):
  File "/home/brujoand/klippy-env/lib/python3.9/site-packages/numpy/core/__init__.py", line 24, in <module>
    from . import multiarray
  File "/home/brujoand/klippy-env/lib/python3.9/site-packages/numpy/core/multiarray.py", line 10, in <module>
    from . import overrides
  File "/home/brujoand/klippy-env/lib/python3.9/site-packages/numpy/core/overrides.py", line 8, in <module>
    from numpy.core._multiarray_umath import (
ImportError: libopenblas.so.0: cannot open shared object file: No such file or directory
```

Further down is a link to the documentation which instructs the user to install the missing package. Ref: https://numpy.org/devdocs/user/troubleshooting-importerror.html

I noticed a lot of discussions on reddit regarding this issue where users are guided to downgrade to python2. By adding this additional package all resonance testing worked as expected on my RPI 2b. 