### PR TITLE
Basic support for memory-mapped IO on Raspberry Pi SBCs

### DIFF
--- a/scripts/flash-raspberrypi-linux.sh
+++ b/scripts/flash-raspberrypi-linux.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This script installs the Raspberry Pi Linux MCU code to /usr/local/bin/
+
+if [ "$EUID" -ne 0 ]; then
+    echo "This script must be run as root"
+    exit -1
+fi
+set -e
+
+# Setting build output directory
+if [ -z "${1}" ]; then
+    out='out'
+else
+    out=${1}
+fi
+
+# Install new micro-controller code
+echo "Installing micro-controller code to /usr/local/bin/"
+rm -f /usr/local/bin/klipper_raspberrypi_mcu
+cp ${out}/klipper.elf /usr/local/bin/klipper_raspberrypi_mcu
+
+# Restart (if system install script present)
+if [ -f /etc/init.d/klipper_raspberrypi_mcu ]; then
+    echo "Attempting host MCU restart..."
+    service klipper_raspberrypi_mcu restart
+fi
+
+if [ -f /etc/systemd/system/klipper-raspberrypi-mcu.service ]; then
+    echo "Attempting host MCU restart..."
+    systemctl restart klipper-raspberrypi-mcu
+fi

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -28,6 +28,8 @@ choice
         bool "Beaglebone PRU"
     config MACH_AR100
         bool "Allwinner A64 AR100"
+    config MACH_RASPBERRYPI
+        bool "Linux process on Raspberry Pi"
     config MACH_LINUX
         bool "Linux process"
     config MACH_SIMU
@@ -43,6 +45,7 @@ source "src/hc32f460/Kconfig"
 source "src/rp2040/Kconfig"
 source "src/pru/Kconfig"
 source "src/ar100/Kconfig"
+source "src/raspberrypi/Kconfig"
 source "src/linux/Kconfig"
 source "src/simulator/Kconfig"
 

--- a/src/raspberrypi/Kconfig
+++ b/src/raspberrypi/Kconfig
@@ -1,0 +1,20 @@
+# Kconfig settings for compiling and running the micro-controller code
+# in a Linux process on a Raspberry Pi using memory-mapped IO rather
+# than system calls.
+
+if MACH_RASPBERRYPI
+
+config RASPBERRYPI_SELECT
+    bool
+    default y
+    select HAVE_GPIO
+
+config BOARD_DIRECTORY
+    string
+    default "raspberrypi"
+
+config CLOCK_FREQ
+    int
+    default 54000000
+
+endif

--- a/src/raspberrypi/Makefile
+++ b/src/raspberrypi/Makefile
@@ -1,0 +1,13 @@
+# Additional Raspberry Pi build rules
+
+dirs-y += src/raspberrypi src/generic src/raspberrypi/ringbuf
+
+src-y += raspberrypi/main.c raspberrypi/timer.c raspberrypi/console.c
+src-y += raspberrypi/gpio.c generic/crc16_ccitt.c generic/alloc.c
+src-y += raspberrypi/ringbuf/ringbuf.c
+
+CFLAGS_klipper.elf += -lutil -lrt -lpthread
+
+flash: $(OUT)klipper.elf
+	@echo "  Flashing"
+	$(Q)sudo ./scripts/flash-raspberrypi-linux.sh $(OUT)

