### PR TITLE
config: Set safe Z-homing point in Creality CR-6 SE configuration

### DIFF
--- a/config/printer-creality-cr6se-2020.cfg
+++ b/config/printer-creality-cr6se-2020.cfg
@@ -98,6 +98,10 @@ z_offset: 0.0
 speed: 2.0
 samples: 5
 
+[safe_z_home]
+home_xy_position: 117, 117
+z_hop: 10
+
 [filament_switch_sensor filament_sensor]
 pause_on_runout: true
 switch_pin: ^!PA7

--- a/config/printer-creality-cr6se-2021.cfg
+++ b/config/printer-creality-cr6se-2021.cfg
@@ -98,6 +98,10 @@ z_offset: 0.0
 speed: 2.0
 samples: 5
 
+[safe_z_home]
+home_xy_position: 117, 117
+z_hop: 10
+
 [filament_switch_sensor filament_sensor]
 pause_on_runout: true
 switch_pin: ^!PA7


### PR DESCRIPTION
The Creality CR-6 SE has a strain gauge on its hotend, which is used for z-probing and homing. Currently, running G28 to home all axes puts the hotend just outside of the print bed and thus assumes a wrong homing point for the Z axis.

This pull request aims to address this issue by setting a safe Z-homing point (in the middle of the print bed) into the Creality CR-6 SE 2020 and 2021-revision config files.