### PR TITLE
Successfully flashed the firmware on my KingRoon KP5L

### DIFF
--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -97,7 +97,7 @@
 */
 
 
-#define FF_USE_LFN		0
+#define FF_USE_LFN		1
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -128,6 +128,15 @@ BOARD_DEFS = {
         'mcu': "stm32g0b1xx",
         'spi_bus': "spi1",
         "cs_pin": "PB8"
+    },
+    'kingroon-kp3-v1.3-board': {
+        'mcu': "stm32f103xe",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        "cs_pin": "PC11",
+        "firmware_path": "Robin_nano.bin",
+        "current_firmware_path": "Robin_nano.cur",
+        'skip_verify': True
     }
 }
 


### PR DESCRIPTION
I've successfully flashed the firmware using the flash-sdcard.sh script on my KingRoon KP5L with KingRoon KP3 v1.3 board.