### PR TITLE
Include missing instructions

### DIFF
--- a/config/printer-creality-ender3pro-2020.cfg
+++ b/config/printer-creality-ender3pro-2020.cfg
@@ -1,7 +1,8 @@
 # This file contains pin mappings for the stock 2020 Creality Ender 3
 # Pro with the 32-bit Creality 4.2.2 board. To use this config, during
-# "make menuconfig" select the STM32F103 with a "28KiB bootloader" and
-# serial (on USART1 PA10/PA9) communication.
+# "make menuconfig" select the STM32F103 with a "28KiB bootloader",
+# serial (on USART1 PA10/PA9) communication and under "Enable extra 
+# low-level configuration options" set the Baud rate to 115200
 
 # It should be noted that newer variations of this printer shipping in
 # 2022 may have GD32F103 chips installed and not STM32F103. You may
@@ -92,6 +93,7 @@ pin: PA0
 [mcu]
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 restart_method: command
+baud: 115200
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
The specified Creality boards requires a baud rate of 115200

This [seems to be a common issue](https://old.reddit.com/r/klippers/comments/skgf5f/mcumcu_unable_to_connect/iotd0rd/) when setting up Ender 3s with Klipper.