### PR TITLE
accelerometer: Fix LIS2DW and MPU9250 abnormal reading

### DIFF
--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -37,7 +37,12 @@ class LIS2DW:
     def __init__(self, config):
         self.printer = config.get_printer()
         adxl345.AccelCommandHelper(config, self)
-        self.axes_map = adxl345.read_axes_map(config)
+        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
+              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
+        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
+        if any([a not in am for a in axes_map]):
+            raise config.error("Invalid lis2dw axes_map parameter")
+        self.axes_map = [am[a.strip()] for a in axes_map]
         self.data_rate = 1600
         # Setup mcu sensor_lis2dw bulk query code
         self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=5000000)

--- a/klippy/extras/mpu9250.py
+++ b/klippy/extras/mpu9250.py
@@ -59,7 +59,12 @@ class MPU9250:
     def __init__(self, config):
         self.printer = config.get_printer()
         adxl345.AccelCommandHelper(config, self)
-        self.axes_map = adxl345.read_axes_map(config)
+        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
+              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
+        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
+        if any([a not in am for a in axes_map]):
+            raise config.error("Invalid mpu9250 axes_map parameter")
+        self.axes_map = [am[a.strip()] for a in axes_map]
         self.data_rate = config.getint('rate', 4000)
         if self.data_rate not in SAMPLE_RATE_DIVS:
             raise config.error("Invalid rate parameter: %d" % (self.data_rate,))


### PR DESCRIPTION
Fix abnormal reading when using `ACCELEROMETER_QUERY` and `MEASURE_AXES_NOISE`.

Below is what happen after commit `43ce7c0b9ad4f30277c10b086b86a0937dbfebbc`. The `ACCELEROMETER_QUERY` and `MEASURE_AXES_NOISE` reading are abnormal. It around 7 times larger than normal value.
![Screenshot 2024-04-29 112602](https://github.com/Klipper3d/klipper/assets/36069884/1d39356b-ac2d-4ebd-a26a-17b65584f235)

line 40 in `lis2dw.py`
``` python
        self.axes_map = adxl345.read_axes_map(config)
```
The LIS2DW and MCP9250 are using the ADXL345 `SCALE` value. 

After change `self.axes_map` using the LIS2DW  `SCALE` value.
``` python
        am = {'x': (0, SCALE), 'y': (1, SCALE), 'z': (2, SCALE),
              '-x': (0, -SCALE), '-y': (1, -SCALE), '-z': (2, -SCALE)}
        axes_map = config.getlist('axes_map', ('x','y','z'), count=3)
        if any([a not in am for a in axes_map]):
            raise config.error("Invalid lis2dw axes_map parameter")
        self.axes_map = [am[a.strip()] for a in axes_map]
```

Below is the result after using LIS2DW  `SCALE` value.
![Screenshot 2024-04-29 125339](https://github.com/Klipper3d/klipper/assets/36069884/ee12359d-4a54-48e8-af2a-46ee47883cc9)

Signed-off-by: Vecter Fang <vecterfang@icloud.com>