### PR TITLE
feat(klippy, toolhead): add S<seconds> param to G4 command

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -7,7 +7,7 @@ commands that one may enter into the OctoPrint terminal tab.
 
 Klipper supports the following standard G-Code commands:
 - Move (G0 or G1): `G1 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>] [F<speed>]`
-- Dwell: `G4 P<milliseconds>`
+- Dwell: `G4 P<milliseconds>` or `G4 S<seconds>` or `G4 S<seconds> P<milliseconds>`
 - Move to origin: `G28 [X] [Y] [Z]`
 - Turn off motors: `M18` or `M84`
 - Wait for current moves to finish: `M400`

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -602,10 +602,19 @@ class ToolHead:
         self.junction_deviation = scv2 * (math.sqrt(2.) - 1.) / self.max_accel
         self.max_accel_to_decel = min(self.requested_accel_to_decel,
                                       self.max_accel)
+
     def cmd_G4(self, gcmd):
         # Dwell
-        delay = gcmd.get_float('P', 0., minval=0.) / 1000.
+        delay_in_seconds = gcmd.get_float('S', None, minval=0.)
+        delay_in_milliseconds = gcmd.get_float('P', None, minval=0.)
+
+        if delay_in_seconds is None and delay_in_milliseconds is None:
+            logging.warning("neither S nor P argument given")
+            return
+
+        delay = (delay_in_seconds or 0) + (delay_in_milliseconds or 0) / 1000.
         self.dwell(delay)
+
     def cmd_M400(self, gcmd):
         # Wait for current moves to finish
         self.wait_moves()


### PR DESCRIPTION
this adds the ability to pass an `S<seconds>` parameter to the G4 dwell command.
its even possible to combine the existing `P<milliseconds>` with the newly added `S` param.

took me a while to realize that klippers G4 interpreter only used the `P` param.. :))

To-Do:

- [ ] ask/clarify: logging format, do we want to prefix it. or dont log at all??
- [ ] ask/clarify: if not dwelling at all for the None case is okay?
- [x] adjust docs

Signed-off-by: Sascha Ehlers [sascha@ehle.rs](mailto:sascha@ehle.rs)
