### PR TITLE
linux: Allow for more i2c buses

### DIFF
--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -14,7 +14,7 @@
 #include "internal.h" // report_errno
 #include "sched.h" // sched_shutdown
 
-DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 7);
+DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 15);
 
 struct i2c_s {
     uint32_t bus;


### PR DESCRIPTION
Similar to commit df79893, this allows klipper to use up to /dev/i2c-14. Similar to before, this limit is arbitrary.

This is required for some other SoCs, which have even more i2c buses available, e.g. the rk3399:

```
$ ls -1 /dev/i2c-*
/dev/i2c-0
/dev/i2c-3
/dev/i2c-7
```