### PR TITLE
Docs: sample-macros.cfg: minor change to avoid confusion

### DIFF
--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -10,7 +10,11 @@
 ######################################################################
 
 # Replace the slicer's custom start and end g-code scripts with
-# START_PRINT and END_PRINT. See docs/Slicers.md for more information on using these macros.
+# START_PRINT and END_PRINT. Please note that using just these g-codes
+# will mean only the default temperatures set in the macro will ever
+# be used. To pass in actual slicer set temperaturees, please see
+# docs/Slicers.md for more information on slicer variables
+# to use.
 
 [gcode_macro START_PRINT]
 gcode:

--- a/config/sample-macros.cfg
+++ b/config/sample-macros.cfg
@@ -12,7 +12,7 @@
 # Replace the slicer's custom start and end g-code scripts with
 # START_PRINT and END_PRINT. Please note that using just these g-codes
 # will mean only the default temperatures set in the macro will ever
-# be used. To pass in actual slicer set temperaturees, please see
+# be used. To pass in actual slicer set temperatures, please see
 # docs/Slicers.md for more information on slicer variables
 # to use.
 


### PR DESCRIPTION
It has been noted a couple of times that this file states to only use the bare macro names in the slicer. Which is fine if you want to set your own temperatures in klipper but not if you want to pass the actual temperatures through as mentioned in the slicers.md doc linked. This minor change is aimed at causing less confusion.

Thanks
James