### PR TITLE
Minor tmc driver improvements

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3327,11 +3327,8 @@ run_current:
 #high_velocity_threshold:
 #   The velocity (in mm/s) to set the TMC driver internal "high
 #   velocity" threshold (THIGH) to. This is typically used to disable
-#   the "CoolStep" feature at high speeds. Important - if
-#   high_velocity_threshold is set and "sensorless homing" is used,
-#   then one must ensure that the homing speed is below the high
-#   velocity threshold! The default is to not set a TMC "high
-#   velocity" threshold.
+#   the "CoolStep" feature at high speeds. The default is to not set a
+#   TMC "high velocity" threshold.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441
@@ -3646,11 +3643,8 @@ run_current:
 #high_velocity_threshold:
 #   The velocity (in mm/s) to set the TMC driver internal "high
 #   velocity" threshold (THIGH) to. This is typically used to disable
-#   the "CoolStep" feature at high speeds. Important - if
-#   high_velocity_threshold is set and "sensorless homing" is used,
-#   then one must ensure that the homing speed is below the high
-#   velocity threshold! The default is to not set a TMC "high
-#   velocity" threshold.
+#   the "CoolStep" feature at high speeds. The default is to not set a
+#   TMC "high velocity" threshold.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441
@@ -3782,11 +3776,8 @@ run_current:
 #high_velocity_threshold:
 #   The velocity (in mm/s) to set the TMC driver internal "high
 #   velocity" threshold (THIGH) to. This is typically used to disable
-#   the "CoolStep" feature at high speeds. Important - if
-#   high_velocity_threshold is set and "sensorless homing" is used,
-#   then one must ensure that the homing speed is below the high
-#   velocity threshold! The default is to not set a TMC "high
-#   velocity" threshold.
+#   the "CoolStep" feature at high speeds. The default is to not set a
+#   TMC "high velocity" threshold.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -577,7 +577,7 @@ def TMCWaveTableHelper(config, mcu_tmc):
     set_config_field(config, "start_sin", 0)
     set_config_field(config, "start_sin90", 247)
 
-# Helper to configure and query the microstep settings
+# Helper to configure the microstep settings
 def TMCMicrostepHelper(config, mcu_tmc):
     fields = mcu_tmc.get_fields()
     stepper_name = " ".join(config.get_name().split()[1:])
@@ -585,13 +585,9 @@ def TMCMicrostepHelper(config, mcu_tmc):
         raise config.error(
             "Could not find config section '[%s]' required by tmc driver"
             % (stepper_name,))
-    stepper_config = ms_config = config.getsection(stepper_name)
-    if (stepper_config.get('microsteps', None, note_valid=False) is None
-        and config.get('microsteps', None, note_valid=False) is not None):
-        # Older config format with microsteps in tmc config section
-        ms_config = config
+    sconfig = config.getsection(stepper_name)
     steps = {256: 0, 128: 1, 64: 2, 32: 3, 16: 4, 8: 5, 4: 6, 2: 7, 1: 8}
-    mres = ms_config.getchoice('microsteps', steps)
+    mres = sconfig.getchoice('microsteps', steps)
     fields.set_field("mres", mres)
     fields.set_field("intpol", config.getboolean("interpolate", True))
 

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -265,6 +265,7 @@ def parse_gear_ratio(config, note_valid):
 
 # Obtain "step distance" information from a config section
 def parse_step_distance(config, units_in_radians=None, note_valid=False):
+    # Check rotation_distance and gear_ratio
     if units_in_radians is None:
         # Caller doesn't know if units are in radians - infer it
         rd = config.get('rotation_distance', None, note_valid=False)
@@ -276,7 +277,7 @@ def parse_step_distance(config, units_in_radians=None, note_valid=False):
     else:
         rotation_dist = config.getfloat('rotation_distance', above=0.,
                                         note_valid=note_valid)
-    # Newer config format with rotation_distance
+    # Check microsteps and full_steps_per_rotation
     microsteps = config.getint('microsteps', minval=1, note_valid=note_valid)
     full_steps = config.getint('full_steps_per_rotation', 200, minval=1,
                                note_valid=note_valid)


### PR DESCRIPTION
A couple of minor enhancements that I noticed after the merge of #6139 .
1. Simplify the `TMCtstepHelper()` code.
2. There is no need to warn the user about setting `high_velocity_threshold` when using sensorless homing as the sensorless homing can save/restore `thigh`.

@leptun - it would be great if you could take a look at these changes.

-Kevin