### PR TITLE
scripts: update greenlet to 3.0.3

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -4,7 +4,8 @@
 #   pip install -r klippy-requirements.txt
 cffi==1.14.6
 pyserial==3.4
-greenlet==2.0.2
+greenlet==2.0.2 ; python_version < '3.12'
+greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1


### PR DESCRIPTION
Installation of requirements fails starting at python 3.12.  
This is due to greenlet requirement of 2.0.2, which is not compatible w/ python 3.12. 

This PR updates greenlet to the latest release 3.0.3