### PR TITLE
Refactor bulksensor timestamp calculation code

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -248,37 +248,25 @@ class ADXL345:
         return aqh
     # Measurement decoding
     def _extract_samples(self, raw_samples):
-        # Load variables to optimize inner loop below
+        # Convert messages to samples
+        samples = self.clock_updater.extract_samples("BBBBB", raw_samples)
+        # Convert samples
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
-        last_sequence = self.clock_updater.get_last_sequence()
-        time_base, chip_base, inv_freq = self.clock_sync.get_time_translation()
-        # Process every message in raw_samples
-        count = seq = 0
-        samples = [None] * (len(raw_samples) * SAMPLES_PER_BLOCK)
-        for params in raw_samples:
-            seq_diff = (params['sequence'] - last_sequence) & 0xffff
-            seq_diff -= (seq_diff & 0x8000) << 1
-            seq = last_sequence + seq_diff
-            d = bytearray(params['data'])
-            msg_cdiff = seq * SAMPLES_PER_BLOCK - chip_base
-            for i in range(len(d) // BYTES_PER_SAMPLE):
-                d_xyz = d[i*BYTES_PER_SAMPLE:(i+1)*BYTES_PER_SAMPLE]
-                xlow, ylow, zlow, xzhigh, yzhigh = d_xyz
-                if yzhigh & 0x80:
-                    self.last_error_count += 1
-                    continue
-                rx = (xlow | ((xzhigh & 0x1f) << 8)) - ((xzhigh & 0x10) << 9)
-                ry = (ylow | ((yzhigh & 0x1f) << 8)) - ((yzhigh & 0x10) << 9)
-                rz = ((zlow | ((xzhigh & 0xe0) << 3) | ((yzhigh & 0xe0) << 6))
-                      - ((yzhigh & 0x40) << 7))
-                raw_xyz = (rx, ry, rz)
-                x = round(raw_xyz[x_pos] * x_scale, 6)
-                y = round(raw_xyz[y_pos] * y_scale, 6)
-                z = round(raw_xyz[z_pos] * z_scale, 6)
-                ptime = round(time_base + (msg_cdiff + i) * inv_freq, 6)
-                samples[count] = (ptime, x, y, z)
-                count += 1
-        self.clock_sync.set_last_chip_clock(seq * SAMPLES_PER_BLOCK + i)
+        count = 0
+        for ptime, xlow, ylow, zlow, xzhigh, yzhigh in samples:
+            if yzhigh & 0x80:
+                self.last_error_count += 1
+                continue
+            rx = (xlow | ((xzhigh & 0x1f) << 8)) - ((xzhigh & 0x10) << 9)
+            ry = (ylow | ((yzhigh & 0x1f) << 8)) - ((yzhigh & 0x10) << 9)
+            rz = ((zlow | ((xzhigh & 0xe0) << 3) | ((yzhigh & 0xe0) << 6))
+                  - ((yzhigh & 0x40) << 7))
+            raw_xyz = (rx, ry, rz)
+            x = round(raw_xyz[x_pos] * x_scale, 6)
+            y = round(raw_xyz[y_pos] * y_scale, 6)
+            z = round(raw_xyz[z_pos] * z_scale, 6)
+            samples[count] = (round(ptime, 6), x, y, z)
+            count += 1
         del samples[count:]
         return samples
     # Start, stop, and process message batches

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -205,11 +205,9 @@ class ADXL345:
         mcu.add_config_cmd("query_adxl345 oid=%d rest_ticks=0"
                            % (oid,), on_restart=True)
         mcu.register_config_callback(self._build_config)
-        self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, oid=oid)
-        # Clock tracking
+        # Bulk sample message reading
         chip_smooth = self.data_rate * BATCH_UPDATES * 2
