### PR TITLE
klippy: add stallguard monitoring tool

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, collections
 import stepper
+from . import bulk_sensor
 
 
 ######################################################################
@@ -220,6 +221,96 @@ class TMCErrorCheck:
             self.last_drv_fields = {n: v for n, v in fields.items() if v}
         return {'drv_status': self.last_drv_fields, 'temperature': temp}
 
+######################################################################
+# Record driver status
+######################################################################
+
+class TMCStallguardDump:
+    def __init__(self, config, mcu_tmc):
+        self.printer = config.get_printer()
+        self.stepper_name = ' '.join(config.get_name().split()[1:])
+        self.mcu_tmc = mcu_tmc
+        self.mcu = self.mcu_tmc.get_mcu()
+        self.fields = self.mcu_tmc.get_fields()
+        self.sg2_supp = False
+        self.sg4_reg_name = None
+        # It is possible to support TMC2660, just disable it for now
+        if not self.fields.all_fields.get("DRV_STATUS", None):
+            return
+        # Collect driver capabilities
+        if self.fields.all_fields["DRV_STATUS"].get("sg_result", None):
+            self.sg2_supp = True
+        # New drivers have separate register for SG4 result
+        if self.mcu_tmc.name_to_reg.get("SG_RESULT", 0):
+            self.sg4_reg_name = "SG_RESULT"
+        # 2240 supports both SG2 & SG4
+        if self.sg4_reg_name is None:
+            if self.mcu_tmc.name_to_reg.get("SG4_RESULT", 0):
+                self.sg4_reg_name = "SG4_RESULT"
+        # TMC2208
+        if self.sg2_supp is None and self.sg4_reg_name is None:
+            return
+        self.optimized_spi = False
+        # Bulk API
+        self.samples = []
+        self.query_timer = None
+        self.error = None
+        self.batch_bulk = bulk_sensor.BatchBulkHelper(
+            self.printer, self._dump, self._start, self._stop)
+        api_resp = {'header': ('time', 'sg_result', 'cs_actual')}
+        self.batch_bulk.add_mux_endpoint("tmc/stallguard_dump", "name",
+                                         self.stepper_name, api_resp)
+    def _start(self):
+        self.error = None
+        status = self.mcu_tmc.get_register_raw("DRV_STATUS")
+        if status.get("spi_status"):
+            self.optimized_spi = True
+        reactor = self.printer.get_reactor()
+        self.query_timer = reactor.register_timer(self._query_tmc,
+                                                  reactor.NOW)
+    def _stop(self):
+        self.printer.get_reactor().unregister_timer(self.query_timer)
+        self.query_timer = None
+        self.samples = []
+    def _query_tmc(self, eventtime):
+        sg_result = -1
+        cs_actual = -1
+        recv_time = eventtime
+        try:
+            if self.optimized_spi or self.sg4_reg_name == "SG4_RESULT":
+                #TMC2130/TMC5160/TMC2240
+                status = self.mcu_tmc.get_register_raw("DRV_STATUS")
+                reg_val = status["data"]
+                cs_actual = self.fields.get_field("cs_actual", reg_val)
+                sg_result = self.fields.get_field("sg_result", reg_val)
+                is_stealth = self.fields.get_field("stealth", reg_val)
+                recv_time = status["#receive_time"]
+                if is_stealth and self.sg4_reg_name == "SG4_RESULT":
+                    sg4_ret = self.mcu_tmc.get_register_raw("SG4_RESULT")
+                    sg_result = sg4_ret["data"]
+                    recv_time = sg4_ret["#receive_time"]
+            else:
+                # TMC2209
+                if self.sg4_reg_name == "SG_RESULT":
+                    sg4_ret = self.mcu_tmc.get_register_raw("SG_RESULT")
+                    sg_result = sg4_ret["data"]
+                    recv_time = sg4_ret["#receive_time"]
+        except self.printer.command_error as e:
+            self.error = e
+            return self.printer.get_reactor().NEVER
+        print_time = self.mcu.estimated_print_time(recv_time)
+        self.samples.append((print_time, sg_result, cs_actual))
+        if self.optimized_spi:
+            return eventtime + 0.001
+        # UART queried as fast as possible
+        return eventtime + 0.005
+    def _dump(self, eventtime):
+            if self.error:
+                raise self.error
+            samples = self.samples
+            self.samples = []
+            return {"data": samples}
+
 
 ######################################################################
 # G-Code command helpers
