### PR TITLE
Update install-octopi.sh

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -8,7 +8,7 @@ PYTHONDIR="${HOME}/klippy-env"
 install_packages()
 {
     # Packages for python cffi
-    PKGLIST="virtualenv python-dev libffi-dev build-essential"
+    PKGLIST="virtualenv python-dev-is-python3 libffi-dev build-essential"
     # kconfig requirements
     PKGLIST="${PKGLIST} libncurses-dev"
     # hub-ctrl


### PR DESCRIPTION
fixing this issue 

###### Installing packages...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'libusb-1.0-0-dev' for regex 'libusb-1.0' Note, selecting 'libusb-1.0-doc' for regex 'libusb-1.0' Note, selecting 'libusb-1.0-0' for regex 'libusb-1.0' Package python-dev is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source
However the following packages replace it:
  python-dev-is-python3