### PR TITLE
Fix build on recent arm gcc/newlibc versions

### DIFF
--- a/src/atsam/Makefile
+++ b/src/atsam/Makefile
@@ -20,7 +20,7 @@ CFLAGS-$(CONFIG_MACH_SAM4E) += -Ilib/sam4e/include
 CFLAGS-$(CONFIG_MACH_SAME70) += -Ilib/same70b/include
 CFLAGS += $(CFLAGS-y) -D__$(MCU)__ -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/atsamd/Makefile
+++ b/src/atsamd/Makefile
@@ -14,7 +14,7 @@ CFLAGS-$(CONFIG_MACH_SAME51) += -Ilib/same51/include
 CFLAGS-$(CONFIG_MACH_SAMX5) += -mcpu=cortex-m4 -Ilib/same54/include
 CFLAGS += $(CFLAGS-y) -D__$(MCU)__ -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/generic/armcm_link.lds.S
+++ b/src/generic/armcm_link.lds.S
@@ -69,5 +69,8 @@ SECTIONS
         // that isn't needed so no need to include them in the binary.
         *(.init)
         *(.fini)
+        // Don't include exception tables
+        *(.ARM.extab)
+        *(.ARM.exidx)
     }
 }

--- a/src/hc32f460/Makefile
+++ b/src/hc32f460/Makefile
@@ -7,7 +7,7 @@ dirs-y += src/hc32f460 src/generic lib/hc32f460/driver/src lib/hc32f460/mcu/comm
 
 CFLAGS += -mthumb -mcpu=cortex-m4 -Isrc/hc32f460 -Ilib/hc32f460/driver/inc -Ilib/hc32f460/mcu/common -Ilib/cmsis-core -DHC32F460
 
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -7,7 +7,7 @@ dirs-y += src/lpc176x src/generic lib/lpc176x/device
 
 CFLAGS += -mthumb -mcpu=cortex-m3 -Ilib/lpc176x/device -Ilib/cmsis-core
 
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -46,7 +46,6 @@ $(OUT)klipper.uf2: $(OUT)klipper.elf $(OUT)lib/rp2040/elf2uf2/elf2uf2
 	$(Q)$(OUT)lib/rp2040/elf2uf2/elf2uf2 $< $@
 
 rptarget-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)klipper.uf2
-rplink-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)src/rp2040/rp2040_link.ld
 stage2-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)stage2.o
 
 # rp2040 building when using a bootloader
@@ -55,13 +54,13 @@ $(OUT)klipper.bin: $(OUT)klipper.elf
 	$(Q)$(OBJCOPY) -O binary $< $@
 
 rptarget-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)klipper.bin
-rplink-$(CONFIG_RP2040_HAVE_BOOTLOADER) := $(OUT)src/rp2040/rp2040_link.ld
 
 # Set klipper.elf linker rules
 target-y += $(rptarget-y)
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs -T $(rplink-y)
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -T $(OUT)src/rp2040/rp2040_link.ld
 OBJS_klipper.elf += $(stage2-y)
-$(OUT)klipper.elf: $(stage2-y) $(rplink-y)
+$(OUT)klipper.elf: $(stage2-y) $(OUT)src/rp2040/rp2040_link.ld
 
 # Flash rules
 lib/rp2040_flash/rp2040_flash:

--- a/src/rp2040/rp2040_link.lds.S
+++ b/src/rp2040/rp2040_link.lds.S
@@ -21,6 +21,16 @@ MEMORY
   ram (rwx) : ORIGIN = CONFIG_RAM_START , LENGTH = CONFIG_RAM_SIZE
 }
 
+// Force flags for each output section to avoid RWX linker warning
+PHDRS
+{
+    text_segment PT_LOAD FLAGS(5); // RX flags
+    ram_vectortable_segment PT_LOAD FLAGS(6); // RW flags
+    data_segment PT_LOAD FLAGS(6); // RW flags
+    bss_segment PT_LOAD FLAGS(6); // RW flags
+    stack_segment PT_LOAD FLAGS(6); // RW flags
+}
+
 SECTIONS
 {
     .text : {
@@ -32,7 +42,7 @@ SECTIONS
         KEEP(*(.vector_table))
         _text_vectortable_end = .;
         *(.text.armcm_boot*)
-    } > rom
+    } > rom :text_segment
 
     . = ALIGN(4);
     _data_flash = .;
@@ -41,7 +51,7 @@ SECTIONS
         _ram_vectortable_start = .;
         . = . + ( _text_vectortable_end - _text_vectortable_start ) ;
         _ram_vectortable_end = .;
-    } > ram
+    } > ram :ram_vectortable_segment
 
     .data : AT (_data_flash)
     {
@@ -53,7 +63,7 @@ SECTIONS
         *(.data .data.*);
         . = ALIGN(4);
         _data_end = .;
-    } > ram
+    } > ram :data_segment
 
     .bss (NOLOAD) :
     {
@@ -63,14 +73,14 @@ SECTIONS
         *(COMMON)
         . = ALIGN(4);
         _bss_end = .;
-    } > ram
+    } > ram :bss_segment
 
     _stack_start = CONFIG_RAM_START + CONFIG_RAM_SIZE - CONFIG_STACK_SIZE ;
     .stack _stack_start (NOLOAD) :
     {
         . = . + CONFIG_STACK_SIZE;
         _stack_end = .;
-    } > ram
+    } > ram :stack_segment
 
     /DISCARD/ : {
         // The .init/.fini sections are used by __libc_init_array(), but

--- a/src/rp2040/rp2040_link.lds.S
+++ b/src/rp2040/rp2040_link.lds.S
@@ -77,5 +77,8 @@ SECTIONS
         // that isn't needed so no need to include them in the binary.
         *(.init)
         *(.fini)
+        // Don't include exception tables
+        *(.ARM.extab)
+        *(.ARM.exidx)
     }
 }

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -31,7 +31,7 @@ CFLAGS-$(CONFIG_MACH_STM32H7) += -mcpu=cortex-m7 -Ilib/stm32h7/include
 CFLAGS-$(CONFIG_MACH_STM32L4) += -mcpu=cortex-m4 -Ilib/stm32l4/include
 CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
-CFLAGS_klipper.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 


### PR DESCRIPTION
It seems recent arm gcc versions no longer build correctly using the `--specs=nano.specs --specs=nosys.specs` linker flags.  Replace those linker flags with `-nostdlib -lgcc -lc_nano`.

This seems to fix the build on recent gcc versions, it eliminates some build time warnings, and does not increase the size of the resulting binary.

-Kevin