### PR TITLE
adds GET_INPUT_SHAPER gcode command

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -731,6 +731,9 @@ together with either of SHAPER_TYPE_X and SHAPER_TYPE_Y parameters.
 See [config reference](Config_Reference.md#input_shaper) for more
 details on each of these parameters.
 
+`GET_INPUT_SHAPER`: Queries the current parameters used by the input
+shaper and displays them on the terminal.
+
 ### [manual_probe]
 
 The manual_probe module is automatically loaded.

--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -99,6 +99,9 @@ class InputShaper:
         gcode.register_command("SET_INPUT_SHAPER",
                                self.cmd_SET_INPUT_SHAPER,
                                desc=self.cmd_SET_INPUT_SHAPER_help)
+        gcode.register_command("GET_INPUT_SHAPER",
+                               self.cmd_GET_INPUT_SHAPER,
+                               desc=self.cmd_GET_INPUT_SHAPER_help)
     def get_shapers(self):
         return self.shapers
     def connect(self):
@@ -162,6 +165,10 @@ class InputShaper:
             for shaper in self.shapers:
                 shaper.update(gcmd)
             self._update_input_shaping()
+        for shaper in self.shapers:
+            shaper.report(gcmd)
+    cmd_GET_INPUT_SHAPER_help = ("Report input shaper paramters")
+    def cmd_GET_INPUT_SHAPER(self, gcmd):
         for shaper in self.shapers:
             shaper.report(gcmd)
 


### PR DESCRIPTION
Module: Input Shaper

This PR adds a gcode command GET_INPUT_SHAPER that allows user to query input shaper currently in use by the printer.  Sample output attached as an image below (same output when setting the shaper).

<img width="757" alt="Screenshot 2024-05-02 at 1 14 01 PM" src="https://github.com/Klipper3d/klipper/assets/388840/7eb1e992-bd34-46dd-b46e-0a5be20c17c3">


The reason I added this is because I was having difficulty debugging and determining what input shaper was enabled.  I know this sounds obvious that you can just look at the config but hear me out... On my Creality K1 an input shaper is automatically selected and enabled by the initial printer setup by default.  My printer is rooted and I wanted to customize the input shaper in order to run comparison tests.  The issue I ran into was that I couldn't determine what input shaper was being loaded - was it the one I put in my printer.cfg or was this being overridden by Reality's shaper.  Maybe there's an easier way to get this value but the only way I could figure it out - outside of adding this code - was by dumping all of the variables with a custom GCODE script.

Adding this PR in case it might be useful to others - I would imagine others with the same machine would benefit from being able to easily debug and determine the input shaper being loaded properly and not overridden.  If it's too much of a corner case I totally understand but for me it seemed logical since other commands have the ability to get the config params, i.e. GET_RETRACTION, and with it added the Input Shaper module will have a total of only two commands. 

Signed-off-by: Jason Hamilton <jasonscotthamilton@gmail.com>