--- a/src/raspberrypi/console.c
+++ b/src/raspberrypi/console.c
@@ -1,0 +1,283 @@
+// TTY based IO
+//
+// Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2024 Liam Powell <klipper@liampwll.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#define _POSIX_C_SOURCE 200809L
+#include <pthread.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <errno.h> // errno
+#include <fcntl.h> // fcntl
+#include <poll.h> // ppoll
+#include <pty.h> // openpty
+#include <stdio.h> // fprintf
+#include <string.h> // memmove
+#include <sys/stat.h> // chmod
+#include <time.h> // struct timespec
+#include <unistd.h> // ttyname
+#include "board/irq.h" // irq_wait
+#include "board/misc.h" // console_sendf
+#include "command.h" // command_find_block
+#include "internal.h" // console_setup
+#include "sched.h" // sched_wake_task
+#include "ringbuf/ringbuf.h"
+
+static ringbuf_t *ringbuf_to_mcu;
+static uint8_t ringbuf_to_mcu_data[1024 * 64];
+static ringbuf_t *ringbuf_from_mcu;
+static uint8_t ringbuf_from_mcu_data[1024 * 64];
+
+static struct pollfd main_pfd[1];
+#define MP_TTY_IDX   0
+
+// Report 'errno' in a message written to stderr
+void
+report_errno(char *where, int rc)
+{
+    int e = errno;
+    fprintf(stderr, "Got error %d in %s: (%d)%s\n", rc, where, e, strerror(e));
+}
+
+static void *
+ringbuf_to_mcu_worker(void *_unused)
+{
+    ringbuf_worker_t *ringbuf_worker;
+    if ((ringbuf_worker = ringbuf_register(ringbuf_to_mcu, 0)) == NULL) {
+        fprintf(stderr, "ringbuf_register failed in %s\n", __func__);
+        exit(1);
+    }
+    static uint8_t local_receive_buf[128];
+
+    for (;;) {
+        int ret = read(main_pfd[MP_TTY_IDX].fd, local_receive_buf, sizeof(local_receive_buf));
+        if (ret < 0) {
+            report_errno("read", ret);
+            continue;
+        }
+
+        ssize_t off;
+
+        while ((off = ringbuf_acquire(ringbuf_to_mcu, ringbuf_worker, ret)) == -1) {
+            nanosleep(&(struct timespec){ .tv_nsec = 500000 }, NULL);
+        }
+
+        memcpy(ringbuf_to_mcu_data + off, local_receive_buf, ret);
+        ringbuf_produce(ringbuf_to_mcu, ringbuf_worker);
+    }
+
+    return NULL;
+}
+
+static void *
+ringbuf_from_mcu_worker(void *_unused)
+{
+    for (;;) {
+        size_t len, off;
+
+        while ((len = ringbuf_consume(ringbuf_from_mcu, &off)) == 0) {
+            nanosleep(&(struct timespec){ .tv_nsec = 500000 }, NULL);
+        }
+
+        int ret = write(main_pfd[MP_TTY_IDX].fd, ringbuf_from_mcu_data + off, len);
+        if (ret < 0)
+            report_errno("write", ret);
+
+        ringbuf_release(ringbuf_from_mcu, len);
+    }
+
+    return NULL;
+}
+
+/****************************************************************
+ * Setup
+ ****************************************************************/
+
+int
+set_non_blocking(int fd)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0) {
+        report_errno("fcntl getfl", flags);
+        return -1;
+    }
+    int ret = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    if (ret < 0) {
+        report_errno("fcntl setfl", flags);
+        return -1;
+    }
+    return 0;
+}
+
+int
+set_close_on_exec(int fd)
+{
+    int ret = fcntl(fd, F_SETFD, FD_CLOEXEC);
+    if (ret < 0) {
+        report_errno("fcntl set cloexec", ret);
+        return -1;
+    }
+    return 0;
+}
+
+int
+console_setup(char *name)
+{
+    // Open pseudo-tty
+    struct termios ti;
+    memset(&ti, 0, sizeof(ti));
+    int mfd, sfd, ret = openpty(&mfd, &sfd, NULL, &ti, NULL);
+    if (ret) {
+        report_errno("openpty", ret);
+        return -1;
+    }
+    ret = set_close_on_exec(mfd);
+    if (ret)
+        return -1;
+    ret = set_close_on_exec(sfd);
+    if (ret)
+        return -1;
+    main_pfd[MP_TTY_IDX].fd = mfd;
+    main_pfd[MP_TTY_IDX].events = POLLIN;
+
+    // Create symlink to tty
+    unlink(name);
+    char *tname = ttyname(sfd);
+    if (!tname) {
+        report_errno("ttyname", 0);
+        return -1;
+    }
+    ret = symlink(tname, name);
+    if (ret) {
+        report_errno("symlink", ret);
+        return -1;
+    }
+    ret = chmod(tname, 0660);
+    if (ret) {
+        report_errno("chmod", ret);
+        return -1;
+    }
+
+    // Make sure stderr is non-blocking
+    ret = set_non_blocking(STDERR_FILENO);
+    if (ret)
+        return -1;
+
+    size_t ringbuf_size;
+    ringbuf_get_sizes(1, &ringbuf_size, NULL);
+    ringbuf_from_mcu = malloc(ringbuf_size);
+    ringbuf_to_mcu = malloc(ringbuf_size);
+    ret = ringbuf_setup(ringbuf_from_mcu, 1, sizeof(ringbuf_from_mcu_data));
+    if (ret)
+        return -1;
+    ret = ringbuf_setup(ringbuf_to_mcu, 1, sizeof(ringbuf_to_mcu_data));
+    if (ret)
+        return -1;
+
+    static pthread_t worker1;
+    pthread_create(&worker1, NULL, ringbuf_to_mcu_worker, NULL);
+    static pthread_t worker2;
+    pthread_create(&worker2, NULL, ringbuf_from_mcu_worker, NULL);
+
+    return 0;
+}
+
+
+/****************************************************************
+ * Console handling
+ ****************************************************************/
+
+static struct task_wake console_wake;
+static uint8_t receive_buf[4096];
+static int receive_pos;
+
+void *
+console_receive_buffer(void)
+{
+    return receive_buf;
+}
+
+// Process any incoming commands
+void
+console_task(void)
+{
+    if (!sched_check_wake(&console_wake))
+        return;
+
+    // Read data
+    size_t off;
+    int ret = (int)ringbuf_consume(ringbuf_to_mcu, &off);
+    if (ret > sizeof(receive_buf) - receive_pos) {
+        ret = sizeof(receive_buf) - receive_pos;
+    }
+    if (ret < 0) {
+        if (errno == EWOULDBLOCK) {
+            ret = 0;
+        } else {
+            report_errno("read", ret);
+            return;
+        }
+    }
+    if (ret != 0) {
+        memcpy(&receive_buf[receive_pos], &ringbuf_to_mcu_data[off], ret);
+        ringbuf_release(ringbuf_to_mcu, ret);
+    }
+    if (ret == 15 && receive_buf[receive_pos+14] == '\n'
+        && memcmp(&receive_buf[receive_pos], "FORCE_SHUTDOWN\n", 15) == 0)
+        shutdown("Force shutdown command");
+
+    // Find and dispatch message blocks in the input
+    int len = receive_pos + ret;
+    uint_fast8_t pop_count, msglen = len > MESSAGE_MAX ? MESSAGE_MAX : len;
+    ret = command_find_and_dispatch(receive_buf, msglen, &pop_count);
+    if (ret) {
+        len -= pop_count;
+        if (len) {
+            memmove(receive_buf, &receive_buf[pop_count], len);
+            sched_wake_task(&console_wake);
+        }
+    }
+    receive_pos = len;
+}
+DECL_TASK(console_task);
+
+// Encode and transmit a "response" message
+void
+console_sendf(const struct command_encoder *ce, va_list args)
+{
+    static ringbuf_worker_t *ringbuf_worker = NULL;
+    if (ringbuf_worker == NULL) {
+        if ((ringbuf_worker = ringbuf_register(ringbuf_to_mcu, 0)) == NULL) {
+            fprintf(stderr, "ringbuf_register failed in %s\n", __func__);
+            exit(1);
+        }
+    }
+
+    // Generate message
+    uint8_t buf[MESSAGE_MAX];
+    uint_fast8_t msglen = command_encode_and_frame(buf, ce, args);
+
+    // Transmit message
+    ssize_t off;
+    if ((off = ringbuf_acquire(ringbuf_from_mcu, ringbuf_worker, msglen)) == -1) {
+        fprintf(stderr, "ringbuf_acquire failed in %s\n", __func__);
+        return;
+    }
+
+    memcpy(ringbuf_from_mcu_data + off, buf, msglen);
+    ringbuf_produce(ringbuf_from_mcu, ringbuf_worker);
+}
+
+void
+console_sleep(void)
+{
+    // Return immediately instead of actually sleeping as we are dedicating a
+    // core to the part of the code that calls this.
+    size_t off;
+    if (ringbuf_consume(ringbuf_to_mcu, &off) != 0) {
+        sched_wake_task(&console_wake);
+    }
+}

