### PR TITLE
Internal rework of PrinterProbe class

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -38,10 +38,13 @@ class AxisTwistCompensation:
 
         # setup calibrater
         self.calibrater = Calibrater(self, config)
+        # register events
+        self.printer.register_event_handler("probe:update_results",
+                                            self._update_z_compensation_value)
 
-    def get_z_compensation_value(self, pos):
+    def _update_z_compensation_value(self, pos):
         if not self.z_compensations:
-            return 0
+            return
 
         x_coord = pos[0]
         z_compensations = self.z_compensations
@@ -55,7 +58,7 @@ class AxisTwistCompensation:
         interpolated_z_compensation = BedMesh.lerp(
             interpolate_t, z_compensations[interpolate_i],
             z_compensations[interpolate_i + 1])
-        return interpolated_z_compensation
+        pos[2] += interpolated_z_compensation
 
     def clear_compensations(self):
         self.z_compensations = []

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -186,7 +186,8 @@ class Calibrater:
                            probe_points[self.current_point_index][1], None))
 
         # probe the point
-        self.current_measured_z = self.probe.run_probe(self.gcmd)[2]
+        pos = probe.run_single_probe(self.probe, self.gcmd)
+        self.current_measured_z = pos[2]
 
         # horizontal_move_z (to prevent probe trigger or hitting bed)
         self._move_helper((None, None, self.horizontal_move_z))

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -95,7 +95,7 @@ class Calibrater:
             config = self.printer.lookup_object('configfile')
             raise config.error(
                 "AXIS_TWIST_COMPENSATION requires [probe] to be defined")
-        self.lift_speed = self.probe.get_lift_speed()
+        self.lift_speed = self.probe.get_probe_params()['lift_speed']
         self.probe_x_offset, self.probe_y_offset, _ = \
             self.probe.get_offsets()
 

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -44,10 +44,7 @@ class BLTouchEndstopWrapper:
         self.next_cmd_time = self.action_end_time = 0.
         self.finish_home_complete = self.wait_trigger_complete = None
         # Create an "endstop" object to handle the sensor pin
-        pin = config.get('sensor_pin')
-        pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
-        mcu = pin_params['chip']
-        self.mcu_endstop = mcu.setup_pin('endstop', pin_params)
+        self.mcu_endstop = ppins.setup_pin('endstop', config.get('sensor_pin'))
         # output mode
         omodes = {'5V': '5V', 'OD': 'OD', None: None}
         self.output_mode = config.getchoice('set_output_mode', omodes, None)

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -28,8 +28,6 @@ class BLTouchEndstopWrapper:
         self.printer = config.get_printer()
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-        self.printer.register_event_handler('klippy:mcu_identify',
-                                            self.handle_mcu_identify)
         self.position_endstop = config.getfloat('z_offset', minval=0.)
         self.stow_on_each_sample = config.getboolean('stow_on_each_sample',
                                                      True)
@@ -70,11 +68,6 @@ class BLTouchEndstopWrapper:
                                     desc=self.cmd_BLTOUCH_STORE_help)
         # multi probes state
         self.multi = 'OFF'
-    def handle_mcu_identify(self):
-        kin = self.printer.lookup_object('toolhead').get_kinematics()
-        for stepper in kin.get_steppers():
-            if stepper.is_active_axis('z'):
-                self.add_stepper(stepper)
     def handle_connect(self):
         self.sync_mcu_print_time()
         self.next_cmd_time += 0.200

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -480,10 +480,7 @@ class ProbeEndstopWrapper:
             config, 'deactivate_gcode', '')
         # Create an "endstop" object to handle the probe pin
         ppins = self.printer.lookup_object('pins')
-        pin = config.get('pin')
-        pin_params = ppins.lookup_pin(pin, can_invert=True, can_pullup=True)
-        mcu = pin_params['chip']
-        self.mcu_endstop = mcu.setup_pin('endstop', pin_params)
+        self.mcu_endstop = ppins.setup_pin('endstop', config.get('pin'))
         self.printer.register_event_handler('klippy:mcu_identify',
                                             self._handle_mcu_identify)
         # Wrappers

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -309,15 +309,9 @@ class ProbeSessionHelper:
             if "Timeout during endstop homing" in reason:
                 reason += HINT_TIMEOUT
             raise self.printer.command_error(reason)
