### PR TITLE
Add new pin set for spi2 on stm32g0 chips

### DIFF
--- a/src/stm32/spi.c
+++ b/src/stm32/spi.c
@@ -12,7 +12,7 @@
 
 struct spi_info {
     SPI_TypeDef *spi;
-    uint8_t miso_pin, mosi_pin, sck_pin, function;
+    uint8_t miso_pin, mosi_pin, sck_pin, miso_af, mosi_af, sck_af;
 };
 
 DECL_ENUMERATION("spi_bus", "spi2", 0);
@@ -21,6 +21,7 @@ DECL_ENUMERATION("spi_bus", "spi1", 1);
 DECL_CONSTANT_STR("BUS_PINS_spi1", "PA6,PA7,PA5");
 DECL_ENUMERATION("spi_bus", "spi1a", 2);
 DECL_CONSTANT_STR("BUS_PINS_spi1a", "PB4,PB5,PB3");
+
 #if CONFIG_MACH_STM32G4
  DECL_ENUMERATION("spi_bus", "spi2_PA10_PA11_PF1", 3);
  DECL_CONSTANT_STR("BUS_PINS_spi2_PA10_PA11_PF1", "PA10,PA11,PF1");
@@ -42,32 +43,43 @@ DECL_CONSTANT_STR("BUS_PINS_spi1a", "PB4,PB5,PB3");
    DECL_CONSTANT_STR("BUS_PINS_spi2b", "PI2,PI3,PI1");
   #endif
  #endif
+ #if CONFIG_MACH_STM32G0B1
+    DECL_ENUMERATION("spi_bus", "spi2_PB2_PB11_PB10", 5);
+    DECL_CONSTANT_STR("BUS_PINS_spi2_PB2_PB11_PB10", "PB2,PB11,PB10");
+#endif
 #endif
 
+#define GPIO_FUNCTION_ALL(fn) GPIO_FUNCTION(fn), \
+    GPIO_FUNCTION(fn), GPIO_FUNCTION(fn)
+
 #if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32G0
- #define SPI_FUNCTION GPIO_FUNCTION(0)
+ #define SPI_FUNCTION_ALL GPIO_FUNCTION_ALL(0)
 #else
- #define SPI_FUNCTION GPIO_FUNCTION(5)
+ #define SPI_FUNCTION_ALL GPIO_FUNCTION_ALL(5)
 #endif
 
 static const struct spi_info spi_bus[] = {
-    { SPI2, GPIO('B', 14), GPIO('B', 15), GPIO('B', 13), SPI_FUNCTION },
-    { SPI1, GPIO('A', 6), GPIO('A', 7), GPIO('A', 5), SPI_FUNCTION },
-    { SPI1, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), SPI_FUNCTION },
+    { SPI2, GPIO('B', 14), GPIO('B', 15), GPIO('B', 13), SPI_FUNCTION_ALL },
+    { SPI1, GPIO('A', 6), GPIO('A', 7), GPIO('A', 5), SPI_FUNCTION_ALL },
+    { SPI1, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), SPI_FUNCTION_ALL },
 #if CONFIG_MACH_STM32G4
-    { SPI2, GPIO('A', 10), GPIO('A', 11), GPIO('F', 1), SPI_FUNCTION },
+    { SPI2, GPIO('A', 10), GPIO('A', 11), GPIO('F', 1), SPI_FUNCTION_ALL },
 #else
-    { SPI2, GPIO('C', 2), GPIO('C', 3), GPIO('B', 10), SPI_FUNCTION },
+    { SPI2, GPIO('C', 2), GPIO('C', 3), GPIO('B', 10), SPI_FUNCTION_ALL },
 #endif
 #ifdef SPI3
-    { SPI3, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), GPIO_FUNCTION(6) },
+    { SPI3, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), GPIO_FUNCTION_ALL(6) },
  #if CONFIG_MACH_STM32F4 || CONFIG_MACH_STM32G4
-    { SPI3, GPIO('C', 11), GPIO('C', 12), GPIO('C', 10), GPIO_FUNCTION(6) },
+    { SPI3, GPIO('C', 11), GPIO('C', 12), GPIO('C', 10), GPIO_FUNCTION_ALL(6) },
   #ifdef SPI4
-    { SPI4, GPIO('E', 13), GPIO('E', 14), GPIO('E', 12), GPIO_FUNCTION(5) },
+    { SPI4, GPIO('E', 13), GPIO('E', 14), GPIO('E', 12), GPIO_FUNCTION_ALL(5) },
   #elif defined(GPIOI)
-    { SPI2, GPIO('I', 2), GPIO('I', 3), GPIO('I', 1), GPIO_FUNCTION(5) },
+    { SPI2, GPIO('I', 2), GPIO('I', 3), GPIO('I', 1), GPIO_FUNCTION_ALL(5) },
   #endif
+ #endif
+ #if CONFIG_MACH_STM32G0B1
+    { SPI2, GPIO('B', 2), GPIO('B', 11), GPIO('B', 10),
+        GPIO_FUNCTION(1), GPIO_FUNCTION(0), GPIO_FUNCTION(5) },
  #endif
 #endif
 };
@@ -82,9 +94,9 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
     SPI_TypeDef *spi = spi_bus[bus].spi;
     if (!is_enabled_pclock((uint32_t)spi)) {
         enable_pclock((uint32_t)spi);
-        gpio_peripheral(spi_bus[bus].miso_pin, spi_bus[bus].function, 1);
-        gpio_peripheral(spi_bus[bus].mosi_pin, spi_bus[bus].function, 0);
-        gpio_peripheral(spi_bus[bus].sck_pin, spi_bus[bus].function, 0);
+        gpio_peripheral(spi_bus[bus].miso_pin, spi_bus[bus].miso_af, 1);
+        gpio_peripheral(spi_bus[bus].mosi_pin, spi_bus[bus].mosi_af, 0);
+        gpio_peripheral(spi_bus[bus].sck_pin, spi_bus[bus].sck_af, 0);
 
         // Configure CR2 on stm32 f0/f7/g0/l4/g4
 #if CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32F7 || \


### PR DESCRIPTION
This is an update to the pasren89 patch for the naming convention of new spi pin sets.
	modified:   src/stm32/spi.c