### PR TITLE
Check and warn if mcu frequency differs from configured frequency

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -588,6 +588,7 @@ class MCU:
         printer.register_event_handler("klippy:connect", self._connect)
         printer.register_event_handler("klippy:shutdown", self._shutdown)
         printer.register_event_handler("klippy:disconnect", self._disconnect)
+        printer.register_event_handler("klippy:ready", self._ready)
     # Serial callbacks
     def _handle_mcu_stats(self, params):
         count = params['count']
@@ -799,6 +800,19 @@ class MCU:
         self.register_response(self._handle_shutdown, 'shutdown')
         self.register_response(self._handle_shutdown, 'is_shutdown')
         self.register_response(self._handle_mcu_stats, 'stats')
+    def _ready(self):
+        if self.is_fileoutput():
+            return
+        # Check that reported mcu frequency is in range
+        mcu_freq = self._mcu_freq
+        systime = self._reactor.monotonic()
+        get_clock = self._clocksync.get_clock
+        calc_freq = get_clock(systime + 1) - get_clock(systime)
+        mcu_freq_mhz = int(mcu_freq / 1000000. + 0.5)
+        calc_freq_mhz = int(calc_freq / 1000000. + 0.5)
+        if mcu_freq_mhz != calc_freq_mhz:
+            logging.warn("MCU '%s' configured for %dMhz but running at %dMhz!",
+                         self._name, mcu_freq_mhz, calc_freq_mhz)
     # Config creation helpers
     def setup_pin(self, pin_type, pin_params):
         pcs = {'endstop': MCU_endstop,

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -811,8 +811,10 @@ class MCU:
         mcu_freq_mhz = int(mcu_freq / 1000000. + 0.5)
         calc_freq_mhz = int(calc_freq / 1000000. + 0.5)
         if mcu_freq_mhz != calc_freq_mhz:
-            logging.warn("MCU '%s' configured for %dMhz but running at %dMhz!",
-                         self._name, mcu_freq_mhz, calc_freq_mhz)
+            pconfig = self._printer.lookup_object('configfile')
+            msg = ("MCU '%s' configured for %dMhz but running at %dMhz!"
+                    % (self._name, mcu_freq_mhz, calc_freq_mhz))
+            pconfig.runtime_warning(msg)
     # Config creation helpers
     def setup_pin(self, pin_type, pin_params):
         pcs = {'endstop': MCU_endstop,


### PR DESCRIPTION
Several micro-controllers require a clock speed (or clock reference) to be configured in "make menuconfig".  Normally if this value is not configured correctly then the host will be unable to communicate with the micro-controller.  However, on a few boards, it is possible to establish communication with the mcu even if it has been incorrectly configured.  Unfortunately, when this happens the connection is often unstable, unexpected errors can occur, or confusing printer motion can result.

This PR updates the host code to check if the detected mcu frequency is notably different from the configured mcu frequency.  If there is a large difference then it will report a warning in the log and via the `printer.configfile.warnings` API server object.

@pedrolamas , @meteyou , @Arksine - as part of this change I have added a new type to the `printer.configfile.warnings` status object.  The format is `{"type": "runtime_warning", "message": "some message"}`.  I'm hoping this will not cause an issue for the frontends.  If there is a concern, I can change the format and/or delay the rollout of that part of the change.  I'm not sure `printer.configfile.warnings` is the best place to put this info, but it does seem to be a convenient place to report it.

-Kevin