### PR TITLE
Support 2-byte message ids in host/mcu protocol

### DIFF
--- a/klippy/extras/bulk_sensor.py
+++ b/klippy/extras/bulk_sensor.py
@@ -198,7 +198,7 @@ class ClockSyncRegression:
         inv_freq = clock_to_print_time(base_mcu + inv_cfreq) - base_time
         return base_time, base_chip, inv_freq
 
-MAX_BULK_MSG_SIZE = 52
+MAX_BULK_MSG_SIZE = 51
 
 # Read sensor_bulk_data and calculate timestamps for devices that take
 # samples at a fixed frequency (and produce fixed data size samples).

--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -117,7 +117,7 @@ class LDC1612:
         cmdqueue = self.i2c.get_command_queue()
         self.query_ldc1612_cmd = self.mcu.lookup_command(
             "query_ldc1612 oid=%c rest_ticks=%u", cq=cmdqueue)
-        self.ffreader.setup_query_command("query_ldc1612_status oid=%c",
+        self.ffreader.setup_query_command("query_status_ldc1612 oid=%c",
                                           oid=self.oid, cq=cmdqueue)
         self.ldc1612_setup_home_cmd = self.mcu.lookup_command(
             "ldc1612_setup_home oid=%c clock=%u threshold=%u"

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -87,7 +87,7 @@ class CommandWrapper:
         if cmd_queue is None:
             cmd_queue = serial.get_default_command_queue()
         self._cmd_queue = cmd_queue
-        self._msgtag = msgparser.lookup_msgtag(msgformat) & 0xffffffff
+        self._msgtag = msgparser.lookup_msgid(msgformat) & 0xffffffff
     def send(self, data=(), minclock=0, reqclock=0):
         cmd = self._cmd.encode(data)
         self._serial.raw_send(cmd, minclock, reqclock, self._cmd_queue)

--- a/klippy/msgproto.py
+++ b/klippy/msgproto.py
@@ -1,6 +1,6 @@
 # Protocol definitions for firmware communication
 #
-# Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import json, zlib, logging
@@ -160,8 +160,8 @@ def convert_msg_format(msgformat):
     return msgformat
 
 class MessageFormat:
-    def __init__(self, msgid, msgformat, enumerations={}):
-        self.msgid = msgid
+    def __init__(self, msgid_bytes, msgformat, enumerations={}):
+        self.msgid_bytes = msgid_bytes
         self.msgformat = msgformat
         self.debugformat = convert_msg_format(msgformat)
         self.name = msgformat.split()[0]
@@ -169,19 +169,17 @@ class MessageFormat:
         self.param_types = [t for name, t in self.param_names]
         self.name_to_type = dict(self.param_names)
     def encode(self, params):
-        out = []
-        out.append(self.msgid)
+        out = list(self.msgid_bytes)
         for i, t in enumerate(self.param_types):
             t.encode(out, params[i])
         return out
     def encode_by_name(self, **params):
-        out = []
-        out.append(self.msgid)
+        out = list(self.msgid_bytes)
         for name, t in self.param_names:
             t.encode(out, params[name])
         return out
     def parse(self, s, pos):
-        pos += 1
+        pos += len(self.msgid_bytes)
         out = {}
         for name, t in self.param_names:
             v, pos = t.parse(s, pos)
@@ -198,13 +196,13 @@ class MessageFormat:
 
 class OutputFormat:
     name = '#output'
-    def __init__(self, msgid, msgformat):
-        self.msgid = msgid
+    def __init__(self, msgid_bytes, msgformat):
+        self.msgid_bytes = msgid_bytes
         self.msgformat = msgformat
         self.debugformat = convert_msg_format(msgformat)
         self.param_types = lookup_output_params(msgformat)
     def parse(self, s, pos):
-        pos += 1
+        pos += len(self.msgid_bytes)
         out = []
         for t in self.param_types:
             v, pos = t.parse(s, pos)
@@ -219,7 +217,7 @@ class OutputFormat:
 class UnknownFormat:
     name = '#unknown'
     def parse(self, s, pos):
-        msgid = s[pos]
+        msgid, param_pos = PT_int32().parse(s, pos)
         msg = bytes(bytearray(s))
         return {'#msgid': msgid, '#msg': msg}, len(s)-MESSAGE_TRAILER_SIZE
     def format_params(self, params):
@@ -234,7 +232,8 @@ class MessageParser:
         self.messages = []
         self.messages_by_id = {}
         self.messages_by_name = {}
-        self.msgtag_by_format = {}
+        self.msgid_by_format = {}
+        self.msgid_parser = PT_int32()
         self.config = {}
         self.version = self.build_versions = ""
         self.raw_identify_data = ""
@@ -266,7 +265,7 @@ class MessageParser:
         out = ["seq: %02x" % (msgseq,)]
         pos = MESSAGE_HEADER_SIZE
         while 1:
-            msgid = s[pos]
+            msgid, param_pos = self.msgid_parser.parse(s, pos)
             mid = self.messages_by_id.get(msgid, self.unknown)
             params, pos = mid.parse(s, pos)
             out.append(mid.format_params(params))
@@ -283,14 +282,14 @@ class MessageParser:
             return "%s %s" % (name, msg)
         return str(params)
     def parse(self, s):
-        msgid = s[MESSAGE_HEADER_SIZE]
+        msgid, param_pos = self.msgid_parser.parse(s, MESSAGE_HEADER_SIZE)
         mid = self.messages_by_id.get(msgid, self.unknown)
         params, pos = mid.parse(s, MESSAGE_HEADER_SIZE)
         if pos != len(s)-MESSAGE_TRAILER_SIZE:
             self._error("Extra data at end of message")
         params['#name'] = mid.name
         return params
-    def encode(self, seq, cmd):
+    def encode_msgblock(self, seq, cmd):
         msglen = MESSAGE_MIN + len(cmd)
         seq = (seq & MESSAGE_SEQ_MASK) | MESSAGE_DEST
         out = [msglen, seq] + cmd
@@ -317,11 +316,11 @@ class MessageParser:
             self._error("Command format mismatch: %s vs %s",
                         msgformat, mp.msgformat)
         return mp
-    def lookup_msgtag(self, msgformat):
-        msgtag = self.msgtag_by_format.get(msgformat)
-        if msgtag is None:
+    def lookup_msgid(self, msgformat):
+        msgid = self.msgid_by_format.get(msgformat)
+        if msgid is None:
             self._error("Unknown command: %s", msgformat)
-        return msgtag
+        return msgid
     def create_command(self, msg):
         parts = msg.strip().split()
         if not parts:
@@ -372,22 +371,22 @@ class MessageParser:
                 start_value, count = value
                 for i in range(count):
                     enums[enum_root + str(start_enum + i)] = start_value + i
-    def _init_messages(self, messages, command_tags=[], output_tags=[]):
-        for msgformat, msgtag in messages.items():
+    def _init_messages(self, messages, command_ids=[], output_ids=[]):
+        for msgformat, msgid in messages.items():
             msgtype = 'response'
-            if msgtag in command_tags:
+            if msgid in command_ids:
                 msgtype = 'command'
-            elif msgtag in output_tags:
+            elif msgid in output_ids:
                 msgtype = 'output'
-            self.messages.append((msgtag, msgtype, msgformat))
-            if msgtag < -32 or msgtag > 95:
-                self._error("Multi-byte msgtag not supported")
-            self.msgtag_by_format[msgformat] = msgtag
-            msgid = msgtag & 0x7f
+            self.messages.append((msgid, msgtype, msgformat))
+            self.msgid_by_format[msgformat] = msgid
+            msgid_bytes = []
+            self.msgid_parser.encode(msgid_bytes, msgid)
             if msgtype == 'output':
-                self.messages_by_id[msgid] = OutputFormat(msgid, msgformat)
+                self.messages_by_id[msgid] = OutputFormat(msgid_bytes,
+                                                          msgformat)
             else:
-                msg = MessageFormat(msgid, msgformat, self.enumerations)
+                msg = MessageFormat(msgid_bytes, msgformat, self.enumerations)
                 self.messages_by_id[msgid] = msg
                 self.messages_by_name[msg.name] = msg
     def process_identify(self, data, decompress=True):

--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -251,8 +251,9 @@ class HandleCommandGeneration:
     def __init__(self):
         self.commands = {}
         self.encoders = []
-        self.msg_to_id = dict(msgproto.DefaultMessages)
-        self.messages_by_name = { m.split()[0]: m for m in self.msg_to_id }
+        self.msg_to_encid = dict(msgproto.DefaultMessages)
+        self.encid_to_msgid = {}
+        self.messages_by_name = { m.split()[0]: m for m in self.msg_to_encid }
         self.all_param_types = {}
         self.ctr_dispatch = {
             'DECL_COMMAND_FLAGS': self.decl_command,
@@ -280,37 +281,47 @@ class HandleCommandGeneration:
     def decl_output(self, req):
         msg = req.split(None, 1)[1]
         self.encoders.append((None, msg))
+    def convert_encoded_msgid(self, encoded_msgid):
+        if encoded_msgid >= 0x80:
+            data = [(encoded_msgid >> 7) | 0x80, encoded_msgid & 0x7f]
+        else:
+            data = [encoded_msgid]
+        return msgproto.PT_int32().parse(data, 0)[0]
     def create_message_ids(self):
         # Create unique ids for each message type
-        msgid = max(self.msg_to_id.values())
+        encoded_msgid = max(self.msg_to_encid.values())
         mlist = list(self.commands.keys()) + [m for n, m in self.encoders]
         for msgname in mlist:
             msg = self.messages_by_name.get(msgname, msgname)
-            if msg not in self.msg_to_id:
-                msgid += 1
-                self.msg_to_id[msg] = msgid
-        if msgid >= 128:
-            # The mcu currently assumes all message ids encode to one byte
+            if msg not in self.msg_to_encid:
+                encoded_msgid += 1
+                self.msg_to_encid[msg] = encoded_msgid
+        if encoded_msgid >= 1<<14:
+            # The mcu currently assumes all message ids encode to 1 or 2 bytes
             error("Too many message ids")
+        self.encid_to_msgid = {
+            encoded_msgid: self.convert_encoded_msgid(encoded_msgid)
+            for encoded_msgid in self.msg_to_encid.values()
+        }
     def update_data_dictionary(self, data):
-        # Handle message ids over 96 (they are decoded as negative numbers)
-        msg_to_tag = {msg: msgid if msgid < 96 else msgid - 128
-                      for msg, msgid in self.msg_to_id.items()}
-        command_tags = [msg_to_tag[msg]
+        # Convert ids to standard form (use both positive and negative numbers)
+        msg_to_msgid = {msg: self.encid_to_msgid[encoded_msgid]
+                        for msg, encoded_msgid in self.msg_to_encid.items()}
+        command_ids = [msg_to_msgid[msg]
+                       for msgname, msg in self.messages_by_name.items()
+                       if msgname in self.commands]
+        response_ids = [msg_to_msgid[msg]
                         for msgname, msg in self.messages_by_name.items()
-                        if msgname in self.commands]
-        response_tags = [msg_to_tag[msg]
-                         for msgname, msg in self.messages_by_name.items()
-                         if msgname not in self.commands]
-        data['commands'] = { msg: msgtag for msg, msgtag in msg_to_tag.items()
-                             if msgtag in command_tags }
-        data['responses'] = { msg: msgtag for msg, msgtag in msg_to_tag.items()
-                              if msgtag in response_tags }
-        output = {msg: msgtag for msg, msgtag in msg_to_tag.items()
-                  if msgtag not in command_tags and msgtag not in response_tags}
+                        if msgname not in self.commands]
+        data['commands'] = { msg: msgid for msg, msgid in msg_to_msgid.items()
+                             if msgid in command_ids }
+        data['responses'] = { msg: msgid for msg, msgid in msg_to_msgid.items()
+                              if msgid in response_ids }
+        output = {msg: msgid for msg, msgid in msg_to_msgid.items()
+                  if msgid not in command_ids and msgid not in response_ids}
         if output:
             data['output'] = output
-    def build_parser(self, msgid, msgformat, msgtype):
+    def build_parser(self, encoded_msgid, msgformat, msgtype):
         if msgtype == "output":
             param_types = msgproto.lookup_output_params(msgformat)
             comment = "Output: " + msgformat
@@ -327,17 +338,21 @@ class HandleCommandGeneration:
             params = 'command_parameters%d' % (paramid,)
         out = """
     // %s
-    .msg_id=%d,
+    .encoded_msgid=%d, // msgid=%d
     .num_params=%d,
     .param_types = %s,
-""" % (comment, msgid, len(types), params)
+""" % (comment, encoded_msgid, self.encid_to_msgid[encoded_msgid],
+       len(types), params)
         if msgtype == 'response':
             num_args = (len(types) + types.count('PT_progmem_buffer')
                         + types.count('PT_buffer'))
             out += "    .num_args=%d," % (num_args,)
         else:
+            msgid_size = 1
+            if encoded_msgid >= 0x80:
+                msgid_size = 2
             max_size = min(msgproto.MESSAGE_MAX,
-                           (msgproto.MESSAGE_MIN + 1
+                           (msgproto.MESSAGE_MIN + msgid_size
                             + sum([t.max_length for t in param_types])))
             out += "    .max_size=%d," % (max_size,)
         return out
@@ -347,22 +362,23 @@ class HandleCommandGeneration:
         encoder_code = []
         did_output = {}
         for msgname, msg in self.encoders:
-            msgid = self.msg_to_id[msg]
-            if msgid in did_output:
+            encoded_msgid = self.msg_to_encid[msg]
+            if encoded_msgid in did_output:
                 continue
-            did_output[msgid] = True
+            did_output[encoded_msgid] = True
             code = ('    if (__builtin_strcmp(str, "%s") == 0)\n'
-                    '        return &command_encoder_%s;\n' % (msg, msgid))
+                    '        return &command_encoder_%s;\n'
+                    % (msg, encoded_msgid))
             if msgname is None:
-                parsercode = self.build_parser(msgid, msg, 'output')
+                parsercode = self.build_parser(encoded_msgid, msg, 'output')
                 output_code.append(code)
             else:
-                parsercode = self.build_parser(msgid, msg, 'command')
+                parsercode = self.build_parser(encoded_msgid, msg, 'command')
                 encoder_code.append(code)
             encoder_defs.append(
                 "const struct command_encoder command_encoder_%s PROGMEM = {"
                 "    %s\n};\n" % (
-                    msgid, parsercode))
+                    encoded_msgid, parsercode))
         fmt = """
 %s
 
@@ -384,21 +400,21 @@ ctr_lookup_output(const char *str)
                       "".join(encoder_code).strip(),
                       "".join(output_code).strip())
     def generate_commands_code(self):
-        cmd_by_id = {
-            self.msg_to_id[self.messages_by_name.get(msgname, msgname)]: cmd
+        cmd_by_encid = {
+            self.msg_to_encid[self.messages_by_name.get(msgname, msgname)]: cmd
             for msgname, cmd in self.commands.items()
         }
-        max_cmd_msgid = max(cmd_by_id.keys())
+        max_cmd_encid = max(cmd_by_encid.keys())
         index = []
         externs = {}
-        for msgid in range(max_cmd_msgid+1):
-            if msgid not in cmd_by_id:
+        for encoded_msgid in range(max_cmd_encid+1):
+            if encoded_msgid not in cmd_by_encid:
                 index.append(" {\n},")
                 continue
-            funcname, flags, msgname = cmd_by_id[msgid]
+            funcname, flags, msgname = cmd_by_encid[encoded_msgid]
             msg = self.messages_by_name[msgname]
             externs[funcname] = 1
-            parsercode = self.build_parser(msgid, msg, 'response')
+            parsercode = self.build_parser(encoded_msgid, msg, 'response')
             index.append(" {%s\n    .flags=%s,\n    .func=%s\n}," % (
                 parsercode, flags, funcname))
         index = "".join(index).strip()
@@ -411,7 +427,7 @@ const struct command_parser command_index[] PROGMEM = {
 %s
 };
 
-const uint8_t command_index_size PROGMEM = ARRAY_SIZE(command_index);
+const uint16_t command_index_size PROGMEM = ARRAY_SIZE(command_index);
 """
         return fmt % (externs, index)
     def generate_param_code(self):

--- a/src/command.c
+++ b/src/command.c
@@ -1,6 +1,6 @@
 // Code for parsing incoming commands and encoding outgoing messages
 //
-// Copyright (C) 2016,2017  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -69,6 +69,28 @@ parse_int(uint8_t **pp)
     return v;
 }
 
+// Write an encoded msgid (optimized 2-byte VLQ encoder)
+static uint8_t *
+encode_msgid(uint8_t *p, uint_fast16_t encoded_msgid)
+{
+    if (encoded_msgid >= 0x80)
+        *p++ = (encoded_msgid >> 7) | 0x80;
+    *p++ = encoded_msgid & 0x7f;
+    return p;
+}
+
+// Parse an encoded msgid (optimized 2-byte parser, return as positive number)
+uint_fast16_t
+command_parse_msgid(uint8_t **pp)
+{
+    uint8_t *p = *pp;
+    uint_fast16_t encoded_msgid = *p++;
+    if (encoded_msgid & 0x80)
+        encoded_msgid = ((encoded_msgid & 0x7f) << 7) | (*p++);
+    *pp = p;
+    return encoded_msgid;
+}
+
 // Parse an incoming command into 'args'
 uint8_t *
 command_parsef(uint8_t *p, uint8_t *maxend
@@ -119,7 +141,7 @@ command_encodef(uint8_t *buf, const struct command_encoder *ce, va_list args)
     uint8_t *maxend = &p[max_size - MESSAGE_MIN];
     uint_fast8_t num_params = READP(ce->num_params);
     const uint8_t *param_types = READP(ce->param_types);
-    *p++ = READP(ce->msg_id);
+    p = encode_msgid(p, READP(ce->encoded_msgid));
     while (num_params--) {
         if (p > maxend)
             goto error;
@@ -227,7 +249,7 @@ DECL_SHUTDOWN(sendf_shutdown);
 
 // Find the command handler associated with a command
 static const struct command_parser *
-command_lookup_parser(uint_fast8_t cmdid)
+command_lookup_parser(uint_fast16_t cmdid)
 {
     if (!cmdid || cmdid >= READP(command_index_size))
         shutdown("Invalid command");
@@ -309,7 +331,7 @@ command_dispatch(uint8_t *buf, uint_fast8_t msglen)
     uint8_t *p = &buf[MESSAGE_HEADER_SIZE];
     uint8_t *msgend = &buf[msglen-MESSAGE_TRAILER_SIZE];
     while (p < msgend) {
-        uint_fast8_t cmdid = *p++;
+        uint_fast16_t cmdid = command_parse_msgid(&p);
         const struct command_parser *cp = command_lookup_parser(cmdid);
         uint32_t args[READP(cp->num_args)];
         p = command_parsef(p, msgend, cp, args);

--- a/src/command.h
+++ b/src/command.h
@@ -57,11 +57,13 @@
 #define MESSAGE_SYNC 0x7E
 
 struct command_encoder {
-    uint8_t msg_id, max_size, num_params;
+    uint16_t encoded_msgid;
+    uint8_t max_size, num_params;
     const uint8_t *param_types;
 };
 struct command_parser {
-    uint8_t msg_id, num_args, flags, num_params;
+    uint16_t encoded_msgid;
+    uint8_t num_args, flags, num_params;
     const uint8_t *param_types;
     void (*func)(uint32_t *args);
 };
@@ -72,6 +74,7 @@ enum {
 
 // command.c
 void *command_decode_ptr(uint32_t v);
+uint_fast16_t command_parse_msgid(uint8_t **pp);
 uint8_t *command_parsef(uint8_t *p, uint8_t *maxend
                         , const struct command_parser *cp, uint32_t *args);
 uint_fast8_t command_encode_and_frame(
@@ -86,7 +89,7 @@ int_fast8_t command_find_and_dispatch(uint8_t *buf, uint_fast8_t buf_len
 
 // out/compile_time_request.c (auto generated file)
 extern const struct command_parser command_index[];
-extern const uint8_t command_index_size;
+extern const uint16_t command_index_size;
 extern const uint8_t command_identify_data[];
 extern const uint32_t command_identify_size;
 const struct command_encoder *ctr_lookup_encoder(const char *str);

--- a/src/pru/pru0.c
+++ b/src/pru/pru0.c
@@ -141,7 +141,7 @@ do_dispatch(uint8_t *buf, uint32_t msglen)
     uint8_t *msgend = &buf[msglen-MESSAGE_TRAILER_SIZE];
     while (p < msgend) {
         // Parse command
-        uint_fast8_t cmdid = *p++;
+        uint_fast16_t cmdid = command_parse_msgid(&p);
         const struct command_parser *cp = &SHARED_MEM->command_index[cmdid];
         if (!cmdid || cmdid >= SHARED_MEM->command_index_size
             || cp->num_args > ARRAY_SIZE(SHARED_MEM->next_command_args)) {

--- a/src/sensor_bulk.h
+++ b/src/sensor_bulk.h
@@ -4,7 +4,7 @@
 struct sensor_bulk {
     uint16_t sequence, possible_overflows;
     uint8_t data_count;
-    uint8_t data[52];
+    uint8_t data[51];
 };
 
 void sensor_bulk_reset(struct sensor_bulk *sb);

--- a/src/sensor_ldc1612.c
+++ b/src/sensor_ldc1612.c
@@ -210,7 +210,7 @@ command_query_ldc1612(uint32_t *args)
 DECL_COMMAND(command_query_ldc1612, "query_ldc1612 oid=%c rest_ticks=%u");
 
 void
-command_query_ldc1612_status(uint32_t *args)
+command_query_status_ldc1612(uint32_t *args)
 {
     struct ldc1612 *ld = oid_lookup(args[0], command_config_ldc1612);
 
@@ -232,7 +232,7 @@ command_query_ldc1612_status(uint32_t *args)
     uint32_t fifo = status & 0x08 ? BYTES_PER_SAMPLE : 0;
     sensor_bulk_status(&ld->sb, args[0], time1, time2-time1, fifo);
 }
-DECL_COMMAND(command_query_ldc1612_status, "query_ldc1612_status oid=%c");
+DECL_COMMAND(command_query_status_ldc1612, "query_status_ldc1612 oid=%c");
 
 void
 ldc1612_task(void)


### PR DESCRIPTION
Currently the message protocol only supports 128 possible message ids.  However, some microcontroller builds need up to ~125 messages today and some proposed code additions are exceeding the limit.

This PR increases the limit from 128 message ids to 16384 ids.  It does this by adding support for either 1 or 2 byte message ids in the low-level message parsing code.

This does mean that the bulk sensor code should use no more than 51 bytes of data when reporting results back to the host.  (A message can be up to 64 bytes long: 5 bytes for the headers, 2 bytes for the response id, 2 bytes for oid, 3 bytes for the sequence number, 1 byte for data length, 51 bytes of data.)  This is a breaking change for the ldc1612 sensor support - users with this sensor will need to recompile and reflash their mcu code after applying this update.

@garethky - fyi.

-Kevin