### PR TITLE
Temperature_fan: ControlPID modified to work correctly

### DIFF
--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -142,9 +142,14 @@ class ControlPID:
         # Calculate output
         co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
         bounded_co = max(0., min(self.temperature_fan.get_max_speed(), co))
-        self.temperature_fan.set_speed(
-            read_time, max(self.temperature_fan.get_min_speed(),
-                           self.temperature_fan.get_max_speed() - bounded_co))
+        
+        if temp_err>0:  # stop the fan if the temp is lower than the target temp
+            spd = 0.
+        else:
+            if temp_err<-1: #enable the fan when the temp diff. is >1°C
+                spd = max(self.temperature_fan.get_min_speed(),bounded_co)
+            
+        self.temperature_fan.set_speed(read_time, spd)
         # Store state for next measurement
         self.prev_temp = temp
         self.prev_temp_time = read_time


### PR DESCRIPTION
Whereas the bang-bang control works as expected (fan turns on when measured temp is > reference temp), the ControlPID as designed doesn't have the same behavior and the duty cycle is max_speed - PID value, which is not the expected behavior.

The correction allows the PID to work correctly.

As the minimum fan speed is generally about 20%, a 1° C tolerance has been programmed to avoid that the fan oscillate near the reference value.

The temp_err variable is < 0 when the fan should power-on and if the value is lower, the fan must speed up, so all PID coefficients must be negative. (or the temp_err should be inverted).

I'm using this to control the fan of a water-cooling system, and it is suitable to have it silent most of the time. A 80 mm radiator & fan is more than sufficient to cool the head and motors to 3-4° above ambient temp.