### PR TITLE
tmc2240: add ADC voltage formatters

### DIFF
--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -259,6 +259,8 @@ FieldFormatters.update({
     "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
     "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
     "adc_temp":         (lambda v: "0x%04x(%.1fC)" % (v, ((v - 2038) / 7.7))),
+    "adc_vsupply":      (lambda v: "0x%04x(%.3fV)" % (v, v * 0.009732)),
+    "adc_ain":          (lambda v: "0x%04x(%.3fmV)" % (v, v * 0.3052)),
 })
 
 


### PR DESCRIPTION
ADC values will be shown in Volts.

Output sample:
```
// ADC_VSUPPLY_AIN: 02d709b7 adc_vsupply=0x09b7(24.203V) adc_ain=0x02d7(221.880mV)
```