### PR TITLE
z_thermal_adjust: fix temperature start-up behaviour

### DIFF
--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -42,7 +42,8 @@ class ZThermalAdjuster:
         pheaters.register_sensor(config, self)
 
         self.last_temp = 0.
-        self.measured_min = self.measured_max = 0.
+        self.measured_min = 99999999.
+        self.measured_max = 0.
         self.smoothed_temp = 0.
         self.last_temp_time = 0.
         self.ref_temperature = 0.

--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -136,15 +136,16 @@ class ZThermalAdjuster:
 
     def temperature_callback(self, read_time, temp):
         'Called everytime the Z adjust thermistor is read'
-        with self.lock:
-            time_diff = read_time - self.last_temp_time
-            self.last_temp = temp
-            self.last_temp_time = read_time
-            temp_diff = temp - self.smoothed_temp
-            adj_time = min(time_diff * self.inv_smooth_time, 1.)
-            self.smoothed_temp += temp_diff * adj_time
-            self.measured_min = min(self.measured_min, self.smoothed_temp)
-            self.measured_max = max(self.measured_max, self.smoothed_temp)
+        if temp:
+            with self.lock:
+                time_diff = read_time - self.last_temp_time
+                self.last_temp = temp
+                self.last_temp_time = read_time
+                temp_diff = temp - self.smoothed_temp
+                adj_time = min(time_diff * self.inv_smooth_time, 1.)
+                self.smoothed_temp += temp_diff * adj_time
+                self.measured_min = min(self.measured_min, self.smoothed_temp)
+                self.measured_max = max(self.measured_max, self.smoothed_temp)
 
     def get_temp(self, eventtime):
         return self.smoothed_temp, 0.


### PR DESCRIPTION
Addresses two minor issues around start-up temperature handling:

- Initial 0.0degC "reading" no longer affects smoothing and adjustment on start up
- Fixes min_temp reporting for front-end client: no longer perpetually 0.0degC