--- a/src/raspberrypi/gpio.c
+++ b/src/raspberrypi/gpio.c
@@ -1,0 +1,272 @@
+// Raspberry Pi memory-mapped GPIO.
+// Based on https://abyz.me.uk/rpi/pigpio/examples.html#Misc_minimal_gpio
+//
+// Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2024 Liam Powell <klipper@liampwll.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+#include "command.h"
+#include "gpio.h"
+#include "internal.h"
+#include "sched.h"
+
+static uint32_t pi_periph_base = 0x20000000;
+
+static int pi_is_2711 = 0;
+
+#define SYST_BASE (pi_periph_base + 0x003000)
+#define DMA_BASE (pi_periph_base + 0x007000)
+#define CLK_BASE (pi_periph_base + 0x101000)
+#define GPIO_BASE (pi_periph_base + 0x200000)
+#define UART0_BASE (pi_periph_base + 0x201000)
+#define PCM_BASE (pi_periph_base + 0x203000)
+#define SPI0_BASE (pi_periph_base + 0x204000)
+#define I2C0_BASE (pi_periph_base + 0x205000)
+#define PWM_BASE (pi_periph_base + 0x20C000)
+#define BSCS_BASE (pi_periph_base + 0x214000)
+#define UART1_BASE (pi_periph_base + 0x215000)
+#define I2C1_BASE (pi_periph_base + 0x804000)
+#define I2C2_BASE (pi_periph_base + 0x805000)
+#define DMA15_BASE (pi_periph_base + 0xE05000)
+
+#define DMA_LEN 0x1000 /* allow access to all channels */
+#define CLK_LEN 0xA8
+#define GPIO_LEN 0xF4
+#define SYST_LEN 0x1C
+#define PCM_LEN 0x24
+#define PWM_LEN 0x28
+#define I2C_LEN 0x1C
+#define BSCS_LEN 0x40
+
+#define GPSET0 7
+#define GPSET1 8
+
+#define GPCLR0 10
+#define GPCLR1 11
+
+#define GPLEV0 13
+#define GPLEV1 14
+
+#define GPPUD 37
+#define GPPUDCLK0 38
+#define GPPUDCLK1 39
+
+/* BCM2711 has different pulls */
+
+#define GPPUPPDN0 57
+#define GPPUPPDN1 58
+#define GPPUPPDN2 59
+#define GPPUPPDN3 60
+
+#define SYST_CS 0
+#define SYST_CLO 1
+#define SYST_CHI 2
+
+static volatile uint32_t *gpio_reg = MAP_FAILED;
+static volatile uint32_t *syst_reg = MAP_FAILED;
+static volatile uint32_t *bscs_reg = MAP_FAILED;
+
+#define PI_BANK(gpio) (gpio >> 5)
+#define PI_BIT(gpio) (1 << (gpio & 0x1F))
+
+/* gpio modes. */
+
+#define PI_INPUT 0
+#define PI_OUTPUT 1
+#define PI_ALT0 4
+#define PI_ALT1 5
+#define PI_ALT2 6
+#define PI_ALT3 7
+#define PI_ALT4 3
+#define PI_ALT5 2
+
+static uint8_t gpio_out_states[58] = {0};
+
+static unsigned
+gpio_hardware_revision(void)
+{
+    static unsigned rev = 0;
+
+    FILE *filp;
+    char buf[512];
+    char term;
+    int chars = 4; /* number of chars in revision string */
+
+    filp = fopen("/proc/cpuinfo", "r");
+
+    if (filp != NULL) {
+        while (fgets(buf, sizeof(buf), filp) != NULL) {
+            if (!strncasecmp("revision", buf, 8)) {
+                if (sscanf(buf + strlen(buf) - (chars + 1), "%x%c", &rev, &term) == 2) {
+                    if (term != '\n')
+                        rev = 0;
+                    else
+                        rev &= 0xFFFFFF; /* mask out warranty bit */
+                }
+            }
+        }
+
+        fclose(filp);
+    }
+
+    if ((filp = fopen("/proc/device-tree/soc/ranges", "rb"))) {
+        if (fread(buf, 1, sizeof(buf), filp) >= 8) {
+            pi_periph_base = buf[4] << 24 | buf[5] << 16 | buf[6] << 8 | buf[7];
+            if (!pi_periph_base)
+                pi_periph_base = buf[8] << 24 | buf[9] << 16 | buf[10] << 8 | buf[11];
+
+            if (pi_periph_base == 0xFE00000)
+                pi_is_2711 = 1;
+        }
+        fclose(filp);
+    }
+
+    return rev;
+}
+
+/* Map in registers. */
+static uint32_t *
+init_map_mem(int fd, uint32_t addr, uint32_t len)
+{
+    return (uint32_t *)mmap(0, len, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED | MAP_LOCKED, fd, addr);
+}
+
+int
+gpio_initialise(void)
+{
+    int fd;
+
+    gpio_hardware_revision(); /* sets rev and peripherals base address */
+
+    fd = open("/dev/mem", O_RDWR | O_SYNC);
+
+    if (fd < 0) {
+        fprintf(stderr, "This program needs root privileges.  Try using sudo\n");
+        return -1;
+    }
+
+    gpio_reg = init_map_mem(fd, GPIO_BASE, GPIO_LEN);
+    syst_reg = init_map_mem(fd, SYST_BASE, SYST_LEN);
+    bscs_reg = init_map_mem(fd, BSCS_BASE, BSCS_LEN);
+
+    close(fd);
+
+    if ((gpio_reg == MAP_FAILED) || (syst_reg == MAP_FAILED) || (bscs_reg == MAP_FAILED)) {
+        fprintf(stderr, "Bad, mmap failed\n");
+        return -1;
+    }
+    return 0;
+}
+
+struct gpio_out
+gpio_out_setup(uint32_t pin, uint8_t val)
+{
+    struct gpio_out g = { .pin = pin };
+    gpio_out_reset(g, val);
+    return g;
+}
+
+void
+gpio_out_reset(struct gpio_out g, uint8_t val)
+{
+    int reg, shift;
+    reg = g.pin / 10;
+    shift = (g.pin % 10) * 3;
+    gpio_reg[reg] = (gpio_reg[reg] & ~(7 << shift)) | (PI_OUTPUT << shift);
+
+    gpio_out_write(g, val);
+}
+
+void
+gpio_out_write(struct gpio_out g, uint8_t val)
+{
+    if (val == 0) {
+        *(gpio_reg + GPCLR0 + PI_BANK(g.pin)) = PI_BIT(g.pin);
+    } else {
+        *(gpio_reg + GPSET0 + PI_BANK(g.pin)) = PI_BIT(g.pin);
+    }
+    gpio_out_states[g.pin] = val;
+}
+
+void
+gpio_out_toggle_noirq(struct gpio_out g)
+{
+    gpio_out_write(g, !gpio_out_states[g.pin]);
+}
+
+void
+gpio_out_toggle(struct gpio_out g)
+{
+    gpio_out_toggle_noirq(g);
+}
+
+struct gpio_in
+gpio_in_setup(uint32_t pin, int8_t pull_up)
+{
+    struct gpio_in g = { .pin = pin };
+    gpio_in_reset(g, pull_up);
+    return g;
+}
+
+void
+gpio_in_reset(struct gpio_in g, int8_t pull_up)
+{
+    {
+        int reg, shift;
+        reg = g.pin / 10;
+        shift = (g.pin % 10) * 3;
+        gpio_reg[reg] = (gpio_reg[reg] & ~(7 << shift)) | (PI_INPUT << shift);
+    }
+
+    {
+        uint32_t pull_reg_val;
+
+        if (pull_up > 0) {
+            if (pi_is_2711) {
+                pull_reg_val = 1;
+            } else {
+                pull_reg_val = 2;
+            }
+        } else if (pull_up < 0) {
+            if (pi_is_2711) {
+                pull_reg_val = 2;
+            } else {
+                pull_reg_val = 1;
+            }
+        } else {
+            pull_reg_val = 0;
+        }
+
+        if (pi_is_2711) {
+            int shift = (g.pin & 0xf) << 1;
+            uint32_t bits = *(gpio_reg + GPPUPPDN0 + (g.pin >> 4));
+            bits &= ~(3 << shift);
+            bits |= (pull_reg_val << shift);
+            *(gpio_reg + GPPUPPDN0 + (g.pin >> 4)) = bits;
+        } else {
+            *(gpio_reg + GPPUD) = pull_reg_val;
+            usleep(20);
+            *(gpio_reg + GPPUDCLK0 + PI_BANK(g.pin)) = PI_BIT(g.pin);
+            usleep(20);
+            *(gpio_reg + GPPUD) = 0;
+            *(gpio_reg + GPPUDCLK0 + PI_BANK(g.pin)) = 0;
+        }
+    }
+}
+
+uint8_t
+gpio_in_read(struct gpio_in g)
+{
+    return *(gpio_reg + GPLEV0 + PI_BANK(g.pin)) & PI_BIT(g.pin);
+}

