### PR TITLE
Update Measuring_Resonances.md

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -207,7 +207,7 @@ software dependencies not installed by default. First, run on your Raspberry Pi
 the following commands:
 ```
 sudo apt update
-sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-base
+sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-dev
 ```
 
 Next, in order to install NumPy in the Klipper environment, run the command:


### PR DESCRIPTION
**[Module]** 
Measuring_Resonances

**[Change Point]**
Changed `libopenblas-base` to `libopenblas-dev`.

**[Change Reason]**
Current instructions cause NumPy installation failure on host machines running Debian Bookworm.

**[Change Background/Evidence]**
Package Support table:
|  | libopenblas-base  | libopenblas-dev | Reference |
| ---| ----------------- | ------------------ | ----------- |
| Debian Buster  | Supported | Supported | [Buster openblas](https://packages.debian.org/source/buster/openblas) |
| Debian Bullseye | Supported  | Supported | [Bullseye openblas](https://packages.debian.org/source/bullseye/openblas) |
| Debian Bookworm | **Not Supported**  | Supported | [Bookworm openblas](https://packages.debian.org/source/bookworm/openblas) |

The table above shows that `libopenblas-base` is not supported by Bookworm, while `libopenblas-dev` is supported by all three.

This change _should_ have improved compatibility with host devices (especially with more devices moving to Bookworm).

**[Test Result]**
The new instructions have been tested on a fresh install of PiOS Lite (Bookworm) on a Pi5. NumPy (and supporting packages) were installed successfully without errors:
![image](https://github.com/Klipper3d/klipper/assets/158858389/fd715ce7-a9e2-49d3-8b6e-7ed83b15673b)

Signed-off-by: Philip Weber <philiprweb@gmail.com>