### PR TITLE
[WIP] Add mSLA capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 out
 *.so
 *.pyc
+.idea
 .config
 .config.old
 klippy/.version

--- a/klippy/extras/framebuffer_display.py
+++ b/klippy/extras/framebuffer_display.py
@@ -1,0 +1,287 @@
+# mSLA and DLP display properties
+#
+# Copyright (C) 2024  Tiago Conceição <tiago_caza@hotmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+import io
+import logging
+import math
+import re
+import os
+import mmap
+import time
+
+from PIL import Image
+import threading
+
+
+class FramebufferDisplay():
+    def __init__(self, config):
+        self.printer = config.get_printer()
+
+        self.model = config.get('model', None)
+        atypes = {'Mono': 'Mono', 'RGB': 'RGB', 'RGBA': 'RGBA'}
+        self.type = config.getchoice('type', atypes, default='Mono')
+        self.framebuffer_index = config.getint('framebuffer_index', minval=0)
+        if not os.path.exists(self.get_framebuffer_path()):
+            msg = f"The frame buffer device {self.get_framebuffer_path()} does not exists."
+            logging.exception(msg)
+            raise config.error(msg)
+
+        self.resolution_x = config.getint('resolution_x', minval=1)  # In pixels
+        self.resolution_y = config.getint('resolution_y', minval=1)  # In pixels
+        self.display_width = config.getfloat('display_width', 0., above=0.)  # In millimeters
+        self.display_height = config.getfloat('display_height', 0., above=0.)  # In millimeters
+        self.pixel_width = config.getfloat('pixel_width', 0., above=0.)  # In millimeters
+        self.pixel_height = config.getfloat('pixel_height', 0., above=0.)  # In millimeters
+
+        if self.display_width == 0. and self.pixel_width == 0.:
+            msg = "Either display_width or pixel_width must be provided."
+            logging.exception(msg)
+            raise config.error(msg)
+
+        if self.display_height == 0. and self.pixel_height == 0.:
+            msg = "Either display_height or pixel_height must be provided."
+            logging.exception(msg)
+            raise config.error(msg)
+
+        if self.display_width == 0.:
+            self.display_width = round(self.resolution_x * self.pixel_width, 4)
+        elif self.pixel_width == 0.:
+            self.pixel_width = round(self.display_width / self.resolution_x, 5)
+
+        if self.display_height == 0.:
+            self.display_height = round(self.resolution_y * self.pixel_height, 4)
+        elif self.pixel_height == 0.:
+            self.pixel_height = round(self.display_height / self.resolution_y, 5)
+
+        # Calculated values
+        self.bit_depth = 8 if self.type == 'Mono' else 24
+        self.is_landscape = self.resolution_x >= self.resolution_y
+        self.is_portrait = not self.is_landscape
+        self.diagonal_inch = round(math.sqrt(self.display_width ** 2 + self.display_height ** 2) / 25.4, 2)
+
+        # get modes width and height
+        with open(f"/sys/class/graphics/fb{self.framebuffer_index}/modes", "r") as f:
+            modes = f.read()
+            match = re.search(r"(\d+)x(\d+)", modes)
+            if match:
+                self.fb_modes_width = int(match.group(1))
+                self.fb_modes_height = int(match.group(2))
+            else:
+                msg = f"Unable to extract \"modes\" information from fame buffer device fb{self.framebuffer_index}."
+                logging.exception(msg)
+                raise config.error(msg)
+
+        # get virtual width and height
+        with open(f"/sys/class/graphics/fb{self.framebuffer_index}/virtual_size", "r") as f:
+            virtual_size = f.read()
+            width_string, height_string = virtual_size.split(',')
+            self.fb_virtual_width = int(width_string)  # width
+            self.fb_virtual_height = int(height_string)  # height
+
+        # get stride
+        with open(f"/sys/class/graphics/fb{self.framebuffer_index}/stride", "r") as f:
+            self.fb_stride = int(f.read())
+
+        # get bits per pixel
+        with open(f"/sys/class/graphics/fb{self.framebuffer_index}/bits_per_pixel", "r") as f:
+            self.fb_bits_per_pixel = int(f.read())
+
+        # Check if configured resolutions match framebuffer information
+        if self.resolution_x not in (self.fb_stride, self.fb_modes_width):
+            msg = f"The configured resolution_x of {self.resolution_x} does not match any of the framebuffer stride of ({self.fb_stride}) nor the modes of ({self.fb_modes_width})."
+            logging.exception(msg)
+            raise config.error(msg)
+        if self.resolution_y != self.fb_modes_height:
+            msg = f"The configured resolution_y of {self.resolution_y} does not match the framebuffer modes of ({self.fb_modes_height})."
+            logging.exception(msg)
+            raise config.error(msg)
+
+        self.fb_maxsize = self.fb_stride * self.fb_modes_height
+
+        # Defines the current thread that hold the display session to the framebuffer
+        self._framebuffer_thread = None
+        self.is_busy = False
+
+    def get_framebuffer_path(self) -> str:
+        """
+        Gets the framebuffer device path associated with this object.
+        @return: /dev/fb[i]
+        """
+        return f"/dev/fb{self.framebuffer_index}"
+
+    def wait_framebuffer_thread(self, timeout=None):
+        """
+        Wait for the framebuffer thread to terminate (Finish writes).
+        @param timeout: Timeout time to wait for framebuffer thread to terminate.
+        """
+        if self._framebuffer_thread is not None and self._framebuffer_thread.is_alive():
+            self._framebuffer_thread.join(timeout)  # Wait for other render completion
+
+    def get_image_buffer(self, path) -> bytes:
+        """
+        Reads an image from disk and return it buffer, ready to send.
+        Note that it does not do any file check, it will always try to open an image file.
+        @param path: Image path
+        @return: bytes buffer
+        """
+        with Image.open(path) as img:
+            return img.tobytes()
+
+    def clear_framebuffer(self):
+        """
+        Clears the display with zeros (black background).
+        """
+        self.is_busy = True
+        with open(self.get_framebuffer_path(), mode='r+b') as framebuffer_device:  # open R/W
+            with mmap.mmap(framebuffer_device.fileno(), self.fb_stride * self.fb_modes_height, mmap.MAP_SHARED,
+                           mmap.PROT_WRITE | mmap.PROT_READ) as framebuffer_memory_map:
+                color = 0
+                framebuffer_memory_map.write(color.to_bytes(1, byteorder='little') * self.fb_maxsize)
+        self.is_busy = False
+
+    def clear_framebuffer_threaded(self, wait_thread=False):
+        """
+        Wait for the framebuffer thread to terminate (Finish writes).
+        @param wait_thread: Wait for the framebuffer thread to terminate.
+        """
+        self.wait_framebuffer_thread()
+        self._framebuffer_thread = threading.Thread(target=self.clear_framebuffer,
+                                                    name=f"Clears the fb{self.framebuffer_index}")
+        self._framebuffer_thread.start()
+        if wait_thread:
+            self._framebuffer_thread.join()
+
+    def send_buffer(self, buffer, clear_first=False, offset=0):
+        """
+        Send a byte array to the framebuffer device.
+        @param buffer: A 1D byte array with data to send
+        @param clear_first: If true first clears the display and then show the image.
+        @param offset: Sets a positive offset from start position of the buffer.
+        """
+        if buffer is None or len(buffer) == 0:
+            return
+
+        if not isinstance(buffer, (list, bytes)):
+            msg = f"The buffer must be a 1D byte array. {type(buffer)} was passed"
+            logging.exception(msg)
+            raise Exception(msg)
+
+        if offset < 0:
+            msg = f"The offset {offset} can not be negative value."
+            logging.exception(msg)
+            raise Exception(msg)
+
+        # open framebuffer and map it onto a python bytearray
+        self.is_busy = True
+        with open(self.get_framebuffer_path(), mode='r+b') as framebuffer_device:  # open R/W
+            with mmap.mmap(framebuffer_device.fileno(), self.fb_stride * self.fb_modes_height, mmap.MAP_SHARED,
+                           mmap.PROT_WRITE | mmap.PROT_READ) as framebuffer_memory_map:
+                if clear_first:
+                    color = 0
+                    framebuffer_memory_map.write(color.to_bytes(1, byteorder='little') * self.fb_maxsize)
+
+                buffer_size = len(buffer)
+                if buffer_size + offset > self.fb_maxsize:
+                    msg = f"The buffer size of {buffer_size} + {offset} is larger than actual framebuffer size of {self.fb_maxsize}."
+                    logging.exception(msg)
+                    raise Exception(msg)
+
+                if offset > 0:
+                    framebuffer_memory_map.seek(offset)
+
+                framebuffer_memory_map.write(buffer)
+        self.is_busy = False
+
+    def send_buffer_threaded(self, buffer, clear_first=False, offset=0, wait_thread=False):
+        """
+        Send a byte array to the framebuffer device in a separate thread.
+        @param buffer: A 1D byte array with data to send
+        @param clear_first: If true first clears the display and then show the image.
+        @param offset: Sets a positive offset from start position of the buffer.
+        @param wait_thread: If true wait for the framebuffer thread to terminate
+        """
+        self.wait_framebuffer_thread()
+        self._framebuffer_thread = threading.Thread(target=lambda: self.send_buffer(buffer, clear_first, offset),
+                                                    name=f"Sends an buffer to fb{self.framebuffer_index}")
+        self._framebuffer_thread.start()
+        if wait_thread:
+            self._framebuffer_thread.join()
+
+    def send_image(self, path, clear_first=False, offset=0):
+        """
+        Reads an image from a path and sends the bitmap to the framebuffer device.
+        @param path: Image file path to be read.
+        @param clear_first: If true first clears the display and then show the image.
+        @param offset: Sets a positive offset from start position of the buffer.
+        """
+        if offset < 0:
+            msg = f"The offset {offset} can not be negative value."
+            logging.exception(msg)
+            raise Exception(msg)
+
+        if not isinstance(path, str):
+            msg = f"Path must be a string."
+            logging.exception(msg)
+            raise Exception(msg)
+
+        if not os.path.isfile(path):
+            msg = f"The file '{path}' does not exists."
+            logging.exception(msg)
+            raise Exception(msg)
+
+        self.is_busy = True
+        buffer = self.get_image_buffer(path)
+        self.send_buffer(buffer, clear_first, offset)
+
+    def send_image_threaded(self, path, clear_first=False, offset=0, wait_thread=False):
+        """
+        Reads an image from a path and sends the bitmap to the framebuffer device.
+        @param path: Image file path to be read.
+        @param clear_first: If true first clears the display and then show the image.
+        @param offset: Sets a positive offset from start position of the buffer.
+        @param wait_thread: If true wait for the framebuffer thread to terminate.
+        """
+        self.wait_framebuffer_thread()
+        self._framebuffer_thread = threading.Thread(target=lambda: self.send_image(path, clear_first, offset),
+                                                    name=f"Render an image to fb{self.framebuffer_index}")
+        self._framebuffer_thread.start()
+        if wait_thread:
+            self._framebuffer_thread.join()
+
+
+class FramebufferDisplayWrapper(FramebufferDisplay):
+    def __init__(self, config):
+        super().__init__(config)
+
+        device_name = config.get_name().split()[1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("FRAMEBUFFER_CLEAR", "DEVICE", device_name, self.cmd_FRAMEBUFFER_CLEAR,
+                                   desc=self.cmd_FRAMEBUFFER_CLEAR_help)
+        gcode.register_mux_command("FRAMEBUFFER_SEND_IMAGE", "DEVICE", device_name, self.cmd_FRAMEBUFFER_SEND_IMAGE,
+                                   desc=self.cmd_FRAMEBUFFER_SEND_IMAGE_help)
+
+
+    cmd_FRAMEBUFFER_CLEAR_help = "Clears the display with zeros (black background)"
+    def cmd_FRAMEBUFFER_CLEAR(self, gcmd):
+        wait_thread = gcmd.get_int('WAIT', 0, 0, 1)
+
+        self.clear_framebuffer_threaded(wait_thread)
+
+    cmd_FRAMEBUFFER_SEND_IMAGE_help = "Send a image from a path and display it on the framebuffer."
+    def cmd_FRAMEBUFFER_SEND_IMAGE(self, gcmd):
+        path = gcmd.get('PATH')
+        offset = gcmd.get_int('OFFSET', 0, 0)
+        clear_first = gcmd.get_int('CLEAR', 0, 0, 1)
+        wait_thread = gcmd.get_int('WAIT', 0, 0, 1)
+
+        if not os.path.isfile(path):
+            raise gcmd.error(f"The file '{path}' does not exists.")
+
+        self.send_image_threaded(path, clear_first, offset, wait_thread)
+
+
+def load_config_prefix(config):
+    return FramebufferDisplayWrapper(config)

--- a/klippy/extras/msla_display.py
+++ b/klippy/extras/msla_display.py
@@ -1,0 +1,266 @@
+# mSLA and DLP display properties
+#
+# Copyright (C) 2024  Tiago Conceição <tiago_caza@hotmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+
+import logging
+import os
+import re
+import threading
+import time
+import tempfile
+from pathlib import Path
+from PIL import Image
+from . import framebuffer_display
+
+CACHE_MIN_FREE_RAM = 256  # 256 MB
+
+
+class mSLADisplay(framebuffer_display.FramebufferDisplay):
+    """
+    Represents an mSLA display with an associated UV LED
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.buffer_cache_count = config.getint('cache', 0, 0, 100)
+
+        # RAM guard
+        if self.buffer_cache_count > 0 and os.path.isfile('/proc/meminfo'):
+            with open('/proc/meminfo', 'r') as mem:
+                for i in mem:
+                    sline = i.split()
+                    if str(sline[0]) == 'MemFree:':
+                        free_memory_mb = int(sline[1]) / 1024.
+                        buffer_max_size = (self.buffer_cache_count + 1) * self.fb_maxsize / 1024. / 1024.
+                        if free_memory_mb - buffer_max_size < CACHE_MIN_FREE_RAM:
+                            msg = ("The current cache count of %d requires %.2f MB of RAM, currently have %.2f MB of "
+                                   "free memory. It requires at least a margin of %.2f MB of free RAM.\n"
+                                   "Please reduce the cache count.") % (
+                                  self.buffer_cache_count, buffer_max_size, free_memory_mb, CACHE_MIN_FREE_RAM)
+                            logging.exception(msg)
+                            raise config.error(msg)
+                        break
+
+        self._cache = []
+        self._cache_thread = None
+
+        self.uvled_output_pin_name = config.get('uvled_output_pin_name', 'msla_uvled')
+        self.uvled = self.printer.lookup_object(f"output_pin {self.uvled_output_pin_name}")
+
+        self._sd = self.printer.lookup_object("virtual_sdcard")
+
+        # Events
+        self.printer.register_event_handler("virtual_sdcard:reset_file", self.clear_cache)
+
+        # Register commands
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_command("MSLA_DISPLAY_CLEAR", self.cmd_MSLA_DISPLAY_CLEAR,
+                               desc=self.cmd_MSLA_DISPLAY_CLEAR_help)
+        gcode.register_command("MSLA_DISPLAY_IMAGE", self.cmd_MSLA_DISPLAY_IMAGE,
+                               desc=self.cmd_MSLA_DISPLAY_IMAGE_help)
+        gcode.register_command("MSLA_DISPLAY_RESPONSE_TIME", self.cmd_MSLA_DISPLAY_RESPONSE_TIME,
+                               desc=self.cmd_MSLA_DISPLAY_RESPONSE_TIME_help)
+
+        gcode.register_command('M1400', self.cmd_M1400, desc=self.cmd_M1400_help)
+
+    def get_status(self, eventtime):
+        return {'display_busy': self.is_busy,
+                'uvled_value': self.uvled.last_value * 255.}
+
+    def clear_cache(self):
+        """
+        Clear all cached buffers
+        """
+        self._cache.clear()
+
+    def _can_cache(self) -> bool:
+        """
+        Returns true if is ready to cache
+        @rtype: bool
+        """
+        return self.buffer_cache_count > 0 and (self._cache_thread is None or not self._cache_thread.is_alive())
+
+    def _wait_cache_thread(self) -> bool:
+        """
+        Waits for cache thread completion
+        @rtype: bool
+        @return: True if waited, otherwise false
+        """
+        if self._cache_thread is not None and self._cache_thread.is_alive():
+            self._cache_thread.join()
+            return True
+        return False
+
+    def _process_cache(self, last_cache):
+        """
+        Cache next items from last cache position.
+        @param last_cache:
+        """
+        # Dequeue items
+        while len(self._cache) >= self.buffer_cache_count:
+            self._cache.pop(0)
+
+        cache_len = len(self._cache)
+        if cache_len:
+            last_cache = self._cache[-1]
+
+        # Cache new items
+        item_count = self.buffer_cache_count - cache_len
+        layer_index = last_cache.get_layer_index()
+        for i in range(item_count):
+            layer_index += 1
+            new_path = last_cache.new_path_layerindex(layer_index)
+            if os.path.isfile(new_path):
+                buffer = self.get_image_buffer(new_path)
+                self._cache.append(BufferCache(new_path, buffer))
+
+    def _get_cache_index(self, path) -> int:
+        """
+        Gets the index of the cache position on the list given a path
+        @param path: Path to seek
+        @return: Index of the cache on the list, otherwise -1
+        """
+        for i, cache in enumerate(self._cache):
+            if cache.path == path:
+                return i
+        return -1
+
+    def _get_image_buffercache(self, gcmd, path) -> bytes:
+        """
+        Gets a image buffer from cache if available, otherwise it creates the buffer from the path image
+        @param gcmd:
+        @param path: Image path
+        @return: Image buffer
+        """
+        # If currently printing, use print directory to select the file
+        current_filepath = self._sd.file_path()
+        if current_filepath is not None and path[0] != '/':
+            path = os.path.join(os.path.dirname(current_filepath), path)
+            if not os.path.isfile(path):
+                raise gcmd.error(f"M1400: The file '{path}' does not exists.")
+
+            if self.buffer_cache_count > 0:
+                self._wait_cache_thread()  # May be worth to wait if streaming images
+                i = self._get_cache_index(path)
+                #gcmd.respond_raw(f"File in cache: {i}, cache size: {len(self._cache)}, Can cache: {self._can_cache()}")
+                if i >= 0:
+                    cache = self._cache[i]
+                    # RTrim up to cache
+                    self._cache = self._cache[i + 1:]
+
+                    if self._can_cache():
+                        self._cache_thread = threading.Thread(target=self._process_cache, args=(cache,))
+                        self._cache_thread.start()
+
+                    return cache.buffer
+
+        if not os.path.isfile(path):
+            raise gcmd.error(f"M1400: The file '{path}' does not exists.")
+
+        buffer = self.get_image_buffer(path)
+        if self._can_cache():
+            cache = BufferCache(path, buffer)
+            self._cache_thread = threading.Thread(target=self._process_cache, args=(cache,))
+            self._cache_thread.start()
+
+        return buffer
+
+    cmd_MSLA_DISPLAY_CLEAR_help = "Clears the display by send a full buffer of zeros."
+
+    def cmd_MSLA_DISPLAY_CLEAR(self, gcmd):
+        wait_thread = gcmd.get_int('WAIT', 0, 0, 1)
+        self.clear_framebuffer_threaded(wait_thread)
+
+    cmd_MSLA_DISPLAY_IMAGE_help = "Sends a image from a path and display it on the main display."
+
+    def cmd_MSLA_DISPLAY_IMAGE(self, gcmd):
+        path = gcmd.get('PATH')
+        clear_first = gcmd.get_int('CLEAR', 0, 0, 1)
+        offset = gcmd.get_int('OFFSET', 0, 0)
+        wait_thread = gcmd.get_int('WAIT', 0, 0, 1)
+        path = os.path.normpath(os.path.expanduser(path))
+
+        times = time.time()
+        buffer = self._get_image_buffercache(gcmd, path)
+        self.send_buffer_threaded(buffer, clear_first, offset, wait_thread)
+        gcmd.respond_raw("Get/cache buffer: %.2f ms" % ((time.time() - times) * 1000.,))
+
+    cmd_MSLA_DISPLAY_RESPONSE_TIME_help = "Send a buffer to display and test it response time to fill that buffer."
+
+    def cmd_MSLA_DISPLAY_RESPONSE_TIME(self, gcmd):
+        avg = gcmd.get_int('AVG', 1, 1, 20)
+
+        gcmd.respond_raw(
+            'Buffer size: %d bytes (%.2f MB)' % (self.fb_maxsize, round(self.fb_maxsize / 1024.0 / 1024.0, 2)))
+
+        time_sum = 0
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'buffer.png')
+            with Image.new('L', (self.resolution_x, self.resolution_y), color='black') as image:
+                image.save(path, "PNG")
+            for _ in range(avg):
+                timems = time.time()
+                self.send_image(path)
+                time_sum += time.time() - timems
+        gcmd.respond_raw('Read image from disk + send time: %fms (%d samples)' % (round(time_sum * 1000 / avg, 6), avg))
+
+        time_sum = 0
+        buffer = bytes(os.urandom(self.fb_maxsize))
+        for _ in range(avg):
+            timems = time.time()
+            self.send_buffer(buffer)
+            time_sum += time.time() - timems
+        gcmd.respond_raw('Send cached buffer: %fms (%d samples)' % (round(time_sum * 1000 / avg, 6), avg))
+
+        time_sum = 0
+        for _ in range(avg):
+            timems = time.time()
+            self.clear_framebuffer()
+            time_sum += time.time() - timems
+        gcmd.respond_raw('Clear time: %fms (%d samples)' % (round(time_sum * 1000 / avg, 6), avg))
+
+    cmd_M1400_help = "Turn the main UV LED to cure the pixels."
+
+    def cmd_M1400(self, gcmd):
+        """
+        Turn the main UV LED to cure the pixels.
+        M1400 comes from the wavelength of UV radiation (UVR) lies in the range of 100–400 nm,
+        and is further subdivided into UVA (315–400 nm), UVB (280–315 nm), and UVC (100–280 nm).
+        @param gcmd:
+        """
+        value = gcmd.get_float('S', minval=0., maxval=255.)
+        if self.uvled.is_pwm:
+            value /= 255.0
+        else:
+            value = 1 if value else 0
+
+        if value > 0:
+            # Sync display
+            self.wait_framebuffer_thread()
+
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_lookahead_callback(lambda print_time: self.uvled._set_pin(print_time, value))
+
+
+class BufferCache():
+    def __init__(self, path, buffer):
+        self.path = path
+        self.buffer = buffer
+        self.pathinfo = Path(path)
+
+    def new_path_layerindex(self, n):
+        return re.sub(rf"\d+\{self.pathinfo.suffix}$", f"{n}{self.pathinfo.suffix}", self.path)
+
+    def get_layer_index(self):
+        match = re.search(rf"(\d+)\{self.pathinfo.suffix}$", self.path)
+        if match is None:
+            return None
+
+        return int(match.group(1))
+
+
+def load_config(config):
+    return mSLADisplay(config)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -4,14 +4,20 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, sys, logging, io
+import hashlib, shutil
+import zipfile, tarfile
+import time
 
 VALID_GCODE_EXTS = ['gcode', 'g', 'gco']
+VALID_ARCHIVE_EXTS = ['zip', 'tar']
 
 DEFAULT_ERROR_GCODE = """
 {% if 'heaters' in printer %}
    TURN_OFF_HEATERS
 {% endif %}
 """
+
+DEFAULT_ARCHIVE_HASH_FILENAME = 'hash.md5'
 
 class VirtualSD:
     def __init__(self, config):
@@ -21,6 +27,13 @@ class VirtualSD:
         # sdcard state
         sd = config.get('path')
         self.sdcard_dirname = os.path.normpath(os.path.expanduser(sd))
+
+        archive_temp_path = os.path.join(os.sep, 'tmp', 'klipper-archive-print-contents')
+        if self.sdcard_dirname.count(os.sep) >= 3:
+            archive_temp_path = os.path.normpath(os.path.expanduser(os.path.join(self.sdcard_dirname, '..', 'tmparchive')))
+
+        archive_temp_path = config.get('archive_temp_path', archive_temp_path)
+        self.sdcard_archive_temp_dirname = os.path.normpath(os.path.expanduser(archive_temp_path))
         self.current_file = None
         self.file_position = self.file_size = 0
         # Print Stat Tracking
@@ -64,6 +77,20 @@ class VirtualSD:
         if self.work_timer is None:
             return False, ""
         return True, "sd_pos=%d" % (self.file_position,)
+    def get_archive_files(self, path):
+        if path.endswith('.zip'):
+            try:
+                with zipfile.ZipFile(path, "r") as file:
+                    return file.namelist()
+            except:
+                pass
+        elif path.endswith('.tar'):
+            try:
+                with tarfile.open(path, "r") as file:
+                    return file.getnames()
+            except:
+                pass
+        return []
     def get_file_list(self, check_subdirs=False):
         if check_subdirs:
             flist = []
@@ -71,10 +98,24 @@ class VirtualSD:
                     self.sdcard_dirname, followlinks=True):
                 for name in files:
                     ext = name[name.rfind('.')+1:]
-                    if ext not in VALID_GCODE_EXTS:
+                    if ext not in VALID_GCODE_EXTS + VALID_ARCHIVE_EXTS:
                         continue
+
                     full_path = os.path.join(root, name)
                     r_path = full_path[len(self.sdcard_dirname) + 1:]
+
+                    if ext in VALID_ARCHIVE_EXTS:
+                        entries = self.get_archive_files(full_path)
+
+                        # Support only 1 gcode file as if theres more we unable to guess what to print
+                        count = 0
+                        for entry in entries:
+                            entry_ext = entry[entry.rfind('.') + 1:]
+                            if entry_ext in VALID_GCODE_EXTS:
+                                count += 1
+                        if count != 1:
+                            continue
+
                     size = os.path.getsize(full_path)
                     flist.append((r_path, size))
             return sorted(flist, key=lambda f: f[0].lower())
@@ -182,11 +223,68 @@ class VirtualSD:
         try:
             if fname not in flist:
                 fname = files_by_lower[fname.lower()]
-            fname = os.path.join(self.sdcard_dirname, fname)
+
+            ext = fname[fname.rfind('.') + 1:]
+            if ext in VALID_ARCHIVE_EXTS:
+                need_extract = True
+                hashfile = os.path.join(self.sdcard_archive_temp_dirname, DEFAULT_ARCHIVE_HASH_FILENAME)
+
+                gcmd.respond_raw(f"Calculating {fname} hash")
+                hash = self._file_hash(os.path.join(self.sdcard_dirname, fname))
+
+                if os.path.isfile(hashfile):
+                    with open(hashfile, 'r') as f:
+                        found_hash = f.readline()
+                        if len(found_hash) == 32:
+                            if hash == found_hash:
+                                need_extract = False
+
+                if ext == 'zip':
+                    with zipfile.ZipFile(os.path.join(self.sdcard_dirname, fname), "r") as zip_file:
+                        if need_extract:
+                            if os.path.isdir(self.sdcard_archive_temp_dirname):
+                                shutil.rmtree(self.sdcard_archive_temp_dirname)
+                            gcmd.respond_raw(f"Decompressing {fname}...")
+                            timenow = time.time()
+                            zip_file.extractall(self.sdcard_archive_temp_dirname)
+                            timenow = time.time() - timenow
+                            gcmd.respond_raw(f"Decompress done in {timenow:.2f} seconds")
+                            with open(hashfile, 'w') as f:
+                                f.write(hash)
+
+                        entries = zip_file.namelist()
+                        for entry in entries:
+                            entry_ext = entry[entry.rfind('.') + 1:]
+                            if entry_ext in VALID_GCODE_EXTS:
+                                fname = os.path.join(os.path.join(self.sdcard_archive_temp_dirname, entry))
+                                break
+                elif ext == 'tar':
+                    with tarfile.open(os.path.join(self.sdcard_dirname, fname), "r") as tar_file:
+                        if need_extract:
+                            if os.path.isdir(self.sdcard_archive_temp_dirname):
+                                shutil.rmtree(self.sdcard_archive_temp_dirname)
+                            gcmd.respond_raw(f"Decompressing {fname}...")
+                            timenow = time.time()
+                            tar_file.extractall(self.sdcard_archive_temp_dirname)
+                            timenow = time.time() - timenow
+                            gcmd.respond_raw(f"Decompress done in {timenow:.2f} seconds")
+                            with open(hashfile, 'w') as f:
+                                f.write(hash)
+
+                        entries = tar_file.getnames()
+                        for entry in entries:
+                            entry_ext = entry[entry.rfind('.') + 1:]
+                            if entry_ext in VALID_GCODE_EXTS:
+                                fname = os.path.join(os.path.join(self.sdcard_archive_temp_dirname, entry))
+                                break
+            else:
+                fname = os.path.join(self.sdcard_dirname, fname)
+
             f = io.open(fname, 'r', newline='')
             f.seek(0, os.SEEK_END)
             fsize = f.tell()
             f.seek(0)
+
         except:
             logging.exception("virtual_sdcard file open")
             raise gcmd.error("Unable to open file")
@@ -303,6 +401,15 @@ class VirtualSD:
         else:
             self.print_stats.note_complete()
         return self.reactor.NEVER
+    def _file_hash(self, filepath, block_size=2**20) -> str:
+        md5 = hashlib.md5()
+        with open(filepath, "rb") as f:
+            while True:
+                data = f.read(block_size)
+                if not data:
+                    break
+                md5.update(data)
+            return md5.hexdigest()
 
 def load_config(config):
     return VirtualSD(config)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -214,6 +214,18 @@ class ToolHead:
         self.lookahead = LookAheadQueue(self)
         self.lookahead.set_flush_time(BUFFER_TIME_HIGH)
         self.commanded_pos = [0., 0., 0., 0.]
+        # The manufacturing process type
+        atypes = {'FDM': 'FDM', 'SLA': 'SLA', 'mSLA': 'mSLA', 'DLP': 'DLP'}
+        self.manufacturing_process = config.getchoice('manufacturing_process', atypes, default='FDM')
+
+        if self.manufacturing_process in ('mSLA', 'DLP'):
+            for s in ('output_pin msla_uvled', 'msla_display'):
+                section = self.printer.lookup_object(s, None)
+                if section is None:
+                    msg = "Error: A section with [%s] is required for mSLA/DLP printers." % (s,)
+                    logging.exception(msg)
+                    raise config.error(msg)
+
         # Velocity and acceleration control
         self.max_velocity = config.getfloat('max_velocity', above=0.)
         self.max_accel = config.getfloat('max_accel', above=0.)
@@ -282,6 +294,11 @@ class ToolHead:
                                self.cmd_SET_VELOCITY_LIMIT,
                                desc=self.cmd_SET_VELOCITY_LIMIT_help)
         gcode.register_command('M204', self.cmd_M204)
+
+        gcode.register_command('QUERY_MANUFACTORING_PROCESS', self.cmd_QUERY_MANUFACTORING_PROCESS,
+                               desc="Query manufacturing process")
+
+
         self.printer.register_event_handler("klippy:shutdown",
                                             self._handle_shutdown)
         # Load some default modules
@@ -664,6 +681,14 @@ class ToolHead:
             accel = min(p, t)
         self.max_accel = accel
         self._calc_junction_deviation()
+
+    def cmd_QUERY_MANUFACTORING_PROCESS(self, gcmd):
+        """
+        Returns the manufacturing process
+        @param gcmd:
+        """
+        gcmd.respond_raw(self.manufacturing_process)
+
 
 def add_printer_objects(config):
     config.get_printer().add_object('toolhead', ToolHead(config))

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -9,3 +9,4 @@ greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1
+pillow


### PR DESCRIPTION
# Background

I'm the creator of [UVtools](https://github.com/sn4k3/UVtools), a software dedicated to help and make resin printing sane (mSLA/DLP) with tons of manipulations and checks.  

From past 4 years I'm amazed with the fact that mSLA is far behind FDM in slicing features (In fact I could not believe 4 years ago that mSLA was not gcoded and open like FDM). We are very limited to static file formats that only follow a structure with few or none options. The existing gcode printers in this technology can be counted by hand and the ones that exists suffer from bugs or bad performance.

The bad firmwares are ruining the printers "completely", they never listen to community, never fix bugs that in a normal case takes just 1 day to fix and send the patch firmware online. They really don't care, they just fold the market with models and models of machines that many are very decent on it hardware but the firmware make them a crap machine.
Companies right now are tied to one or two solutions, which are always locking formats and make the best effort to encrypt and make sure no others can be used. 

Myself got asked by a board company what could be done to improve the eco-system. I tell them: Well, make the format open-source and run over gcode... A: That's not possible, our hardware is not capable, parse gcode is very hard, run png's is not possible, not economical, can't be made open-source, bla bla bla. All runaround.
The fact is that now they have 4GB boards running linux, is load png still too hard? Is gcode still not possible? 🤦

Then big promises came, open-source boards and format. Guess what? They call themself open-source by just having a repo in github with just a few documentation on the format, which even with the docs we are unsure about the meaning of some fields... 

Lies, promises, bad products, and more lies... This is a loop in mSLA.

This crappy mindset are ruining the technology and the overall experience. Myself I don't active do nor like resin printing, but I can't just see this and doing nothing when I have to power to change the situation! That lead me to this PR.

# What is required run mSLA?

mSLA only need one Z axis, feed image to a screen and lit a UV LED over it. Looping layer by layer and forming a solid piece from cured resin from the lit pixels.
FDM is far more complex to build because it motion system. So now you see another point here, why such simple tech is soo hard to implement? The answer is: Drive the displays! Most displays are held, no datasheets no information how to drive it, require custom FPC = custom board.
However today most LCDs are HDMI! And you guess it, plug HDMI to PC and send image. Easy!

# Why Klipper?

I have been told: Why klipper for that? Thats OP for what you want.
I can't disagree more!

- I'm a FDM user, I know marlin and klipper and used both. Klipper is very solid and flexible, easy to configure and tune, "no compilation required", well documented, very strong, plugin based, good interfaces, etc.
- We still need an computer (Pi) because we need to drive the display (4k, 8k, 12k). So why not merge a good Pi and Klipper and have the best of two worlds?
- Gcode! --> We really need this (Different cure times for supports, better tests, variable layer, dynamic lifts, etc, etc.)
- People can now convert their HDMI printer into something much better and dump horrible boards and firmwares
- People can start to configure their heaters and fans
- People can start to configure their cameras and having timelapses
- People can start to configure their lame RGB leds
- People can start to monitor their printer
- New sensors and improved hardware with new capabilities
- Remote management
- More time and confidence
- (More could be written, but each user can find it own needs on this)

So is Klipper OP for this!? NO! It's just perfect!

Also I think it's time for klipper to embrace other manufacturing processes, it's a win-win and will make klipper richer in capabilities and features.

# Hardware

Right now I'm using:

- BTT Manta M5P + Pi CM4 4gb
- UNIZ IBEE printer with all it hardware

# The PR / Implementation

Note that I mark this PR as a draft because I wan't it to be review, it's my first time dealing with klipper sources. In fact I did what most said impossible in just 3 days but had my printer displaying the image using klipper in just one day. This alone means klipper perfect :)
So forgive-me If something is not soo well defined.

# GCode sample:

```
MSLA_DISPLAY_VALIDATE RESOLUTION=3840,2400 PIXEL=0.05,0.050

G21;
G90;
M17;
M1400 S0;
G28 Z0;
M106 S255

M6054 F"1.png"; Render image into display (LED is OFF)
G0 Z7.1 F800;
G0 Z0.1 F1000;
G4 P3000;
M1400 S255 ; Turn LED ON, if image not render yet, it waits before turn ON for completion
G4 P4000;
M1400 S0;
G4 P3000;

M6054 F"2.png";
G0 Z7.2 F800;
G0 Z0.2 F1000;
G4 P3000;
M1400 S255
G4 P4000;
M1400 S0;
G4 P3000;
...
```

## Image display

The displays are now connected via HDMI on the Pi.
Pi itself let us configure the framebuffer (config.txt) to match the display. So all we need is set correct parameters there.
After I created a **[framebuffer_display]** module into klipper. Which allow us to configure any framebuffer and send buffers/images over there. See **framebuffer_display.py**
I created to be generic and mux, so some may use it for other displays and send pics to a HDMI display.
All code is python and it direct address the framebuffer without any external dependencies.

From that I created the **[msla_display]** which is the keypoint

eg:
```
[msla_display]
type: Mono
model: TM089CFSP01
framebuffer_index: 0
resolution_x: 3840
resolution_y: 2400
pixel_width: 0.05
pixel_height: 0.05
cache: 1
uvled_output_pin_name: msla_uvled
```

`type`, `model` are just information, not actually used.
All other parameters are used to have sane checks but also provide information about the display which is required.
the `cache` parameter is a smart-feature to cache next layers so buffer is much more fast to send when time comes.

The most smart approach to exposure an layer is:

1. UV led is OFF, start starts
2. Display image
3. Do lift/rectract and/or wait times
4. Turn on UV LED

In my implementation before UV LED is turn on, it waits for image buffer send to be completed. A smart feature that most of gcode printers does not have, they never know when buffer is actually completed, in consequence UV LED can be lit before image is present. I really can't understand why, why so hard to make it right?
With cache system and direct buffers I manage fast speeds on transfers, not that we really need them, because they way mSLA works with lifts and waits make time to image to complete (In most cases).

Here the results of an 4K buffer, sampled and avg 10 times:

```
Clear time: 10.389328ms (10 samples)
Send cached buffer: 6.993413ms (10 samples)
Read image from disk + send time: 98.335290ms (10 samples)
Buffer size: 9216000 bytes (8.79 MB)
MSLA_DISPLAY_RESPONSE_TIME AVG=10
```

So in normal conditions if image is load from disk it took about 100ms, but if cached it took 7ms to be rendered to the display. Pretty good.

Some gcode commands where created to: 

- Clear the display (M6054)
- Send image to the display (M6054 F"file.png")
  - When printer is printing, partial path always start at gcode basedir
- Measure display times
- Control the UV LED (M1400 S0-255) 

**M6054:** Command used by other gcode printers to display the image
**M1400:** Because UV wavelength goes from 100nm-400nm

Commands are debatable, we should set an standard now.

## [virtual_sdcard]

The mSLA requires an image per layer. Some users prints can go up to 4000 layers. Upload folders is a bit messy, the format I think is best it's the Zip file (pngs + gcode)
I had to alter the **virtual_sdcard.py** with some features:

- Accept zip and tar files, it will analyze them, if they have one gcode file, they got decompressed and selected to be printed.
- Archieve is decompressed to a folder other than "gcodes" to not show on file manager. They are extracted to a folder selectable by user, see **sdcard_archive_temp_dirname**. If same file is printed it compare the hash, if equal no need to extract again. On a different hash it will then remove folder and extract new contents.
- This also means, a zip with a gcode is now printable

## [toolhead.py]

I admit that I had a hard time discovering the [printer] 😅
I have added the property `manufacturing_process` this is required for others interfaces to adapt. Up now all is related to FDM, so interfaces like mainsail would need to know proper process to adapt interface, eg: For mSLA we want to see current layer image that is printing.

# What's missing

- Stats for mSLA? I'm not sure if klipper does stats for FDM, so this is a question.
- UI LCD interface
- Axis freedom: I tried to create a new kinematic with just an Z, but I failed, it complain that require two more axis (YZ), so I guess klipper at the moment is constrained to 3 axis min? To bypass this I use cartesian and end in configure 2 more steppers that are not used. As we only use Z, it prints happy without touch X and Y. Just the home must be issued with **G28 Z**. I think kinematics should constrain that and not the core as a global rule. There are many applications for few axis and while I search I found other users with same problem. Creating manual_stepper is ugly, break interface and gcodes. Displaying the fake XY is not that bad but...
- Docs: I would complete the docs when PR is done, without further changes to make.

# Breaking changes:

None.

# Video

(Sorry for the bad quality.)

- Proof of the concept: https://www.youtube.com/watch?v=MRWmT9H_ENI
- Print no delays: https://youtu.be/8hCJMWzb3Ow
- Image streaming: https://youtu.be/2lB8FmHEx2U

# Sample file

https://we.tl/t-l9a9fMftQN

# WIP

This is a WIP, looking for ideias, improvements but the implementation is working stable.