--- a/src/raspberrypi/gpio.h
+++ b/src/raspberrypi/gpio.h
@@ -1,0 +1,24 @@
+#ifndef RASPBERRYPI_GPIO_H_
+#define RASPBERRYPI_GPIO_H_
+
+#include <stdint.h> // uint8_t
+
+int gpio_initialise(void);
+
+struct gpio_out {
+    uint32_t pin;
+};
+struct gpio_out gpio_out_setup(uint32_t pin, uint8_t val);
+void gpio_out_reset(struct gpio_out g, uint8_t val);
+void gpio_out_toggle_noirq(struct gpio_out g);
+void gpio_out_toggle(struct gpio_out g);
+void gpio_out_write(struct gpio_out g, uint8_t val);
+
+struct gpio_in {
+    uint32_t pin;
+};
+struct gpio_in gpio_in_setup(uint32_t pin, int8_t pull_up);
+void gpio_in_reset(struct gpio_in g, int8_t pull_up);
+uint8_t gpio_in_read(struct gpio_in g);
+
+#endif // RASPBERRYPI_GPIO_H_

--- a/src/raspberrypi/internal.h
+++ b/src/raspberrypi/internal.h
@@ -1,0 +1,18 @@
+#ifndef RASPBERRYPI_INTERNAL_H_
+#define RASPBERRYPI_INTERNAL_H_
+// Local definitions for micro-controllers running on linux
+
+#include <signal.h> // sigset_t
+#include <stdint.h> // uint32_t
+
+// console.c
+void report_errno(char *where, int rc);
+int set_non_blocking(int fd);
+int set_close_on_exec(int fd);
+int console_setup(char *name);
+void console_sleep();
+
+// timer.c
+int timer_check_periodic(uint32_t *ts);
+
+#endif // RASPBERRYPI_INTERNAL_H_

--- a/src/raspberrypi/main.c
+++ b/src/raspberrypi/main.c
@@ -1,0 +1,123 @@
+// Main starting point for micro-controller code running on Raspberry Pi's on Linux.
+//
+// Copyright (C) 2017  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2024 Liam Powell <klipper@liampwll.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#define _GNU_SOURCE
+#include </usr/include/sched.h> // sched_setscheduler sched_get_priority_max
+#include <stdio.h> // fprintf
+#include <stdlib.h>
+#include <string.h> // memset
+#include <unistd.h> // getopt
+#include <sys/mman.h> // mlockall MCL_CURRENT MCL_FUTURE
+#include "board/misc.h" // console_sendf
+#include "command.h" // DECL_CONSTANT
+#include "internal.h" // console_setup
+#include "sched.h" // sched_main
+#include "gpio.h"
+
+DECL_CONSTANT_STR("MCU", "raspberrypi");
+
+static void int_handler(int _unused) {
+    exit(0);
+}
+
+/****************************************************************
+ * Real-time setup
+ ****************************************************************/
+
+static int
+realtime_setup(void)
+{
+    struct sched_param sp;
+    memset(&sp, 0, sizeof(sp));
+    sp.sched_priority = sched_get_priority_max(SCHED_FIFO) / 2;
+    int ret = sched_setscheduler(0, SCHED_FIFO, &sp);
+    if (ret < 0) {
+        report_errno("sched_setscheduler", ret);
+        return -1;
+    }
+    // Lock ourselves into memory
+    ret = mlockall(MCL_CURRENT | MCL_FUTURE);
+    if (ret) {
+        report_errno("mlockall", ret);
+        return -1;
+    }
+    return 0;
+}
+
+
+/****************************************************************
+ * Restart
+ ****************************************************************/
+
+static char **orig_argv;
+
+void
+command_config_reset(uint32_t *args)
+{
+    if (! sched_is_shutdown())
+        shutdown("config_reset only available when shutdown");
+    int ret = execv(orig_argv[0], orig_argv);
+    report_errno("execv", ret);
+}
+DECL_COMMAND_FLAGS(command_config_reset, HF_IN_SHUTDOWN, "config_reset");
+
+
+/****************************************************************
+ * Startup
+ ****************************************************************/
+
+int
+main(int argc, char **argv)
+{
+    signal(SIGINT, int_handler);
+
+    // Parse program args
+    orig_argv = argv;
+    int opt, realtime_cpu = 3;
+    char *serial = "/tmp/klipper_host_mcu";
+    while ((opt = getopt(argc, argv, "I:c:")) != -1) {
+        switch (opt) {
+        case 'I':
+            serial = optarg;
+            break;
+        case 'c':
+            realtime_cpu = atoi(optarg);
+            break;
+        default:
+            fprintf(stderr, "Usage: %s [-I path] [-c core]\n", argv[0]);
+            return -1;
+        }
+    }
+
+    // Initial setup
+    if (console_setup(serial)) {
+        fprintf(stderr, "Console setup failed.");
+        return -1;
+    }
+
+    if (gpio_initialise()) {
+        fprintf(stderr, "GPIO setup failed.");
+        return -1;
+    }
+
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(realtime_cpu, &cpuset);
+    if (sched_setaffinity(getpid(), sizeof(cpuset), &cpuset)) {
+        fprintf(stderr, "Could not set CPU affinity.");
+        return -1;
+    }
+
+    if (realtime_setup()) {
+        fprintf(stderr, "Realtime setup failed.");
+        return -1;
+    }
+
+    // Main loop
+    sched_main();
+    return 0;
+}

--- a/src/raspberrypi/ringbuf/LICENSE
+++ b/src/raspberrypi/ringbuf/LICENSE
@@ -1,0 +1,25 @@
+/*-
+ * Copyright (c) 2016-2017 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */

