### PR TITLE
Update Kconfig

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -288,7 +288,7 @@ choice
     config STM32_FLASH_START_9000
         bool "36KiB bootloader" if MACH_STM32F1
     config STM32_FLASH_START_C000
-        bool "48KiB bootloader" if MACH_STM32F4x5
+        bool "48KiB bootloader" if MACH_STM32F4x5 || MACH_STM32F401
     config STM32_FLASH_START_10000
         bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F4
 


### PR DESCRIPTION
Artillery Sidewinder X3 Pro and Plus boards require a 48KiB bootloader on the STM32F402RCT6. This allows SD card flashing instead of DFU mode on the X3 MCU.