### PR TITLE
[smart_effector] Fix error when use smart_effector as z virtual endstop

### DIFF
--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -110,6 +110,8 @@ class SmartEffectorProbe:
             self.gcode.run_script_from_command(
                     "M204 S%.3f" % (self.old_max_accel,))
         self.probe_wrapper.probe_finish(hmove)
+    def get_position_endstop(self):
+        return self.probe_wrapper.get_position_endstop()
     def _send_command(self, buf):
         # Each byte is sent to the SmartEffector as
         # [0 0 1 0 b7 b6 b5 b4 !b4 b3 b2 b1 b0 !b0]


### PR DESCRIPTION
The smart_effector's `recovery_time` and `probe_accel` are very useful options, even with a normal probe.
However when using it as the z endstop the klipper gives the following error:
> Option 'position_endstop' in section 'stepper_z' must be specified

And this PR should fix this issue and make smart_effector useable.