--- a/src/raspberrypi/ringbuf/ringbuf.c
+++ b/src/raspberrypi/ringbuf/ringbuf.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2016-2017 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+/*
+ * Atomic multi-producer single-consumer ring buffer, which supports
+ * contiguous range operations and which can be conveniently used for
+ * message passing.
+ *
+ * There are three offsets -- think of clock hands:
+ * - NEXT: marks the beginning of the available space,
+ * - WRITTEN: the point up to which the data is actually written.
+ * - Observed READY: point up to which data is ready to be written.
+ *
+ * Producers
+ *
+ *	Observe and save the 'next' offset, then request N bytes from
+ *	the ring buffer by atomically advancing the 'next' offset.  Once
+ *	the data is written into the "reserved" buffer space, the thread
+ *	clears the saved value; these observed values are used to compute
+ *	the 'ready' offset.
+ *
+ * Consumer
+ *
+ *	Writes the data between 'written' and 'ready' offsets and updates
+ *	the 'written' value.  The consumer thread scans for the lowest
+ *	seen value by the producers.
+ *
+ * Key invariant
+ *
+ *	Producers cannot go beyond the 'written' offset; producers are
+ *	also not allowed to catch up with the consumer.  Only the consumer
+ *	is allowed to catch up with the producer i.e. set the 'written'
+ *	offset to be equal to the 'next' offset.
+ *
+ * Wrap-around
+ *
+ *	If the producer cannot acquire the requested length due to little
+ *	available space at the end of the buffer, then it will wraparound.
+ *	WRAP_LOCK_BIT in 'next' offset is used to lock the 'end' offset.
+ *
+ *	There is an ABA problem if one producer stalls while a pair of
+ *	producer and consumer would both successfully wrap-around and set
+ *	the 'next' offset to the stale value of the first producer, thus
+ *	letting it to perform a successful CAS violating the invariant.
+ *	A counter in the 'next' offset (masked by WRAP_COUNTER) is used
+ *	to prevent from this problem.  It is incremented on wraparounds.
+ *
+ *	The same ABA problem could also cause a stale 'ready' offset,
+ *	which could be observed by the consumer.  We set WRAP_LOCK_BIT in
+ *	the 'seen' value before advancing the 'next' and clear this bit
+ *	after the successful advancing; this ensures that only the stable
+ *	'ready' is observed by the consumer.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
+#define _DEFAULT_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+#include "ringbuf.h"
+#include "utils.h"
+
+#define	RBUF_OFF_MASK	(0x00000000ffffffffUL)
+#define	WRAP_LOCK_BIT	(0x8000000000000000UL)
+#define	RBUF_OFF_MAX	(UINT64_MAX & ~WRAP_LOCK_BIT)
+
+#define	WRAP_COUNTER	(0x7fffffff00000000UL)
+#define	WRAP_INCR(x)	(((x) + 0x100000000UL) & WRAP_COUNTER)
+
+typedef uint64_t	ringbuf_off_t;
+
+struct ringbuf_worker {
+	volatile ringbuf_off_t	seen_off;
+	int			registered;
+};
+
+struct ringbuf {
+	/* Ring buffer space. */
+	size_t			space;
+
+	/*
+	 * The NEXT hand is atomically updated by the producer.
+	 * WRAP_LOCK_BIT is set in case of wrap-around; in such case,
+	 * the producer can update the 'end' offset.
+	 */
+	volatile ringbuf_off_t	next;
+	ringbuf_off_t		end;
+
+	/* The following are updated by the consumer. */
+	ringbuf_off_t		written;
+	unsigned		nworkers;
+	ringbuf_worker_t	workers[];
+};
+
+/*
+ * ringbuf_setup: initialise a new ring buffer of a given length.
+ */
+int
+ringbuf_setup(ringbuf_t *rbuf, unsigned nworkers, size_t length)
+{
+	if (length >= RBUF_OFF_MASK) {
+		errno = EINVAL;
+		return -1;
+	}
+	memset(rbuf, 0, offsetof(ringbuf_t, workers[nworkers]));
+	rbuf->space = length;
+	rbuf->end = RBUF_OFF_MAX;
+	rbuf->nworkers = nworkers;
+	return 0;
+}
+
+/*
+ * ringbuf_get_sizes: return the sizes of the ringbuf_t and ringbuf_worker_t.
+ */
+void
+ringbuf_get_sizes(unsigned nworkers,
+    size_t *ringbuf_size, size_t *ringbuf_worker_size)
+{
+	if (ringbuf_size)
+		*ringbuf_size = offsetof(ringbuf_t, workers[nworkers]);
+	if (ringbuf_worker_size)
+		*ringbuf_worker_size = sizeof(ringbuf_worker_t);
+}
+
+/*
+ * ringbuf_register: register the worker (thread/process) as a producer
+ * and pass the pointer to its local store.
+ */
+ringbuf_worker_t *
+ringbuf_register(ringbuf_t *rbuf, unsigned i)
+{
+	ringbuf_worker_t *w = &rbuf->workers[i];
+
+	w->seen_off = RBUF_OFF_MAX;
+	atomic_store_explicit(&w->registered, true, memory_order_release);
+	return w;
+}
+
+void
+ringbuf_unregister(ringbuf_t *rbuf, ringbuf_worker_t *w)
+{
+	w->registered = false;
+	(void)rbuf;
+}
+
+/*
+ * stable_nextoff: capture and return a stable value of the 'next' offset.
+ */
+static inline ringbuf_off_t
+stable_nextoff(ringbuf_t *rbuf)
+{
+	unsigned count = SPINLOCK_BACKOFF_MIN;
+	ringbuf_off_t next;
+retry:
+	next = atomic_load_explicit(&rbuf->next, memory_order_acquire);
+	if (next & WRAP_LOCK_BIT) {
+		SPINLOCK_BACKOFF(count);
+		goto retry;
+	}
+	ASSERT((next & RBUF_OFF_MASK) < rbuf->space);
+	return next;
+}
+
+/*
+ * stable_seenoff: capture and return a stable value of the 'seen' offset.
+ */
+static inline ringbuf_off_t
+stable_seenoff(ringbuf_worker_t *w)
+{
+	unsigned count = SPINLOCK_BACKOFF_MIN;
+	ringbuf_off_t seen_off;
+retry:
+	seen_off = atomic_load_explicit(&w->seen_off, memory_order_acquire);
+	if (seen_off & WRAP_LOCK_BIT) {
+		SPINLOCK_BACKOFF(count);
+		goto retry;
+	}
+	return seen_off;
+}
+
+/*
+ * ringbuf_acquire: request a space of a given length in the ring buffer.
+ *
+ * => On success: returns the offset at which the space is available.
+ * => On failure: returns -1.
+ */
+ssize_t
+ringbuf_acquire(ringbuf_t *rbuf, ringbuf_worker_t *w, size_t len)
+{
+	ringbuf_off_t seen, next, target;
+
+	ASSERT(len > 0 && len <= rbuf->space);
+	ASSERT(w->seen_off == RBUF_OFF_MAX);
+
+	do {
+		ringbuf_off_t written;
+
+		/*
+		 * Get the stable 'next' offset.  Save the observed 'next'
+		 * value (i.e. the 'seen' offset), but mark the value as
+		 * unstable (set WRAP_LOCK_BIT).
+		 *
+		 * Note: CAS will issue a memory_order_release for us and
+		 * thus ensures that it reaches global visibility together
+		 * with new 'next'.
+		 */
+		seen = stable_nextoff(rbuf);
+		next = seen & RBUF_OFF_MASK;
+		ASSERT(next < rbuf->space);
+		atomic_store_explicit(&w->seen_off, next | WRAP_LOCK_BIT,
+		    memory_order_relaxed);
+
+		/*
+		 * Compute the target offset.  Key invariant: we cannot
+		 * go beyond the WRITTEN offset or catch up with it.
+		 */
+		target = next + len;
+		written = rbuf->written;
+		if (__predict_false(next < written && target >= written)) {
+			/* The producer must wait. */
+			atomic_store_explicit(&w->seen_off,
+			    RBUF_OFF_MAX, memory_order_release);
+			return -1;
+		}
+
+		if (__predict_false(target >= rbuf->space)) {
+			const bool exceed = target > rbuf->space;
+
+			/*
+			 * Wrap-around and start from the beginning.
+			 *
+			 * If we would exceed the buffer, then attempt to
+			 * acquire the WRAP_LOCK_BIT and use the space in
+			 * the beginning.  If we used all space exactly to
+			 * the end, then reset to 0.
+			 *
+			 * Check the invariant again.
+			 */
+			target = exceed ? (WRAP_LOCK_BIT | len) : 0;
+			if ((target & RBUF_OFF_MASK) >= written) {
+				atomic_store_explicit(&w->seen_off,
+				    RBUF_OFF_MAX, memory_order_release);
+				return -1;
+			}
+			/* Increment the wrap-around counter. */
+			target |= WRAP_INCR(seen & WRAP_COUNTER);
+		} else {
+			/* Preserve the wrap-around counter. */
+			target |= seen & WRAP_COUNTER;
+		}
+	} while (!atomic_compare_exchange_weak(&rbuf->next, &seen, target));
+
+	/*
+	 * Acquired the range.  Clear WRAP_LOCK_BIT in the 'seen' value
+	 * thus indicating that it is stable now.
+	 *
+	 * No need for memory_order_release, since CAS issued a fence.
+	 */
+	atomic_store_explicit(&w->seen_off, w->seen_off & ~WRAP_LOCK_BIT,
+	    memory_order_relaxed);
+
+	/*
+	 * If we set the WRAP_LOCK_BIT in the 'next' (because we exceed
+	 * the remaining space and need to wrap-around), then save the
+	 * 'end' offset and release the lock.
+	 */
+	if (__predict_false(target & WRAP_LOCK_BIT)) {
+		/* Cannot wrap-around again if consumer did not catch-up. */
+		ASSERT(rbuf->written <= next);
+		ASSERT(rbuf->end == RBUF_OFF_MAX);
+		rbuf->end = next;
+		next = 0;
+
+		/*
+		 * Unlock: ensure the 'end' offset reaches global
+		 * visibility before the lock is released.
+		 */
+		atomic_store_explicit(&rbuf->next,
+		    (target & ~WRAP_LOCK_BIT), memory_order_release);
+	}
+	ASSERT((target & RBUF_OFF_MASK) <= rbuf->space);
+	return (ssize_t)next;
+}
+
+/*
+ * ringbuf_produce: indicate the acquired range in the buffer is produced
+ * and is ready to be consumed.
+ */
+void
+ringbuf_produce(ringbuf_t *rbuf, ringbuf_worker_t *w)
+{
+	(void)rbuf;
+	ASSERT(w->registered);
+	ASSERT(w->seen_off != RBUF_OFF_MAX);
+	atomic_store_explicit(&w->seen_off, RBUF_OFF_MAX, memory_order_release);
+}
+
+/*
+ * ringbuf_consume: get a contiguous range which is ready to be consumed.
+ */
+size_t
+ringbuf_consume(ringbuf_t *rbuf, size_t *offset)
+{
+	ringbuf_off_t written = rbuf->written, next, ready;
+	size_t towrite;
+retry:
+	/*
+	 * Get the stable 'next' offset.  Note: stable_nextoff() issued
+	 * a load memory barrier.  The area between the 'written' offset
+	 * and the 'next' offset will be the *preliminary* target buffer
+	 * area to be consumed.
+	 */
+	next = stable_nextoff(rbuf) & RBUF_OFF_MASK;
+	if (written == next) {
+		/* If producers did not advance, then nothing to do. */
+		return 0;
+	}
+
+	/*
+	 * Observe the 'ready' offset of each producer.
+	 *
+	 * At this point, some producer might have already triggered the
+	 * wrap-around and some (or all) seen 'ready' values might be in
+	 * the range between 0 and 'written'.  We have to skip them.
+	 */
+	ready = RBUF_OFF_MAX;
+
+	for (unsigned i = 0; i < rbuf->nworkers; i++) {
+		ringbuf_worker_t *w = &rbuf->workers[i];
+		ringbuf_off_t seen_off;
+
+		/*
+		 * Skip if the worker has not registered.
+		 *
+		 * Get a stable 'seen' value.  This is necessary since we
+		 * want to discard the stale 'seen' values.
+		 */
+		if (!atomic_load_explicit(&w->registered, memory_order_relaxed))
+			continue;
+		seen_off = stable_seenoff(w);
+
+		/*
+		 * Ignore the offsets after the possible wrap-around.
+		 * We are interested in the smallest seen offset that is
+		 * not behind the 'written' offset.
+		 */
+		if (seen_off >= written) {
+			ready = MIN(seen_off, ready);
+		}
+		ASSERT(ready >= written);
+	}
+
+	/*
+	 * Finally, we need to determine whether wrap-around occurred
+	 * and deduct the safe 'ready' offset.
+	 */
+	if (next < written) {
+		const ringbuf_off_t end = MIN(rbuf->space, rbuf->end);
+
+		/*
+		 * Wrap-around case.  Check for the cut off first.
+		 *
+		 * Reset the 'written' offset if it reached the end of
+		 * the buffer or the 'end' offset (if set by a producer).
+		 * However, we must check that the producer is actually
+		 * done (the observed 'ready' offsets are clear).
+		 */
+		if (ready == RBUF_OFF_MAX && written == end) {
+			/*
+			 * Clear the 'end' offset if was set.
+			 */
+			if (rbuf->end != RBUF_OFF_MAX) {
+				rbuf->end = RBUF_OFF_MAX;
+			}
+
+			/*
+			 * Wrap-around the consumer and start from zero.
+			 */
+			written = 0;
+			atomic_store_explicit(&rbuf->written,
+			    written, memory_order_release);
+			goto retry;
+		}
+
+		/*
+		 * We cannot wrap-around yet; there is data to consume at
+		 * the end.  The ready range is smallest of the observed
+		 * 'ready' or the 'end' offset.  If neither is set, then
+		 * the actual end of the buffer.
+		 */
+		ASSERT(ready > next);
+		ready = MIN(ready, end);
+		ASSERT(ready >= written);
+	} else {
+		/*
+		 * Regular case.  Up to the observed 'ready' (if set)
+		 * or the 'next' offset.
+		 */
+		ready = MIN(ready, next);
+	}
+	towrite = ready - written;
+	*offset = written;
+
+	ASSERT(ready >= written);
+	ASSERT(towrite <= rbuf->space);
+	return towrite;
+}
+
+/*
+ * ringbuf_release: indicate that the consumed range can now be released.
+ */
+void
+ringbuf_release(ringbuf_t *rbuf, size_t nbytes)
+{
+	const size_t nwritten = rbuf->written + nbytes;
+
+	ASSERT(rbuf->written <= rbuf->space);
+	ASSERT(rbuf->written <= rbuf->end);
+	ASSERT(nwritten <= rbuf->space);
+
+	rbuf->written = (nwritten == rbuf->space) ? 0 : nwritten;
+}

