### PR TITLE
rp2040: fix hang on startup on Twotrees SK1 toolhead board

### DIFF
--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -104,6 +104,12 @@ pll_setup(pll_hw_t *pll, uint32_t mul, uint32_t postdiv)
     pll->prim = ((postdiv1 << PLL_PRIM_POSTDIV1_LSB)
                  | (postdiv2 << PLL_PRIM_POSTDIV2_LSB));
     pll->pwr = PLL_PWR_DSMPD_BITS;
+
+    // Extra wait here. TwoTrees SK1 toolhead board cannot boot normally without these waits.
+    // TODO: find a more elegant way for this waiting loop, maybe wait for some bit (waiting
+    // for pll->cs like the loop above does not seem to work)
+    for(volatile int i=0; i<1000; i++)
+        ;
 }
 
 static void

--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -105,9 +105,10 @@ pll_setup(pll_hw_t *pll, uint32_t mul, uint32_t postdiv)
                  | (postdiv2 << PLL_PRIM_POSTDIV2_LSB));
     pll->pwr = PLL_PWR_DSMPD_BITS;
 
-    // Extra wait here. TwoTrees SK1 toolhead board cannot boot normally without these waits.
-    // TODO: find a more elegant way for this waiting loop, maybe wait for some bit (waiting
-    // for pll->cs like the loop above does not seem to work)
+    // Extra wait here. TwoTrees SK1 toolhead board cannot boot normally without
+    // these waits.
+    // TODO: find a more elegant way for this waiting loop, maybe wait for some
+    // bit (waiting for pll->cs like the loop above does not seem to work)
     for(volatile int i=0; i<1000; i++)
         ;
 }


### PR DESCRIPTION
After upgrading to recent Klipper, the Twotrees SK1 toolhead's microcontroller does not boot normally. In most of the cases it hangs during startup, or falls into HardFault exception.

Using the onboard LED connected to GPIO23, setting it to on/off in different places of the initialization code it was found that the issue happens around configuring the PLLs. Moreover, adding a small delay at the end of pll_setup() function fixes the issue, and the board boots normally.

Notes:
- I understand that adding a raw delay looks suspicious - I am open for ideas how to make this in a more elegant way. In the meantime I tried using udelay() from generic/armcm_timer.c, but it does not compile for rp2040. 
- I also tried to use `while (!(pll->cs & PLL_CS_LOCK_BITS))` similar to the loop above, but it does not fix the issue. 
- I checked with the datasheet, but it does not indicate necessity of any waits here, but adding waits definitely improves the situation.