### PR TITLE
Add setuptools to klippy requirements for python 3.12

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -9,3 +9,4 @@ greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1
+setuptools==69.2.0 ; python_version >= '3.12'


### PR DESCRIPTION
In Python 3.12 `setuptools` is no longer installed by default on virtual environment creation (see https://docs.python.org/3/whatsnew/3.12.html and https://github.com/python/cpython/issues/95299)
This is breaking Klipper when connecting through CAN due to missing dependencies.

This PR adds `setuptools` conditionally like `greenlet` already is.

Klipper error as well to properly show the issue:


    Unhandled exception during connect
    Traceback (most recent call last):
      File "/opt/klipper/klippy/klippy.py", line 176, in _connect
        self.send_event("klippy:mcu_identify")
      File "/opt/klipper/klippy/klippy.py", line 263, in send_event
        return [cb(*params) for cb in self.event_handlers.get(event, [])]
                ^^^^^^^^^^^
      File "/opt/klipper/klippy/mcu.py", line 763, in _mcu_identify
        self._serial.connect_canbus(self._serialport, nodeid,
      File "/opt/klipper/klippy/serialhdl.py", line 112, in connect_canbus
        import can # XXX
        ^^^^^^^^^^
      File "/opt/venv/lib/python3.12/site-packages/can/__init__.py", line 31, in <module>
        from .io import Logger, Printer, LogReader, MessageSync
      File "/opt/venv/lib/python3.12/site-packages/can/io/__init__.py", line 11, in <module>
        from .logger import Logger
      File "/opt/venv/lib/python3.12/site-packages/can/io/logger.py", line 13, in <module>
        from .asc import ASCWriter
      File "/opt/venv/lib/python3.12/site-packages/can/io/asc.py", line 19, in <module>
        from ..util import channel2int
      File "/opt/venv/lib/python3.12/site-packages/can/util.py", line 23, in <module>
        from can.interfaces import VALID_INTERFACES
      File "/opt/venv/lib/python3.12/site-packages/can/interfaces/__init__.py", line 8, in <module>
        from pkg_resources import iter_entry_points
    ModuleNotFoundError: No module named 'pkg_resources'