### PR TITLE
[Probe] Decouple Homing from probing Session.

### DIFF
--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -65,6 +65,7 @@ class BLTouchProbe:
             config, self, self.mcu_endstop.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.probe_session = probe.ProbeSessionHelper(config, self)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self)
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -242,7 +242,6 @@ class ProbeSessionHelper:
             pconfig = config.getsection('printer')
             self.z_position = pconfig.getfloat('minimum_z_position', 0.,
                                                note_valid=False)
-        self.homing_helper = HomingViaProbeHelper(config, mcu_probe)
         # Configurable probing speeds
         self.speed = config.getfloat('speed', 5.0, above=0.)
         self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)
@@ -543,6 +542,7 @@ class PrinterProbe:
                                              self.mcu_probe.query_endstop)
         self.probe_offsets = ProbeOffsetsHelper(config)
         self.probe_session = ProbeSessionHelper(config, self.mcu_probe)
+        self.homing_helper = HomingViaProbeHelper(config, self.mcu_probe)
     def get_probe_params(self, gcmd=None):
         return self.probe_session.get_probe_params(gcmd)
     def get_offsets(self):

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -324,6 +324,7 @@ class PrinterEddyProbe:
             config, self, self.mcu_probe.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.probe_session = probe.ProbeSessionHelper(config, self.mcu_probe)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe)
         self.printer.add_object('probe', self)
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -69,6 +69,7 @@ class SmartEffectorProbe:
             config, self, self.probe_wrapper.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.probe_session = probe.ProbeSessionHelper(config, self)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self)
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:


### PR DESCRIPTION
The probe refactor is very helpful in making things more modular.
However the Homing and Probing are stil tied together.
This is a one-liner to make them independant.
Allowing to have multiple probes and assigning homing to one.

Related: https://github.com/viesturz/klipper-toolchanger/commit/83873f82a9a64de35cafe698965efa2ef51f7adc