@@ -233,6 +324,7 @@ class TMCCommandHelper:
         self.mcu_tmc = mcu_tmc
         self.current_helper = current_helper
         self.echeck_helper = TMCErrorCheck(config, mcu_tmc)
+        self.record_helper = TMCStallguardDump(config, mcu_tmc)
         self.fields = mcu_tmc.get_fields()
         self.read_registers = self.read_translate = None
         self.toff = None

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -272,6 +272,13 @@ class MCU_TMC_SPI:
         with self.mutex:
             resp = self.tmc_spi.reg_read(reg, self.chain_pos)
         return resp
+    def decode_spi_status(spi_status):
+        return {
+            "standstill": spi_status >> 3 & 0x1,
+            "sg2": spi_status >> 2 & 0x1,
+            "driver_error": spi_status >> 1 & 0x1,
+            "reset_flag": spi_status & 0x1
+        }
     def get_register(self, reg_name):
         return self.get_register_raw(reg_name)["data"]
     def set_register(self, reg_name, val, print_time=None):

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -232,6 +232,8 @@ class MCU_TMC_SPI_chain:
         pr = pr[(self.chain_len - chain_pos) * 5 :
                 (self.chain_len - chain_pos + 1) * 5]
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]
+    def get_mcu(self):
+        return self.spi.get_mcu()
 
 # Helper to setup an spi daisy chain bus from settings in a config section
 def lookup_tmc_spi_chain(config):
@@ -292,6 +294,8 @@ class MCU_TMC_SPI:
             "Unable to write tmc spi '%s' register %s" % (self.name, reg_name))
     def get_tmc_frequency(self):
         return self.tmc_frequency
+    def get_mcu(self):
+        return self.tmc_spi.get_mcu()
 
 
 ######################################################################

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -231,6 +231,8 @@ class MCU_TMC2660_SPI:
             self.spi.spi_send(msg, minclock)
     def get_tmc_frequency(self):
         return None
+    def get_mcu(self):
+        return self.spi.get_mcu()
 
 
 ######################################################################

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -187,6 +187,8 @@ class MCU_TMC_uart_bitbang:
             self.analog_mux.activate(instance_id)
         msg = self._encode_write(0xf5, addr, reg | 0x80, val)
         self.tmcuart_send_cmd.send([self.oid, msg, 0], minclock=minclock)
+    def get_mcu(self):
+        return self.mcu
 
 # Lookup a (possibly shared) tmc uart
 def lookup_tmc_uart_bitbang(config, max_addr):
@@ -261,3 +263,5 @@ class MCU_TMC_uart:
             "Unable to write tmc uart '%s' register %s" % (self.name, reg_name))
     def get_tmc_frequency(self):
         return self.tmc_frequency
+    def get_mcu(self):
+        return self.mcu_uart.get_mcu()

--- a/scripts/motan/data_logger.py
+++ b/scripts/motan/data_logger.py
@@ -162,6 +162,10 @@ class DataLogger:
                     lname = "%s:%s" % (st, aname)
                     qcmd = "%s/dump_%s" % (st, st)
                     self.send_subscribe(lname, qcmd, {"sensor": aname})
+            if cfgname.startswith("tmc"):
+                driver = ' '.join(cfgname.split()[1:])
+                self.send_subscribe("stallguard:" + driver,
+                                    "tmc/stallguard_dump", {"name": driver})
     def handle_dump(self, msg, raw_msg):
         msg_id = msg["id"]
         if "result" not in msg:


