### PR TITLE
Fixes build on Darwin by using target toolchain gcc 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,17 @@ export KCONFIG_CONFIG     := $(CURDIR)/.config
 
 # Common command definitions
 CC=$(CROSS_PREFIX)gcc
+CXX=$(CROSS_PREFIX)g++
 AS=$(CROSS_PREFIX)as
 LD=$(CROSS_PREFIX)ld
 OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
-CPP=cpp
+READELF=$(CROSS_PREFIX)readelf
 PYTHON=python3
+
+# export the cross readelf, for check-gcc to use it
+export READELF
 
 # Source files
 src-y =
@@ -65,7 +69,7 @@ $(OUT)%.o: %.c $(OUT)autoconf.h
 
 $(OUT)%.ld: %.lds.S $(OUT)autoconf.h
 	@echo "  Preprocessing $@"
-	$(Q)$(CPP) -I$(OUT) -P -MD -MT $@ $< -o $@
+	$(Q)$(CC) -E -I$(OUT) -P -MD -MT $@ $< -o $@
 
 $(OUT)klipper.elf: $(OBJS_klipper.elf)
 	@echo "  Linking $@"

--- a/scripts/check-gcc.sh
+++ b/scripts/check-gcc.sh
@@ -4,8 +4,11 @@
 f1="$1"
 f2="$2"
 
-s1=`readelf -A "$f1" | grep "Tag_ARM_ISA_use"`
-s2=`readelf -A "$f2" | grep "Tag_ARM_ISA_use"`
+# Get the cross toolchain readelf as an env var, if set by the makefile
+READELF="${READELF:-readelf}"
+
+s1=`${READELF} -A "$f1" | grep "Tag_ARM_ISA_use"`
+s2=`${READELF} -A "$f2" | grep "Tag_ARM_ISA_use"`
 
 if [ "$s1" != "$s2" ]; then
     echo ""


### PR DESCRIPTION
Target toolchain gcc with `-E` is now used for preprocessing.

Also changes `check-gcc.sh` to use target toolchain `readelf`, to make builds work.

This has been tested with `arm-none-eabi-` cross toolchain on OSX 14.3