-        self.clock_updater = bulk_sensor.ChipClockUpdater(mcu, chip_smooth,
-                                                          "BBBBB")
+        self.ffreader = bulk_sensor.FixedFreqReader(mcu, chip_smooth, "BBBBB")
         self.last_error_count = 0
         # Process messages in batches
         self.batch_bulk = bulk_sensor.BatchBulkHelper(
@@ -223,8 +221,8 @@ class ADXL345:
         cmdqueue = self.spi.get_command_queue()
         self.query_adxl345_cmd = self.mcu.lookup_command(
             "query_adxl345 oid=%c rest_ticks=%u", cq=cmdqueue)
-        self.clock_updater.setup_query_command("query_adxl345_status oid=%c",
-                                               oid=self.oid, cq=cmdqueue)
+        self.ffreader.setup_query_command("query_adxl345_status oid=%c",
+                                          oid=self.oid, cq=cmdqueue)
     def read_reg(self, reg):
         params = self.spi.spi_transfer([reg | REG_MOD_READ, 0x00])
         response = bytearray(params['response'])
@@ -243,10 +241,7 @@ class ADXL345:
         self.batch_bulk.add_client(aqh.handle_batch)
         return aqh
     # Measurement decoding
-    def _extract_samples(self, raw_samples):
-        # Convert messages to samples
-        samples = self.clock_updater.extract_samples(raw_samples)
-        # Convert samples
+    def _convert_samples(self, samples):
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
         count = 0
         for ptime, xlow, ylow, zlow, xzhigh, yzhigh in samples:
@@ -264,7 +259,6 @@ class ADXL345:
             samples[count] = (round(ptime, 6), x, y, z)
             count += 1
         del samples[count:]
-        return samples
     # Start, stop, and process message batches
     def _start_measurements(self):
         # In case of miswiring, testing ADXL345 device ID prevents treating
@@ -283,30 +277,26 @@ class ADXL345:
         self.set_reg(REG_BW_RATE, QUERY_RATES[self.data_rate])
         self.set_reg(REG_FIFO_CTL, SET_FIFO_CTL)
         # Start bulk reading
-        self.bulk_queue.clear_samples()
         rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
         self.query_adxl345_cmd.send([self.oid, rest_ticks])
         self.set_reg(REG_POWER_CTL, 0x08)
         logging.info("ADXL345 starting '%s' measurements", self.name)
         # Initialize clock tracking
-        self.clock_updater.note_start()
+        self.ffreader.note_start()
         self.last_error_count = 0
     def _finish_measurements(self):
         # Halt bulk reading
         self.set_reg(REG_POWER_CTL, 0x00)
         self.query_adxl345_cmd.send_wait_ack([self.oid, 0])
-        self.bulk_queue.clear_samples()
+        self.ffreader.note_end()
         logging.info("ADXL345 finished '%s' measurements", self.name)
     def _process_batch(self, eventtime):
-        self.clock_updater.update_clock()
-        raw_samples = self.bulk_queue.pull_samples()
-        if not raw_samples:
-            return {}
-        samples = self._extract_samples(raw_samples)
+        samples = self.ffreader.pull_samples()
+        self._convert_samples(samples)
         if not samples:
             return {}
         return {'data': samples, 'errors': self.last_error_count,
-                'overflows': self.clock_updater.get_last_overflows()}
+                'overflows': self.ffreader.get_last_overflows()}
 
 def load_config(config):
     return ADXL345(config)

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -529,7 +529,7 @@ class Angle:
         logging.info("Starting angle '%s' measurements", self.name)
         self.sensor_helper.start()
         # Start bulk reading
-        self.bulk_queue.clear_samples()
+        self.bulk_queue.clear_queue()
         self.last_sequence = 0
         systime = self.printer.get_reactor().monotonic()
         print_time = self.mcu.estimated_print_time(systime) + MIN_MSG_TIME
@@ -541,13 +541,13 @@ class Angle:
     def _finish_measurements(self):
         # Halt bulk reading
         self.query_spi_angle_cmd.send_wait_ack([self.oid, 0, 0, 0])
