### PR TITLE
Add i2c3_PA8_PC9 bus to STM32H7

### DIFF
--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -84,6 +84,8 @@ struct i2c_info {
   DECL_CONSTANT_STR("BUS_PINS_i2c1_PB8_PB9", "PB8,PB9");
   DECL_ENUMERATION("i2c_bus", "i2c2_PB10_PB11", 2);
   DECL_CONSTANT_STR("BUS_PINS_i2c2_PB10_PB11", "PB10,PB11");
+  DECL_ENUMERATION("i2c_bus", "i2c3_PA8_PC9", 3);
+  DECL_CONSTANT_STR("BUS_PINS_i2c3_PA8_PC9", "PA8,PC9");
 #endif
 
 static const struct i2c_info i2c_bus[] = {
@@ -123,6 +125,7 @@ static const struct i2c_info i2c_bus[] = {
     { I2C1, GPIO('B', 6), GPIO('B', 7), GPIO_FUNCTION(4) },
     { I2C1, GPIO('B', 8), GPIO('B', 9), GPIO_FUNCTION(4) },
     { I2C2, GPIO('B', 10), GPIO('B', 11), GPIO_FUNCTION(4) },
+    { I2C3, GPIO('A', 8), GPIO('C', 9), GPIO_FUNCTION(4) },
 #endif
 };
 


### PR DESCRIPTION
Adds the 3rd hardware I2C bus for H7 based mainboards like the BTT Octopus Pro or the Manta M8P v2.0. 

Been running this commit for 2 weeks now on my Manta M8P v2.0 with a BME280 connected to it with no issues.

Signed-off-by: Balanuta Simion <contact@cybersnets.com>