### PR TITLE
Add kconfig options for rp2040 uart

### DIFF
--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -97,56 +97,39 @@ config RP2040_STAGE2_CLKDIV
 choice
  prompt "Communication Interface"
  config RP2040_USB
-     bool "Enable USB communication"
+     bool "USBSERIAL"
      select USBSERIAL
- config RP2040_SERIAL
-     bool "Enable Serial communication"
-     select SERIAL
+ config RP2040_SERIAL_UART0_PINS_0_1
+      bool "UART0 on GPIO0/GPIO1"
+      select SERIAL
+ config RP2040_SERIAL_UART0_PINS_12_13
+      bool "UART0 on GPIO12/GPIO13" if LOW_LEVEL_OPTIONS
+      select SERIAL
+ config RP2040_SERIAL_UART0_PINS_16_17
+      bool "UART0 on GPIO16/GPIO17" if LOW_LEVEL_OPTIONS
+      select SERIAL
+  config RP2040_SERIAL_UART0_PINS_28_29
+      bool "UART0 on GPIO28/GPIO29" if LOW_LEVEL_OPTIONS
+      select SERIAL
+ config RP2040_SERIAL_UART1_PINS_4_5
+      bool "UART1 on GPIO4/GPIO5" if LOW_LEVEL_OPTIONS
+      select SERIAL
+ config RP2040_SERIAL_UART1_PINS_8_9
+      bool "UART1 on  GPIO8/GPIO9" if LOW_LEVEL_OPTIONS
+      select SERIAL
+ config RP2040_SERIAL_UART1_PINS_20_21
+      bool "UART1 on  GPIO20/GPIO21" if LOW_LEVEL_OPTIONS
+      select SERIAL
+ config RP2040_SERIAL_UART1_PINS_24_25
+      bool "UART1 on GPIO24/GPIO25"  if LOW_LEVEL_OPTIONS
+      select SERIAL
  config RP2040_CANBUS
-      bool "CAN bus"
-      select CANSERIAL
+       bool "CAN bus"
+       select CANSERIAL
  config RP2040_USBCANBUS
-      bool "USB to CAN bus bridge"
-      select USBCANBUS
+       bool "USB to CAN bus bridge"
+       select USBCANBUS
 endchoice
-
-if RP2040_SERIAL
- choice
-     prompt "Select Serial communication interface"
-     config RP2040_SERIAL_UART0
-         bool "Serial (UART0)"
-     config RP2040_SERIAL_UART1
-         bool "Serial (UART1)"
- endchoice
- if RP2040_SERIAL_UART0
- choice
-     prompt "Select UART0 TX/RX pin pair"
-     config RP2040_SERIAL_UART0_PINS_0_1
-         bool "GPIO0 for TX, GPIO1 for RX (Default)"
-     config RP2040_SERIAL_UART0_PINS_12_13
-         bool "GPIO12 for TX, GPIO13 for RX"
-     config RP2040_SERIAL_UART0_PINS_16_17
-         bool "GPIO16 for TX, GPIO17 for RX"
-     config RP2040_SERIAL_UART0_PINS_28_29
-         bool "GPIO28 for TX, GPIO29 for RX"
- endchoice
- endif # End of RP2040_SERIAL_UART0
- if RP2040_SERIAL_UART1
- choice
-     prompt "Select UART1 TX/RX pin pair"
-     config RP2040_SERIAL_UART1_PINS_4_5
-         bool "GPIO4 for TX, GPIO5 for RX"
-     config RP2040_SERIAL_UART1_PINS_8_9
-         bool "GPIO8 for TX, GPIO9 for RX"
-     config RP2040_SERIAL_UART1_PINS_20_21
-         bool "GPIO20 for TX, GPIO21 for RX"
-     config RP2040_SERIAL_UART1_PINS_24_25
-         bool "GPIO24 for TX, GPIO25 for RX"
- endchoice
- endif # End of RP2040_SERIAL_UART1
- endif # End of RP2040_SERIAL
-
-
 
 config RP2040_CANBUS_GPIO_RX
     int "CAN RX gpio number" if CANBUS

--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -95,20 +95,58 @@ config RP2040_STAGE2_CLKDIV
 ######################################################################
 
 choice
