### PR TITLE
Fix docs typo

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -44,10 +44,9 @@ probe_count: 5, 3
 
 - `mesh_max: 240, 198`\
   _Required_\
-  The probed coordinate farthest from the origin.  This is not
-  necessarily the last point probed, as the probing process occurs in a
-  zig-zag fashion.  As with `mesh_min`, this coordinate is relative to
-  the probe's location.
+  The probed coordinate farthest from the origin.  This is not necessarily
+  the last point probed, as the probing process occurs in a zig-zag fashion.
+  As with `mesh_min`, this coordinate is relative to the probe's location.
 
 - `probe_count: 5, 3`\
   _Default Value: 3, 3_\

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -44,7 +44,7 @@ probe_count: 5, 3
 
 - `mesh_max: 240, 198`\
   _Required_\
-  The probed coordinate farthest farthest from the origin.  This is not
+  The probed coordinate farthest from the origin.  This is not
   necessarily the last point probed, as the probing process occurs in a
   zig-zag fashion.  As with `mesh_min`, this coordinate is relative to
   the probe's location.


### PR DESCRIPTION
Fixed a typo and reformatted the `mesh_max` section in `Bed_Mesh.md`