### PR TITLE
Added 50k thermistor config definition

### DIFF
--- a/klippy/extras/temperature_sensors.cfg
+++ b/klippy/extras/temperature_sensors.cfg
@@ -80,6 +80,16 @@ resistance2: 1770
 temperature3: 250
 resistance3: 230
 
+# Definition from https://amwei.com/ntc-50k-ohm-beta-3950k-radial-glass-bead/
+# Sampling values at lower tempertures, as these probes are best suited for chassis/ambient temperature monitoring
+[thermistor Generic 50K 3950]
+temperature1: 25
+resistance1: 50000
+temperature2: 50
+resistance2: 17941
+temperature3: 100
+resistance3: 3296
+
 # Definition from (20211101): https://www.sliceengineering.com/products/thermistor-high-temperature and https://docs.google.com/spreadsheets/d/1904x5JK-Sup-cX5DqHiiZWaFVTK6_PQBFxgi_6yXEJw/edit#gid=0
 [thermistor SliceEngineering 450]
 temperature1: 25


### PR DESCRIPTION
Added a sensor_type configuration for a generic 50K 3950 thermistor, useful as a temperature_fan sensor.

The existing profiles were all based on 100K thermistors, which are better suited for extruder/bed temperatures, but inexpensive 50K probes are useful for monitoring ambient temperature or chipsets.