-        self.bulk_queue.clear_samples()
+        self.bulk_queue.clear_queue()
         self.sensor_helper.last_temperature = None
         logging.info("Stopped angle '%s' measurements", self.name)
     def _process_batch(self, eventtime):
         if self.sensor_helper.is_tcode_absolute:
             self.sensor_helper.update_clock()
-        raw_samples = self.bulk_queue.pull_samples()
+        raw_samples = self.bulk_queue.pull_queue()
         if not raw_samples:
             return {}
         samples, error_count = self._extract_samples(raw_samples)

--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -92,11 +92,9 @@ class LDC1612:
         mcu.add_config_cmd("query_ldc1612 oid=%d rest_ticks=0"
                            % (oid,), on_restart=True)
         mcu.register_config_callback(self._build_config)
-        self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, oid=oid)
-        # Clock tracking
+        # Bulk sample message reading
         chip_smooth = self.data_rate * BATCH_UPDATES * 2
-        self.clock_updater = bulk_sensor.ChipClockUpdater(mcu, chip_smooth,
-                                                          ">I")
+        self.ffreader = bulk_sensor.FixedFreqReader(mcu, chip_smooth, ">I")
         self.last_error_count = 0
         # Process messages in batches
         self.batch_bulk = bulk_sensor.BatchBulkHelper(
@@ -110,8 +108,8 @@ class LDC1612:
         cmdqueue = self.i2c.get_command_queue()
         self.query_ldc1612_cmd = self.mcu.lookup_command(
             "query_ldc1612 oid=%c rest_ticks=%u", cq=cmdqueue)
-        self.clock_updater.setup_query_command("query_ldc1612_status oid=%c",
-                                               oid=self.oid, cq=cmdqueue)
+        self.ffreader.setup_query_command("query_ldc1612_status oid=%c",
+                                          oid=self.oid, cq=cmdqueue)
         self.ldc1612_setup_home_cmd = self.mcu.lookup_command(
             "ldc1612_setup_home oid=%c clock=%u threshold=%u"
             " trsync_oid=%c trigger_reason=%c", cq=cmdqueue)
@@ -144,10 +142,7 @@ class LDC1612:
         tclock = self.mcu.clock32_to_clock64(params['trigger_clock'])
         return self.mcu.clock_to_print_time(tclock)
     # Measurement decoding
-    def _extract_samples(self, raw_samples):
-        # Convert messages to samples
-        samples = self.clock_updater.extract_samples(raw_samples)
-        # Convert samples
+    def _convert_samples(self, samples):
         freq_conv = float(LDC1612_FREQ) / (1<<28)
         count = 0
         for ptime, val in samples:
@@ -156,7 +151,6 @@ class LDC1612:
                 self.last_error_count += 1
             samples[count] = (round(ptime, 6), round(freq_conv * mv, 3), 999.9)
             count += 1
-        return samples
     # Start, stop, and process message batches
     def _start_measurements(self):
         # In case of miswiring, testing LDC1612 device ID prevents treating
@@ -180,27 +174,23 @@ class LDC1612:
         self.set_reg(REG_CONFIG, 0x001 | (1<<12) | (1<<10) | (1<<9))
         self.set_reg(REG_DRIVE_CURRENT0, self.dccal.get_drive_current() << 11)
         # Start bulk reading
-        self.bulk_queue.clear_samples()
         rest_ticks = self.mcu.seconds_to_clock(0.5 / self.data_rate)
         self.query_ldc1612_cmd.send([self.oid, rest_ticks])
         logging.info("LDC1612 starting '%s' measurements", self.name)
         # Initialize clock tracking
-        self.clock_updater.note_start()
+        self.ffreader.note_start()
         self.last_error_count = 0
     def _finish_measurements(self):
         # Halt bulk reading
         self.query_ldc1612_cmd.send_wait_ack([self.oid, 0])
-        self.bulk_queue.clear_samples()
+        self.ffreader.note_end()
         logging.info("LDC1612 finished '%s' measurements", self.name)
     def _process_batch(self, eventtime):
-        self.clock_updater.update_clock()
-        raw_samples = self.bulk_queue.pull_samples()
-        if not raw_samples:
-            return {}
-        samples = self._extract_samples(raw_samples)
+        samples = self.ffreader.pull_samples()
+        self._convert_samples(samples)
         if not samples:
             return {}
         if self.calibration is not None:
             self.calibration.apply_calibration(samples)
         return {'data': samples, 'errors': self.last_error_count,
-                'overflows': self.clock_updater.get_last_overflows()}
+                'overflows': self.ffreader.get_last_overflows()}

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -49,11 +49,9 @@ class LIS2DW:
         mcu.add_config_cmd("query_lis2dw oid=%d rest_ticks=0"
                            % (oid,), on_restart=True)
         mcu.register_config_callback(self._build_config)
