### PR TITLE
makefile: fix warning about lto serial compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ cc-option=$(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`" \
 CFLAGS := -I$(OUT) -Isrc -I$(OUT)board-generic/ -std=gnu11 -O2 -MD \
     -Wall -Wold-style-definition $(call cc-option,$(CC),-Wtype-limits,) \
     -ffunction-sections -fdata-sections -fno-delete-null-pointer-checks
-CFLAGS += -flto -fwhole-program -fno-use-linker-plugin -ggdb3
+CFLAGS += -flto=auto -fwhole-program -fno-use-linker-plugin -ggdb3
 
 OBJS_klipper.elf = $(patsubst %.c, $(OUT)src/%.o,$(src-y))
 OBJS_klipper.elf += $(OUT)compile_time_request.o


### PR DESCRIPTION
When building, a warning message appears at the end of the build output:

```
...
Version: ?-20240326_165244-67c86037cf03
  Preprocessing out/src/generic/armcm_link.ld
  Linking out/klipper.elf
lto-wrapper: warning: using serial compilation of 4 LTRANS jobs
lto-wrapper: note: see the '-flto' option documentation for more information
  Creating hex file out/klipper.bin
...
```

To avoid this non-erroneous output, we set `CFLAGS` LTO flag with `-flto=auto` in the `Makefile`.

Signed-off-by: John Unland <junland.foss@gmail.com>