--- a/src/raspberrypi/ringbuf/ringbuf.h
+++ b/src/raspberrypi/ringbuf/ringbuf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the LICENSE file.
+ */
+
+#ifndef _RINGBUF_H_
+#define _RINGBUF_H_
+
+__BEGIN_DECLS
+
+#include <stddef.h>
+#include <sys/types.h>
+
+typedef struct ringbuf ringbuf_t;
+typedef struct ringbuf_worker ringbuf_worker_t;
+
+int		ringbuf_setup(ringbuf_t *, unsigned, size_t);
+void		ringbuf_get_sizes(unsigned, size_t *, size_t *);
+
+ringbuf_worker_t *ringbuf_register(ringbuf_t *, unsigned);
+void		ringbuf_unregister(ringbuf_t *, ringbuf_worker_t *);
+
+ssize_t		ringbuf_acquire(ringbuf_t *, ringbuf_worker_t *, size_t);
+void		ringbuf_produce(ringbuf_t *, ringbuf_worker_t *);
+size_t		ringbuf_consume(ringbuf_t *, size_t *);
+void		ringbuf_release(ringbuf_t *, size_t);
+
+__END_DECLS
+
+#endif

--- a/src/raspberrypi/ringbuf/utils.h
+++ b/src/raspberrypi/ringbuf/utils.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Berkeley Software Design, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)cdefs.h	8.8 (Berkeley) 1/9/95
+ */
+
+#ifndef _UTILS_H_
+#define _UTILS_H_
+
+#include <assert.h>
+
+/*
+ * A regular assert (debug/diagnostic only).
+ */
+#if defined(DEBUG)
+#define	ASSERT		assert
+#else
+#define	ASSERT(x)
+#endif
+
+/*
+ * Minimum, maximum and rounding macros.
+ */
+
+#ifndef MIN
+#define	MIN(x, y)	((x) < (y) ? (x) : (y))
+#endif
+
+#ifndef MAX
+#define	MAX(x, y)	((x) > (y) ? (x) : (y))
+#endif
+
+/*
+ * Branch prediction macros.
+ */
+#ifndef __predict_true
+#define	__predict_true(x)	__builtin_expect((x) != 0, 1)
+#define	__predict_false(x)	__builtin_expect((x) != 0, 0)
+#endif
+
+/*
+ * Atomic operations and memory barriers.  If C11 API is not available,
+ * then wrap the GCC builtin routines.
+ *
+ * Note: This atomic_compare_exchange_weak does not do the C11 thing of
+ * filling *(expected) with the actual value, because we don't need
+ * that here.
+ */
+#ifndef atomic_compare_exchange_weak
+#define	atomic_compare_exchange_weak(ptr, expected, desired) \
+    __sync_bool_compare_and_swap(ptr, *(expected), desired)
+#endif
+
+#ifndef atomic_thread_fence
+#define	memory_order_relaxed	__ATOMIC_RELAXED
+#define	memory_order_acquire	__ATOMIC_ACQUIRE
+#define	memory_order_release	__ATOMIC_RELEASE
+#define	memory_order_seq_cst	__ATOMIC_SEQ_CST
+#define	atomic_thread_fence(m)	__atomic_thread_fence(m)
+#endif
+#ifndef atomic_store_explicit
+#define	atomic_store_explicit	__atomic_store_n
+#endif
+#ifndef atomic_load_explicit
+#define	atomic_load_explicit	__atomic_load_n
+#endif
+
+/*
+ * Exponential back-off for the spinning paths.
+ */
+#define	SPINLOCK_BACKOFF_MIN	4
+#define	SPINLOCK_BACKOFF_MAX	128
+#if defined(__x86_64__) || defined(__i386__)
+#define SPINLOCK_BACKOFF_HOOK	__asm volatile("pause" ::: "memory")
+#else
+#define SPINLOCK_BACKOFF_HOOK
+#endif
+#define	SPINLOCK_BACKOFF(count)					\
+do {								\
+	for (int __i = (count); __i != 0; __i--) {		\
+		SPINLOCK_BACKOFF_HOOK;				\
+	}							\
+	if ((count) < SPINLOCK_BACKOFF_MAX)			\
+		(count) += (count);				\
+} while (/* CONSTCOND */ 0);
+
+#endif