-    prompt "Communication interface"
-    config RP2040_USB
-        bool "USB"
-        select USBSERIAL
-    config RP2040_SERIAL_UART0
-        bool "Serial (on UART0 GPIO1/GPIO0)"
-        select SERIAL
-    config RP2040_CANBUS
-        bool "CAN bus"
-        select CANSERIAL
-    config RP2040_USBCANBUS
-        bool "USB to CAN bus bridge"
-        select USBCANBUS
+ prompt "Communication Interface"
+ config RP2040_USB
+     bool "Enable USB communication"
+     select USBSERIAL
+ config RP2040_SERIAL
+     bool "Enable Serial communication"
+     select SERIAL
+ config RP2040_CANBUS
+      bool "CAN bus"
+      select CANSERIAL
+ config RP2040_USBCANBUS
+      bool "USB to CAN bus bridge"
+      select USBCANBUS
 endchoice
+
+if RP2040_SERIAL
+ choice
+     prompt "Select Serial communication interface"
+     config RP2040_SERIAL_UART0
+         bool "Serial (UART0)"
+     config RP2040_SERIAL_UART1
+         bool "Serial (UART1)"
+ endchoice
+ if RP2040_SERIAL_UART0
+ choice
+     prompt "Select UART0 TX/RX pin pair"
+     config RP2040_SERIAL_UART0_PINS_0_1
+         bool "GPIO0 for TX, GPIO1 for RX (Default)"
+     config RP2040_SERIAL_UART0_PINS_12_13
+         bool "GPIO12 for TX, GPIO13 for RX"
+     config RP2040_SERIAL_UART0_PINS_16_17
+         bool "GPIO16 for TX, GPIO17 for RX"
+     config RP2040_SERIAL_UART0_PINS_28_29
+         bool "GPIO28 for TX, GPIO29 for RX"
+ endchoice
+ endif # End of RP2040_SERIAL_UART0
+ if RP2040_SERIAL_UART1
+ choice
+     prompt "Select UART1 TX/RX pin pair"
+     config RP2040_SERIAL_UART1_PINS_4_5
+         bool "GPIO4 for TX, GPIO5 for RX"
+     config RP2040_SERIAL_UART1_PINS_8_9
+         bool "GPIO8 for TX, GPIO9 for RX"
+     config RP2040_SERIAL_UART1_PINS_20_21
+         bool "GPIO20 for TX, GPIO21 for RX"
+     config RP2040_SERIAL_UART1_PINS_24_25
+         bool "GPIO24 for TX, GPIO25 for RX"
+ endchoice
+ endif # End of RP2040_SERIAL_UART1
+ endif # End of RP2040_SERIAL
+
+
 
 config RP2040_CANBUS_GPIO_RX
     int "CAN RX gpio number" if CANBUS

--- a/src/rp2040/serial.c
+++ b/src/rp2040/serial.c
@@ -2,6 +2,7 @@
 //
 // Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 //
+// This file may be distributed under the terms of the GNU GPLv3 license.
 
 
 #include <stdint.h> // uint32_t

--- a/src/rp2040/serial.c
+++ b/src/rp2040/serial.c
@@ -2,8 +2,7 @@
 //
 // Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 //
-// This file may be distributed under the terms of the GNU GPLv3 license.
-//Modified 04/04/2024 by Amken3d (info@amken.us) to add all UART pin combos
+
 
 #include <stdint.h> // uint32_t
 #include "autoconf.h" // Include configuration header

--- a/src/rp2040/serial.c
+++ b/src/rp2040/serial.c
@@ -3,14 +3,14 @@
 // Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
-//Modified 04/04/2024 by Amken3d (info@amken.us) to dynamically select all possible UART combinations for RP2040
+//Modified 04/04/2024 by Amken3d (info@amken.us) to add all UART pin combos
 
 #include <stdint.h> // uint32_t
 #include "autoconf.h" // Include configuration header
 #include "board/armcm_boot.h" // armcm_enable_irq
 #include "board/irq.h" // irq_save
 #include "board/serial_irq.h" // serial_rx_data
