### PR TITLE
Update python-can to 4.3.x for Python 3.12 and later

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -7,5 +7,6 @@ pyserial==3.4
 greenlet==2.0.2 ; python_version < '3.12'
 greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==2.11.3
-python-can==3.3.4
+python-can==3.3.4 ; python_version < '3.12'
+python-can~=4.3   ; python_version >= '3.12'
 markupsafe==1.1.1


### PR DESCRIPTION
This PR is a follow up on https://github.com/Klipper3d/klipper/pull/6550


In Python 3.12 setuptools is no longer installed by default on virtual environment creation (see https://docs.python.org/3/whatsnew/3.12.html and https://github.com/python/cpython/issues/95299)
This is breaking Klipper when connecting through CAN due to missing dependencies.

Latest python-can does not depend on setuptools, a conditional requirement was added for Python 3.12 and later, the same way it is currently done with `greenlet`.

I have tested on my setup and no issues, CAN connects and I can print.