--- a/src/raspberrypi/timer.c
+++ b/src/raspberrypi/timer.c
@@ -1,0 +1,178 @@
+// Handling of timers on linux systems
+//
+// Copyright (C) 2017-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2024 Liam Powell <klipper@liampwll.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <time.h> // struct timespec
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
+#include "board/io.h" // readl
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_from_us
+#include "command.h" // DECL_CONSTANT
+#include "internal.h" // console_sleep
+#include "sched.h" // DECL_INIT
+
+// Global storage for timer handling
+static struct {
+    uint32_t start;
+    // Last time reported by timer_read_time()
+    uint32_t last_read_time;
+    // Flags for tracking irq_enable()/irq_disable()
+    uint32_t must_wake_timers;
+    // Time of next software timer (also used to convert from ticks to systime)
+    uint32_t next_wake;
+} TimerInfo;
+
+/****************************************************************
+ * Timers
+ ****************************************************************/
+
+DECL_CONSTANT("CLOCK_FREQ", CONFIG_CLOCK_FREQ);
+
+// Check if a given time has past
+int
+timer_check_periodic(uint32_t *ts)
+{
+    uint32_t lrt = TimerInfo.last_read_time;
+    if (timer_is_before(lrt, *ts))
+        return 0;
+    *ts = lrt + timer_from_us(2000000);
+    return 1;
+}
+
+// Return the number of clock ticks for a given number of microseconds
+uint32_t
+timer_from_us(uint32_t us)
+{
+    return us * (CONFIG_CLOCK_FREQ / 1000000);
+}
+
+// Return true if time1 is before time2.  Always use this function to
+// compare times as regular C comparisons can fail if the counter
+// rolls over.
+uint8_t
+timer_is_before(uint32_t time1, uint32_t time2)
+{
+    return (int32_t)(time1 - time2) < 0;
+}
+
+// Return the current time (in clock ticks)
+uint32_t
+timer_read_time(void)
+{
+    uint64_t cntvct;
+    asm volatile ("isb; mrs %0, cntvct_el0;" : "=r"(cntvct) :: "memory");
+    TimerInfo.last_read_time = (uint32_t)cntvct - TimerInfo.start;
+    return TimerInfo.last_read_time;
+}
+
+// Activate timer dispatch as soon as possible
+void
+timer_kick(void)
+{
+    TimerInfo.must_wake_timers = 1;
+}
+
+#define TIMER_IDLE_REPEAT_COUNT 100
+#define TIMER_REPEAT_COUNT 20
+
+#define TIMER_MIN_TRY_TICKS timer_from_us(2)
+
+// Invoke timers
+static void
+timer_dispatch(void)
+{
+    uint32_t repeat_count = TIMER_REPEAT_COUNT, next;
+    for (;;) {
+        // Run the next software timer
+        next = sched_timer_dispatch();
+
+        repeat_count--;
+        uint32_t lrt = TimerInfo.last_read_time;
+        if (!timer_is_before(lrt, next) && repeat_count)
+            // Can run next timer without overhead of calling timer_read_time()
+            continue;
+
+        uint32_t now = timer_read_time();
+        int32_t diff = next - now;
+        if (diff > (int32_t)TIMER_MIN_TRY_TICKS)
+            // Schedule next timer normally.
+            break;
+
+        if (unlikely(!repeat_count)) {
+            // Check if there are too many repeat timers
+            if (diff < (int32_t)(-timer_from_us(100000)))
+                try_shutdown("Rescheduled timer in the past");
+            if (sched_tasks_busy())
+                return;
+            repeat_count = TIMER_IDLE_REPEAT_COUNT;
+        }
+
+        // Next timer in the past or near future - wait for it to be ready
+        while (unlikely(diff > 0))
+            diff = next - timer_read_time();
+    }
+
+    TimerInfo.next_wake = next;
+    TimerInfo.must_wake_timers = 0;
+}
+
+void
+timer_init(void)
+{
+    TimerInfo.start = 0;
+    TimerInfo.start = timer_read_time();
+    TimerInfo.next_wake = timer_read_time();
+    timer_kick();
+}
+DECL_INIT(timer_init);
+
+/****************************************************************
+ * Interrupt wrappers
+ ****************************************************************/
+
+void
+irq_disable(void)
+{
+}
+
+void
+irq_enable(void)
+{
+}
+
+irqstatus_t
+irq_save(void)
+{
+    return 0;
+}
+
+void
+irq_restore(irqstatus_t flag)
+{
+}
+
+void
+irq_wait(void)
+{
+    uint32_t current_time = timer_read_time();
+    if (!timer_is_before(current_time, TimerInfo.next_wake)) {
+        TimerInfo.must_wake_timers = 1;
+    }
+
+    if (!TimerInfo.must_wake_timers) {
+        console_sleep();
+    }
+
+    irq_poll();
+}
+
+void
+irq_poll(void)
+{
+    if (TimerInfo.must_wake_timers) {
+        timer_dispatch();
+    }
+}


