### PR TITLE
Fixes exceptions regarding bytes vs str

### DIFF
--- a/scripts/whconsole.py
+++ b/scripts/whconsole.py
@@ -40,7 +40,7 @@ class KeyboardReader:
         self.poll.register(self.webhook_socket, select.POLLIN | select.POLLHUP)
         self.kbd_data = self.socket_data = ""
     def process_socket(self):
-        data = self.webhook_socket.recv(4096)
+        data = self.webhook_socket.recv(4096).decode()
         if not data:
             sys.stderr.write("Socket closed\n")
             sys.exit(0)
@@ -50,7 +50,7 @@ class KeyboardReader:
         for line in parts:
             sys.stdout.write("GOT: %s\n" % (line,))
     def process_kbd(self):
-        data = os.read(self.kbd_fd, 4096)
+        data = os.read(self.kbd_fd, 4096).decode()
         parts = data.split('\n')
         parts[0] = self.kbd_data + parts[0]
         self.kbd_data = parts.pop()
@@ -65,7 +65,7 @@ class KeyboardReader:
                 continue
             cm = json.dumps(m, separators=(',', ':'))
             sys.stdout.write("SEND: %s\n" % (cm,))
-            self.webhook_socket.send("%s\x03" % (cm,))
+            self.webhook_socket.send(("%s\x03" % (cm,)).encode())
     def run(self):
         while 1:
             res = self.poll.poll(1000.)


### PR DESCRIPTION
Clean install on raspberry pi CM4, Bookworm, Python 3.11.2:

scripts/whconsole.py is throwing exception:
```
TypeError: a bytes-like object is required, not 'str'
```
I simply added encode / decode where it seemed necessary to get rid of the exception.