### PR TITLE
Fix PID_CALIBRATE command when used with heater_generic

### DIFF
--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -43,11 +43,12 @@ class PIDCalibrate:
             "The SAVE_CONFIG command will update the printer config file\n"
             "with these parameters and restart the printer." % (Kp, Ki, Kd))
         # Store results for SAVE_CONFIG
+        cfgname = heater.get_name()
         configfile = self.printer.lookup_object('configfile')
-        configfile.set(heater_name, 'control', 'pid')
-        configfile.set(heater_name, 'pid_Kp', "%.3f" % (Kp,))
-        configfile.set(heater_name, 'pid_Ki', "%.3f" % (Ki,))
-        configfile.set(heater_name, 'pid_Kd', "%.3f" % (Kd,))
+        configfile.set(cfgname, 'control', 'pid')
+        configfile.set(cfgname, 'pid_Kp', "%.3f" % (Kp,))
+        configfile.set(cfgname, 'pid_Ki', "%.3f" % (Ki,))
+        configfile.set(cfgname, 'pid_Kd', "%.3f" % (Kd,))
 
 TUNE_PID_DELTA = 5.0
 


### PR DESCRIPTION
Make sure the SAVE_CONFIG command saves the calculated PID parameters to the correct config name.

This issue was reported at https://klipper.discourse.group/t/issue-with-pid-calibrate-heater-generic-save-config/14349 .

-Kevin