### PR TITLE
Draft: custom_component: allow to load python components natively

### DIFF
--- a/klippy/extras/custom_component.py
+++ b/klippy/extras/custom_component.py
@@ -1,0 +1,35 @@
+# Custom Component Module
+#
+# Copyright (C) 2024  Kamil Trzciński <ayufan@ayufan.eu>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging, util, os.path, importlib.util
+
+class CustomComponent:
+    def __init__(self, config):
+        self.name = config.get_name().split()[-1]
+        self.path = config.get('path')
+        self.used = 0
+        self.module = None
+        self.git_info = None
+
+    def load_module(self):
+        self.used += 1
+        if not self.module:
+          full_path = os.path.expanduser(self.path)
+          spec = importlib.util.spec_from_file_location(self.name, full_path)
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          self.git_info = util.get_git_version(full_path)
+          self.module = module
+        return self.module
+
+    def get_status(self, eventtime):
+        return {
+          'path': self.path,
+          'git_info': self.git_info,
+          'used': self.used
+        }
+
+def load_config_prefix(config):
+    return CustomComponent(config)

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -110,15 +110,21 @@ class Printer:
             return self.objects[section]
         module_parts = section.split()
         module_name = module_parts[0]
-        py_name = os.path.join(os.path.dirname(__file__),
-                               'extras', module_name + '.py')
-        py_dirname = os.path.join(os.path.dirname(__file__),
-                                  'extras', module_name, '__init__.py')
-        if not os.path.exists(py_name) and not os.path.exists(py_dirname):
-            if default is not configfile.sentinel:
-                return default
-            raise self.config_error("Unable to load module '%s'" % (section,))
-        mod = importlib.import_module('extras.' + module_name)
+        mod = None
+        if config.has_section('custom_component ' + module_name):
+            custom_component = self.load_object(config, 'custom_component ' + module_name, default=None)
+            if custom_component:
+                mod = custom_component.load_module()
+        if not mod:
+            py_name = os.path.join(os.path.dirname(__file__),
+                                'extras', module_name + '.py')
+            py_dirname = os.path.join(os.path.dirname(__file__),
+                                    'extras', module_name, '__init__.py')
+            if not os.path.exists(py_name) and not os.path.exists(py_dirname):
+                if default is not configfile.sentinel:
+                    return default
+                raise self.config_error("Unable to load module '%s'" % (section,))
+            mod = importlib.import_module('extras.' + module_name)
         init_func = 'load_config'
         if len(module_parts) > 1:
             init_func = 'load_config_prefix'
@@ -343,7 +349,7 @@ def main():
     else:
         logging.getLogger().setLevel(debuglevel)
     logging.info("Starting Klippy...")
-    git_info = util.get_git_version()
+    git_info = util.get_git_version(__file__)
     git_vers = git_info["version"]
     extra_files = [fname for code, fname in git_info["file_status"]
                    if (code in ('??', '!!') and fname.endswith('.py')

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -182,7 +182,7 @@ def _get_repo_info(gitdir):
         logging.debug("Error fetching repo info: %s", traceback.format_exc())
     return repo_info
 
-def get_git_version(from_file=True):
+def get_git_version(src, from_file=True):
     git_info = {
         "version": "?",
         "file_status": [],
@@ -190,7 +190,7 @@ def get_git_version(from_file=True):
         "remote": "?",
         "url": "?"
     }
-    klippy_src = os.path.dirname(__file__)
+    klippy_src = os.path.dirname(src)
 
     # Obtain version info from "git" program
     gitdir = os.path.join(klippy_src, '..')


### PR DESCRIPTION
It become quite common for Klipper users to create custom components and create a dance to symlink them into `extras` folder. This PR provides a first class support for `custom_components` that can be loaded as part of `printer.cfg`:

1. First: Every custom component to be used to be declared as `custom_component`, component name to load, and path where the component is loaded.
2. The component will be lazily loaded on a first use.
3. The custom component will track how many times the component was used, and expose git information if component is repository.
4. It is responsibility of the custom component author to ensure compatibility with Klipper.
5. The `custom_component` load module is only compatible with Python 3.5+, for older versions there's no support for `custom_component`.

#### `printer.cfg`

```yaml
[custom_component hello_world]
path: ~/my_klipper/hello_world.py

[hello_world]
```

#### `hello_world.py`

```python
class HelloWorld:
    def __init__(self, config):
        self.printer = config.get_printer()

        # Register commands
        self.gcode = self.printer.lookup_object('gcode')
        self.gcode.register_command("HELLO_WORLD", self.cmd_HELLO_WORLD)

    def cmd_HELLO_WORLD(self, gcmd):
        gcmd.respond_info("Hello World")

def load_config(config):
    return HelloWorld(config)
```

#### `GET /printer/objects/query?custom_component%20hello_world`

```json
{
    "result": {
        "eventtime": 2422.219077722,
        "status": {
            "custom_component hello_world": {
                "path": "/home/ayufan/my_klipper/hello_world.py",
                "git_info": {
                    "version": "fc11477a-dirty",
                    "file_status": [],
                    "branch": "master",
                    "remote": "origin",
                    "url": "git@github.com:ayufan/printer-klipper-data.git"
                },
                "used": 1
            }
        }
    }
}
```

## References

1. https://github.com/moggieuk/ERCF-Software-V3/blob/master/install.sh#L101
2. https://github.com/beacon3d/beacon_klipper/blob/master/install.sh#L22
3. https://esphome.io/components/external_components
