### PR TITLE
Populate minimum_cruise_ratio to printer.configfile.settings

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -217,16 +217,17 @@ class ToolHead:
         # Velocity and acceleration control
         self.max_velocity = config.getfloat('max_velocity', above=0.)
         self.max_accel = config.getfloat('max_accel', above=0.)
-        self.min_cruise_ratio = config.getfloat('minimum_cruise_ratio', None,
-                                                below=1., minval=0.)
-        if self.min_cruise_ratio is None:
-            self.min_cruise_ratio = 0.5
+        min_cruise_ratio = 0.5
+        if config.getfloat('minimum_cruise_ratio', None) is None:
             req_accel_to_decel = config.getfloat('max_accel_to_decel', None,
                                                  above=0.)
             if req_accel_to_decel is not None:
                 config.deprecate('max_accel_to_decel')
-                self.min_cruise_ratio = 1. - min(1., (req_accel_to_decel
-                                                      / self.max_accel))
+                min_cruise_ratio = 1. - min(1., (req_accel_to_decel
+                                                 / self.max_accel))
+        self.min_cruise_ratio = config.getfloat('minimum_cruise_ratio',
+                                                min_cruise_ratio,
+                                                below=1., minval=0.)
         self.square_corner_velocity = config.getfloat(
             'square_corner_velocity', 5., minval=0.)
         self.junction_deviation = self.max_accel_to_decel = 0.


### PR DESCRIPTION
The default minimum_cruise_ratio setting does not get populated to the printer.configfile.settings information due to the way the max_accel_to_decel backwards compatibility support was implemented. Slightly rework the config reading so that the default for minimum_cruise_ratio is populated there.

Reported by @ReXT3D.

-Kevin