### PR TITLE
webhooks default JSON dump type

### DIFF
--- a/klippy/webhooks.py
+++ b/klippy/webhooks.py
@@ -269,7 +269,7 @@ class ClientConnection:
 
     def send(self, data):
         try:
-            jmsg = json.dumps(data, separators=(',', ':'))
+            jmsg = json.dumps(data, separators=(',', ':'), default=str)
             self.send_buffer += jmsg.encode() + b"\x03"
         except (TypeError, ValueError) as e:
             msg = ("json encoding error: %s" % (str(e),))


### PR DESCRIPTION
In some cases, if module developers use NumPy or SciPy, it happens that json dumps end up with data of type bool_ or others that it does not understand. This fix prevents errors from occurring on the Klipper side, but retains the ability for developers to process their data that they receive via webhooks