### PR TITLE
scripts: Add octopi installation on Debian Bookworm

### DIFF
--- a/scripts/install-octopi-bookworm.sh
+++ b/scripts/install-octopi-bookworm.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# This script installs Klipper on a Raspberry Pi machine running the
+# OctoPi distribution.
+
+PYTHONDIR="${HOME}/klippy-env"
+
+# Step 1: Install system packages
+install_packages()
+{
+    # Packages for python cffi
+    PKGLIST="virtualenv libpython3-dev libffi-dev build-essential"
+    # kconfig requirements
+    PKGLIST="${PKGLIST} libncurses-dev"
+    # hub-ctrl
+    PKGLIST="${PKGLIST} libusb-dev"
+    # AVR chip installation and building
+    PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
+    # ARM chip installation and building
+    PKGLIST="${PKGLIST} stm32flash dfu-util libnewlib-arm-none-eabi"
+    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0"
+
+    # Update system package info
+    report_status "Running apt-get update..."
+    sudo apt-get update
+
+    # Install desired packages
+    report_status "Installing packages..."
+    sudo apt-get install --yes ${PKGLIST}
+}
+
+# Step 2: Create python virtual environment
+create_virtualenv()
+{
+    report_status "Updating python virtual environment..."
+
+    # Create virtualenv if it doesn't already exist
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python ${PYTHONDIR}
+
+    # Install/update dependencies
+    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+}
+
+# Step 3: Install startup script
+install_script()
+{
+    report_status "Installing system start script..."
+    sudo cp "${SRCDIR}/scripts/klipper-start.sh" /etc/init.d/klipper
+    sudo update-rc.d klipper defaults
+}
+
+# Step 4: Install startup script config
+install_config()
+{
+    DEFAULTS_FILE=/etc/default/klipper
+    [ -f $DEFAULTS_FILE ] && return
+
+    report_status "Installing system start configuration..."
+    sudo /bin/sh -c "cat > $DEFAULTS_FILE" <<EOF
+# Configuration for /etc/init.d/klipper
+
+KLIPPY_USER=$USER
+
+KLIPPY_EXEC=${PYTHONDIR}/bin/python
+
+KLIPPY_ARGS="${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l /tmp/klippy.log"
+
+EOF
+}
+
+# Step 5: Start host software
+start_software()
+{
+    report_status "Launching Klipper host software..."
+    sudo /etc/init.d/klipper restart
+}
+
+# Helper functions
+report_status()
+{
+    echo -e "\n\n###### $1"
+}
+
+verify_ready()
+{
+    if [ "$EUID" -eq 0 ]; then
+        echo "This script must not run as root"
+        exit -1
+    fi
+}
+
+# Force script to exit if an error occurs
+set -e
+
+# Find SRCDIR from the pathname of this script
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+# Run installation steps defined above
+verify_ready
+install_packages
+create_virtualenv
+install_script
+install_config
+start_software


### PR DESCRIPTION
Recent octopi nightly releases are based on Debian Bookworm as shown on the nightly build pages https://unofficialpi.org/Distros/OctoPi/nightly/ with the most recent ones named *-octopi-bookworm-armhf-lite-*.

This copies the original octopi scripts, making python2->python3 tweaks to installation targets.