### PR TITLE
CI: add PR check for DCO signoff

### DIFF
--- a/.github/workflows/pulls.yaml
+++ b/.github/workflows/pulls.yaml
@@ -1,0 +1,21 @@
+name: Check PR
+
+on:
+  pull_request_target:
+
+jobs:
+  check-sign-off:
+    name: Write comment if unsigned commits found
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: cloudforet-io/check-pr-action@v1
+        id: review
+      # fail the "check" if review is negative
+      - name: Notify Result
+        if: ${{ steps.review.outputs.signedoff == 'false' }}
+        run: |
+          echo "The DCO signoff is missing"
+          exit 1


### PR DESCRIPTION
This workflow will test whether every commit in a PR contains the
signoff. If not, the check will be marked as failed and a comment will
be added, explaining to the author what is missing.

Note that this workflow triggers on 'pull_request_target', not
'pull_request', because only then Github Actions can write comments in
the upstream repo from a fork.