-#include "hardware/structs/resets.h" // RESETS_RESET_UART0_BITS, RESETS_RESET_UART1_BITS
+#include "hardware/structs/resets.h" // RESETS_RESET_UART0/1_BITS
 #include "hardware/structs/uart.h" // uart0_hw, uart1_hw
 #include "internal.h" // UART0_IRQn, UART1_IRQn
 #include "sched.h" // DECL_INIT

--- a/src/rp2040/serial.c
+++ b/src/rp2040/serial.c
@@ -16,45 +16,52 @@
 #include "sched.h" // DECL_INIT
 
 // Dynamically select UART and IRQ based on configuration
-#if CONFIG_RP2040_SERIAL_UART0
-#define UARTx uart0_hw
-    #define UARTx_IRQn UART0_IRQ_IRQn
+
+
     #if CONFIG_RP2040_SERIAL_UART0_PINS_0_1
         #define GPIO_Rx 1
         #define GPIO_Tx 0
+        #define UARTx uart0_hw
+        #define UARTx_IRQn UART0_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART0_PINS_12_13
         #define GPIO_Rx 13
         #define GPIO_Tx 12
+        #define UARTx uart0_hw
+        #define UARTx_IRQn UART0_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART0_PINS_16_17
         #define GPIO_Rx 17
         #define GPIO_Tx 16
+        #define UARTx uart0_hw
+        #define UARTx_IRQn UART0_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART0_PINS_28_29
         #define GPIO_Rx 29
         #define GPIO_Tx 28
-    #else
-        #error "UART0 pin configuration not specified"
-    #endif
-#elif CONFIG_RP2040_SERIAL_UART1
-#define UARTx uart1_hw
-    #define UARTx_IRQn UART1_IRQ_IRQn
-    #if CONFIG_RP2040_SERIAL_UART1_PINS_4_5
+        #define UARTx uart1_hw
+        #define UARTx_IRQn UART1_IRQ_IRQn
+        #define UARTx uart0_hw
+        #define UARTx_IRQn UART0_IRQ_IRQn
+    #elif CONFIG_RP2040_SERIAL_UART1_PINS_4_5
         #define GPIO_Rx 5
         #define GPIO_Tx 4
+        #define UARTx uart1_hw
+        #define UARTx_IRQn UART1_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART1_PINS_8_9
         #define GPIO_Rx 9
         #define GPIO_Tx 8
+        #define UARTx uart1_hw
+        #define UARTx_IRQn UART1_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART1_PINS_20_21
         #define GPIO_Rx 20
         #define GPIO_Tx 21
+        #define UARTx uart1_hw
+        #define UARTx_IRQn UART1_IRQ_IRQn
     #elif CONFIG_RP2040_SERIAL_UART1_PINS_24_25
-       #define GPIO_Rx 24
-       #define GPIO_Tx 25
-    #else
-        #error "UART1 pin configuration not specified"
+        #define GPIO_Rx 24
+        #define GPIO_Tx 25
+        #define UARTx uart1_hw
+        #define UARTx_IRQn UART1_IRQ_IRQn
     #endif
-#else
-#error "No UART selected"
-#endif
+
 
 // Write tx bytes to the serial port
 static void
@@ -105,13 +112,15 @@ void
 serial_init(void)
 {
 
-#if CONFIG_RP2040_SERIAL_UART0
-    enable_pclock(RESETS_RESET_UART0_BITS);
-    uint32_t pclk = get_pclock_frequency(RESETS_RESET_UART0_BITS);
-#elif CONFIG_RP2040_SERIAL_UART1
-    enable_pclock(RESETS_RESET_UART1_BITS);
-    uint32_t pclk = get_pclock_frequency(RESETS_RESET_UART1_BITS);
-#endif
+    uint32_t pclk= 0x00;
+    if (UARTx == uart0_hw){
+        enable_pclock(RESETS_RESET_UART0_BITS);
+        pclk= get_pclock_frequency(RESETS_RESET_UART0_BITS);
+    } else {
+        enable_pclock(RESETS_RESET_UART1_BITS);
+        pclk = get_pclock_frequency(RESETS_RESET_UART1_BITS);
+    }
+
 
     // Setup baud
 


### PR DESCRIPTION
Current implementation only supports UART0 on Pin0 and 1. 
This change brings in all the possible UART 0 and 1 pin combinations for the RP2040.
Has been tested on a custom board with UART1 on 24,25