### PR TITLE
"static_value" in [output_pin enable_pin] is deprecated

### DIFF
--- a/config/printer-anycubic-kobra-go-2022.cfg
+++ b/config/printer-anycubic-kobra-go-2022.cfg
@@ -118,7 +118,7 @@ cycle_time: 0.00005 #20kHz
 
 [output_pin enable_pin]
 pin: PB6
-static_value: 1
+value: 1
     #This pin enables the bed, hotend, extruder fan, part fan.
 
 [mcu]


### PR DESCRIPTION
As the title says, "static_value" is deprecated, so I removed it and replaced it with "value". 