### PR TITLE
bed_mesh: add support for "rapid" scanning

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -401,3 +401,130 @@ might return:
 
 As with the "gcode/script" endpoint, this endpoint only completes
 after any pending G-Code commands complete.
+
+### bed_mesh/dump_mesh
+
+Dumps the configuration and state for the current mesh and all
+saved profiles.
+
+For example:
+`{"id": 123, "method": "bed_mesh/dump_mesh"}`
+
+might return:
+
+```
+{
+    "current_mesh": {
+        "name": "eddy-scan-test",
+        "probed_matrix": [...],
+        "mesh_matrix": [...],
+        "mesh_params": {
+            "x_count": 9,
+            "y_count": 9,
+            "mesh_x_pps": 2,
+            "mesh_y_pps": 2,
+            "algo": "bicubic",
+            "tension": 0.5,
+            "min_x": 20,
+            "max_x": 330,
+            "min_y": 30,
+            "max_y": 320
+        }
+    },
+    "profiles": {
+        "default": {
+            "points": [...],
+            "mesh_params": {
+                "min_x": 20,
+                "max_x": 330,
+                "min_y": 30,
+                "max_y": 320,
+                "x_count": 9,
+                "y_count": 9,
+                "mesh_x_pps": 2,
+                "mesh_y_pps": 2,
+                "algo": "bicubic",
+                "tension": 0.5
+            }
+        },
+        "eddy-scan-test": {
+            "points": [...],
+            "mesh_params": {
+                "x_count": 9,
+                "y_count": 9,
+                "mesh_x_pps": 2,
+                "mesh_y_pps": 2,
+                "algo": "bicubic",
+                "tension": 0.5,
+                "min_x": 20,
+                "max_x": 330,
+                "min_y": 30,
+                "max_y": 320
+            }
+        },
+        "eddy-rapid-test": {
+            "points": [...],
+            "mesh_params": {
+                "x_count": 9,
+                "y_count": 9,
+                "mesh_x_pps": 2,
+                "mesh_y_pps": 2,
+                "algo": "bicubic",
+                "tension": 0.5,
+                "min_x": 20,
+                "max_x": 330,
+                "min_y": 30,
+                "max_y": 320
+            }
+        }
+    },
+    "calibration": {
+        "points": [...],
+        "config": {
+            "x_count": 9,
+            "y_count": 9,
+            "mesh_x_pps": 2,
+            "mesh_y_pps": 2,
+            "algo": "bicubic",
+            "tension": 0.5,
+            "mesh_min": [
+                20,
+                30
+            ],
+            "mesh_max": [
+                330,
+                320
+            ],
+            "origin": null,
+            "radius": null
+        },
+        "probe_path": [...],
+        "rapid_path": [...]
+    },
+    "probe_offsets": [
+        0,
+        25,
+        0.5
+    ],
+    "axis_minimum": [
+        0,
+        0,
+        -5,
+        0
+    ],
+    "axis_maximum": [
+        351,
+        358,
+        330,
+        0
+    ]
+}
+```
+
+The `dump_mesh` endpoint takes one optional parameter, `mesh_args`.
+This parameter must be an object, where the keys and values are
+parameters available to [BED_MESH_CALIBRATE](#bed_mesh_calibrate).
+This will update the mesh configuration and probe points using the
+supplied parameters prior to returning the result.   It is recommended
+to omit mesh parameters unless it is desired to visualize the probe points
+and/or travel path before performing `BED_MESH_CALIBRATE`.

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -421,12 +421,75 @@ have undesirable results when attempting print moves **outside** of the probed a
 full bed mesh has a variance greater than 1 layer height, caution must be taken when using
 adaptive bed meshes and attempting print moves outside of the meshed area.
 
+## Surface Scans
+
+Some probes, such as the [Eddy Current Probe](./Eddy_Probe.md), are capable of
+"scanning" the surface of the bed.  That is, these probes can sample a mesh
+without lifting the tool between samples.  To activate scanning mode, the
+`METHOD=scan` or `METHOD=rapid_scan` probe parameter should be passed in the
+`BED_MESH_CALIBRATE` gcode command.
+
+### Scan Height
+
+The scan height is set by the `horizontal_move_z` option in `[bed_mesh]`.  In
+addition it can be supplied with the `BED_MESH_CALIBRATE` gcode command via the
+`HORIZONTAL_MOVE_Z` parameter.
+
+The scan height must be sufficiently low to avoid scanning errors.  Typically
+a height of 2mm (ie: `HORIZONTAL_MOVE_Z=2`) should work well, presuming that the
+probe is mounted correctly.
+
+It should be noted that if the probe is more than 4mm above the surface then the
+results will be invalid.  Thus, scanning is not possible on beds with severe
+surface deviation or beds with extreme tilt that hasn't been corrected.
+
+### Rapid (Continuous) Scanning
+
+When performing a `rapid_scan` one should keep in mind that the results will
+have some amount of error.  This error should be low enough to be useful on
+large print areas with reasonably thick layer heights.  Some probes may be
+more prone to error than others.
+
+It is not recommended that rapid mode be used to scan a "dense" mesh.  Some of
+the error introduced during a rapid scan may be gaussian noise from the sensor,
+and a dense mesh will reflect this noise (ie: there will be peaks and valleys).
+
+Bed Mesh will attempt to optimize the travel path to provide the best possible
+result based on the configuration.  This includes avoiding faulty regions
+when collecting samples and "overshooting" the mesh when changing direction.
+This overshoot improves sampling at the edges of a mesh, however it requires
+that the mesh be configured in a way that allows the tool to travel outside
+of the mesh.
+
+```
+[bed_mesh]
+speed: 120
+horizontal_move_z: 5
+mesh_min: 35, 6
+mesh_max: 240, 198
+probe_count: 5
+scan_overshoot: 8
+```
+
+- `scan_overshoot`
+  _Default Value: 0 (disabled)_\
+  The maximum amount of travel (in mm) available outside of the mesh.
+  For rectangular beds this applies to travel on the X axis, and for round beds
+  it applies to the entire radius.  The tool must be able to travel the amount
+  specified outside of the mesh.  This value is used to optimize the travel
+  path when performing a "rapid scan".  The minimum value that may be specified
+  is 1.  The default is no overshoot.
+
+If no scan overshoot is configured then travel path optimization will not
+be applied to changes in direction.
+
 ## Bed Mesh Gcodes
 
 ### Calibration
 
-`BED_MESH_CALIBRATE PROFILE=<name> METHOD=[manual | automatic] [<probe_parameter>=<value>]
- [<mesh_parameter>=<value>] [ADAPTIVE=[0|1] [ADAPTIVE_MARGIN=<value>]`\
+`BED_MESH_CALIBRATE PROFILE=<name> METHOD=[manual | automatic | scan | rapid_scan] \
+[<probe_parameter>=<value>] [<mesh_parameter>=<value>] [ADAPTIVE=[0|1] \
+[ADAPTIVE_MARGIN=<value>]`\
 _Default Profile:  default_\
 _Default Method:  automatic if a probe is detected, otherwise manual_ \
 _Default Adaptive: 0_ \
@@ -435,9 +498,17 @@ _Default Adaptive Margin: 0_
 Initiates the probing procedure for Bed Mesh Calibration.
 
 The mesh will be saved into a profile specified by the `PROFILE` parameter,
-or `default` if unspecified. If `METHOD=manual` is selected then manual probing
-will occur.  When switching between automatic and manual probing the generated
-mesh points will automatically be adjusted.
+or `default` if unspecified. The `METHOD` parameter takes one of the following
+values:
+
+- `METHOD=manual`: enables manual probing using the nozzle and the paper test
+- `METHOD=automatic`:  Automatic (standard) probing.  This is the default.
+- `METHOD=scan`: Enables surface scanning.  The tool will pause over each position
+                 to collect a sample.
+- `METHOD=rapid_scan`: Enables continuous surface scanning.
+
+XY positions are automatically adjusted to include the X and/or Y offsets
+when a probing method other than `manual` is selected.
 
 It is possible to specify mesh parameters to modify the probed area.  The
 following parameters are available:
@@ -451,6 +522,7 @@ following parameters are available:
   - `MESH_ORIGIN`
   - `ROUND_PROBE_COUNT`
 - All beds:
+  - `MESH_PPS`
   - `ALGORITHM`
   - `ADAPTIVE`
   - `ADAPTIVE_MARGIN`
@@ -557,3 +629,191 @@ is intended to compensate for a `gcode offset` when [mesh fade](#mesh-fade)
 is enabled.  For example, if a secondary extruder is higher than the primary
 and needs a negative gcode offset, ie: `SET_GCODE_OFFSET Z=-.2`, it can be
 accounted for in `bed_mesh` with `BED_MESH_OFFSET ZFADE=.2`.
+
+## Bed Mesh Webhooks APIs
+
+### Dumping mesh data
+
+`{"id": 123, "method": "bed_mesh/dump_mesh"}`
+
+Dumps the configuration and state for the current mesh and all
+saved profiles.
+
+The `dump_mesh` endpoint takes one optional parameter, `mesh_args`.
+This parameter must be an object, where the keys and values are
+parameters available to [BED_MESH_CALIBRATE](#bed_mesh_calibrate).
+This will update the mesh configuration and probe points using the
+supplied parameters prior to returning the result.   It is recommended
+to omit mesh parameters unless it is desired to visualize the probe points
+and/or travel path before performing `BED_MESH_CALIBRATE`.
+
+## Visualization and analysis
+
+Most users will likely find that the visualizers included with
+applications such as Mainsail, Fluidd, and Octoprint are sufficient
+for basic analysis.  However, Klipper's `scripts` folder contains the
+`graph_mesh.py` script that may be used to perform additional
+visualizations and more detailed analysis, particularly useful
+for debugging hardware or the results produced by `bed_mesh`:
+
+```
+usage: graph_mesh.py [-h] {list,plot,analyze,dump} ...
+
+Graph Bed Mesh Data
+
+positional arguments:
+  {list,plot,analyze,dump}
+    list                List available plot types
+    plot                Plot a specified type
+    analyze             Perform analysis on mesh data
+    dump                Dump API response to json file
+
+options:
+  -h, --help            show this help message and exit
+```
+
+### Pre-requisites
+
+Like most graphing tools provided by Klipper, `graph_mesh.py` requires
+the `matplotlib` and `numpy` python dependencies. In addition, connecting
+to Klipper via Moonraker's websocket requires the `websockets` python
+dependency.  While all visualizations can be output to an `svg` file, most of
+the visualizations offered by `graph_mesh.py` are better viewed in live
+preview mode on a desktop class PC. For example, the 3D visualizations may be
+rotated and zoomed in preview mode, and the path visualizations can optionally
+be animated in preview mode.
+
+### Plotting Mesh data
+
+The `graph_mesh.py` tool can plot several types of visualizations.
+Available types can be shown by running `graph_mesh.py list`:
+
+```
+graph_mesh.py list
+points    Plot original generated points
+path      Plot probe travel path
+rapid     Plot rapid scan travel path
+probedz   Plot probed Z values
+meshz     Plot mesh Z values
+overlay   Plots the current probed mesh overlaid with a profile
+delta     Plots the delta between current probed mesh and a profile
+```
+
+Several options are available when plotting visualizations:
+
+```
+usage: graph_mesh.py plot [-h] [-a] [-s] [-p PROFILE_NAME] [-o OUTPUT] <plot type> <input>
+
+positional arguments:
+  <plot type>           Type of data to graph
+  <input>               Path/url to Klipper Socket or path to json file
+
+options:
+  -h, --help            show this help message and exit
+  -a, --animate         Animate paths in live preview
+  -s, --scale-plot      Use axis limits reported by Klipper to scale plot X/Y
+  -p PROFILE_NAME, --profile-name PROFILE_NAME
+                        Optional name of a profile to plot for 'probedz'
+  -o OUTPUT, --output OUTPUT
+                        Output file path
+```
+
+Below is a description of each argument:
+
+- `plot type`: A required positional argument designating the type of
+  visualization to generate.  Must be one of the types output by the
+  `graph_mesh.py list` command.
+- `input`: A required positional argument containing a path or url
+  to the input source.  This must be one of the following:
+  - A path to Klipper's Unix Domain Socket
+  - A url to an instance of Moonraker
+  - A path to a json file produced by `graph_mesh.py dump <input>`
+- `-a`:  Optional animation for the `path` and `rapid` visualization types.
+  Animations only apply to a live preview.
+- `-s`:  Optionally scales a plot using the `axis_minimum` and `axis_maximum`
+  values reported by Klipper's `toolhead` object when the dump file was
+  generated.
+- `-p`: A profile name that may be specified when generating the
+  `probedz` 3D mesh visualization.  When generating an `overlay` or
+  `delta` visualization this argument must be provided.
+- `-o`: An optional file path indicating that the script should save the
+  visualization to this location rather than run in preview mode.  Images
+  are saved in `svg` format.
+
+For example, to plot an animated rapid path, connecting via Klipper's unix
+socket:
+
+```
+graph_mesh.py plot -a rapid ~/printer_data/comms/klippy.sock
+```
+
+Or to plot a 3d visualization of the mesh, connecting via Moonraker:
+
+```
+graph_mesh.py plot meshz http://my-printer.local
+```
+
+### Bed Mesh Analysis
+
+The `graph_mesh.py` tool may also be used to perform an analysis on the
+data provided by the [bed_mesh/dump_mesh](#dumping-mesh-data) API:
+
+```
+graph_mesh.py analyze <input>
+```
+
+As with the `plot` command, the `<input>` must be a path to Klipper's
+unix socket, a URL to an instance of Moonraker, or a path to a json file
+generated by the dump command.
+
+To begin, the analysis will perform various checks on the points and
+probe paths generated by `bed_mesh` at the time of the dump.  This
+includes the following:
+
+- The number of probe points generated, without any additions
+- The number of probe points generated including any points generated
+  as the result faulty regions and/or a configured zero reference position.
+- The number of probe points generated when performing a rapid scan.
+- The total number of moves generated for a rapid scan.
+- A validation that the probe points generated for a rapid scan are
+  identical to the probe points generated for a standard probing procedure.
+- A "backtracking" check for both the standard probe path and a rapid scan
+  path.  Backtracking can be defined as moving to the same position more than
+  once during the probing procedure.  Backtracking should never occur during a
+  standard probe.  Faulty regions *can* result in backtracking during a rapid
+  scan in an attempt to avoid entering a faulty region when approaching or
+  leaving a probe location, however should never occur otherwise.
+
+Next each probed mesh present in the dump will by analyzed, beginning with
+the mesh loaded at the time of the dump (if present) and followed by any
+saved profiles.  The following data is extracted:
+
+- Mesh shape (Min X,Y, Max X,Y Probe Count)
+- Mesh Z range, (Minimum Z, Maximum Z)
+- Mean Z value in the mesh
+- Standard Deviation of the Z values in the Mesh
+
+In addition to the above, a delta analysis is performed between meshes
+with the same shape, reporting the following:
+- The range of the delta between to meshes (Minimum and Maximum)
+- The mean delta
+- Standard Deviation of the delta
+- The absolute maximum difference
+- The absolute mean
+
+### Save mesh data to a file
+
+The `dump` command may be used to save the response to a file which
+can be shared for analysis when troubleshooting:
+
+```
+graph_mesh.py dump -o <output file name> <input>
+```
+
+The `<input>` should be a path to Klipper's unix socket or
+a URL to an instance of Moonraker.  The `-o` option may be used to
+specify the path to the output file.  If omitted, the file will be
+saved in the working directory, with a file name in the following
+format:
+
+`klipper-bedmesh-{year}{month}{day}{hour}{minute}{second}.json`

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -998,6 +998,13 @@ Visual Examples:
 #adaptive_margin:
 #   An optional margin (in mm) to be added around the bed area used by
 #   the defined print objects when generating an adaptive mesh.
+#scan_overshoot:
+#  The maximum amount of travel (in mm) available outside of the mesh.
+#  For rectangular beds this applies to travel on the X axis, and for round beds
+#  it applies to the entire radius.  The tool must be able to travel the amount
+#  specified outside of the mesh.  This value is used to optimize the travel
+#  path when performing a "rapid scan".  The minimum value that may be specified
+#  is 1.  The default is no overshoot.
 ```
 
 ### [bed_tilt]

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -298,130 +298,24 @@ class BedMeshCalibrate:
         self.radius = self.origin = None
         self.mesh_min = self.mesh_max = (0., 0.)
         self.adaptive_margin = config.getfloat('adaptive_margin', 0.0)
-        self.zero_ref_pos = config.getfloatlist(
-            "zero_reference_position", None, count=2
-        )
-        self.zero_reference_mode = ZrefMode.DISABLED
-        self.faulty_regions = []
-        self.substituted_indices = collections.OrderedDict()
         self.bedmesh = bedmesh
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
-        self._generate_points(config.error)
+        self.probe_mgr = ProbeManager(
+            config, self.orig_config, self.probe_finalize
+        )
+        try:
+            self.probe_mgr.generate_points(
+                self.mesh_config, self.mesh_min, self.mesh_max,
+                self.radius, self.origin
+            )
+        except BedMeshError as e:
+            raise config.error(str(e))
         self._profile_name = "default"
-        self.probe_helper = probe.ProbePointsHelper(
-            config, self.probe_finalize, self._get_adjusted_points())
-        self.probe_helper.minimum_points(3)
-        self.probe_helper.use_xy_offsets(True)
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'BED_MESH_CALIBRATE', self.cmd_BED_MESH_CALIBRATE,
             desc=self.cmd_BED_MESH_CALIBRATE_help)
-    def _generate_points(self, error, probe_method="automatic"):
-        x_cnt = self.mesh_config['x_count']
-        y_cnt = self.mesh_config['y_count']
-        min_x, min_y = self.mesh_min
-        max_x, max_y = self.mesh_max
-        x_dist = (max_x - min_x) / (x_cnt - 1)
-        y_dist = (max_y - min_y) / (y_cnt - 1)
-        # floor distances down to next hundredth
-        x_dist = math.floor(x_dist * 100) / 100
-        y_dist = math.floor(y_dist * 100) / 100
-        if x_dist < 1. or y_dist < 1.:
-            raise error("bed_mesh: min/max points too close together")
-
-        if self.radius is not None:
-            # round bed, min/max needs to be recalculated
-            y_dist = x_dist
-            new_r = (x_cnt // 2) * x_dist
-            min_x = min_y = -new_r
-            max_x = max_y = new_r
-        else:
-            # rectangular bed, only re-calc max_x
-            max_x = min_x + x_dist * (x_cnt - 1)
-        pos_y = min_y
-        points = []
-        for i in range(y_cnt):
-            for j in range(x_cnt):
-                if not i % 2:
-                    # move in positive directon
-                    pos_x = min_x + j * x_dist
-                else:
-                    # move in negative direction
-                    pos_x = max_x - j * x_dist
-                if self.radius is None:
-                    # rectangular bed, append
-                    points.append((pos_x, pos_y))
-                else:
-                    # round bed, check distance from origin
-                    dist_from_origin = math.sqrt(pos_x*pos_x + pos_y*pos_y)
-                    if dist_from_origin <= self.radius:
-                        points.append(
-                            (self.origin[0] + pos_x, self.origin[1] + pos_y))
-            pos_y += y_dist
-        self.points = points
-        if self.zero_ref_pos is None or probe_method == "manual":
-            # Zero Reference Disabled
-            self.zero_reference_mode = ZrefMode.DISABLED
-        elif within(self.zero_ref_pos, self.mesh_min, self.mesh_max):
-            # Zero Reference position within mesh
-            self.zero_reference_mode = ZrefMode.IN_MESH
-        else:
-            # Zero Reference position outside of mesh
-            self.zero_reference_mode = ZrefMode.PROBE
-        if not self.faulty_regions:
-            return
-        self.substituted_indices.clear()
-        if self.zero_reference_mode == ZrefMode.PROBE:
-            # Cannot probe a reference within a faulty region
-            for min_c, max_c in self.faulty_regions:
-                if within(self.zero_ref_pos, min_c, max_c):
-                    opt = "zero_reference_position"
-                    raise error(
-                        "bed_mesh: Cannot probe zero reference position at "
-                        "(%.2f, %.2f) as it is located within a faulty region."
-                        " Check the value for option '%s'"
-                        % (self.zero_ref_pos[0], self.zero_ref_pos[1], opt,)
-                    )
-        # Check to see if any points fall within faulty regions
-        if probe_method == "manual":
-            return
-        last_y = self.points[0][1]
-        is_reversed = False
-        for i, coord in enumerate(self.points):
-            if not isclose(coord[1], last_y):
-                is_reversed = not is_reversed
-            last_y = coord[1]
-            adj_coords = []
-            for min_c, max_c in self.faulty_regions:
-                if within(coord, min_c, max_c, tol=.00001):
-                    # Point lies within a faulty region
-                    adj_coords = [
-                        (min_c[0], coord[1]), (coord[0], min_c[1]),
-                        (coord[0], max_c[1]), (max_c[0], coord[1])]
-                    if is_reversed:
-                        # Swap first and last points for zig-zag pattern
-                        first = adj_coords[0]
-                        adj_coords[0] = adj_coords[-1]
-                        adj_coords[-1] = first
-                    break
-            if not adj_coords:
-                # coord is not located within a faulty region
-                continue
-            valid_coords = []
-            for ac in adj_coords:
-                # make sure that coordinates are within the mesh boundary
-                if self.radius is None:
-                    if within(ac, (min_x, min_y), (max_x, max_y), .000001):
-                        valid_coords.append(ac)
-                else:
-                    dist_from_origin = math.sqrt(ac[0]*ac[0] + ac[1]*ac[1])
-                    if dist_from_origin <= self.radius:
-                        valid_coords.append(ac)
-            if not valid_coords:
-                raise error("bed_mesh: Unable to generate coordinates"
-                            " for faulty region at index: %d" % (i))
-            self.substituted_indices[i] = valid_coords
     def print_generated_points(self, print_func):
         x_offset = y_offset = 0.
         probe = self.printer.lookup_object('probe', None)
@@ -429,20 +323,23 @@ class BedMeshCalibrate:
             x_offset, y_offset = probe.get_offsets()[:2]
         print_func("bed_mesh: generated points\nIndex"
                    " |  Tool Adjusted  |   Probe")
-        for i, (x, y) in enumerate(self.points):
+        points = self.probe_mgr.get_base_points()
+        for i, (x, y) in enumerate(points):
             adj_pt = "(%.1f, %.1f)" % (x - x_offset, y - y_offset)
             mesh_pt = "(%.1f, %.1f)" % (x, y)
             print_func(
                 "  %-4d| %-16s| %s" % (i, adj_pt, mesh_pt))
-        if self.zero_ref_pos is not None:
+        zero_ref_pos = self.probe_mgr.get_zero_ref_pos()
+        if zero_ref_pos is not None:
             print_func(
                 "bed_mesh: zero_reference_position is (%.2f, %.2f)"
-                % (self.zero_ref_pos[0], self.zero_ref_pos[1])
+                % (zero_ref_pos[0], zero_ref_pos[1])
             )
-        if self.substituted_indices:
+        substitutes = self.probe_mgr.get_substitutes()
+        if substitutes:
             print_func("bed_mesh: faulty region points")
-            for i, v in self.substituted_indices.items():
-                pt = self.points[i]
+            for i, v in substitutes.items():
+                pt = points[i]
                 print_func("%d (%.2f, %.2f), substituted points: %s"
                            % (i, pt[0], pt[1], repr(v)))
     def _init_mesh_config(self, config):
@@ -481,42 +378,6 @@ class BedMeshCalibrate:
             config.get('algorithm', 'lagrange').strip().lower()
         orig_cfg['tension'] = mesh_cfg['tension'] = config.getfloat(
             'bicubic_tension', .2, minval=0., maxval=2.)
-        for i in list(range(1, 100, 1)):
-            start = config.getfloatlist("faulty_region_%d_min" % (i,), None,
-                                        count=2)
-            if start is None:
-                break
-            end = config.getfloatlist("faulty_region_%d_max" % (i,), count=2)
-            # Validate the corners.  If necessary reorganize them.
-            # c1 = min point, c3 = max point
-            #  c4 ---- c3
-            #  |        |
-            #  c1 ---- c2
-            c1 = [min([s, e]) for s, e in zip(start, end)]
-            c3 = [max([s, e]) for s, e in zip(start, end)]
-            c2 = [c1[0], c3[1]]
-            c4 = [c3[0], c1[1]]
-            # Check for overlapping regions
-            for j, (prev_c1, prev_c3) in enumerate(self.faulty_regions):
-                prev_c2 = [prev_c1[0], prev_c3[1]]
-                prev_c4 = [prev_c3[0], prev_c1[1]]
-                # Validate that no existing corner is within the new region
-                for coord in [prev_c1, prev_c2, prev_c3, prev_c4]:
-                    if within(coord, c1, c3):
-                        raise config.error(
-                            "bed_mesh: Existing faulty_region_%d %s overlaps "
-                            "added faulty_region_%d %s"
-                            % (j+1, repr([prev_c1, prev_c3]),
-                               i, repr([c1, c3])))
-                # Validate that no new corner is within an existing region
-                for coord in [c1, c2, c3, c4]:
-                    if within(coord, prev_c1, prev_c3):
-                        raise config.error(
-                            "bed_mesh: Added faulty_region_%d %s overlaps "
-                            "existing faulty_region_%d %s"
-                            % (i, repr([c1, c3]),
-                               j+1, repr([prev_c1, prev_c3])))
-            self.faulty_regions.append((c1, c3))
         self._verify_algorithm(config.error)
     def _verify_algorithm(self, error):
         params = self.mesh_config
@@ -712,47 +573,36 @@ class BedMeshCalibrate:
 
         if need_cfg_update:
             self._verify_algorithm(gcmd.error)
-            self._generate_points(gcmd.error, probe_method)
+            self.probe_mgr.generate_points(
+                self.mesh_config, self.mesh_min, self.mesh_max,
+                self.radius, self.origin, probe_method
+            )
             gcmd.respond_info("Generating new points...")
             self.print_generated_points(gcmd.respond_info)
-            pts = self._get_adjusted_points()
-            self.probe_helper.update_probe_points(pts, 3)
             msg = "\n".join(["%s: %s" % (k, v)
                              for k, v in self.mesh_config.items()])
             logging.info("Updated Mesh Configuration:\n" + msg)
         else:
-            self._generate_points(gcmd.error, probe_method)
-            pts = self._get_adjusted_points()
-            self.probe_helper.update_probe_points(pts, 3)
-    def _get_adjusted_points(self):
-        adj_pts = []
-        if self.substituted_indices:
-            last_index = 0
-            for i, pts in self.substituted_indices.items():
-                adj_pts.extend(self.points[last_index:i])
-                adj_pts.extend(pts)
-                # Add one to the last index to skip the point
-                # we are replacing
-                last_index = i + 1
-            adj_pts.extend(self.points[last_index:])
-        else:
-            adj_pts = list(self.points)
-        if self.zero_reference_mode == ZrefMode.PROBE:
-            adj_pts.append(self.zero_ref_pos)
-        return adj_pts
+            self.probe_mgr.generate_points(
+                self.mesh_config, self.mesh_min, self.mesh_max,
+                self.radius, self.origin, probe_method
+            )
     cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
     def cmd_BED_MESH_CALIBRATE(self, gcmd):
         self._profile_name = gcmd.get('PROFILE', "default")
         if not self._profile_name.strip():
             raise gcmd.error("Value for parameter 'PROFILE' must be specified")
         self.bedmesh.set_mesh(None)
-        self.update_config(gcmd)
-        self.probe_helper.start_probe(gcmd)
+        try:
+            self.update_config(gcmd)
+        except BedMeshError as e:
+            raise gcmd.error(str(e))
+        self.probe_mgr.start_probe(gcmd)
     def probe_finalize(self, offsets, positions):
         x_offset, y_offset, z_offset = offsets
         positions = [[round(p[0], 2), round(p[1], 2), p[2]]
                      for p in positions]
-        if self.zero_reference_mode == ZrefMode.PROBE:
+        if self.probe_mgr.get_zero_ref_mode() == ZrefMode.PROBE:
             ref_pos = positions.pop()
             logging.info(
                 "bed_mesh: z-offset replaced with probed z value at "
@@ -768,15 +618,17 @@ class BedMeshCalibrate:
         x_cnt = params['x_count']
         y_cnt = params['y_count']
 
-        if self.substituted_indices:
+        substitutes = self.probe_mgr.get_substitutes()
+        base_points = self.probe_mgr.get_base_points()
+        if substitutes:
             # Replace substituted points with the original generated
             # point.  Its Z Value is the average probed Z of the
             # substituted points.
             corrected_pts = []
             idx_offset = 0
             start_idx = 0
-            for i, pts in self.substituted_indices.items():
-                fpt = [p - o for p, o in zip(self.points[i], offsets[:2])]
+            for i, pts in substitutes.items():
+                fpt = [p - o for p, o in zip(base_points[i], offsets[:2])]
                 # offset the index to account for additional samples
                 idx = i + idx_offset
                 # Add "normal" points
@@ -793,13 +645,13 @@ class BedMeshCalibrate:
                 corrected_pts.append(fpt)
             corrected_pts.extend(positions[start_idx:])
             # validate corrected positions
-            if len(self.points) != len(corrected_pts):
+            if len(base_points) != len(corrected_pts):
                 self._dump_points(positions, corrected_pts, offsets)
                 raise self.gcode.error(
                     "bed_mesh: invalid position list size, "
                     "generated count: %d, probed count: %d"
-                    % (len(self.points), len(corrected_pts)))
-            for gen_pt, probed in zip(self.points, corrected_pts):
+                    % (len(base_points), len(corrected_pts)))
+            for gen_pt, probed in zip(base_points, corrected_pts):
                 off_pt = [p - o for p, o in zip(gen_pt, offsets[:2])]
                 if not isclose(off_pt[0], probed[0], abs_tol=.1) or \
                         not isclose(off_pt[1], probed[1], abs_tol=.1):
@@ -866,11 +718,12 @@ class BedMeshCalibrate:
             z_mesh.build_mesh(probed_matrix)
         except BedMeshError as e:
             raise self.gcode.error(str(e))
-        if self.zero_reference_mode == ZrefMode.IN_MESH:
+        if self.probe_mgr.get_zero_ref_mode() == ZrefMode.IN_MESH:
             # The reference can be anywhere in the mesh, therefore
             # it is necessary to set the reference after the initial mesh
             # is generated to lookup the correct z value.
-            z_mesh.set_zero_reference(*self.zero_ref_pos)
+            zero_ref_pos = self.probe_mgr.get_zero_ref_pos()
+            z_mesh.set_zero_reference(*zero_ref_pos)
         self.bedmesh.set_mesh(z_mesh)
         self.gcode.respond_info("Mesh Bed Leveling Complete")
         if self._profile_name is not None:
@@ -878,14 +731,15 @@ class BedMeshCalibrate:
     def _dump_points(self, probed_pts, corrected_pts, offsets):
         # logs generated points with offset applied, points received
         # from the finalize callback, and the list of corrected points
-        max_len = max([len(self.points), len(probed_pts), len(corrected_pts)])
+        points = self.probe_mgr.get_base_points()
+        max_len = max([len(points), len(probed_pts), len(corrected_pts)])
         logging.info(
             "bed_mesh: calibration point dump\nIndex | %-17s| %-25s|"
             " Corrected Point" % ("Generated Point", "Probed Point"))
         for i in list(range(max_len)):
             gen_pt = probed_pt = corr_pt = ""
-            if i < len(self.points):
-                off_pt = [p - o for p, o in zip(self.points[i], offsets[:2])]
+            if i < len(points):
+                off_pt = [p - o for p, o in zip(points[i], offsets[:2])]
                 gen_pt = "(%.2f, %.2f)" % tuple(off_pt)
             if i < len(probed_pts):
                 probed_pt = "(%.2f, %.2f, %.4f)" % tuple(probed_pts[i])
@@ -893,6 +747,453 @@ class BedMeshCalibrate:
                 corr_pt = "(%.2f, %.2f, %.4f)" % tuple(corrected_pts[i])
             logging.info(
                 "  %-4d| %-17s| %-25s| %s" % (i, gen_pt, probed_pt, corr_pt))
+
+class ProbeManager:
+    def __init__(self, config, orig_config, finalize_cb):
+        self.printer = config.get_printer()
+        self.cfg_overshoot = config.getfloat("scan_overshoot", 0, minval=1.)
+        self.orig_config = orig_config
+        self.faulty_regions = []
+        self.overshoot = self.cfg_overshoot
+        self.zero_ref_pos = config.getfloatlist(
+            "zero_reference_position", None, count=2
+        )
+        self.zref_mode = ZrefMode.DISABLED
+        self.base_points = []
+        self.substitutes = collections.OrderedDict()
+        self.is_round = orig_config["radius"] is not None
+        self.probe_helper = probe.ProbePointsHelper(config, finalize_cb, [])
+        self.probe_helper.use_xy_offsets(True)
+        self.rapid_scan_helper = RapidScanHelper(config, self, finalize_cb)
+        self._init_faulty_regions(config)
+
+    def _init_faulty_regions(self, config):
+        for i in list(range(1, 100, 1)):
+            start = config.getfloatlist("faulty_region_%d_min" % (i,), None,
+                                        count=2)
+            if start is None:
+                break
+            end = config.getfloatlist("faulty_region_%d_max" % (i,), count=2)
+            # Validate the corners.  If necessary reorganize them.
+            # c1 = min point, c3 = max point
+            #  c4 ---- c3
+            #  |        |
+            #  c1 ---- c2
+            c1 = [min([s, e]) for s, e in zip(start, end)]
+            c3 = [max([s, e]) for s, e in zip(start, end)]
+            c2 = [c1[0], c3[1]]
+            c4 = [c3[0], c1[1]]
+            # Check for overlapping regions
+            for j, (prev_c1, prev_c3) in enumerate(self.faulty_regions):
+                prev_c2 = [prev_c1[0], prev_c3[1]]
+                prev_c4 = [prev_c3[0], prev_c1[1]]
+                # Validate that no existing corner is within the new region
+                for coord in [prev_c1, prev_c2, prev_c3, prev_c4]:
+                    if within(coord, c1, c3):
+                        raise config.error(
+                            "bed_mesh: Existing faulty_region_%d %s overlaps "
+                            "added faulty_region_%d %s"
+                            % (j+1, repr([prev_c1, prev_c3]),
+                               i, repr([c1, c3])))
+                # Validate that no new corner is within an existing region
+                for coord in [c1, c2, c3, c4]:
+                    if within(coord, prev_c1, prev_c3):
+                        raise config.error(
+                            "bed_mesh: Added faulty_region_%d %s overlaps "
+                            "existing faulty_region_%d %s"
+                            % (i, repr([c1, c3]),
+                               j+1, repr([prev_c1, prev_c3])))
+            self.faulty_regions.append((c1, c3))
+
+    def start_probe(self, gcmd):
+        method = gcmd.get("METHOD", "automatic").lower()
+        can_scan = False
+        pprobe = self.printer.lookup_object("probe", None)
+        if pprobe is not None:
+            probe_name = pprobe.get_status(None).get("name", "")
+            can_scan = probe_name.startswith("probe_eddy_current")
+        if method == "rapid_scan" and can_scan:
+            self.rapid_scan_helper.perform_rapid_scan(gcmd)
+        else:
+            self.probe_helper.start_probe(gcmd)
+
+    def get_zero_ref_pos(self):
+        return self.zero_ref_pos
+
+    def get_zero_ref_mode(self):
+        return self.zref_mode
+
+    def get_substitutes(self):
+        return self.substitutes
+
+    def generate_points(
+        self, mesh_config, mesh_min, mesh_max, radius, origin,
+        probe_method="automatic"
+    ):
+        x_cnt = mesh_config['x_count']
+        y_cnt = mesh_config['y_count']
+        min_x, min_y = mesh_min
+        max_x, max_y = mesh_max
+        x_dist = (max_x - min_x) / (x_cnt - 1)
+        y_dist = (max_y - min_y) / (y_cnt - 1)
+        # floor distances down to next hundredth
+        x_dist = math.floor(x_dist * 100) / 100
+        y_dist = math.floor(y_dist * 100) / 100
+        if x_dist < 1. or y_dist < 1.:
+            raise BedMeshError("bed_mesh: min/max points too close together")
+
+        if radius is not None:
+            # round bed, min/max needs to be recalculated
+            y_dist = x_dist
+            new_r = (x_cnt // 2) * x_dist
+            min_x = min_y = -new_r
+            max_x = max_y = new_r
+        else:
+            # rectangular bed, only re-calc max_x
+            max_x = min_x + x_dist * (x_cnt - 1)
+        pos_y = min_y
+        points = []
+        for i in range(y_cnt):
+            for j in range(x_cnt):
+                if not i % 2:
+                    # move in positive directon
+                    pos_x = min_x + j * x_dist
+                else:
+                    # move in negative direction
+                    pos_x = max_x - j * x_dist
+                if radius is None:
+                    # rectangular bed, append
+                    points.append((pos_x, pos_y))
+                else:
+                    # round bed, check distance from origin
+                    dist_from_origin = math.sqrt(pos_x*pos_x + pos_y*pos_y)
+                    if dist_from_origin <= radius:
+                        points.append(
+                            (origin[0] + pos_x, origin[1] + pos_y))
+            pos_y += y_dist
+        if self.zero_ref_pos is None or probe_method == "manual":
+            # Zero Reference Disabled
+            self.zref_mode = ZrefMode.DISABLED
+        elif within(self.zero_ref_pos, mesh_min, mesh_max):
+            # Zero Reference position within mesh
+            self.zref_mode = ZrefMode.IN_MESH
+        else:
+            # Zero Reference position outside of mesh
+            self.zref_mode = ZrefMode.PROBE
+        self.base_points = points
+        self.substitutes.clear()
+        # adjust overshoot
+        og_min_x = self.orig_config["mesh_min"][0]
+        og_max_x = self.orig_config["mesh_max"][0]
+        add_ovs = min(max(0, min_x - og_min_x), max(0, og_max_x - max_x))
+        self.overshoot = self.cfg_overshoot + math.floor(add_ovs)
+        min_pt, max_pt = (min_x, min_y), (max_x, max_y)
+        self._process_faulty_regions(min_pt, max_pt, radius)
+        self.probe_helper.update_probe_points(self.get_std_path(), 3)
+
+    def _process_faulty_regions(self, min_pt, max_pt, radius):
+        if not self.faulty_regions:
+            return
+        # Cannot probe a reference within a faulty region
+        if self.zref_mode == ZrefMode.PROBE:
+            for min_c, max_c in self.faulty_regions:
+                if within(self.zero_ref_pos, min_c, max_c):
+                    opt = "zero_reference_position"
+                    raise BedMeshError(
+                        "bed_mesh: Cannot probe zero reference position at "
+                        "(%.2f, %.2f) as it is located within a faulty region."
+                        " Check the value for option '%s'"
+                        % (self.zero_ref_pos[0], self.zero_ref_pos[1], opt,)
+                    )
+        # Check to see if any points fall within faulty regions
+        last_y = self.base_points[0][1]
+        is_reversed = False
+        for i, coord in enumerate(self.base_points):
+            if not isclose(coord[1], last_y):
+                is_reversed = not is_reversed
+            last_y = coord[1]
+            adj_coords = []
+            for min_c, max_c in self.faulty_regions:
+                if within(coord, min_c, max_c, tol=.00001):
+                    # Point lies within a faulty region
+                    adj_coords = [
+                        (min_c[0], coord[1]), (coord[0], min_c[1]),
+                        (coord[0], max_c[1]), (max_c[0], coord[1])]
+                    if is_reversed:
+                        # Swap first and last points for zig-zag pattern
+                        first = adj_coords[0]
+                        adj_coords[0] = adj_coords[-1]
+                        adj_coords[-1] = first
+                    break
+            if not adj_coords:
+                # coord is not located within a faulty region
+                continue
+            valid_coords = []
+            for ac in adj_coords:
+                # make sure that coordinates are within the mesh boundary
+                if radius is None:
+                    if within(ac, min_pt, max_pt, .000001):
+                        valid_coords.append(ac)
+                else:
+                    dist_from_origin = math.sqrt(ac[0]*ac[0] + ac[1]*ac[1])
+                    if dist_from_origin <= radius:
+                        valid_coords.append(ac)
+            if not valid_coords:
+                raise BedMeshError(
+                    "bed_mesh: Unable to generate coordinates"
+                    " for faulty region at index: %d" % (i)
+                )
+            self.substitutes[i] = valid_coords
+
+    def get_base_points(self):
+        return self.base_points
+
+    def get_std_path(self):
+        path = []
+        for idx, pt in enumerate(self.base_points):
+            if idx in self.substitutes:
+                for sub_pt in self.substitutes[idx]:
+                    path.append(sub_pt)
+            else:
+                path.append(pt)
+        if self.zref_mode == ZrefMode.PROBE:
+            path.append(self.zero_ref_pos)
+        return path
+
+    def iter_rapid_path(self):
+        ascnd_x = True
+        last_base_pt = last_mv_pt = self.base_points[0]
+        # Generate initial move point
+        if self.overshoot:
+            overshoot = min(8, self.overshoot)
+            last_mv_pt = (last_base_pt[0] - overshoot, last_base_pt[1])
+            yield last_mv_pt, False
+        for idx, pt in enumerate(self.base_points):
+            # increasing Y indicates direction change
+            dir_change = not isclose(pt[1], last_base_pt[1], abs_tol=1e-6)
+            if idx in self.substitutes:
+                fp_gen = self._gen_faulty_path(
+                    last_mv_pt, idx, ascnd_x, dir_change
+                )
+                for sub_pt, is_smp in fp_gen:
+                    yield sub_pt, is_smp
+                    last_mv_pt = sub_pt
+            else:
+                if dir_change:
+                    for dpt in self._gen_dir_change(last_mv_pt, pt, ascnd_x):
+                        yield dpt, False
+                yield pt, True
+                last_mv_pt = pt
+            last_base_pt = pt
+            ascnd_x ^= dir_change
+        if self.zref_mode == ZrefMode.PROBE:
+            if self.overshoot:
+                ovs = min(4, self.overshoot)
+                ovs = ovs if ascnd_x else -ovs
+                yield (last_mv_pt[0] + ovs, last_mv_pt[1]), False
+            yield self.zero_ref_pos, True
+
+    def _gen_faulty_path(self, last_pt, idx, ascnd_x, dir_change):
+        subs = self.substitutes[idx]
+        sub_cnt = len(subs)
+        if dir_change:
+            for dpt in self._gen_dir_change(last_pt, subs[0], ascnd_x):
+                yield dpt, False
+        if self.is_round:
+            # No faulty region path handling for round beds
+            for pt in subs:
+                yield pt, True
+            return
+        # Check to see if this is the first corner
+        first_corner = False
+        sorted_sub_idx = sorted(self.substitutes.keys())
+        if sub_cnt == 2 and idx < len(sorted_sub_idx):
+            first_corner = sorted_sub_idx[idx] == idx
+        yield subs[0], True
+        if sub_cnt == 1:
+            return
+        last_pt, next_pt = subs[:2]
+        if sub_cnt == 2:
+            if first_corner or dir_change:
+                # horizontal move first
+                yield (next_pt[0], last_pt[1]), False
+            else:
+                yield (last_pt[0], next_pt[1]), False
+            yield next_pt, True
+        elif sub_cnt >= 3:
+            if dir_change:
+                # first move should be a vertical switch up.  If overshoot
+                # is available, simulate another direction change.  Otherwise
+                # move inward 2 mm, then up through the faulty region.
+                if self.overshoot:
+                    for dpt in self._gen_dir_change(last_pt, next_pt, ascnd_x):
+                        yield dpt, False
+                else:
+                    shift = -2 if ascnd_x else 2
+                    yield (last_pt[0] + shift, last_pt[1]), False
+                    yield (last_pt[0] + shift, next_pt[1]), False
+                yield next_pt, True
+                last_pt, next_pt = subs[1:3]
+            else:
+                # vertical move
+                yield (last_pt[0], next_pt[1]), False
+                yield next_pt, True
+                last_pt, next_pt = subs[1:3]
+                if sub_cnt == 4:
+                    # Vertical switch up within faulty region
+                    shift = 2 if ascnd_x else -2
+                    yield (last_pt[0] + shift, last_pt[1]), False
+                    yield (next_pt[0] - shift, next_pt[1]), False
+                    yield next_pt, True
+                    last_pt, next_pt = subs[2:4]
+            # horizontal move before final point
+            yield (next_pt[0], last_pt[1]), False
+            yield next_pt, True
+
+    def _gen_dir_change(self, last_pt, next_pt, ascnd_x):
+        if not self.overshoot:
+            return
+        # overshoot X beyond the outer point
+        xdir = 1 if ascnd_x else -1
+        overshoot = 2. if self.overshoot >= 3. else self.overshoot
+        ovr_pt = (last_pt[0] + overshoot * xdir, last_pt[1])
+        yield ovr_pt
+        if self.overshoot < 3.:
+            # No room to generate an arc, move up to next y
+            yield (next_pt[0] + overshoot * xdir, next_pt[1])
+        else:
+            # generate arc
+            STEP_ANGLE = 3
+            START_ANGLE = 270
+            ydiff = abs(next_pt[1] - last_pt[1])
+            xdiff = abs(next_pt[0] - last_pt[0])
+            max_radius = min(self.overshoot - 2, 8)
+            radius = min(ydiff / 2, max_radius)
+            origin = [ovr_pt[0], last_pt[1] + radius]
+            next_origin_y = next_pt[1] - radius
+            # determine angle
+            if xdiff < .01:
+                # Move is aligned on the x-axis
+                angle = 90
+                if next_origin_y - origin[1] < .05:
+                    # The move can be completed in a single arc
+                    angle = 180
+            else:
+                angle = int(math.degrees(math.atan(ydiff / xdiff)))
+                if (
+                    (ascnd_x and next_pt[0] < last_pt[0]) or
+                    (not ascnd_x and next_pt[0] > last_pt[0])
+                ):
+                    angle = 180 - angle
+            count = int(angle // STEP_ANGLE)
+            # Gen first arc
+            step = STEP_ANGLE * xdir
+            start = START_ANGLE + step
+            for arc_pt in self._gen_arc(origin, radius, start, step, count):
+                yield arc_pt
+            if angle == 180:
+                # arc complete
+                return
+            # generate next arc
+            origin = [next_pt[0] + overshoot * xdir, next_origin_y]
+            # start at the angle where the last arc finished
+            start = START_ANGLE + count * step
+            # recalculate the count to make sure we generate a full 180
+            # degrees.  Add a step for the repeated connecting angle
+            count = 61 - count
+            for arc_pt in self._gen_arc(origin, radius, start, step, count):
+                yield arc_pt
+
+    def _gen_arc(self, origin, radius, start, step, count):
+        end = start + step * count
+        # create a segent for every 3 degress of travel
+        for angle in range(start, end, step):
+            rad = math.radians(angle % 360)
+            opp = math.sin(rad) * radius
+            adj = math.cos(rad) * radius
+            yield (origin[0] + adj, origin[1] + opp)
+
+
+MAX_HIT_DIST = 2.
+MM_WIN_SPEED = 125
+
+class RapidScanHelper:
+    def __init__(self, config, probe_mgr, finalize_cb):
+        self.printer = config.get_printer()
+        self.probe_manager = probe_mgr
+        self.speed = config.getfloat("speed", 50., above=0.)
+        self.scan_height = config.getfloat("horizontal_move_z", 5.)
+        self.finalize_callback = finalize_cb
+
+    def perform_rapid_scan(self, gcmd):
+        speed = gcmd.get_float("SCAN_SPEED", self.speed)
+        scan_height = gcmd.get_float("HORIZONTAL_MOVE_Z", self.scan_height)
+        gcmd.respond_info(
+            "Beginning rapid surface scan at height %.2f..." % (scan_height)
+        )
+        pprobe = self.printer.lookup_object("probe")
+        toolhead = self.printer.lookup_object("toolhead")
+        # Calculate time window around which a sample is valid.  Current
+        # assumption is anything within 2mm is usable, so:
+        # window = 2 / max_speed
+        #
+        # TODO: validate maximum speed allowed based on sample rate of probe
+        # Scale the hit distance window for speeds lower than 125mm/s.  The
+        # lower the speed the less the window shrinks.
+        scale = max(0, 1 - speed / MM_WIN_SPEED) + 1
+        hit_dist = min(MAX_HIT_DIST, scale * speed / MM_WIN_SPEED)
+        half_window = hit_dist / speed
+        gcmd.respond_info(
+            "Sample hit distance +/- %.4fmm, time window +/- ms %.4f"
+            % (hit_dist, half_window * 1000)
+        )
+        gcmd_params = gcmd.get_command_parameters()
+        gcmd_params["SAMPLE_TIME"] = half_window * 2
+        self._raise_tool(gcmd, scan_height)
+        probe_session = pprobe.start_probe_session(gcmd)
+        offsets = pprobe.get_offsets()
+        initial_move = True
+        for pos, is_probe_pt in self.probe_manager.iter_rapid_path():
+            pos = self._apply_offsets(pos[:2], offsets)
+            toolhead.manual_move(pos, speed)
+            if initial_move:
+                initial_move = False
+                self._move_to_scan_height(gcmd, scan_height)
+            if is_probe_pt:
+                probe_session.run_probe(gcmd)
+        results = probe_session.pull_probed_results()
+        toolhead.get_last_move_time()
+        self.finalize_callback(offsets, results)
+        probe_session.end_probe_session()
+
+    def _raise_tool(self, gcmd, scan_height):
+        # If the nozzle is below scan height raise the tool
+        toolhead = self.printer.lookup_object("toolhead")
+        pprobe = self.printer.lookup_object("probe")
+        cur_pos = toolhead.get_position()
+        if cur_pos[2] >= scan_height:
+            return
+        pparams = pprobe.get_probe_params(gcmd)
+        lift_speed = pparams["lift_speed"]
+        cur_pos[2] = self.scan_height + .5
+        toolhead.manual_move(cur_pos, lift_speed)
+
+    def _move_to_scan_height(self, gcmd, scan_height):
+        time_window = gcmd.get_float("SAMPLE_TIME")
+        toolhead = self.printer.lookup_object("toolhead")
+        pprobe = self.printer.lookup_object("probe")
+        cur_pos = toolhead.get_position()
+        pparams = pprobe.get_probe_params(gcmd)
+        lift_speed = pparams["lift_speed"]
+        probe_speed = pparams["probe_speed"]
+        cur_pos[2] = scan_height + .5
+        toolhead.manual_move(cur_pos, lift_speed)
+        cur_pos[2] = scan_height
+        toolhead.manual_move(cur_pos, probe_speed)
+        toolhead.dwell(time_window / 2 + .01)
+
+    def _apply_offsets(self, point, offsets):
+        return [(pos - ofs) for pos, ofs in zip(point, offsets)]
 
 
 class MoveSplitter:

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -594,6 +594,12 @@ class BedMeshCalibrate:
                 self.mesh_config['y_count'] = y_cnt
                 need_cfg_update = True
 
+        if "MESH_PPS" in params:
+            xpps, ypps = parse_gcmd_pair(gcmd, 'MESH_PPS', minval=0)
+            self.mesh_config['mesh_x_pps'] = xpps
+            self.mesh_config['mesh_y_pps'] = ypps
+            need_cfg_update = True
+
         if "ALGORITHM" in params:
             self.mesh_config['algo'] = gcmd.get('ALGORITHM').strip().lower()
             need_cfg_update = True

--- a/scripts/graph_mesh.py
+++ b/scripts/graph_mesh.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+# Bed Mesh data plotting and analysis
+#
+# Copyright (C) 2024 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import argparse
+import sys
+import os
+import stat
+import errno
+import time
+import socket
+import re
+import json
+import collections
+import numpy as np
+import matplotlib
+import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import matplotlib.animation as ani
+
+MESH_DUMP_REQUEST = json.dumps(
+    {"id": 1, "method": "bed_mesh/dump_mesh"}
+)
+
+def sock_error_exit(msg):
+    sys.stderr.write(msg + "\n")
+    sys.exit(-1)
+
+def webhook_socket_create(uds_filename):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    while 1:
+        try:
+            sock.connect(uds_filename)
+        except socket.error as e:
+            if e.errno == errno.ECONNREFUSED:
+                time.sleep(0.1)
+                continue
+            sock_error_exit(
+                "Unable to connect socket %s [%d,%s]"
+                % (uds_filename, e.errno, errno.errorcode[e.errno])
+            )
+        break
+    print("Connected")
+    return sock
+
+def process_message(msg):
+    try:
+        resp = json.loads(msg)
+    except json.JSONDecodeError:
+        return None
+    if resp.get("id", -1) != 1:
+        return None
+    if "error" in resp:
+        err = resp["error"].get("message", "Unknown")
+        sock_error_exit(
+            "Error requesting mesh dump: %s" % (err,)
+        )
+    return resp["result"]
+
+
+def request_from_unixsocket(unix_sock_name):
+    print("Connecting to Unix Socket File '%s'" % (unix_sock_name,))
+    whsock = webhook_socket_create(unix_sock_name)
+    whsock.settimeout(1.)
+    # send mesh query
+    whsock.send(MESH_DUMP_REQUEST.encode() + b"\x03")
+    sock_data = b""
+    end_time = time.monotonic() + 10.0
+    try:
+        while time.monotonic() < end_time:
+            try:
+                data = whsock.recv(4096)
+            except TimeoutError:
+                pass
+            else:
+                if not data:
+                    sock_error_exit("Socket closed before mesh received")
+                parts = data.split(b"\x03")
+                parts[0] = sock_data + parts[0]
+                sock_data = parts.pop()
+                for msg in parts:
+                    result = process_message(msg)
+                    if result is not None:
+                        return result
+            time.sleep(.1)
+    finally:
+        whsock.close()
+    sock_error_exit("Mesh dump request timed out")
+
+def request_from_websocket(url):
+    print("Connecting to websocket url '%s'" % (url,))
+    try:
+        from websockets.sync.client import connect
+    except ModuleNotFoundError:
+        sock_error_exit("Python module 'websockets' not installed.")
+        raise
+    with connect(url) as websocket:
+        websocket.send(MESH_DUMP_REQUEST)
+        end_time = time.monotonic() + 20.0
+        while time.monotonic() < end_time:
+            try:
+                msg = websocket.recv(10.)
+            except TimeoutError:
+                continue
+            result = process_message(msg)
+            if result is not None:
+                return result
+            time.sleep(.1)
+    sock_error_exit("Mesh dump request timed out")
+
+def request_mesh_data(input_name):
+    url_match = re.match(r"((?:https?)|(?:wss?))://(.+)", input_name.lower())
+    if url_match is None:
+        file_path = os.path.abspath(os.path.expanduser(input_name))
+        if not os.path.exists(file_path):
+            sock_error_exit("Path '%s' does not exist" % (file_path,))
+        st_res = os.stat(file_path)
+        if stat.S_ISSOCK(st_res.st_mode):
+            return request_from_unixsocket(file_path)
+        else:
+            print("Reading mesh data from json file '%s'" % (file_path,))
+            with open(file_path, "r") as f:
+                return json.load(f)
+    scheme = url_match.group(1)
+    host = url_match.group(2).rstrip("/")
+    scheme = scheme.replace("http", "ws")
+    url = "%s://%s/klippysocket" % (scheme, host)
+    return request_from_websocket(url)
+
+class PathAnimation:
+    instance = None
+    def __init__(self, artist, x_travel, y_travel):
+        self.travel_artist = artist
+        self.x_travel = x_travel
+        self.y_travel = y_travel
+        fig = plt.gcf()
+        self.animation = ani.FuncAnimation(
+            fig=fig, func=self.update, frames=self.gen_path_position(),
+            cache_frame_data=False, interval=60
+        )
+        PathAnimation.instance = self
+
+    def gen_path_position(self):
+        count = 1
+        x_travel, y_travel = self.x_travel, self.y_travel
+        last_x, last_y = x_travel[0], y_travel[0]
+        yield count
+        for xpos, ypos in zip(x_travel[1:], y_travel[1:]):
+            count += 1
+            if xpos == last_x or ypos == last_y:
+                yield count
+            last_x, last_y = xpos, ypos
+
+    def update(self, frame):
+        x_travel, y_travel = self.x_travel, self.y_travel
+        self.travel_artist.set_xdata(x_travel[:frame])
+        self.travel_artist.set_ydata(y_travel[:frame])
+        return (self.travel_artist,)
+
+
+def _gen_mesh_coords(min_c, max_c, count):
+    dist = (max_c - min_c) / (count - 1)
+    return [min_c + i * dist for i in range(count)]
+
+def _plot_path(travel_path, probed, diff, cmd_args):
+    x_travel, y_travel = np.array(travel_path).transpose()
+    x_probed, y_probed = np.array(probed).transpose()
+    plt.xlabel("X")
+    plt.ylabel("Y")
+    # plot travel
+    travel_line = plt.plot(x_travel, y_travel, "b-")[0]
+    # plot intermediate points
+    plt.plot(x_probed, y_probed, "k.")
+    # plot start point
+    plt.plot([x_travel[0]], [y_travel[0]], "g>")
+    # plot stop point
+    plt.plot([x_travel[-1]], [y_travel[-1]], "r*")
+    if diff:
+        diff_x, diff_y = np.array(diff).transpose()
+        plt.plot(diff_x, diff_y, "m.")
+    if cmd_args.animate and cmd_args.output is None:
+        PathAnimation(travel_line, x_travel, y_travel)
+
+def _format_mesh_data(matrix, params):
+    min_pt = (params["min_x"], params["min_y"])
+    max_pt = (params["max_x"], params["max_y"])
+    xvals = _gen_mesh_coords(min_pt[0], max_pt[0], len(matrix[0]))
+    yvals = _gen_mesh_coords(min_pt[1], max_pt[0], len(matrix))
+    x, y = np.meshgrid(xvals, yvals)
+    z = np.array(matrix)
+    return x, y, z
+
+def _set_xy_limits(mesh_data, cmd_args):
+    if not cmd_args.scale_plot:
+        return
+    ax = plt.gca()
+    axis_min = mesh_data["axis_minimum"]
+    axis_max = mesh_data["axis_maximum"]
+    ax.set_xlim((axis_min[0], axis_max[0]))
+    ax.set_ylim((axis_min[1], axis_max[1]))
+
+def _plot_mesh(ax, matrix, params, cmap=cm.viridis, label=None):
+    x, y, z = _format_mesh_data(matrix, params)
+    surface = ax.plot_surface(x, y, z, cmap=cmap, label=label)
+    scale = max(abs(z.min()), abs(z.max())) * 3
+    return surface, scale
+
+def plot_probe_points(mesh_data, cmd_args):
+    """Plot original generated points"""
+    calibration = mesh_data["calibration"]
+    x, y = np.array(calibration["points"]).transpose()
+    plt.title("Generated Probe Points")
+    plt.xlabel("X")
+    plt.ylabel("Y")
+    plt.plot(x, y, "b.")
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_probe_path(mesh_data, cmd_args):
+    """Plot probe travel path"""
+    calibration = mesh_data["calibration"]
+    orig_pts = calibration["points"]
+    path_pts = calibration["probe_path"]
+    diff = [pt for pt in orig_pts if pt not in path_pts]
+    plt.title("Probe Travel Path")
+    _plot_path(path_pts, path_pts[1:-1], diff, cmd_args)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_rapid_path(mesh_data, cmd_args):
+    """Plot rapid scan travel path"""
+    calibration = mesh_data["calibration"]
+    orig_pts = calibration["points"]
+    rapid_pts = calibration["rapid_path"]
+    rapid_path = [pt[0] for pt in rapid_pts]
+    probed = [pt for pt, is_ppt in rapid_pts if is_ppt]
+    diff = [pt for pt in orig_pts if pt not in probed]
+    plt.title("Rapid Scan Travel Path")
+    _plot_path(rapid_path, probed, diff, cmd_args)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_probed_matrix(mesh_data, cmd_args):
+    """Plot probed Z values"""
+    ax = plt.subplot(projection="3d")
+    profile = cmd_args.profile_name
+    if profile is not None:
+        req_mesh = mesh_data["profiles"].get(profile)
+        if req_mesh is None:
+            raise Exception("Profile %s not found" % (profile,))
+        matrix = req_mesh["points"]
+        name = profile
+    else:
+        req_mesh = mesh_data["current_mesh"]
+        if not req_mesh:
+            raise Exception("No current mesh data in dump")
+        matrix = req_mesh["probed_matrix"]
+        name = req_mesh["name"]
+    params = req_mesh["mesh_params"]
+    surface, scale = _plot_mesh(ax, matrix, params)
+    ax.set_title("Probed Mesh (%s)" % (name,))
+    ax.set(zlim=(-scale, scale))
+    plt.gcf().colorbar(surface, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_mesh_matrix(mesh_data, cmd_args):
+    """Plot mesh Z values"""
+    ax = plt.subplot(projection="3d")
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    matrix = req_mesh["mesh_matrix"]
+    params = req_mesh["mesh_params"]
+    surface, scale = _plot_mesh(ax, matrix, params)
+    name = req_mesh["name"]
+    ax.set_title("Interpolated Mesh (%s)" % (name,))
+    ax.set(zlim=(-scale, scale))
+    plt.gcf().colorbar(surface, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_overlay(mesh_data, cmd_args):
+    """Plots the current probed mesh overlaid with a profile"""
+    ax = plt.subplot(projection="3d")
+    # Plot Profile
+    profile = cmd_args.profile_name
+    if profile is None:
+        raise Exception("A profile must be specified to plot an overlay")
+    req_mesh = mesh_data["profiles"].get(profile)
+    if req_mesh is None:
+        raise Exception("Profile %s not found" % (profile,))
+    matrix = req_mesh["points"]
+    params = req_mesh["mesh_params"]
+    prof_surf, prof_scale = _plot_mesh(ax, matrix, params, label=profile)
+    # Plot Current
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    matrix = req_mesh["probed_matrix"]
+    params = req_mesh["mesh_params"]
+    cur_name = req_mesh["name"]
+    cur_surf, cur_scale = _plot_mesh(ax, matrix, params, cm.inferno, cur_name)
+    ax.set_title("Probed Mesh Overlay")
+    scale = max(cur_scale, prof_scale)
+    ax.set(zlim=(-scale, scale))
+    ax.legend(loc='best')
+    plt.gcf().colorbar(prof_surf, shrink=.75)
+    _set_xy_limits(mesh_data, cmd_args)
+
+def plot_delta(mesh_data, cmd_args):
+    """Plots the delta between current probed mesh and a profile"""
+    ax = plt.subplot(projection="3d")
+    # Plot Profile
+    profile = cmd_args.profile_name
+    if profile is None:
+        raise Exception("A profile must be specified to plot an overlay")
+    req_mesh = mesh_data["profiles"].get(profile)
+    if req_mesh is None:
+        raise Exception("Profile %s not found" % (profile,))
+    prof_matix = req_mesh["points"]
+    prof_params = req_mesh["mesh_params"]
+    req_mesh = mesh_data["current_mesh"]
+    if not req_mesh:
+        raise Exception("No current mesh data in dump")
+    cur_matrix = req_mesh["probed_matrix"]
+    cur_params = req_mesh["mesh_params"]
+    cur_name = req_mesh["name"]
+    # validate that the params match
+    pfields = ("x_count", "y_count", "min_x", "max_x", "min_y", "max_y")
+    for field in pfields:
+        if abs(prof_params[field] - cur_params[field]) >= 1e-6:
+            raise Exception(
+                "Values for field %s do not match, cant plot deviation"
+            )
+    delta = np.array(cur_matrix) - np.array(prof_matix)
+    surface, scale = _plot_mesh(ax, delta, cur_params)
+    ax.set(zlim=(-scale, scale))
+    ax.set_title("Probed Mesh Delta (%s, %s)" % (cur_name, profile))
+    _set_xy_limits(mesh_data, cmd_args)
+
+
+PLOT_TYPES = {
+    "points": plot_probe_points,
+    "path": plot_probe_path,
+    "rapid": plot_rapid_path,
+    "probedz": plot_probed_matrix,
+    "meshz": plot_mesh_matrix,
+    "overlay": plot_overlay,
+    "delta": plot_delta,
+}
+
+def print_types(cmd_args):
+    typelist = [
+        "%-10s%s" % (name, func.__doc__) for name, func in PLOT_TYPES.items()
+    ]
+    print("\n".join(typelist))
+
+def plot_mesh_data(cmd_args):
+    mesh_data = request_mesh_data(cmd_args.input)
+    if cmd_args.output is not None:
+        matplotlib.use("svg")
+
+    fig = plt.figure()
+    plot_func = PLOT_TYPES[cmd_args.type]
+    plot_func(mesh_data, cmd_args)
+    fig.set_size_inches(10, 8)
+    fig.tight_layout()
+    if cmd_args.output is None:
+        plt.show()
+    else:
+        fig.savefig(cmd_args.output)
+
+def _check_path_unique(name, path):
+    path = np.array(path)
+    unique_pts, counts = np.unique(path, return_counts=True, axis=0)
+    for idx, count in enumerate(counts):
+        if count != 1:
+            coord = unique_pts[idx]
+            print(
+                "  WARNING: Backtracking or duplicate found in %s path at %s, "
+                "this may be due to multiple samples in a faulty region."
+                % (name, coord)
+            )
+
+def _analyze_mesh(name, mesh_axes):
+    print("\nAnalyzing Probed Mesh %s..." % (name,))
+    x, y, z = mesh_axes
+    min_idx, max_idx = z.argmin(), z.argmax()
+    min_x, min_y = x.flatten()[min_idx], y.flatten()[min_idx]
+    max_x, max_y = x.flatten()[max_idx], y.flatten()[max_idx]
+
+    print(
+        "  Min Coord (%.2f, %.2f), Max Coord (%.2f, %.2f), "
+        "Probe Count: (%d, %d)" %
+        (x.min(), y.min(), x.max(), y.max(), len(z), len(z[0]))
+    )
+    print(
+        "  Mesh range: min %.4f (%.2f, %.2f), max %.4f (%.2f, %.2f)"
+        % (z.min(), min_x, min_y, z.max(), max_x, max_y)
+    )
+    print("  Mean: %.4f, Standard Deviation: %.4f" % (z.mean(), z.std()))
+
+def _compare_mesh(name_a, name_b, mesh_a, mesh_b):
+    ax, ay, az = mesh_a
+    bx, by, bz = mesh_b
+    if not np.array_equal(ax, bx) or not np.array_equal(ay, by):
+        return
+    delta = az - bz
+    abs_max = max(abs(delta.max()), abs(delta.min()))
+    abs_mean = sum([abs(z) for z in delta.flatten()]) / len(delta.flatten())
+    min_idx, max_idx = delta.argmin(), delta.argmax()
+    min_x, min_y = ax.flatten()[min_idx], ay.flatten()[min_idx]
+    max_x, max_y = ax.flatten()[max_idx], ay.flatten()[max_idx]
+    print("  Delta from %s to %s..." % (name_a, name_b))
+    print(
+        "    Range: min %.4f (%.2f, %.2f), max %.4f (%.2f, %.2f)\n"
+        "    Mean: %.6f, Standard Deviation: %.6f\n"
+        "    Absolute Max: %.6f, Absolute Mean: %.6f"
+        % (delta.min(), min_x, min_y, delta.max(), max_x, max_y,
+           delta.mean(), delta.std(), abs_max, abs_mean)
+    )
+
+def analyze(cmd_args):
+    mesh_data = request_mesh_data(cmd_args.input)
+    print("Analyzing Travel Path...")
+    calibration = mesh_data["calibration"]
+    org_pts = calibration["points"]
+    probe_path = calibration["probe_path"]
+    rapid_path = calibration["rapid_path"]
+    rapid_points = [pt for pt, is_pt in rapid_path if is_pt]
+    rapid_moves = [pt[0] for pt in rapid_path]
+    print("  Original point count: %d" % (len(org_pts)))
+    print("  Probe path count: %d" % (len(probe_path)))
+    print("  Rapid scan sample count: %d" % (len(probe_path)))
+    print("  Rapid scan move count: %d" % (len(rapid_moves)))
+    if np.array_equal(rapid_points, probe_path):
+        print("  Rapid scan points match probe path points")
+    else:
+        diff = [pt for pt in rapid_points if pt not in probe_path]
+        print(
+            "  ERROR: Rapid scan points do not match probe points\n"
+            "difference: %s" % (diff,)
+        )
+    _check_path_unique("probe", probe_path)
+    _check_path_unique("rapid scan", rapid_moves)
+    req_mesh = mesh_data["current_mesh"]
+    formatted_data = collections.OrderedDict()
+    if req_mesh:
+        matrix = req_mesh["probed_matrix"]
+        params = req_mesh["mesh_params"]
+        name = req_mesh["name"]
+        formatted_data[name] = _format_mesh_data(matrix, params)
+    profiles = mesh_data["profiles"]
+    for prof_name, prof_data in profiles.items():
+        if prof_name in formatted_data:
+            continue
+        matrix = prof_data["points"]
+        params = prof_data["mesh_params"]
+        formatted_data[prof_name] = _format_mesh_data(matrix, params)
+    while formatted_data:
+        name, current_axes = formatted_data.popitem()
+        _analyze_mesh(name, current_axes)
+        for prof_name, prof_axes in formatted_data.items():
+            _compare_mesh(name, prof_name, current_axes, prof_axes)
+
+def dump_request(cmd_args):
+    mesh_data = request_mesh_data(cmd_args.input)
+    outfile = cmd_args.output
+    if outfile is None:
+        postfix = time.strftime("%Y%m%d_%H%M%S")
+        outfile = "klipper-bedmesh-%s.json" % (postfix,)
+    outfile = os.path.abspath(os.path.expanduser(outfile))
+    print("Saving Mesh Output to '%s'" % (outfile))
+    with open(outfile, "w") as f:
+        f.write(json.dumps(mesh_data))
+
+def main():
+    parser = argparse.ArgumentParser(description="Graph Bed Mesh Data")
+    sub_parsers = parser.add_subparsers()
+    list_parser = sub_parsers.add_parser(
+        "list", help="List available plot types"
+    )
+    list_parser.set_defaults(func=print_types)
+    plot_parser = sub_parsers.add_parser("plot", help="Plot a specified type")
+    analyze_parser = sub_parsers.add_parser(
+        "analyze", help="Perform analysis on mesh data"
+    )
+    dump_parser = sub_parsers.add_parser(
+        "dump", help="Dump API response to json file"
+    )
+    plot_parser.add_argument(
+        "-a", "--animate", action="store_true",
+        help="Animate paths in live preview"
+    )
+    plot_parser.add_argument(
+        "-s", "--scale-plot", action="store_true",
+        help="Use axis limits reported by Klipper to scale plot X/Y"
+    )
+    plot_parser.add_argument(
+        "-p", "--profile-name", type=str, default=None,
+        help="Optional name of a profile to plot for 'probedz'"
+    )
+    plot_parser.add_argument(
+        "-o", "--output", type=str, default=None,
+        help="Output file path"
+    )
+    plot_parser.add_argument(
+        "type", metavar="<plot type>", type=str, choices=PLOT_TYPES.keys(),
+        help="Type of data to graph"
+    )
+    plot_parser.add_argument(
+        "input", metavar="<input>",
+        help="Path/url to Klipper Socket or path to json file"
+    )
+    plot_parser.set_defaults(func=plot_mesh_data)
+    analyze_parser.add_argument(
+        "input", metavar="<input>",
+        help="Path/url to Klipper Socket or path to json file"
+    )
+    analyze_parser.set_defaults(func=analyze)
+    dump_parser.add_argument(
+        "-o", "--output", type=str, default=None,
+        help="Json output file path"
+    )
+    dump_parser.add_argument(
+        "input", metavar="<input>",
+        help="Path or url to Klipper Socket"
+    )
+    dump_parser.set_defaults(func=dump_request)
+    cmd_args = parser.parse_args()
+    cmd_args.func(cmd_args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request builds on #6610, adding support for optimized travel paths when a `rapid_scan` is requested.   In addition, the `probe_finalize()` method no longer depends on on the XY coordinates received from the probing procedure to populate the Z matrix.

The final commit in this series updates `gnupru` to the latest release in `ci-install.sh`.  It appears that version `2023.1` fails due to a missing dependency.