-        # get z compensation from axis_twist_compensation
-        axis_twist_compensation = self.printer.lookup_object(
-            'axis_twist_compensation', None)
-        z_compensation = 0
-        if axis_twist_compensation is not None:
-            z_compensation = (
-                axis_twist_compensation.get_z_compensation_value(pos))
-        # add z compensation to probe position
-        epos[2] += z_compensation
+        # Allow axis_twist_compensation to update results
+        self.printer.send_event("probe:update_results", epos)
+        # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
                            % (epos[0], epos[1], epos[2]))

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -536,12 +536,13 @@ class ProbeEndstopWrapper:
 
 # Main external probe interface
 class PrinterProbe:
-    def __init__(self, config, mcu_probe):
+    def __init__(self, config):
         self.printer = config.get_printer()
+        self.mcu_probe = ProbeEndstopWrapper(config)
         self.cmd_helper = ProbeCommandHelper(config, self,
-                                             mcu_probe.query_endstop)
+                                             self.mcu_probe.query_endstop)
         self.probe_offsets = ProbeOffsetsHelper(config)
-        self.probe_session = ProbeSessionHelper(config, mcu_probe)
+        self.probe_session = ProbeSessionHelper(config, self.mcu_probe)
     def get_probe_params(self, gcmd=None):
         return self.probe_session.get_probe_params(gcmd)
     def get_offsets(self):
@@ -552,4 +553,4 @@ class PrinterProbe:
         return self.probe_session.start_probe_session(gcmd)
 
 def load_config(config):
-    return PrinterProbe(config, ProbeEndstopWrapper(config))
+    return PrinterProbe(config)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -196,13 +196,6 @@ class EddyEndstopWrapper:
         self._samples = []
         self._is_sampling = self._start_from_home = self._need_stop = False
         self._trigger_time = 0.
-        self._printer.register_event_handler('klippy:mcu_identify',
-                                             self._handle_mcu_identify)
-    def _handle_mcu_identify(self):
-        kin = self._printer.lookup_object('toolhead').get_kinematics()
-        for stepper in kin.get_steppers():
-            if stepper.is_active_axis('z'):
-                self.add_stepper(stepper)
     # Measurement gathering
     def _start_measurements(self, is_home=False):
         self._need_stop = False

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -48,7 +48,7 @@ class ControlPinHelper:
             bit_time += bit_step
         return bit_time
 
-class SmartEffectorEndstopWrapper:
+class SmartEffectorProbe:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
@@ -64,6 +64,11 @@ class SmartEffectorEndstopWrapper:
         self.query_endstop = self.probe_wrapper.query_endstop
         self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
         self.multi_probe_end = self.probe_wrapper.multi_probe_end
+        # Common probe implementation helpers
+        self.cmd_helper = probe.ProbeCommandHelper(
+            config, self, self.probe_wrapper.query_endstop)
+        self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        self.probe_session = probe.ProbeSessionHelper(config, self)
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:
@@ -78,6 +83,14 @@ class SmartEffectorEndstopWrapper:
         self.gcode.register_command("SET_SMART_EFFECTOR",
                                     self.cmd_SET_SMART_EFFECTOR,
                                     desc=self.cmd_SET_SMART_EFFECTOR_help)
+    def get_probe_params(self, gcmd=None):
+        return self.probe_session.get_probe_params(gcmd)
+    def get_offsets(self):
+        return self.probe_offsets.get_offsets()
+    def get_status(self, eventtime):
+        return self.cmd_helper.get_status(eventtime)
+    def start_probe_session(self, gcmd):
+        return self.probe_session.start_probe_session(gcmd)
     def probing_move(self, pos, speed):
         phoming = self.printer.lookup_object('homing')
         return phoming.probing_move(self, pos, speed)
@@ -151,7 +164,6 @@ class SmartEffectorEndstopWrapper:
         gcmd.respond_info('SmartEffector sensitivity was reset')
 
 def load_config(config):
-    smart_effector = SmartEffectorEndstopWrapper(config)
-    config.get_printer().add_object('probe',
-                                    probe.PrinterProbe(config, smart_effector))
+    smart_effector = SmartEffectorProbe(config)
+    config.get_printer().add_object('probe', smart_effector)
     return smart_effector


### PR DESCRIPTION
This is an internal refactoring of the probe.py PrinterProbe class.  Basically the goal is to split up the functionality in that class into a series of more manageable classes (ProbeCommandHelper, ProbeSessionHelper, HomingViaProbeHelper, and ProbeOffsetsHelper).  The goal is to separate functionality so that it is easier to add features in the future.  There should be no user visible changes as part of this PR.

@Arksine - fyi.

-Kevin