### PR TITLE
Define a default for virtual_sdcard on_gcode_error

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240415: The `on_error_gcode` parameter in the `[virtual_sdcard]`
+config section now has a default. If this parameter is not specified
+it now defaults to `TURN_OFF_HEATERS`. If the previous behavior is
+desired (take no default action on an error during a virtual_sdcard
+print) then define `on_error_gcode` with an empty value.
+
 20240313: The `max_accel_to_decel` parameter in the `[printer]` config
 section has been deprecated. The `ACCEL_TO_DECEL` parameter of the
 `SET_VELOCITY_LIMIT` command has been deprecated. The

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1472,7 +1472,8 @@ path:
 #   be provided.
 #on_error_gcode:
 #   A list of G-Code commands to execute when an error is reported.
-
+#   See docs/Command_Templates.md for G-Code format. The default is to
+#   run TURN_OFF_HEATERS.
 ```
 
 ### [sdcard_loop]

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -7,6 +7,12 @@ import os, sys, logging, io
 
 VALID_GCODE_EXTS = ['gcode', 'g', 'gco']
 
+DEFAULT_ERROR_GCODE = """
+{% if 'heaters' in printer %}
+   TURN_OFF_HEATERS
+{% endif %}
+"""
+
 class VirtualSD:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -27,7 +33,7 @@ class VirtualSD:
         # Error handling
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.on_error_gcode = gcode_macro.load_template(
-            config, 'on_error_gcode', '')
+            config, 'on_error_gcode', DEFAULT_ERROR_GCODE)
         # Register commands
         self.gcode = self.printer.lookup_object('gcode')
         for cmd in ['M20', 'M21', 'M23', 'M24', 'M25', 'M26', 'M27']:


### PR DESCRIPTION
The `on_gcode_error` parameter allows one to run a set of g-code commands if an error is found while running a print using the virtual_sdcard system.  (Which is very common, as all the Klipper graphical frontends use this system to print.)

There is currently no default for this parameter.  That's not ideal, as an error that occurs during a print could result in the toolhead stopping with the heaters enabled and the nozzle directly over a partial print.

This PR adds a default - if the parameter is not specified it will default to `TURN_OFF_HEATERS`.  I think this is likely an improvement over the existing behavior.

Arguably, it would be even better to also raise the Z a few millimeters on a host detected command error.  Unfortunately, it's difficult to do that reliably, and I fear it may be too complex to be a good default.  So, this PR is a compromise - it just turns off the heaters by default.

Note that the motors are not disabled by a host detected command error in a virtual_sdcard print (neither before this PR nor after it).

-Kevin

P.S.  I did come up with the following possible macro to try to raise the Z.  I wasn't happy with it because of its complexity (and there are still cases where it would not work correctly):
```
{% if 'heaters' in printer %}
   TURN_OFF_HEATERS
{% endif %}

SAVE_GCODE_STATE NAME=_VIRTUAL_SDCARD_ERROR
{% if 'z' in printer.toolhead.homed_axes %}
  {% set gcode_z = printer.gcode_position.z %}
  {% set max_z = printer.toolhead.axis_maximum.z|default(gcode_z) %}
  {% set new_z = [ gcode_z + 10.0, [gcode_z, max_z]|max ]|min %}
  G90
  G1 Z{new_Z} F300
{% endif %}
RESTORE_GCODE_STATE NAME=_VIRTUAL_SDCARD_ERROR
```