### PR TITLE
probe_eddy_current: implement surface scannng

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -998,6 +998,13 @@ Visual Examples:
 #adaptive_margin:
 #   An optional margin (in mm) to be added around the bed area used by
 #   the defined print objects when generating an adaptive mesh.
+#scan_overshoot:
+#  The maximum amount of travel (in mm) available outside of the mesh.
+#  For rectangular beds this applies to travel on the X axis, and for round beds
+#  it applies to the entire radius.  The tool must be able to travel the amount
+#  specified outside of the mesh.  This value is used to optimize the travel
+#  path when performing a "rapid scan".  The minimum value that may be specified
+#  is 1.  The default is no overshoot.
 ```
 
 ### [bed_tilt]

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1995,6 +1995,40 @@ z_offset:
 #   See the "probe" section for more information on the parameters above.
 ```
 
+### [probe_eddy_current]
+
+Support for eddy current inductive probes. One may define this section
+(instead of a probe section) to enable this probe. See the
+[command reference](G-Codes.md#probe_eddy_current) for further information.
+
+```
+[probe_eddy_current my_eddy_probe]
+sensor_type: ldc1612
+#   The sensor chip used to perform eddy current measurements. This
+#   parameter must be provided and must be set to ldc1612.
+#z_offset:
+#   The nominal distance (in mm) between the nozzle and bed that a
+#   probing attempt should stop at. This parameter must be provided.
+#i2c_address:
+#i2c_mcu:
+#i2c_bus:
+#i2c_software_scl_pin:
+#i2c_software_sda_pin:
+#i2c_speed:
+#   The i2c settings for the sensor chip. See the "common I2C
+#   settings" section for a description of the above parameters.
+#x_offset:
+#y_offset:
+#speed:
+#lift_speed:
+#samples:
+#sample_retract_dist:
+#samples_result:
+#samples_tolerance:
+#samples_tolerance_retries:
+#   See the "probe" section for information on these parameters.
+```
+
 ### [axis_twist_compensation]
 
 A tool to compensate for inaccurate probe readings due to twist in X gantry. See

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -1,0 +1,56 @@
+# Eddy Current Inductive probe
+
+This document describes how to use an
+[eddy current](https://en.wikipedia.org/wiki/Eddy_current) inductive
+probe in Klipper.
+
+Currently, an eddy current probe can not be used for Z homing. The
+sensor can only be used for Z probing.
+
+Start by declaring a
+[probe_eddy_current config section](Config_Reference.md#probe_eddy_current)
+in the printer.cfg file. It is recommended to set the `z_offset` to
+0.5mm. It is typical for the sensor to require an `x_offset` and
+`y_offset`. If these values are not known, one should estimate the
+values during initial calibration.
+
+The first step in calibration is to determine the appropriate
+DRIVE_CURRENT for the sensor. Home the printer and navigate the
+toolhead so that the sensor is near the center of the bed and is about
+20mm above the bed. Then issue an `LDC_CALIBRATE_DRIVE_CURRENT
+CHIP=<config_name>` command. For example, if the config section was
+named `[probe_eddy_current my_eddy_probe]` then one would run
+`LDC_CALIBRATE_DRIVE_CURRENT CHIP=my_eddy_probe`. This command should
+complete in a few seconds.  After it completes, issue a `SAVE_CONFIG`
+command to save the results to the printer.cfg and restart.
+
+The second step in calibration is to correlate the sensor readings to
+the corresponding Z heights. Home the printer and navigate the
+toolhead so that the nozzle is near the center of the bed. Then run an
+`PROBE_EDDY_CURRENT_CALIBRATE CHIP=my_eddy_probe` command. Once the
+tool starts, follow the steps described at
+["the paper test"](Bed_Level.md#the-paper-test) to determine the
+actual distance between the nozzle and bed at the given location. Once
+those steps are complete one can `ACCEPT` the position. The tool will
+then move the the toolhead so that the sensor is above the point where
+the nozzle used to be and run a series of movements to correlate the
+sensor to Z positions. This will take a couple of minutes. After the
+tool completes, issue a `SAVE_CONFIG` command to save the results to
+the printer.cfg and restart.
+
+After initial calibration it is a good idea to verify that the
+`x_offset` and `y_offset` are accurate. Follow the steps to
+[calibrate probe x and y offsets](Probe_Calibrate.md#calibrating-probe-x-and-y-offsets).
+If either the `x_offset` or `y_offset` is modified then be sure to run
+the `PROBE_EDDY_CURRENT_CALIBRATE` command (as described above) after
+making the change.
+
+Once calibration is complete, one may use all the standard Klipper
+tools that use a Z probe.
+
+Note that eddy current sensors (and inductive probes in general) are
+susceptible to "thermal drift". That is, changes in temperature can
+result in changes in reported Z height. Changes in either the bed
+surface temperature or sensor hardware temperature can skew the
+results. It is important that calibration and probing is only done
+when the printer is at a stable temperature.

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -984,6 +984,28 @@ babystepping), and subtract if from the probe's z_offset.  This acts
 to take a frequently used babystepping value, and "make it permanent".
 Requires a `SAVE_CONFIG` to take effect.
 
+### [probe_eddy_current]
+
+The following commands are available when a
+[probe_eddy_current config section](Config_Reference.md#probe_eddy_current)
+is enabled.
+
+#### PROBE_EDDY_CURRENT_CALIBRATE
+`PROBE_EDDY_CURRENT_CALIBRATE CHIP=<config_name>`: This starts a tool
+that calibrates the sensor resonance frequencies to corresponding Z
+heights. The tool will take a couple of minutes to complete. After
+completion, use the SAVE_CONFIG command to store the results in the
+printer.cfg file.
+
+#### LDC_CALIBRATE_DRIVE_CURRENT
+`LDC_CALIBRATE_DRIVE_CURRENT CHIP=<config_name>` This tool will
+calibrate the ldc1612 DRIVE_CURRENT0 register. Prior to using this
+tool, move the sensor so that it is near the center of the bed and
+about 20mm above the bed surface. Run this command to determine an
+appropriate DRIVE_CURRENT for the sensor. After running this command
+use the SAVE_CONFIG command to store that new setting in the
+printer.cfg config file.
+
 ### [pwm_cycle_time]
 
 The following command is available when a

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -208,6 +208,24 @@ adjustment after a tool change.  Note that a ZFADE offset does not apply
 additional z-adjustment directly, it is used to correct the `fade`
 calculation when a `gcode offset` has been applied to the Z axis.
 
+#### BED_MESH_DUMP
+`BED_MESH_DUMP [FILENAME=<name>] [<mesh_parameter>=<value>]`:
+Dumps the current mesh configuration and state in json format for
+[visualization and analysis](./Bed_Mesh.md#visualization-and-analysis).
+The `FILENAME` parameter is optional and should be a relative name, when
+not specified the file's name will be in the format of
+`klipper-bedmesh-{year}{month}{day}{hour}{minute}{second}.json`. The
+file will be saved in a location relative to the parent of
+klipper's configuration file, this is commonly at
+`~/printer_data/config` or the user's home directory.
+
+In addition, one may specify `mesh parameters` available to
+[BED_MESH_CALIBRATE](#bed_mesh_calibrate).  This will result in a dump
+containing a mesh configuration and probe points using the
+supplied parameters.   It is recommended to omit Mesh parameters
+unless it is desired to visualize the probe points and/or travel
+path before performing `BED_MESH_CALIBRATE`.
+
 ### [bed_screws]
 
 The following commands are available when the

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -99,3 +99,4 @@ communication with the Klipper developers.
     troubleshooting CAN bus.
 - [TSL1401CL filament width sensor](TSL1401CL_Filament_Width_Sensor.md)
 - [Hall filament width sensor](Hall_Filament_Width_Sensor.md)
+- [Eddy Current Inductive probe](Eddy_Probe.md)

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -138,4 +138,5 @@ nav:
     - CANBUS_Troubleshooting.md
     - TSL1401CL_Filament_Width_Sensor.md
     - Hall_Filament_Width_Sensor.md
+    - Eddy_Probe.md
   - Sponsors.md

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -620,6 +620,12 @@ class BedMeshCalibrate:
                 self.mesh_config['y_count'] = y_cnt
                 need_cfg_update = True
 
+        if "MESH_PPS" in params:
+            xpps, ypps = parse_gcmd_pair(gcmd, 'MESH_PPS', minval=0)
+            self.mesh_config['mesh_x_pps'] = xpps
+            self.mesh_config['mesh_y_pps'] = ypps
+            need_cfg_update = True
+
         if "ALGORITHM" in params:
             self.mesh_config['algo'] = gcmd.get('ALGORITHM').strip().lower()
             need_cfg_update = True
@@ -630,8 +636,6 @@ class BedMeshCalibrate:
         if need_cfg_update:
             self._verify_algorithm(gcmd.error)
             self._generate_points(gcmd.error, probe_method)
-            gcmd.respond_info("Generating new points...")
-            self.print_generated_points(gcmd.respond_info)
             msg = "\n".join(["%s: %s" % (k, v)
                              for k, v in self.mesh_config.items()])
             logging.info("Updated Mesh Configuration:\n" + msg)

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -183,6 +183,9 @@ class BLTouchEndstopWrapper:
         self.verify_raise_probe()
         self.sync_print_time()
         self.multi = 'OFF'
+    def probing_move(self, pos, speed):
+        phoming = self.printer.lookup_object('homing')
+        return phoming.probing_move(self, pos, speed)
     def probe_prepare(self, hmove):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self.lower_probe()

--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -1,0 +1,154 @@
+# Support for reading frequency samples from ldc1612
+#
+# Copyright (C) 2020-2024  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+from . import bus, bulk_sensor
+
+MIN_MSG_TIME = 0.100
+
+BATCH_UPDATES = 0.100
+
+BYTES_PER_SAMPLE = 4
+SAMPLES_PER_BLOCK = bulk_sensor.MAX_BULK_MSG_SIZE // BYTES_PER_SAMPLE
+
+LDC1612_ADDR = 0x2a
+
+LDC1612_FREQ = 12000000
+SETTLETIME = 0.005
+DRIVECUR = 15
+DEGLITCH = 0x05 # 10 Mhz
+
+LDC1612_MANUF_ID = 0x5449
+LDC1612_DEV_ID = 0x3055
+
+REG_RCOUNT0 = 0x08
+REG_OFFSET0 = 0x0c
+REG_SETTLECOUNT0 = 0x10
+REG_CLOCK_DIVIDERS0 = 0x14
+REG_ERROR_CONFIG = 0x19
+REG_CONFIG = 0x1a
+REG_MUX_CONFIG = 0x1b
+REG_DRIVE_CURRENT0 = 0x1e
+REG_MANUFACTURER_ID = 0x7e
+REG_DEVICE_ID = 0x7f
+
+# Interface class to LDC1612 mcu support
+class LDC1612:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.data_rate = 250
+        # Setup mcu sensor_ldc1612 bulk query code
+        self.i2c = bus.MCU_I2C_from_config(config,
+                                           default_addr=LDC1612_ADDR,
+                                           default_speed=400000)
+        self.mcu = mcu = self.i2c.get_mcu()
+        self.oid = oid = mcu.create_oid()
+        self.query_ldc1612_cmd = None
+        mcu.add_config_cmd("config_ldc1612 oid=%d i2c_oid=%d"
+                           % (oid, self.i2c.get_oid()))
+        mcu.add_config_cmd("query_ldc1612 oid=%d rest_ticks=0"
+                           % (oid,), on_restart=True)
+        mcu.register_config_callback(self._build_config)
+        self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, oid=oid)
+        # Clock tracking
+        chip_smooth = self.data_rate * BATCH_UPDATES * 2
+        self.clock_sync = bulk_sensor.ClockSyncRegression(mcu, chip_smooth)
+        self.clock_updater = bulk_sensor.ChipClockUpdater(self.clock_sync,
+                                                          BYTES_PER_SAMPLE)
+        self.last_error_count = 0
+        # Process messages in batches
+        self.batch_bulk = bulk_sensor.BatchBulkHelper(
+            self.printer, self._process_batch,
+            self._start_measurements, self._finish_measurements, BATCH_UPDATES)
+        self.name = config.get_name().split()[-1]
+        hdr = ('time', 'frequency')
+        self.batch_bulk.add_mux_endpoint("ldc1612/dump_ldc1612", "sensor",
+                                         self.name, {'header': hdr})
+    def _build_config(self):
+        cmdqueue = self.i2c.get_command_queue()
+        self.query_ldc1612_cmd = self.mcu.lookup_command(
+            "query_ldc1612 oid=%c rest_ticks=%u", cq=cmdqueue)
+        self.clock_updater.setup_query_command(
+            self.mcu, "query_ldc1612_status oid=%c", oid=self.oid, cq=cmdqueue)
+    def read_reg(self, reg):
+        params = self.i2c.i2c_read([reg], 2)
+        response = bytearray(params['response'])
+        return (response[0] << 8) | response[1]
+    def set_reg(self, reg, val, minclock=0):
+        self.i2c.i2c_write([reg, (val >> 8) & 0xff, val & 0xff],
+                           minclock=minclock)
+    # Measurement decoding
+    def _extract_samples(self, raw_samples):
+        # Load variables to optimize inner loop below
+        last_sequence = self.clock_updater.get_last_sequence()
+        time_base, chip_base, inv_freq = self.clock_sync.get_time_translation()
+        freq_conv = float(LDC1612_FREQ) / (1<<28)
+        # Process every message in raw_samples
+        count = seq = 0
+        samples = [None] * (len(raw_samples) * SAMPLES_PER_BLOCK)
+        for params in raw_samples:
+            seq_diff = (params['sequence'] - last_sequence) & 0xffff
+            seq_diff -= (seq_diff & 0x8000) << 1
+            seq = last_sequence + seq_diff
+            d = bytearray(params['data'])
+            msg_cdiff = seq * SAMPLES_PER_BLOCK - chip_base
+            for i in range(len(d) // BYTES_PER_SAMPLE):
+                v = d[i*BYTES_PER_SAMPLE:(i+1)*BYTES_PER_SAMPLE]
+                if v[0] & 0xf0:
+                    self.last_error_count += 1
+                val = ((v[0] & 0x0f) << 24) | (v[1] << 16) | (v[2] << 8) | v[3]
+                ptime = round(time_base + (msg_cdiff + i) * inv_freq, 6)
+                samples[count] = (ptime, round(freq_conv * val, 3))
+                count += 1
+        self.clock_sync.set_last_chip_clock(seq * SAMPLES_PER_BLOCK + i)
+        del samples[count:]
+        return samples
+    # Start, stop, and process message batches
+    def _start_measurements(self):
+        # In case of miswiring, testing LDC1612 device ID prevents treating
+        # noise or wrong signal as a correctly initialized device
+        manuf_id = self.read_reg(REG_MANUFACTURER_ID)
+        dev_id = self.read_reg(REG_DEVICE_ID)
+        if manuf_id != LDC1612_MANUF_ID or dev_id != LDC1612_DEV_ID:
+            raise self.printer.command_error(
+                "Invalid ldc1612 id (got %x,%x vs %x,%x).\n"
+                "This is generally indicative of connection problems\n"
+                "(e.g. faulty wiring) or a faulty ldc1612 chip."
+                % (manuf_id, dev_id, LDC1612_MANUF_ID, LDC1612_DEV_ID))
+        # Setup chip in requested query rate
+        rcount0 = LDC1612_FREQ / (16. * (self.data_rate - 4))
+        self.set_reg(REG_RCOUNT0, int(rcount0 + 0.5))
+        self.set_reg(REG_OFFSET0, 0)
+        self.set_reg(REG_SETTLECOUNT0, int(SETTLETIME*LDC1612_FREQ/16. + .5))
+        self.set_reg(REG_CLOCK_DIVIDERS0, (1 << 12) | 1)
+        self.set_reg(REG_ERROR_CONFIG, (0x1f << 11) | 1)
+        self.set_reg(REG_MUX_CONFIG, 0x0208 | DEGLITCH)
+        self.set_reg(REG_CONFIG, 0x001 | (1<<12) | (1<<10) | (1<<9))
+        self.set_reg(REG_DRIVE_CURRENT0, DRIVECUR << 11)
+        #self.set_reg(REG_CONFIG, 0x001 | (1<<9))
+        #self.set_reg(REG_DRIVE_CURRENT0, DRIVECUR << 11)
+        # Start bulk reading
+        self.bulk_queue.clear_samples()
+        rest_ticks = self.mcu.seconds_to_clock(0.5 / self.data_rate)
+        self.query_ldc1612_cmd.send([self.oid, rest_ticks])
+        logging.info("LDC1612 starting '%s' measurements", self.name)
+        # Initialize clock tracking
+        self.clock_updater.note_start()
+        self.last_error_count = 0
+    def _finish_measurements(self):
+        # Halt bulk reading
+        self.query_ldc1612_cmd.send_wait_ack([self.oid, 0])
+        self.bulk_queue.clear_samples()
+        logging.info("LDC1612 finished '%s' measurements", self.name)
+    def _process_batch(self, eventtime):
+        self.clock_updater.update_clock()
+        raw_samples = self.bulk_queue.pull_samples()
+        if not raw_samples:
+            return {}
+        samples = self._extract_samples(raw_samples)
+        if not samples:
+            return {}
+        return {'data': samples, 'errors': self.last_error_count,
+                'overflows': self.clock_updater.get_last_overflows()}

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -117,11 +117,10 @@ class PrinterProbe:
         curtime = self.printer.get_reactor().monotonic()
         if 'z' not in toolhead.get_status(curtime)['homed_axes']:
             raise self.printer.command_error("Must home before probe")
-        phoming = self.printer.lookup_object('homing')
         pos = toolhead.get_position()
         pos[2] = self.z_position
         try:
-            epos = phoming.probing_move(self.mcu_probe, pos, speed)
+            epos = self.mcu_probe.probing_move(pos, speed)
         except self.printer.command_error as e:
             reason = str(e)
             if "Timeout during endstop homing" in reason:
@@ -325,14 +324,14 @@ class ProbeEndstopWrapper:
         for stepper in kin.get_steppers():
             if stepper.is_active_axis('z'):
                 self.add_stepper(stepper)
-    def raise_probe(self):
+    def _raise_probe(self):
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.deactivate_gcode.run_gcode_from_command()
         if toolhead.get_position()[:3] != start_pos[:3]:
             raise self.printer.command_error(
                 "Toolhead moved during probe activate_gcode script")
-    def lower_probe(self):
+    def _lower_probe(self):
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.activate_gcode.run_gcode_from_command()
@@ -346,16 +345,19 @@ class ProbeEndstopWrapper:
     def multi_probe_end(self):
         if self.stow_on_each_sample:
             return
-        self.raise_probe()
+        self._raise_probe()
         self.multi = 'OFF'
+    def probing_move(self, pos, speed):
+        phoming = self.printer.lookup_object('homing')
+        return phoming.probing_move(self, pos, speed)
     def probe_prepare(self, hmove):
         if self.multi == 'OFF' or self.multi == 'FIRST':
-            self.lower_probe()
+            self._lower_probe()
             if self.multi == 'FIRST':
                 self.multi = 'ON'
     def probe_finish(self, hmove):
         if self.multi == 'OFF':
-            self.raise_probe()
+            self._raise_probe()
     def get_position_endstop(self):
         return self.position_endstop
 

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -1,0 +1,182 @@
+# Support for eddy current based Z probes
+#
+# Copyright (C) 2021-2024  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging, math, bisect
+import mcu
+from . import ldc1612, probe, manual_probe
+
+# Tool for calibrating the sensor Z detection and applying that calibration
+class EddyCalibration:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+        # Current calibration data
+        self.cal_freqs = []
+        self.cal_zpos = []
+        cal = config.get('calibrate', None)
+        if cal is not None:
+            cal = [list(map(float, d.strip().split(':', 1)))
+                   for d in cal.split(',')]
+            self.load_calibration(cal)
+        # Probe calibrate state
+        self.probe_speed = 0.
+        # Register commands
+        cname = self.name.split()[-1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("PROBE_EDDY_CURRENT_CALIBRATE", "CHIP",
+                                   cname, self.cmd_EDDY_CALIBRATE,
+                                   desc=self.cmd_EDDY_CALIBRATE_help)
+    def load_calibration(self, cal):
+        cal = sorted([(c[1], c[0]) for c in cal])
+        self.cal_freqs = [c[0] for c in cal]
+        self.cal_zpos = [c[1] for c in cal]
+    def apply_calibration(self, samples):
+        for i, (samp_time, freq, dummy_z) in enumerate(samples):
+            pos = bisect.bisect(self.cal_freqs, freq)
+            if pos >= len(self.cal_zpos):
+                zpos = -99.9
+            elif pos == 0:
+                zpos = 99.9
+            else:
+                # XXX - optimize and avoid div by zero
+                this_freq = self.cal_freqs[pos]
+                prev_freq = self.cal_freqs[pos - 1]
+                this_zpos = self.cal_zpos[pos]
+                prev_zpos = self.cal_zpos[pos - 1]
+                gain = (this_zpos - prev_zpos) / (this_freq - prev_freq)
+                offset = prev_zpos - prev_freq * gain
+                zpos = freq * gain + offset
+            samples[i] = (samp_time, freq, round(zpos, 6))
+    def do_calibration_moves(self, move_speed):
+        toolhead = self.printer.lookup_object('toolhead')
+        kin = toolhead.get_kinematics()
+        move = toolhead.manual_move
+        # Start data collection
+        msgs = []
+        is_finished = False
+        def handle_batch(msg):
+            if is_finished:
+                return False
+            msgs.append(msg)
+            return True
+        self.printer.lookup_object(self.name).add_client(handle_batch)
+        toolhead.dwell(1.)
+        # Move to each 50um position
+        max_z = 4
+        samp_dist = 0.050
+        num_steps = int(max_z / samp_dist + .5) + 1
+        start_pos = toolhead.get_position()
+        times = []
+        for i in range(num_steps):
+            # Move to next position (always descending to reduce backlash)
+            hop_pos = list(start_pos)
+            hop_pos[2] += i * samp_dist + 0.500
+            move(hop_pos, move_speed)
+            next_pos = list(start_pos)
+            next_pos[2] += i * samp_dist
+            move(next_pos, move_speed)
+            # Note sample timing
+            start_query_time = toolhead.get_last_move_time() + 0.050
+            end_query_time = start_query_time + 0.100
+            toolhead.dwell(0.200)
+            # Find Z position based on actual commanded stepper position
+            toolhead.flush_step_generation()
+            kin_spos = {s.get_name(): s.get_commanded_position()
+                        for s in kin.get_steppers()}
+            kin_pos = kin.calc_position(kin_spos)
+            times.append((start_query_time, end_query_time, kin_pos[2]))
+        toolhead.dwell(1.0)
+        toolhead.wait_moves()
+        # Finish data collection
+        is_finished = True
+        # Correlate query responses
+        cal = {}
+        step = 0
+        for msg in msgs:
+            for query_time, freq, old_z in msg['data']:
+                # Add to step tracking
+                while step < len(times) and query_time > times[step][1]:
+                    step += 1
+                if step < len(times) and query_time >= times[step][0]:
+                    cal.setdefault(times[step][2], []).append(freq)
+        if len(cal) != len(times):
+            raise self.printer.command_error(
+                "Failed calibration - incomplete sensor data")
+        return cal
+    def calc_freqs(self, meas):
+        total_count = total_variance = 0
+        positions = {}
+        for pos, freqs in meas.items():
+            count = len(freqs)
+            freq_avg = float(sum(freqs)) / count
+            positions[pos] = freq_avg
+            total_count += count
+            total_variance += sum([(f - freq_avg)**2 for f in freqs])
+        return positions, math.sqrt(total_variance / total_count), total_count
+    def post_manual_probe(self, kin_pos):
+        if kin_pos is None:
+            # Manual Probe was aborted
+            return
+        curpos = list(kin_pos)
+        move = self.printer.lookup_object('toolhead').manual_move
+        # Move away from the bed
+        probe_calibrate_z = curpos[2]
+        curpos[2] += 5.
+        move(curpos, self.probe_speed)
+        # Move sensor over nozzle position
+        pprobe = self.printer.lookup_object("probe")
+        x_offset, y_offset, z_offset = pprobe.get_offsets()
+        curpos[0] -= x_offset
+        curpos[1] -= y_offset
+        move(curpos, self.probe_speed)
+        # Descend back to bed
+        curpos[2] -= 5. - 0.050
+        move(curpos, self.probe_speed)
+        # Perform calibration movement and capture
+        cal = self.do_calibration_moves(self.probe_speed)
+        # Calculate each sample position average and variance
+        positions, std, total = self.calc_freqs(cal)
+        last_freq = 0.
+        for pos, freq in reversed(sorted(positions.items())):
+            if freq <= last_freq:
+                raise self.printer.command_error(
+                    "Failed calibration - frequency not increasing each step")
+            last_freq = freq
+        gcode = self.printer.lookup_object("gcode")
+        gcode.respond_info(
+            "probe_eddy_current: stddev=%.3f in %d queries\n"
+            "The SAVE_CONFIG command will update the printer config file\n"
+            "and restart the printer." % (std, total))
+        # Save results
+        cal_contents = []
+        for i, (pos, freq) in enumerate(sorted(positions.items())):
+            if not i % 3:
+                cal_contents.append('\n')
+            cal_contents.append("%.6f:%.3f" % (pos - probe_calibrate_z, freq))
+            cal_contents.append(',')
+        cal_contents.pop()
+        configfile = self.printer.lookup_object('configfile')
+        configfile.set(self.name, 'calibrate', ''.join(cal_contents))
+    cmd_EDDY_CALIBRATE_help = "Calibrate eddy current probe"
+    def cmd_EDDY_CALIBRATE(self, gcmd):
+        self.probe_speed = gcmd.get_float("PROBE_SPEED", 5., above=0.)
+        # Start manual probe
+        manual_probe.ManualProbeHelper(self.printer, gcmd,
+                                       self.post_manual_probe)
+
+# Main "printer object"
+class PrinterEddyProbe:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.calibration = EddyCalibration(config)
+        # Sensor type
+        sensors = { "ldc1612": ldc1612.LDC1612 }
+        sensor_type = config.getchoice('sensor_type', {s: s for s in sensors})
+        self.sensor_helper = sensors[sensor_type](config, self.calibration)
+    def add_client(self, cb):
+        self.sensor_helper.add_client(cb)
+
+def load_config_prefix(config):
+    return PrinterEddyProbe(config)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -78,6 +78,9 @@ class SmartEffectorEndstopWrapper:
         self.gcode.register_command("SET_SMART_EFFECTOR",
                                     self.cmd_SET_SMART_EFFECTOR,
                                     desc=self.cmd_SET_SMART_EFFECTOR_help)
+    def probing_move(self, pos, speed):
+        phoming = self.printer.lookup_object('homing')
+        return phoming.probing_move(self, pos, speed)
     def probe_prepare(self, hmove):
         toolhead = self.printer.lookup_object('toolhead')
         self.probe_wrapper.probe_prepare(hmove)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -226,23 +226,17 @@ class MCU_trsync:
 TRSYNC_TIMEOUT = 0.025
 TRSYNC_SINGLE_MCU_TIMEOUT = 0.250
 
-class MCU_endstop:
-    RETRY_QUERY = 1.000
-    def __init__(self, mcu, pin_params):
+class TriggerDispatch:
+    def __init__(self, mcu):
         self._mcu = mcu
-        self._pin = pin_params['pin']
-        self._pullup = pin_params['pullup']
-        self._invert = pin_params['invert']
-        self._oid = self._mcu.create_oid()
-        self._home_cmd = self._query_cmd = None
-        self._mcu.register_config_callback(self._build_config)
         self._trigger_completion = None
-        self._rest_ticks = 0
         ffi_main, ffi_lib = chelper.get_ffi()
         self._trdispatch = ffi_main.gc(ffi_lib.trdispatch_alloc(), ffi_lib.free)
         self._trsyncs = [MCU_trsync(mcu, self._trdispatch)]
-    def get_mcu(self):
-        return self._mcu
+    def get_oid(self):
+        return self._trsyncs[0].get_oid()
+    def get_command_queue(self):
+        return self._trsyncs[0].get_command_queue()
     def add_stepper(self, stepper):
         trsyncs = {trsync.get_mcu(): trsync for trsync in self._trsyncs}
         trsync = trsyncs.get(stepper.get_mcu())
@@ -261,6 +255,51 @@ class MCU_endstop:
                                      " multi-mcu shared axis")
     def get_steppers(self):
         return [s for trsync in self._trsyncs for s in trsync.get_steppers()]
+    def start(self, print_time):
+        reactor = self._mcu.get_printer().get_reactor()
+        self._trigger_completion = reactor.completion()
+        expire_timeout = TRSYNC_TIMEOUT
+        if len(self._trsyncs) == 1:
+            expire_timeout = TRSYNC_SINGLE_MCU_TIMEOUT
+        for i, trsync in enumerate(self._trsyncs):
+            report_offset = float(i) / len(self._trsyncs)
+            trsync.start(print_time, report_offset,
+                         self._trigger_completion, expire_timeout)
+        etrsync = self._trsyncs[0]
+        ffi_main, ffi_lib = chelper.get_ffi()
+        ffi_lib.trdispatch_start(self._trdispatch, etrsync.REASON_HOST_REQUEST)
+        return self._trigger_completion
+    def wait_end(self, end_time):
+        etrsync = self._trsyncs[0]
+        etrsync.set_home_end_time(end_time)
+        if self._mcu.is_fileoutput():
+            self._trigger_completion.complete(True)
+        self._trigger_completion.wait()
+    def stop(self):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        ffi_lib.trdispatch_stop(self._trdispatch)
+        res = [trsync.stop() for trsync in self._trsyncs]
+        if any([r == MCU_trsync.REASON_COMMS_TIMEOUT for r in res]):
+            return MCU_trsync.REASON_COMMS_TIMEOUT
+        return res[0]
+
+class MCU_endstop:
+    def __init__(self, mcu, pin_params):
+        self._mcu = mcu
+        self._pin = pin_params['pin']
+        self._pullup = pin_params['pullup']
+        self._invert = pin_params['invert']
+        self._oid = self._mcu.create_oid()
+        self._home_cmd = self._query_cmd = None
+        self._mcu.register_config_callback(self._build_config)
+        self._rest_ticks = 0
+        self._dispatch = TriggerDispatch(mcu)
+    def get_mcu(self):
+        return self._mcu
+    def add_stepper(self, stepper):
+        self._dispatch.add_stepper(stepper)
+    def get_steppers(self):
+        return self._dispatch.get_steppers()
     def _build_config(self):
         # Setup config
         self._mcu.add_config_cmd("config_endstop oid=%d pin=%s pull_up=%d"
@@ -270,7 +309,7 @@ class MCU_endstop:
             " rest_ticks=0 pin_value=0 trsync_oid=0 trigger_reason=0"
             % (self._oid,), on_restart=True)
         # Lookup commands
-        cmd_queue = self._trsyncs[0].get_command_queue()
+        cmd_queue = self._dispatch.get_command_queue()
         self._home_cmd = self._mcu.lookup_command(
             "endstop_home oid=%c clock=%u sample_ticks=%u sample_count=%c"
             " rest_ticks=%u pin_value=%c trsync_oid=%c trigger_reason=%c",
@@ -284,36 +323,20 @@ class MCU_endstop:
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
         self._rest_ticks = rest_ticks
-        reactor = self._mcu.get_printer().get_reactor()
-        self._trigger_completion = reactor.completion()
-        expire_timeout = TRSYNC_TIMEOUT
-        if len(self._trsyncs) == 1:
-            expire_timeout = TRSYNC_SINGLE_MCU_TIMEOUT
-        for i, trsync in enumerate(self._trsyncs):
-            report_offset = float(i) / len(self._trsyncs)
-            trsync.start(print_time, report_offset,
-                         self._trigger_completion, expire_timeout)
-        etrsync = self._trsyncs[0]
-        ffi_main, ffi_lib = chelper.get_ffi()
-        ffi_lib.trdispatch_start(self._trdispatch, etrsync.REASON_HOST_REQUEST)
+        trigger_completion = self._dispatch.start(print_time)
         self._home_cmd.send(
             [self._oid, clock, self._mcu.seconds_to_clock(sample_time),
              sample_count, rest_ticks, triggered ^ self._invert,
-             etrsync.get_oid(), etrsync.REASON_ENDSTOP_HIT], reqclock=clock)
-        return self._trigger_completion
+             self._dispatch.get_oid(), MCU_trsync.REASON_ENDSTOP_HIT],
+            reqclock=clock)
+        return trigger_completion
     def home_wait(self, home_end_time):
-        etrsync = self._trsyncs[0]
-        etrsync.set_home_end_time(home_end_time)
-        if self._mcu.is_fileoutput():
-            self._trigger_completion.complete(True)
-        self._trigger_completion.wait()
+        self._dispatch.wait_end(home_end_time)
         self._home_cmd.send([self._oid, 0, 0, 0, 0, 0, 0, 0])
-        ffi_main, ffi_lib = chelper.get_ffi()
-        ffi_lib.trdispatch_stop(self._trdispatch)
-        res = [trsync.stop() for trsync in self._trsyncs]
-        if any([r == etrsync.REASON_COMMS_TIMEOUT for r in res]):
+        res = self._dispatch.stop()
+        if res == MCU_trsync.REASON_COMMS_TIMEOUT:
             return -1.
-        if res[0] != etrsync.REASON_ENDSTOP_HIT:
+        if res != MCU_trsync.REASON_ENDSTOP_HIT:
             return 0.
         if self._mcu.is_fileoutput():
             return home_end_time

--- a/scripts/graph-mesh.py
+++ b/scripts/graph-mesh.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+# Bed Mesh data plotting and analysis
+#
+# Copyright (C) 2024 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import argparse
+import json
+import collections
+import numpy as np
+import matplotlib
+import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import matplotlib.animation as ani
+
+class PathAnimation:
+    instance = None
+    def __init__(self, artist, x_travel, y_travel):
+        self.travel_artist = artist
+        self.x_travel = x_travel
+        self.y_travel = y_travel
+        fig = plt.gcf()
+        self.animation = ani.FuncAnimation(
+            fig=fig, func=self.update, frames=self.gen_path_position(),
+            cache_frame_data=False, interval=60
+        )
+        PathAnimation.instance = self
+
+    def gen_path_position(self):
+        count = 1
+        x_travel, y_travel = self.x_travel, self.y_travel
+        last_x, last_y = x_travel[0], y_travel[0]
+        yield count
+        for xpos, ypos in zip(x_travel[1:], y_travel[1:]):
+            count += 1
+            if xpos == last_x or ypos == last_y:
+                yield count
+            last_x, last_y = xpos, ypos
+
+    def update(self, frame):
+        x_travel, y_travel = self.x_travel, self.y_travel
+        self.travel_artist.set_xdata(x_travel[:frame])
+        self.travel_artist.set_ydata(y_travel[:frame])
+        return (self.travel_artist,)
+
+
+def _gen_mesh_coords(min_c, max_c, count):
+    dist = (max_c - min_c) / (count - 1)
+    return [min_c + i * dist for i in range(count)]
+
+def _plot_path(travel_path, probed, diff, cmd_args):
+    x_travel, y_travel = np.array(travel_path).transpose()
+    x_probed, y_probed = np.array(probed).transpose()
+    plt.xlabel("X")
+    plt.ylabel("Y")
+    # plot travel
+    travel_line = plt.plot(x_travel, y_travel, "b-")[0]
+    # plot intermediate points
+    plt.plot(x_probed, y_probed, "k.")
+    # plot start point
+    plt.plot([x_travel[0]], [y_travel[0]], "g>")
+    # plot stop point
+    plt.plot([x_travel[-1]], [y_travel[-1]], "r*")
+    if diff:
+        diff_x, diff_y = np.array(diff).transpose()
+        plt.plot(diff_x, diff_y, "m.")
+    if cmd_args.animate and cmd_args.output is None:
+        PathAnimation(travel_line, x_travel, y_travel)
+
+def _format_mesh_data(matrix, params):
+    min_pt = (params["min_x"], params["min_y"])
+    max_pt = (params["max_x"], params["max_y"])
+    xvals = _gen_mesh_coords(min_pt[0], max_pt[0], len(matrix[0]))
+    yvals = _gen_mesh_coords(min_pt[1], max_pt[0], len(matrix))
+    x, y = np.meshgrid(xvals, yvals)
+    z = np.array(matrix)
+    return x, y, z
+
+def _set_xy_limits(mesh_data, cmd_args):
+    if not cmd_args.scale_plot:
+        return
+    ax = plt.gca()
+    axis_min = mesh_data["axis_minimum"]
+    axis_max = mesh_data["axis_maximum"]
+    ax.set_xlim((axis_min[0], axis_max[0]))
+    ax.set_ylim((axis_min[1], axis_max[1]))
+
+def _plot_mesh(ax, matrix, params, cmap=cm.viridis, label=None):
+    x, y, z = _format_mesh_data(matrix, params)
+    surface = ax.plot_surface(x, y, z, cmap=cmap, label=label)
+    scale = max(abs(z.min()), abs(z.max())) * 3
+    return surface, scale
+
+def plot_probe_points(mesh_data, cmd_args):
+    """Plot original generated points"""
+    calibration = mesh_data["calibration"]
+    x, y = np.array(calibration["points"]).transpose()
+    plt.title("Generated Probe Points")
+    plt.xlabel("X")
+    plt.ylabel("Y")
+    plt.plot(x, y, "b.")
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_probe_path(mesh_data, cmd_args):
+    """Plot probe travel path"""
+    calibration = mesh_data["calibration"]
+    orig_pts = calibration["points"]
+    path_pts = calibration["probe_path"]
+    diff = [pt for pt in orig_pts if pt not in path_pts]
+    plt.title("Probe Travel Path")
+    _plot_path(path_pts, path_pts[1:-1], diff, cmd_args)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_rapid_path(mesh_data, cmd_args):
+    """Plot rapid scan travel path"""
+    calibration = mesh_data["calibration"]
+    orig_pts = calibration["points"]
+    rapid_pts = calibration["rapid_path"]
+    rapid_path = [pt[0] for pt in rapid_pts]
+    probed = [pt for pt, is_ppt in rapid_pts if is_ppt]
+    diff = [pt for pt in orig_pts if pt not in probed]
+    plt.title("Rapid Scan Travel Path")
+    _plot_path(rapid_path, probed, diff, cmd_args)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_probed_matrix(mesh_data, cmd_args):
+    """Plot probed Z values"""
+    ax = plt.subplot(projection="3d")
+    profile = cmd_args.profile_name
+    if profile is not None:
+        req_mesh = mesh_data["profiles"].get(profile)
+        if req_mesh is None:
+            raise Exception("Profile %s not found" % (profile,))
+        matrix = req_mesh["points"]
+        name = profile
+    else:
+        req_mesh = mesh_data["current_mesh"]
+        if not req_mesh:
+            raise Exception("No current mesh data in dump")
+        matrix = req_mesh["probed_matrix"]
+        name = req_mesh["name"]
+    params = req_mesh["mesh_params"]
+    surface, scale = _plot_mesh(ax, matrix, params)
+    ax.set_title("Probed Mesh (%s)" % (name,))
+    ax.set(zlim=(-scale, scale))
+    plt.gcf().colorbar(surface, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_mesh_matrix(mesh_data, cmd_args):
+    """Plot mesh Z values"""
+    ax = plt.subplot(projection="3d")
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    matrix = req_mesh["mesh_matrix"]
+    params = req_mesh["mesh_params"]
+    surface, scale = _plot_mesh(ax, matrix, params)
+    name = req_mesh["name"]
+    ax.set_title("Interpolated Mesh (%s)" % (name,))
+    ax.set(zlim=(-scale, scale))
+    plt.gcf().colorbar(surface, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_overlay(mesh_data, cmd_args):
+    """Plots the current probed mesh overlaid with a profile"""
+    ax = plt.subplot(projection="3d")
+    # Plot Profile
+    profile = cmd_args.profile_name
+    if profile is None:
+        raise Exception("A profile must be specified to plot an overlay")
+    req_mesh = mesh_data["profiles"].get(profile)
+    if req_mesh is None:
+        raise Exception("Profile %s not found" % (profile,))
+    matrix = req_mesh["points"]
+    params = req_mesh["mesh_params"]
+    prof_surf, prof_scale = _plot_mesh(ax, matrix, params, label=profile)
+    # Plot Current
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    matrix = req_mesh["probed_matrix"]
+    params = req_mesh["mesh_params"]
+    cur_name = req_mesh["name"]
+    cur_surf, cur_scale = _plot_mesh(ax, matrix, params, cm.inferno, cur_name)
+    ax.set_title("Probed Mesh Overlay")
+    scale = max(cur_scale, prof_scale)
+    ax.set(zlim=(-scale, scale))
+    ax.legend(loc='best')
+    plt.gcf().colorbar(prof_surf, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_delta(mesh_data, cmd_args):
+    """Plots the delta between current probed mesh and a profile"""
+    ax = plt.subplot(projection="3d")
+    # Plot Profile
+    profile = cmd_args.profile_name
+    if profile is None:
+        raise Exception("A profile must be specified to plot an overlay")
+    req_mesh = mesh_data["profiles"].get(profile)
+    if req_mesh is None:
+        raise Exception("Profile %s not found" % (profile,))
+    prof_matix = req_mesh["points"]
+    prof_params = req_mesh["mesh_params"]
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    cur_matrix = req_mesh["probed_matrix"]
+    cur_params = req_mesh["mesh_params"]
+    cur_name = req_mesh["name"]
+    # validate that the params match
+    pfields = ("x_count", "y_count", "min_x", "max_x", "min_y", "max_y")
+    for field in pfields:
+        if abs(prof_params[field] - cur_params[field]) >= 1e-6:
+            raise Exception(
+                "Values for field %s do not match, cant plot deviation"
+            )
+    delta = np.array(cur_matrix) - np.array(prof_matix)
+    surface, scale = _plot_mesh(ax, delta, cur_params)
+    ax.set(zlim=(-scale, scale))
+    ax.set_title("Probed Mesh Delta (%s, %s)" % (cur_name, profile))
+    _set_xy_limits(mesh_data, cmd_args)
+
+
+PLOT_TYPES = {
+    "points": plot_probe_points,
+    "path": plot_probe_path,
+    "rapid": plot_rapid_path,
+    "probedz": plot_probed_matrix,
+    "meshz": plot_mesh_matrix,
+    "overlay": plot_overlay,
+    "delta": plot_delta,
+}
+
+def print_types(cmd_args):
+    typelist = [
+        "%-10s%s" % (name, func.__doc__) for name, func in PLOT_TYPES.items()
+    ]
+    print("\n".join(typelist))
+
+def plot_mesh_data(cmd_args):
+    with open(cmd_args.input_file, "r") as f:
+        mesh_data = json.load(f)
+
+    if cmd_args.output is not None:
+        matplotlib.use("svg")
+
+    fig = plt.figure()
+    plot_func = PLOT_TYPES[cmd_args.type]
+    plot_func(mesh_data, cmd_args)
+    fig.set_size_inches(10, 8)
+    fig.tight_layout()
+    if cmd_args.output is None:
+        plt.show()
+    else:
+        fig.savefig(cmd_args.output)
+
+def _check_path_unique(name, path):
+    path = np.array(path)
+    unique_pts, counts = np.unique(path, return_counts=True, axis=0)
+    for idx, count in enumerate(counts):
+        if count != 1:
+            coord = unique_pts[idx]
+            print(
+                "  WARNING: Backtracking or duplicate found in %s path at %s, "
+                "this may be due to multiple samples in a faulty region."
+                % (name, coord)
+            )
+
+def _analyze_mesh(name, mesh_axes):
+    print("\nAnalyzing Probed Mesh %s..." % (name,))
+    x, y, z = mesh_axes
+    min_idx, max_idx = z.argmin(), z.argmax()
+    min_x, min_y = x.flatten()[min_idx], y.flatten()[min_idx]
+    max_x, max_y = x.flatten()[max_idx], y.flatten()[max_idx]
+
+    print(
+        "  Min Coord (%.2f, %.2f), Max Coord (%.2f, %.2f), "
+        "Probe Count: (%d, %d)" %
+        (x.min(), y.min(), x.max(), y.max(), len(z), len(z[0]))
+    )
+    print(
+        "  Mesh range: min %.4f (%.2f, %.2f), max %.4f (%.2f, %.2f)"
+        % (z.min(), min_x, min_y, z.max(), max_x, max_y)
+    )
+    print("  Mean: %.4f, Standard Deviation: %.4f" % (z.mean(), z.std()))
+
+def _compare_mesh(name_a, name_b, mesh_a, mesh_b):
+    ax, ay, az = mesh_a
+    bx, by, bz = mesh_b
+    if not np.array_equal(ax, bx) or not np.array_equal(ay, by):
+        return
+    delta = az - bz
+    abs_max = max(abs(delta.max()), abs(delta.min()))
+    abs_mean = sum([abs(z) for z in delta.flatten()]) / len(delta.flatten())
+    min_idx, max_idx = delta.argmin(), delta.argmax()
+    min_x, min_y = ax.flatten()[min_idx], ay.flatten()[min_idx]
+    max_x, max_y = ax.flatten()[max_idx], ay.flatten()[max_idx]
+    print("  Delta from %s to %s..." % (name_a, name_b))
+    print(
+        "    Range: min %.4f (%.2f, %.2f), max %.4f (%.2f, %.2f)\n"
+        "    Mean: %.6f, Standard Deviation: %.6f\n"
+        "    Absolute Max: %.6f, Absolute Mean: %.6f"
+        % (delta.min(), min_x, min_y, delta.max(), max_x, max_y,
+           delta.mean(), delta.std(), abs_max, abs_mean)
+    )
+
+def analyze(cmd_args):
+    with open(cmd_args.input_file, "r") as f:
+        mesh_data = json.load(f)
+    print("Analyzing Travel Path...")
+    calibration = mesh_data["calibration"]
+    org_pts = calibration["points"]
+    probe_path = calibration["probe_path"]
+    rapid_path = calibration["rapid_path"]
+    rapid_points = [pt for pt, is_pt in rapid_path if is_pt]
+    rapid_moves = [pt[0] for pt in rapid_path]
+    print("  Original point count: %d" % (len(org_pts)))
+    print("  Probe path count: %d" % (len(probe_path)))
+    print("  Rapid scan sample count: %d" % (len(probe_path)))
+    print("  Rapid scan move count: %d" % (len(rapid_moves)))
+    if np.array_equal(rapid_points, probe_path):
+        print("  Rapid scan points match probe path points")
+    else:
+        diff = [pt for pt in rapid_points if pt not in probe_path]
+        print(
+            "  ERROR: Rapid scan points do not match probe points\n"
+            "difference: %s" % (diff,)
+        )
+    _check_path_unique("probe", probe_path)
+    _check_path_unique("rapid scan", rapid_moves)
+    req_mesh = mesh_data["current_mesh"]
+    formatted_data = collections.OrderedDict()
+    if req_mesh:
+        matrix = req_mesh["probed_matrix"]
+        params = req_mesh["mesh_params"]
+        name = req_mesh["name"]
+        formatted_data[name] = _format_mesh_data(matrix, params)
+    profiles = mesh_data["profiles"]
+    for prof_name, prof_data in profiles.items():
+        if prof_name in formatted_data:
+            continue
+        matrix = prof_data["points"]
+        params = prof_data["mesh_params"]
+        formatted_data[prof_name] = _format_mesh_data(matrix, params)
+    while formatted_data:
+        name, current_axes = formatted_data.popitem()
+        _analyze_mesh(name, current_axes)
+        for prof_name, prof_axes in formatted_data.items():
+            _compare_mesh(name, prof_name, current_axes, prof_axes)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Graph Bed Mesh Data")
+    sub_parsers = parser.add_subparsers()
+    list_parser = sub_parsers.add_parser(
+        "list", help="List available plot types"
+    )
+    list_parser.set_defaults(func=print_types)
+    plot_parser = sub_parsers.add_parser("plot", help="Plot a specified type")
+    analyze_parser = sub_parsers.add_parser(
+        "analyze", help="Perform analysis on mesh data"
+    )
+    plot_parser.add_argument(
+        "-a", "--animate", action="store_true",
+        help="Animate paths in live preview"
+    )
+    plot_parser.add_argument(
+        "-s", "--scale-plot", action="store_true",
+        help="Use axis limits reported by Klipper to scale plot X/Y"
+    )
+    plot_parser.add_argument(
+        "-p", "--profile-name", type=str, default=None,
+        help="Optional name of a profile to plot for 'probedz'"
+    )
+    plot_parser.add_argument(
+        "-o", "--output", type=str, default=None,
+        help="Output file path"
+    )
+    plot_parser.add_argument(
+        "type", metavar="<plot type>", type=str, choices=PLOT_TYPES.keys(),
+        help="Type of data to graph"
+    )
+    plot_parser.add_argument(
+        "input_file", metavar="<input file>",
+        help="Path to file containing mesh dump"
+    )
+    plot_parser.set_defaults(func=plot_mesh_data)
+    analyze_parser.add_argument(
+        "input_file", metavar="<input file>",
+        help="Path to file containing mesh dump"
+    )
+    analyze_parser.set_defaults(func=analyze)
+    cmd_args = parser.parse_args()
+    cmd_args.func(cmd_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/motan/data_logger.py
+++ b/scripts/motan/data_logger.py
@@ -152,10 +152,12 @@ class DataLogger:
                                 "motion_report/dump_stepper", {"name": stepper})
         # Subscribe to additional sensor data
         stypes = ["adxl345", "lis2dw", "mpu9250", "angle"]
+        stypes = {st:st for st in stypes}
+        stypes['probe_eddy_current'] = 'ldc1612'
         config = status["configfile"]["settings"]
         for cfgname in config.keys():
-            for st in stypes:
-                if cfgname == st or cfgname.startswith(st + " "):
+            for capprefix, st in sorted(stypes.items()):
+                if cfgname == capprefix or cfgname.startswith(capprefix + " "):
                     aname = cfgname.split()[-1]
                     lname = "%s:%s" % (st, aname)
                     qcmd = "%s/dump_%s" % (st, st)

--- a/scripts/motan/readlog.py
+++ b/scripts/motan/readlog.py
@@ -439,6 +439,71 @@ class HandleAngle:
             self.data_pos += 1
 LogHandlers["angle"] = HandleAngle
 
+def interpolate(next_val, prev_val, next_time, prev_time, req_time):
+    vdiff = next_val - prev_val
+    tdiff = next_time - prev_time
+    rtdiff = req_time - prev_time
+    return prev_val + rtdiff * vdiff / tdiff
+
+# Extract eddy current data
+class HandleEddyCurrent:
+    SubscriptionIdParts = 2
+    ParametersMin = 1
+    ParametersMax = 2
+    DataSets = [
+        ('ldc1612(<name>)', 'Coil resonant frequency'),
+        ('ldc1612(<name>,period)', 'Coil resonant period'),
+        ('ldc1612(<name>,z)', 'Estimated Z height'),
+    ]
+    def __init__(self, lmanager, name, name_parts):
+        self.name = name
+        self.sensor_name = name_parts[1]
+        if len(name_parts) == 3 and name_parts[2] not in ("period", "z"):
+            raise error("Unknown ldc1612 selection '%s'" % (name_parts[2],))
+        self.report_frequency = len(name_parts) == 2
+        self.report_z = len(name_parts) == 3 and name_parts[2] == "z"
+        self.jdispatch = lmanager.get_jdispatch()
+        self.next_samp = self.prev_samp = [0., 0., 0.]
+        self.cur_data = []
+        self.data_pos = 0
+    def get_label(self):
+        if self.report_frequency:
+            label = '%s frequency' % (self.sensor_name,)
+            return {'label': label, 'units': 'Frequency\n(Hz)'}
+        if self.report_z:
+            label = '%s height' % (self.sensor_name,)
+            return {'label': label, 'units': 'Position\n(mm)'}
+        label = '%s period' % (self.sensor_name,)
+        return {'label': label, 'units': 'Period\n(s)'}
+    def pull_data(self, req_time):
+        while 1:
+            next_time, next_freq, next_z = self.next_samp
+            if req_time <= next_time:
+                prev_time, prev_freq, prev_z = self.prev_samp
+                if self.report_frequency:
+                    next_val = next_freq
+                    prev_val = prev_freq
+                elif self.report_z:
+                    next_val = next_z
+                    prev_val = prev_z
+                else:
+                    next_val = 1. / next_freq
+                    prev_val = 1. / prev_freq
+                return interpolate(next_val, prev_val, next_time, prev_time,
+                                   req_time)
+            if self.data_pos >= len(self.cur_data):
+                # Read next data block
+                jmsg = self.jdispatch.pull_msg(req_time, self.name)
+                if jmsg is None:
+                    return 0.
+                self.cur_data = jmsg['data']
+                self.data_pos = 0
+                continue
+            self.prev_samp = self.next_samp
+            self.next_samp = self.cur_data[self.data_pos]
+            self.data_pos += 1
+LogHandlers["ldc1612"] = HandleEddyCurrent
+
 
 ######################################################################
 # Log reading

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -104,6 +104,10 @@ config WANT_LIS2DW
     bool
     depends on HAVE_GPIO_SPI
     default y
+config WANT_LDC1612
+    bool
+    depends on HAVE_GPIO_I2C
+    default y
 config WANT_SOFTWARE_I2C
     bool
     depends on HAVE_GPIO && HAVE_GPIO_I2C
@@ -114,7 +118,7 @@ config WANT_SOFTWARE_SPI
     default y
 config NEED_SENSOR_BULK
     bool
-    depends on WANT_SENSORS || WANT_LIS2DW
+    depends on WANT_SENSORS || WANT_LIS2DW || WANT_LDC1612
     default y
 menu "Optional features (to reduce code size)"
     depends on HAVE_LIMITED_CODE_SIZE
@@ -130,6 +134,9 @@ config WANT_SENSORS
 config WANT_LIS2DW
     bool "Support lis2dw 3-axis accelerometer"
     depends on HAVE_GPIO_SPI
+config WANT_LDC1612
+    bool "Support ldc1612 eddy current sensor"
+    depends on HAVE_GPIO_I2C
 config WANT_SOFTWARE_I2C
     bool "Support software based I2C \"bit-banging\""
     depends on HAVE_GPIO && HAVE_GPIO_I2C

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,4 +19,5 @@ sensors-src-$(CONFIG_HAVE_GPIO_SPI) := thermocouple.c sensor_adxl345.c \
 sensors-src-$(CONFIG_HAVE_GPIO_I2C) += sensor_mpu9250.c
 src-$(CONFIG_WANT_SENSORS) += $(sensors-src-y)
 src-$(CONFIG_WANT_LIS2DW) += sensor_lis2dw.c
+src-$(CONFIG_WANT_LDC1612) += sensor_ldc1612.c
 src-$(CONFIG_NEED_SENSOR_BULK) += sensor_bulk.c

--- a/src/sensor_ldc1612.c
+++ b/src/sensor_ldc1612.c
@@ -1,0 +1,207 @@
+// Support for eddy current sensor data from ldc1612 chip
+//
+// Copyright (C) 2023 Alan.Ma <tech@biqu3d.com>
+// Copyright (C) 2024  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // memcpy
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // i2c_read
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
+#include "command.h" // DECL_COMMAND
+#include "i2ccmds.h" // i2cdev_oid_lookup
+#include "sched.h" // DECL_TASK
+#include "sensor_bulk.h" // sensor_bulk_report
+#include "trsync.h" // trsync_do_trigger
+
+enum {
+    LDC_PENDING = 1<<0,
+    LH_AWAIT_HOMING = 1<<1, LH_CAN_TRIGGER = 1<<2
+};
+
+struct ldc1612 {
+    struct timer timer;
+    uint32_t rest_ticks;
+    struct i2cdev_s *i2c;
+    uint8_t flags;
+    struct sensor_bulk sb;
+    // homing
+    struct trsync *ts;
+    uint8_t homing_flags;
+    uint8_t trigger_reason;
+    uint32_t trigger_threshold;
+    uint32_t homing_clock;
+};
+
+static struct task_wake ldc1612_wake;
+
+// Query ldc1612 data
+static uint_fast8_t
+ldc1612_event(struct timer *timer)
+{
+    struct ldc1612 *ld = container_of(timer, struct ldc1612, timer);
+    if (ld->flags & LDC_PENDING)
+        ld->sb.possible_overflows++;
+    ld->flags |= LDC_PENDING;
+    sched_wake_task(&ldc1612_wake);
+    ld->timer.waketime += ld->rest_ticks;
+    return SF_RESCHEDULE;
+}
+
+void
+command_config_ldc1612(uint32_t *args)
+{
+    struct ldc1612 *ld = oid_alloc(args[0], command_config_ldc1612
+                                   , sizeof(*ld));
+    ld->timer.func = ldc1612_event;
+    ld->i2c = i2cdev_oid_lookup(args[1]);
+}
+DECL_COMMAND(command_config_ldc1612, "config_ldc1612 oid=%c i2c_oid=%c");
+
+void
+command_ldc1612_setup_home(uint32_t *args)
+{
+    struct ldc1612 *ld = oid_lookup(args[0], command_config_ldc1612);
+
+    ld->trigger_threshold = args[2];
+    if (!ld->trigger_threshold) {
+        ld->ts = NULL;
+        ld->homing_flags = 0;
+        return;
+    }
+    ld->homing_clock = args[1];
+    ld->ts = trsync_oid_lookup(args[3]);
+    ld->trigger_reason = args[4];
+    ld->homing_flags = LH_AWAIT_HOMING | LH_CAN_TRIGGER;
+}
+DECL_COMMAND(command_ldc1612_setup_home,
+             "ldc1612_setup_home oid=%c clock=%u threshold=%u"
+             " trsync_oid=%c trigger_reason=%c");
+
+void
+command_query_ldc1612_home_state(uint32_t *args)
+{
+    struct ldc1612 *ld = oid_lookup(args[0], command_config_ldc1612);
+    sendf("ldc1612_home_state oid=%c homing=%c trigger_clock=%u"
+          , args[0], !!(ld->homing_flags & LH_CAN_TRIGGER), ld->homing_clock);
+}
+DECL_COMMAND(command_query_ldc1612_home_state,
+             "query_ldc1612_home_state oid=%c");
+
+// Chip registers
+#define REG_DATA0_MSB 0x00
+#define REG_DATA0_LSB 0x01
+#define REG_STATUS    0x18
+
+// Read a register on the ldc1612
+static void
+read_reg(struct ldc1612 *ld, uint8_t reg, uint8_t *res)
+{
+    i2c_read(ld->i2c->i2c_config, sizeof(reg), &reg, 2, res);
+}
+
+// Read the status register on the ldc1612
+static uint16_t
+read_reg_status(struct ldc1612 *ld)
+{
+    uint8_t data_status[2];
+    read_reg(ld, REG_STATUS, data_status);
+    return (data_status[0] << 8) | data_status[1];
+}
+
+#define BYTES_PER_SAMPLE 4
+
+// Query ldc1612 data
+static void
+ldc1612_query(struct ldc1612 *ld, uint8_t oid)
+{
+    // Clear pending flag
+    irq_disable();
+    ld->flags &= ~LDC_PENDING;
+    irq_enable();
+
+    // Check if data available
+    uint16_t status = read_reg_status(ld);
+    if (status != 0x48)
+        return;
+
+    // Read coil0 frequency
+    uint8_t *d = &ld->sb.data[ld->sb.data_count];
+    read_reg(ld, REG_DATA0_MSB, &d[0]);
+    read_reg(ld, REG_DATA0_LSB, &d[2]);
+    ld->sb.data_count += BYTES_PER_SAMPLE;
+
+    // Check for endstop trigger
+    uint8_t homing_flags = ld->homing_flags;
+    if (homing_flags & LH_CAN_TRIGGER) {
+        uint32_t time = timer_read_time();
+        if (!(homing_flags & LH_AWAIT_HOMING)
+            || !timer_is_before(time, ld->homing_clock)) {
+            homing_flags &= ~LH_AWAIT_HOMING;
+            uint32_t data = (d[0] << 24L) | (d[1] << 16L) | (d[2] << 8) | d[3];
+            if (data > ld->trigger_threshold) {
+                homing_flags = 0;
+                ld->homing_clock = time;
+                trsync_do_trigger(ld->ts, ld->trigger_reason);
+            }
+            ld->homing_flags = homing_flags;
+        }
+    }
+
+    // Flush local buffer if needed
+    if (ld->sb.data_count + BYTES_PER_SAMPLE > ARRAY_SIZE(ld->sb.data))
+        sensor_bulk_report(&ld->sb, oid);
+}
+
+void
+command_query_ldc1612(uint32_t *args)
+{
+    struct ldc1612 *ld = oid_lookup(args[0], command_config_ldc1612);
+
+    sched_del_timer(&ld->timer);
+    ld->flags = 0;
+    if (!args[1])
+        // End measurements
+        return;
+
+    // Start new measurements query
+    ld->rest_ticks = args[1];
+    sensor_bulk_reset(&ld->sb);
+    irq_disable();
+    ld->timer.waketime = timer_read_time() + ld->rest_ticks;
+    sched_add_timer(&ld->timer);
+    irq_enable();
+}
+DECL_COMMAND(command_query_ldc1612, "query_ldc1612 oid=%c rest_ticks=%u");
+
+void
+command_query_ldc1612_status(uint32_t *args)
+{
+    struct ldc1612 *ld = oid_lookup(args[0], command_config_ldc1612);
+
+    uint32_t time1 = timer_read_time();
+    uint16_t status = read_reg_status(ld);
+    uint32_t time2 = timer_read_time();
+
+    uint32_t fifo = status == 0x48 ? BYTES_PER_SAMPLE : 0;
+    sensor_bulk_status(&ld->sb, args[0], time1, time2-time1, fifo);
+}
+DECL_COMMAND(command_query_ldc1612_status, "query_ldc1612_status oid=%c");
+
+void
+ldc1612_task(void)
+{
+    if (!sched_check_wake(&ldc1612_wake))
+        return;
+    uint8_t oid;
+    struct ldc1612 *ld;
+    foreach_oid(oid, ld, command_config_ldc1612) {
+        uint_fast8_t flags = ld->flags;
+        if (!(flags & LDC_PENDING))
+            continue;
+        ldc1612_query(ld, oid);
+    }
+}
+DECL_TASK(ldc1612_task);


### PR DESCRIPTION
This PR build on #6536, adding support for "surface scanning".  The first commit resolves a minor issue where `PROBE_EDDY_CURRENT_CALIBRATE` removes all previous autosaved configuration, including the `reg_drive_current` option saved by `LDC_CALIBRATE`.  If necessary this commit can be removed from this PR and added to another (or to the original).

The rest of this PR makes the necessary modifications to `probe_eddy_current.py`, `probe.py`, and `bed_mesh.py` to support scanning a surface using an eddy probe.  In addition, a `graph-mesh.py` script has been added to visualize and analyze mesh state, which can be dumped to a json file using the new `BED_MESH_DUMP` command.