### PR DESCRIPTION
This PR adds initial support for using memory-mapped IO on Raspberry Pi SBCs rather than relying on syscalls, as well as cntvct_el0 as a timer source and CPU pinning. On a Pi 4 a consistent benchmark result of 8100k with 3 steppers active is achievable, making this faster than any MCU on the list.

To achieve this result, isolcpus on an upstream kernel must be used as the Raspberry Pi kernel delivers some interrupts to isolated cores. Below are instructions to get this working on a Pi 4 running OpenSUSE Tumbleweed (https://en.opensuse.org/HCL:Raspberry_Pi4):

- Run `systemctl disable irqbalance`
- Run `yast2`, navigate to `boot loader > kernel parameters`, and append the following: `nohz=on nohz_full=3 rcu_nocbs=3 isolcpus=nohz,domain,managed_irq,3 rcu_nocb_poll iomem=relaxed`
- Add the following to `/boot/efi/extraconfig.txt`:
   ```
   arm_boost=0
   force_turbo=1
   gpu_mem=16
   ```
- Run `zypper up` and reboot
- Run `echo -1 > /proc/sys/kernel/sched_rt_runtime_us`
- Assuming the Klipper repo located at `/root/klipper`, run the following commands to set up Klipper:
   ```
   zypper in python3-virtualenv python3 python3-devel libffi8 libffi-devel libncurses6 ncurses-devel gcc make
   virtualenv -p python3 /root/klippy-env
   /root/klippy-env/bin/pip install -r /root/klipper/scripts/klippy-requirements.txt
   ```
- Build and run the Klipper MCU as per usual and run the following commands in the Klipper console:
   ```
   allocate_oids count=3
   config_stepper oid=0 step_pin=2 dir_pin=3 invert_step=0 step_pulse_ticks=5
   config_stepper oid=1 step_pin=4 dir_pin=5 invert_step=0 step_pulse_ticks=5
   config_stepper oid=2 step_pin=6 dir_pin=17 invert_step=0 step_pulse_ticks=5
   finalize_config crc=0
   SET start_clock {clock+freq}
   SET ticks 20
   reset_step_clock oid=0 clock={start_clock}
   set_next_step_dir oid=0 dir=0
   queue_step oid=0 interval={ticks} count=60000 add=0
   set_next_step_dir oid=0 dir=1
   queue_step oid=0 interval=3000 count=1 add=0
   reset_step_clock oid=1 clock={start_clock}
   set_next_step_dir oid=1 dir=0
   queue_step oid=1 interval={ticks} count=60000 add=0
   set_next_step_dir oid=1 dir=1
   queue_step oid=1 interval=3000 count=1 add=0
   reset_step_clock oid=2 clock={start_clock}
   set_next_step_dir oid=2 dir=0
   queue_step oid=2 interval={ticks} count=60000 add=0
   set_next_step_dir oid=2 dir=1
   queue_step oid=2 interval=3000 count=1 add=0
   ```