### PR TITLE
motion_report: Don't negate step_distance on steppers with inverted dir pin

### DIFF
--- a/klippy/extras/motion_report.py
+++ b/klippy/extras/motion_report.py
@@ -56,8 +56,6 @@ class DumpStepper:
         mcu_pos = first.start_position
         start_position = self.mcu_stepper.mcu_to_commanded_position(mcu_pos)
         step_dist = self.mcu_stepper.get_step_dist()
-        if self.mcu_stepper.get_dir_inverted()[0]:
-            step_dist = -step_dist
         d = [(s.interval, s.step_count, s.add) for s in data]
         return {"data": d, "start_position": start_position,
                 "start_mcu_position": mcu_pos, "step_distance": step_dist,


### PR DESCRIPTION
When querying the stepper motion queue, the resulting "interval", "count", and "add" are already normalized to the correct direction. That is, the "count" field will be positive if moving in a positive axis direction and negative if moving in the reverse direction.  So, negating the step_distance field just complicates the readers.

-Kevin