### PR DESCRIPTION
Hi, as https://github.com/Klipper3d/klipper/pull/6139 is merged, I can now show the stall guard measurement stuff.
I'm not sure that it is the perfect solution to poll without batch processing, and not sure about timings/frequency.
I try to mimic ADXL345 code, to avoid adding any new complexity.
My [discourse thread](https://klipper.discourse.group/t/tmc-coolstep-and-how-to-make-it-works) with more graphs, and some comments.

So, there is the problem that I'm trying to solve:
Coolstep is simple and hard to configure because there is no near real-time visibility from the user side.
The original TMC solution is to directly reproduce and measure your load.
We can't see Stallguard pin output outside of homing actions, to track stalls.
But we can poll it.

*And there are many different printers and half of them now are CoreXY, which makes things tricky here.

High-level solution:
- Monitor driver for status
- Store History with stallguard/speed/current data.
- Make it human-readable.

For now, I added the command: `MEASURE_STALLGUARD STEPPER=<stepper>`
It will start to poll/filter/store data, and on the second call - store them in csv.
```
cat /tmp/stepper_y-20240515_024227.csv 
#time,velocity,sg_result,csactual
43668.927338,191.3,67,30
43668.952901,203.8,67,28
43668.977954,203.8,67,28
43669.003832,203.8,67,28
43669.363363,203.8,74,27
```

There is a dump script for data processing:
```
scripts/calibrate_stallguard.py /tmp/stepper_y-20240512_010858.csv -o ~/klipper/stepper_y-20240512_010858.png
```
Example output for one hour print with CoolStep enabled, unfiltered, cumulative graph.
```
~/klipper/scripts/calibrate_stallguard.py stepper_y-20240515_004650.csv -o stepper_y-20240515_004650_cumulative_unfiltered.png -e 100000
```
![image](https://github.com/Klipper3d/klipper/assets/3943460/63123584-197e-484f-be7b-55d1fb596335)
As you can see there is crazy noise on low velocities, also there are crazy speeds calculated from step timing - possibly because of step compression.

Let's filter that, and analyze it together. (min 1 mm/s, max 200 mm/s)
```
~/klipper/scripts/calibrate_stallguard.py stepper_y-20240515_004650.csv -o stepper_y-20240515_004650_cumulative_low.png -s 1 -e 200
```
![image](https://github.com/Klipper3d/klipper/assets/3943460/bf85e671-cad7-45fb-b13f-5253ecd1e94f)
There is StallGuard noise below ~35 mm/s - not enough back EMF.
The suggested SG range for StallGuard2 is in range 0..100, assuming there is more or less correct SGT (-10..0..10) value (mine is 1 or 2, depending on the motor).
We can track min & mean SG value, till they stabilize.
Min becomes zero on speeds above ~125 mm/s (> 3 RPS)
Mean becomes acceptable slightly early at ~80 mm/s. (2 RPS)
*CS is 31 on TMC5160 with reasonable sense resistor and equal CS max here.
The minimum threshold for Coolstep is 32, because SEMIN must be > 0, SEMIN = 1, (SG = SEMIN * 32)

So, I picked up the value 150 mm/s as a threshold with a safe margin, and I know my printer is limited to 1000 mm/s.
(let's just ignore high-speed diagonal moves here)

So, the last one with adequate range.
```
~/klipper/scripts/calibrate_stallguard.py stepper_y-20240515_004650.csv -o stepper_y-20240515_004650_cumulative.png -s 130 -e 1000
```
![image](https://github.com/Klipper3d/klipper/assets/3943460/b8dcfb98-824f-4eac-976c-2b2d4a328d36)
Mean SG is around ~60, if SG is above 64 current can be reduced SEMIN=1, SEMAX=0 ~ (SEMIN + SEMAX+1)*32
If below 32, the current should be bumped up.

There we are, with enabled CoolStep there is a mean CS of around 25 and min down to 16, because of SEIMIN=0 (50%).
25/31 * 100 = 80 %, 20% current reduction on medium velocity moves.

There is missing part, I didn't test the "high" velocities where backEMF is too big, because for me they are [too large](https://www.reprapfirmware.org/emf.html).
![image](https://github.com/Klipper3d/klipper/assets/3943460/6a2422d0-ba21-4bc6-861b-d43d3f350f6c)
So, I can suggest assuming half of the supply voltage as back EMF is a safe margin, according to the graph.
Because up to 1000 mm/s there is still adequate response from CoolStep in my test.

---
My 2 cents:
I have only TMC5160 48V & TMC2209, so only this combination was tested.
The motors are LDO 2504AC.
I initially tuned SGT values by sensorless homing.
I so far have no issues with Coolstep, with almost default values.
CoolStep threshold will control sensorless homing, and IIRC, sensorless homing speed must be above that threshold.
On my printer, sensorless homing works fine with 50 mm/s, but with CoolStep at such a low threshold and with allowed reduction SEIMIN=1 (25% of CS) leads to skipping steps.
With an extruder, CoolStep can work, but its usefulness really depends on setup and extrusion flow.
On orbiter 2, flow shall be above 25 mm3^s. to get 2 RPS.

Will be happy to hear any feedback, even if these things are useless.
Thanks!

Raw data:
[stepper_y-20240515_004650.csv](https://github.com/Klipper3d/klipper/files/15315327/stepper_y-20240515_004650.csv)