-        self.bulk_queue = bulk_sensor.BulkDataQueue(mcu, oid=oid)
-        # Clock tracking
+        # Bulk sample message reading
         chip_smooth = self.data_rate * BATCH_UPDATES * 2
-        self.clock_updater = bulk_sensor.ChipClockUpdater(mcu, chip_smooth,
-                                                          "<hhh")
+        self.ffreader = bulk_sensor.FixedFreqReader(mcu, chip_smooth, "<hhh")
         self.last_error_count = 0
         # Process messages in batches
         self.batch_bulk = bulk_sensor.BatchBulkHelper(
@@ -68,8 +66,8 @@ class LIS2DW:
         cmdqueue = self.spi.get_command_queue()
         self.query_lis2dw_cmd = self.mcu.lookup_command(
             "query_lis2dw oid=%c rest_ticks=%u", cq=cmdqueue)
-        self.clock_updater.setup_query_command("query_lis2dw_status oid=%c",
-                                               oid=self.oid, cq=cmdqueue)
+        self.ffreader.setup_query_command("query_lis2dw_status oid=%c",
+                                          oid=self.oid, cq=cmdqueue)
     def read_reg(self, reg):
         params = self.spi.spi_transfer([reg | REG_MOD_READ, 0x00])
         response = bytearray(params['response'])
@@ -88,10 +86,7 @@ class LIS2DW:
         self.batch_bulk.add_client(aqh.handle_batch)
         return aqh
     # Measurement decoding
-    def _extract_samples(self, raw_samples):
-        # Convert messages to samples
-        samples = self.clock_updater.extract_samples(raw_samples)
-        # Convert samples
+    def _convert_samples(self, samples):
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
         count = 0
         for ptime, rx, ry, rz in samples:
@@ -101,7 +96,6 @@ class LIS2DW:
             z = round(raw_xyz[z_pos] * z_scale, 6)
             samples[count] = (round(ptime, 6), x, y, z)
             count += 1
-        return samples
     # Start, stop, and process message batches
     def _start_measurements(self):
         # In case of miswiring, testing LIS2DW device ID prevents treating
@@ -125,31 +119,27 @@ class LIS2DW:
         self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0x94)
 
         # Start bulk reading
-        self.bulk_queue.clear_samples()
         rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
         self.query_lis2dw_cmd.send([self.oid, rest_ticks])
         self.set_reg(REG_LIS2DW_FIFO_CTRL, 0xC0)
         logging.info("LIS2DW starting '%s' measurements", self.name)
         # Initialize clock tracking
-        self.clock_updater.note_start()
+        self.ffreader.note_start()
         self.last_error_count = 0
     def _finish_measurements(self):
         # Halt bulk reading
         self.set_reg(REG_LIS2DW_FIFO_CTRL, 0x00)
         self.query_lis2dw_cmd.send_wait_ack([self.oid, 0])
