### PR TITLE
Fix float inaccuracy when checking for probe movement during probe activate/deactivate gcode

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -328,16 +328,18 @@ class ProbeEndstopWrapper:
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.deactivate_gcode.run_gcode_from_command()
-        if toolhead.get_position()[:3] != start_pos[:3]:
+        if any(abs(a - b) > 1e-6 for a, b in
+               zip(toolhead.get_position()[:3], start_pos[:3])):
             raise self.printer.command_error(
-                "Toolhead moved during probe activate_gcode script")
+                "Toolhead moved during probe deactivate_gcode script")
     def _lower_probe(self):
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.activate_gcode.run_gcode_from_command()
-        if toolhead.get_position()[:3] != start_pos[:3]:
+        if any(abs(a - b) > 1e-6 for a, b in
+               zip(toolhead.get_position()[:3], start_pos[:3])):
             raise self.printer.command_error(
-                "Toolhead moved during probe deactivate_gcode script")
+                f"Toolhead moved during probe activate_gcode script")
     def multi_probe_begin(self):
         if self.stow_on_each_sample:
             return

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -328,18 +328,18 @@ class ProbeEndstopWrapper:
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.deactivate_gcode.run_gcode_from_command()
-        if any(abs(a - b) > 1e-6 for a, b in
-               zip(toolhead.get_position()[:3], start_pos[:3])):
+        position_pairs = zip(toolhead.get_position()[:3], start_pos[:3])
+        if any(abs(a - b) > 1e-6 for a, b in position_pairs):
             raise self.printer.command_error(
                 "Toolhead moved during probe deactivate_gcode script")
     def _lower_probe(self):
         toolhead = self.printer.lookup_object('toolhead')
         start_pos = toolhead.get_position()
         self.activate_gcode.run_gcode_from_command()
-        if any(abs(a - b) > 1e-6 for a, b in
-               zip(toolhead.get_position()[:3], start_pos[:3])):
+        position_pairs = zip(toolhead.get_position()[:3], start_pos[:3])
+        if any(abs(a - b) > 1e-6 for a, b in position_pairs):
             raise self.printer.command_error(
-                f"Toolhead moved during probe activate_gcode script")
+                "Toolhead moved during probe activate_gcode script")
     def multi_probe_begin(self):
         if self.stow_on_each_sample:
             return


### PR DESCRIPTION
This PR allows to move the probe between probing, but ensures that the probe returns to the original position. With the previous approach, any movement will cause float inaccuracy, which triggers the condition. With the fixed approach, the movement is allowed, if the probe goes to its original position at the end of the gcode.
That feature is helpful for some exotic probes (like mine) which require movement between probing.

Also fixed typo.