### PR TITLE
remove dead code

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -189,7 +189,6 @@ class PrinterConfig:
     comment_r = re.compile('[#;].*$')
     value_r = re.compile('[^A-Za-z0-9_].*$')
     def _strip_duplicates(self, data, config):
-        fileconfig = config.fileconfig
         # Comment out fields in 'data' that are defined in 'config'
         lines = data.split('\n')
         section = None

--- a/klippy/extras/dotstar.py
+++ b/klippy/extras/dotstar.py
@@ -10,7 +10,6 @@ BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 class PrinterDotstar:
     def __init__(self, config):
         self.printer = printer = config.get_printer()
-        name = config.get_name().split()[1]
         # Configure a software spi bus
         ppins = printer.lookup_object('pins')
         data_pin_params = ppins.lookup_pin(config.get('data_pin'))

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -191,7 +191,6 @@ class EndstopPhases:
     def generate_stats(self, stepper_name, phase_calc):
         phase_history = phase_calc.phase_history
         wph = phase_history + phase_history
-        count = sum(phase_history)
         phases = len(phase_history)
         half_phases = phases // 2
         res = []

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -45,7 +45,7 @@ class IdleTimeout:
         self.state = "Printing"
         try:
             script = self.idle_gcode.render()
-            res = self.gcode.run_script(script)
+            self.gcode.run_script(script)
         except:
             logging.exception("idle timeout gcode execution")
             self.state = "Ready"

--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -59,7 +59,6 @@ class AxisInputShaper:
         return self.n, self.A, self.T
     def update(self, gcmd):
         self.params.update(gcmd)
-        old_n, old_A, old_T = self.n, self.A, self.T
         self.n, self.A, self.T = self.params.get_shaper()
     def set_shaper_kinematics(self, sk):
         ffi_main, ffi_lib = chelper.get_ffi()

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -11,7 +11,6 @@ from . import idex_modes
 class HybridCoreXYKinematics:
     def __init__(self, toolhead, config):
         self.printer = config.get_printer()
-        printer_config = config.getsection('printer')
         # itersolve parameters
         self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
                        stepper.LookupMultiRail(config.getsection('stepper_y')),

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -11,7 +11,6 @@ from . import idex_modes
 class HybridCoreXZKinematics:
     def __init__(self, toolhead, config):
         self.printer = config.get_printer()
-        printer_config = config.getsection('printer')
         # itersolve parameters
         self.rails = [ stepper.PrinterRail(config.getsection('stepper_x')),
                        stepper.LookupMultiRail(config.getsection('stepper_y')),

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -654,7 +654,6 @@ class MCU:
         self._config_cmds.insert(0, "allocate_oids count=%d"
                                  % (self._oid_count,))
         # Resolve pin names
-        mcu_type = self._serial.get_msgparser().get_constant('MCU')
         ppins = self._printer.lookup_object('pins')
         pin_resolver = ppins.get_pin_resolver(self._name)
         for cmdlist in (self._config_cmds, self._restart_cmds, self._init_cmds):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -575,7 +575,6 @@ class ToolHead:
         self.step_generators.append(handler)
     def note_step_generation_scan_time(self, delay, old_delay=0.):
         self.flush_step_generation()
-        cur_delay = self.kin_flush_delay
         if old_delay:
             self.kin_flush_times.pop(self.kin_flush_times.index(old_delay))
         if delay:


### PR DESCRIPTION
- removes unused param 'eventtime' from heater.check_busy(  )
- removes a few unused assignments that are likely remnants of removed code