### PR TITLE
homing_override: Adds rawparams support

### DIFF
--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -55,6 +55,7 @@ class HomingOverride:
         # Perform homing
         context = self.template.create_template_context()
         context['params'] = gcmd.get_command_parameters()
+        context['rawparams'] = gcmd.get_raw_command_parameters()
         try:
             self.in_script = True
             self.template.run_gcode_from_command(context)


### PR DESCRIPTION
The `[homing_override]` has a gcode template that allows usage of the `params` but not `rawparams`.

This PR adds `rawparams` support to it thus making it consistent with the https://github.com/Klipper3d/klipper/blob/master/docs/Command_Templates.md#the-rawparams-variable information.