### PR TITLE
stm32: Add i2c3_PC0_PC1 for stm32g0

### DIFF
--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -44,6 +44,8 @@ struct i2c_info {
   #ifdef I2C3
     DECL_ENUMERATION("i2c_bus", "i2c3_PB3_PB4", 5);
     DECL_CONSTANT_STR("BUS_PINS_i2c3_PB3_PB4", "PB3,PB4");
+    DECL_ENUMERATION("i2c_bus", "i2c3_PC0_PC1", 6);
+    DECL_CONSTANT_STR("BUS_PINS_i2c3_PC0_PC1", "PC0,PC1");
   #endif
 #elif CONFIG_MACH_STM32L4
   DECL_ENUMERATION("i2c_bus", "i2c1_PB6_PB7", 0);
@@ -99,6 +101,7 @@ static const struct i2c_info i2c_bus[] = {
     { I2C2, GPIO('B', 13), GPIO('B', 14), GPIO_FUNCTION(6) },
   #ifdef I2C3
     { I2C3, GPIO('B', 3), GPIO('B', 4), GPIO_FUNCTION(6) },
+    { I2C3, GPIO('C', 0), GPIO('C', 1), GPIO_FUNCTION(6) },
   #endif
 #elif CONFIG_MACH_STM32L4
     { I2C1, GPIO('B', 6), GPIO('B', 7), GPIO_FUNCTION(4) },


### PR DESCRIPTION
Signed-off-by: Alan.Ma from BigTreeTech tech@biqu3d.com