### PR TITLE
lpc176x: don't write to 0x2FC.

### DIFF
--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -72,7 +72,7 @@ endchoice
 config FLASH_APPLICATION_ADDRESS
     hex
     default 0x4000 if LPC_FLASH_START_4000
-    default 0x0000
+    default 0x0300
 
 
 ######################################################################

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -8,8 +8,8 @@ dirs-y += src/lpc176x src/generic lib/lpc176x/device
 CFLAGS += -mthumb -mcpu=cortex-m3 -Ilib/lpc176x/device -Ilib/cmsis-core
 
 CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
-CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
-$(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
+CFLAGS_klipper.elf += -T $(OUT)src/lpc176x/lpc176x_link.ld
+$(OUT)klipper.elf: $(OUT)src/lpc176x/lpc176x_link.ld
 
 # Add source files
 src-y += lpc176x/main.c lpc176x/gpio.c

--- a/src/lpc176x/lpc176x_link.lds.S
+++ b/src/lpc176x/lpc176x_link.lds.S
@@ -1,0 +1,78 @@
+// Generic ARM Cortex-M linker script
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_FLASH_APPLICATION_ADDRESS
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+MEMORY
+{
+  vector (rx) : ORIGIN = 0 , LENGTH = 0x200
+  rom (rx) : ORIGIN = CONFIG_FLASH_APPLICATION_ADDRESS , LENGTH = CONFIG_FLASH_SIZE
+  ram (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_RAM_SIZE
+}
+
+SECTIONS
+{
+    .vector_table_section : {
+        . = ALIGN(4);
+        _text_vectortable_start = .;
+        KEEP(*(.vector_table))
+        _text_vectortable_end = .;
+    } > vector
+
+    .text : {
+        . = ALIGN(4);
+        *(.text .text.*)
+        *(.rodata .rodata*)
+    } > rom
+
+    . = ALIGN(4);
+    _data_flash = .;
+
+#if CONFIG_ARMCM_RAM_VECTORTABLE
+    .ram_vectortable (NOLOAD) : {
+        _ram_vectortable_start = .;
+        . = . + ( _text_vectortable_end - _text_vectortable_start ) ;
+        _ram_vectortable_end = .;
+    } > ram
+#endif
+
+    .data : AT (_data_flash)
+    {
+        . = ALIGN(4);
+        _data_start = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _data_end = .;
+    } > ram
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _bss_end = .;
+    } > ram
+
+    _stack_start = CONFIG_RAM_START + CONFIG_RAM_SIZE - CONFIG_STACK_SIZE ;
+    .stack _stack_start (NOLOAD) :
+    {
+        . = . + CONFIG_STACK_SIZE;
+        _stack_end = .;
+    } > ram
+
+    /DISCARD/ : {
+        // The .init/.fini sections are used by __libc_init_array(), but
+        // that isn't needed so no need to include them in the binary.
+        *(.init)
+        *(.fini)
+    }
+}


### PR DESCRIPTION
Leave 0x2FC - 0x2FF alone, since it stores values for code read protection. We don't want to lock flash permanently.

According to user manual, 0x2FC is reserved for CRP mechanism. It might happen that generated code is exactly the same as CRP1, CRP2 or CRP3. For that reason we should avoid writing to that area.

![slika](https://github.com/Klipper3d/klipper/assets/61543115/75d77c34-77c3-4280-bf59-fc52cfe6cc9c)