-        self.bulk_queue.clear_samples()
+        self.ffreader.note_end()
         logging.info("LIS2DW finished '%s' measurements", self.name)
         self.set_reg(REG_LIS2DW_FIFO_CTRL, 0x00)
     def _process_batch(self, eventtime):
-        self.clock_updater.update_clock()
-        raw_samples = self.bulk_queue.pull_samples()
-        if not raw_samples:
-            return {}
-        samples = self._extract_samples(raw_samples)
+        samples = self.ffreader.pull_samples()
+        self._convert_samples(samples)
         if not samples:
             return {}
         return {'data': samples, 'errors': self.last_error_count,
-                'overflows': self.clock_updater.get_last_overflows()}
+                'overflows': self.ffreader.get_last_overflows()}
 
 def load_config(config):
     return LIS2DW(config)

--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -93,40 +93,18 @@ class LIS2DW:
         return aqh
     # Measurement decoding
     def _extract_samples(self, raw_samples):
-        # Load variables to optimize inner loop below
+        # Convert messages to samples
+        samples = self.clock_updater.extract_samples("<hhh", raw_samples)
+        # Convert samples
         (x_pos, x_scale), (y_pos, y_scale), (z_pos, z_scale) = self.axes_map
-        last_sequence = self.clock_updater.get_last_sequence()
-        time_base, chip_base, inv_freq = self.clock_sync.get_time_translation()
-        # Process every message in raw_samples
-        count = seq = 0
-        samples = [None] * (len(raw_samples) * SAMPLES_PER_BLOCK)
-        for params in raw_samples:
-            seq_diff = (params['sequence'] - last_sequence) & 0xffff
-            seq_diff -= (seq_diff & 0x8000) << 1
-            seq = last_sequence + seq_diff
-            d = bytearray(params['data'])
-            msg_cdiff = seq * SAMPLES_PER_BLOCK - chip_base
-
-            for i in range(len(d) // BYTES_PER_SAMPLE):
-                d_xyz = d[i*BYTES_PER_SAMPLE:(i+1)*BYTES_PER_SAMPLE]
-                xlow, xhigh, ylow, yhigh, zlow, zhigh = d_xyz
-                # Merge and perform twos-complement
-
-                rx = (((xhigh << 8) | xlow)) - ((xhigh & 0x80) << 9)
-                ry = (((yhigh << 8) | ylow)) - ((yhigh & 0x80) << 9)
-                rz = (((zhigh << 8) | zlow)) - ((zhigh & 0x80) << 9)
-
-                raw_xyz = (rx, ry, rz)
-
-                x = round(raw_xyz[x_pos] * x_scale, 6)
-                y = round(raw_xyz[y_pos] * y_scale, 6)
-                z = round(raw_xyz[z_pos] * z_scale, 6)
-
-                ptime = round(time_base + (msg_cdiff + i) * inv_freq, 6)
-                samples[count] = (ptime, x, y, z)
-                count += 1
-        self.clock_sync.set_last_chip_clock(seq * SAMPLES_PER_BLOCK + i)
-        del samples[count:]
+        count = 0
+        for ptime, rx, ry, rz in samples:
+            raw_xyz = (rx, ry, rz)
+            x = round(raw_xyz[x_pos] * x_scale, 6)
+            y = round(raw_xyz[y_pos] * y_scale, 6)
+            z = round(raw_xyz[z_pos] * z_scale, 6)
+            samples[count] = (round(ptime, 6), x, y, z)
+            count += 1
         return samples
     # Start, stop, and process message batches
     def _start_measurements(self):


### PR DESCRIPTION
The code to calculate a timestamp for each sample in a bulk_sensor report is complex, and every sensor implementation was performing the calculation.  This PR moves that calculation into the generic ChipClockUpdater class.  This simplifies the sensor specific code.

@garethky - fyi.

-Kevin