### PR TITLE
New error_mcu module; report sensor on "ADC out of range"

### DIFF
--- a/klippy/extras/adc_scaled.py
+++ b/klippy/extras/adc_scaled.py
@@ -7,7 +7,6 @@
 SAMPLE_TIME = 0.001
 SAMPLE_COUNT = 8
 REPORT_TIME = 0.300
-RANGE_CHECK_COUNT = 4
 
 class MCU_scaled_adc:
     def __init__(self, main, pin_params):
@@ -18,7 +17,7 @@ class MCU_scaled_adc:
         qname = main.name + ":" + pin_params['pin']
         query_adc.register_adc(qname, self._mcu_adc)
         self._callback = None
-        self.setup_minmax = self._mcu_adc.setup_minmax
+        self.setup_adc_sample = self._mcu_adc.setup_adc_sample
         self.get_mcu = self._mcu_adc.get_mcu
     def _handle_callback(self, read_time, read_value):
         max_adc = self._main.last_vref[1]
@@ -54,8 +53,7 @@ class PrinterADCScaled:
         ppins = self.printer.lookup_object('pins')
         mcu_adc = ppins.setup_pin('adc', pin_name)
         mcu_adc.setup_adc_callback(REPORT_TIME, callback)
-        mcu_adc.setup_minmax(SAMPLE_TIME, SAMPLE_COUNT, minval=0., maxval=1.,
-                             range_check_count=RANGE_CHECK_COUNT)
+        mcu_adc.setup_adc_sample(SAMPLE_TIME, SAMPLE_COUNT)
         query_adc = config.get_printer().load_object(config, 'query_adc')
         query_adc.register_adc(self.name + ":" + name, mcu_adc)
         return mcu_adc

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -32,10 +32,10 @@ class PrinterADCtoTemperature:
         temp = self.adc_convert.calc_temp(read_value)
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
     def setup_minmax(self, min_temp, max_temp):
-        adc_range = [self.adc_convert.calc_adc(t) for t in [min_temp, max_temp]]
-        self.mcu_adc.setup_minmax(SAMPLE_TIME, SAMPLE_COUNT,
-                                  minval=min(adc_range), maxval=max(adc_range),
-                                  range_check_count=RANGE_CHECK_COUNT)
+        arange = [self.adc_convert.calc_adc(t) for t in [min_temp, max_temp]]
+        self.mcu_adc.setup_adc_sample(SAMPLE_TIME, SAMPLE_COUNT,
+                                      minval=min(arange), maxval=max(arange),
+                                      range_check_count=RANGE_CHECK_COUNT)
 
 
 ######################################################################

--- a/klippy/extras/adc_temperature.py
+++ b/klippy/extras/adc_temperature.py
@@ -1,6 +1,6 @@
 # Obtain temperature using linear interpolation of ADC values
 #
-# Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, bisect
@@ -22,8 +22,8 @@ class PrinterADCtoTemperature:
         ppins = config.get_printer().lookup_object('pins')
         self.mcu_adc = ppins.setup_pin('adc', config.get('sensor_pin'))
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
-        query_adc = config.get_printer().load_object(config, 'query_adc')
-        query_adc.register_adc(config.get_name(), self.mcu_adc)
+        self.diag_helper = HelperTemperatureDiagnostics(
+            config, self.mcu_adc, adc_convert.calc_temp)
     def setup_callback(self, temperature_callback):
         self.temperature_callback = temperature_callback
     def get_report_time_delta(self):
@@ -33,9 +33,43 @@ class PrinterADCtoTemperature:
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
     def setup_minmax(self, min_temp, max_temp):
         arange = [self.adc_convert.calc_adc(t) for t in [min_temp, max_temp]]
+        min_adc, max_adc = sorted(arange)
         self.mcu_adc.setup_adc_sample(SAMPLE_TIME, SAMPLE_COUNT,
-                                      minval=min(arange), maxval=max(arange),
+                                      minval=min_adc, maxval=max_adc,
                                       range_check_count=RANGE_CHECK_COUNT)
+        self.diag_helper.setup_diag_minmax(min_temp, max_temp, min_adc, max_adc)
+
+# Tool to register with query_adc and report extra info on ADC range errors
+class HelperTemperatureDiagnostics:
+    def __init__(self, config, mcu_adc, calc_temp_cb):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+        self.mcu_adc = mcu_adc
+        self.calc_temp_cb = calc_temp_cb
+        self.min_temp = self.max_temp = self.min_adc = self.max_adc = None
+        query_adc = self.printer.load_object(config, 'query_adc')
+        query_adc.register_adc(self.name, self.mcu_adc)
+        error_mcu = self.printer.load_object(config, 'error_mcu')
+        error_mcu.add_clarify("ADC out of range", self._clarify_adc_range)
+    def setup_diag_minmax(self, min_temp, max_temp, min_adc, max_adc):
+        self.min_temp, self.max_temp = min_temp, max_temp
+        self.min_adc, self.max_adc = min_adc, max_adc
+    def _clarify_adc_range(self, msg, details):
+        if self.min_temp is None:
+            return None
+        last_value, last_read_time = self.mcu_adc.get_last_value()
+        if not last_read_time:
+            return None
+        if last_value >= self.min_adc and last_value <= self.max_adc:
+            return None
+        tempstr = "?"
+        try:
+            last_temp = self.calc_temp_cb(last_value)
+            tempstr = "%.3f" % (last_temp,)
+        except e:
+            logging.exception("Error in calc_temp callback")
+        return ("Sensor '%s' temperature %s not in range %.3f:%.3f"
+                % (self.name, tempstr, self.min_temp, self.max_temp))
 
 
 ######################################################################

--- a/klippy/extras/buttons.py
+++ b/klippy/extras/buttons.py
@@ -104,7 +104,7 @@ class MCU_ADC_buttons:
         self.max_value = 0.
         ppins = printer.lookup_object('pins')
         self.mcu_adc = ppins.setup_pin('adc', self.pin)
-        self.mcu_adc.setup_minmax(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
+        self.mcu_adc.setup_adc_sample(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
         self.mcu_adc.setup_adc_callback(ADC_REPORT_TIME, self.adc_callback)
         query_adc = printer.lookup_object('query_adc')
         query_adc.register_adc('adc_button:' + pin.strip(), self.mcu_adc)

--- a/klippy/extras/error_mcu.py
+++ b/klippy/extras/error_mcu.py
@@ -1,0 +1,67 @@
+# More verbose information on micro-controller errors
+#
+# Copyright (C) 2024  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+message_shutdown = """
+Once the underlying issue is corrected, use the
+"FIRMWARE_RESTART" command to reset the firmware, reload the
+config, and restart the host software.
+Printer is shutdown
+"""
+
+Common_MCU_errors = {
+    ("Timer too close",): """
+This often indicates the host computer is overloaded. Check
+for other processes consuming excessive CPU time, high swap
+usage, disk errors, overheating, unstable voltage, or
+similar system problems on the host computer.""",
+    ("Missed scheduling of next ",): """
+This is generally indicative of an intermittent
+communication failure between micro-controller and host.""",
+    ("ADC out of range",): """
+This generally occurs when a heater temperature exceeds
+its configured min_temp or max_temp.""",
+    ("Rescheduled timer in the past", "Stepper too far in past"): """
+This generally occurs when the micro-controller has been
+requested to step at a rate higher than it is capable of
+obtaining.""",
+    ("Command request",): """
+This generally occurs in response to an M112 G-Code command
+or in response to an internal error in the host software.""",
+}
+
+def error_hint(msg):
+    for prefixes, help_msg in Common_MCU_errors.items():
+        for prefix in prefixes:
+            if msg.startswith(prefix):
+                return help_msg
+    return ""
+
+class PrinterMCUError:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:notify_mcu_shutdown",
+                                            self._handle_notify_mcu_shutdown)
+    def _check_mcu_shutdown(self, msg, details):
+        mcu_name = details['mcu']
+        mcu_msg = details['reason']
+        event_type = details['event_type']
+        prefix = "MCU '%s' shutdown: " % (mcu_name,)
+        if event_type == 'is_shutdown':
+            prefix = "Previous MCU '%s' shutdown: " % (mcu_name,)
+        # Lookup generic hint
+        hint = error_hint(msg)
+        # Update error message
+        newmsg = "%s%s%s%s" % (prefix, mcu_msg, hint, message_shutdown)
+        self.printer.update_error_msg(msg, newmsg)
+    def _handle_notify_mcu_shutdown(self, msg, details):
+        if msg == "MCU shutdown":
+            self._check_mcu_shutdown(msg, details)
+        else:
+            self.printer.update_error_msg(msg, "%s%s" % (msg, message_shutdown))
+
+def load_config(config):
+    return PrinterMCUError(config)

--- a/klippy/extras/error_mcu.py
+++ b/klippy/extras/error_mcu.py
@@ -23,6 +23,13 @@ Once the underlying issue is corrected, use the "RESTART"
 command to reload the config and restart the host software.
 """
 
+message_mcu_connect_error = """
+Once the underlying issue is corrected, use the
+"FIRMWARE_RESTART" command to reset the firmware, reload the
+config, and restart the host software.
+Error configuring printer
+"""
+
 Common_MCU_errors = {
     ("Timer too close",): """
 This often indicates the host computer is overloaded. Check
@@ -102,9 +109,14 @@ class PrinterMCUError:
         newmsg += msg_update + ["Up-to-date MCU(s):"] + msg_updated
         newmsg += [message_protocol_error2, details['error']]
         self.printer.update_error_msg(msg, "\n".join(newmsg))
+    def _check_mcu_connect_error(self, msg, details):
+        newmsg = "%s%s" % (details['error'], message_mcu_connect_error)
+        self.printer.update_error_msg(msg, newmsg)
     def _handle_notify_mcu_error(self, msg, details):
         if msg == "Protocol error":
             self._check_protocol_error(msg, details)
+        elif msg == "MCU error during connect":
+            self._check_mcu_connect_error(msg, details)
 
 def load_config(config):
     return PrinterMCUError(config)

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -49,10 +49,10 @@ class HallFilamentWidthSensor:
         # Start adc
         self.ppins = self.printer.lookup_object('pins')
         self.mcu_adc = self.ppins.setup_pin('adc', self.pin1)
-        self.mcu_adc.setup_minmax(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
+        self.mcu_adc.setup_adc_sample(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
         self.mcu_adc.setup_adc_callback(ADC_REPORT_TIME, self.adc_callback)
         self.mcu_adc2 = self.ppins.setup_pin('adc', self.pin2)
-        self.mcu_adc2.setup_minmax(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
+        self.mcu_adc2.setup_adc_sample(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
         self.mcu_adc2.setup_adc_callback(ADC_REPORT_TIME, self.adc2_callback)
         # extrude factor updating
         self.extrude_factor_update_timer = self.reactor.register_timer(

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -1,10 +1,11 @@
 # Support for micro-controller chip based temperature sensors
 #
-# Copyright (C) 2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 import mcu
+from . import adc_temperature
 
 SAMPLE_TIME = 0.001
 SAMPLE_COUNT = 8
@@ -31,8 +32,8 @@ class PrinterTemperatureMCU:
         self.mcu_adc = ppins.setup_pin('adc',
                                        '%s:ADC_TEMPERATURE' % (mcu_name,))
         self.mcu_adc.setup_adc_callback(REPORT_TIME, self.adc_callback)
-        query_adc = config.get_printer().load_object(config, 'query_adc')
-        query_adc.register_adc(config.get_name(), self.mcu_adc)
+        self.diag_helper = adc_temperature.HelperTemperatureDiagnostics(
+            config, self.mcu_adc, self.calc_temp)
         # Register callbacks
         if self.printer.get_start_args().get('debugoutput') is not None:
             self.mcu_adc.setup_adc_sample(SAMPLE_TIME, SAMPLE_COUNT)
@@ -51,6 +52,8 @@ class PrinterTemperatureMCU:
     def adc_callback(self, read_time, read_value):
         temp = self.base_temperature + read_value * self.slope
         self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
+    def calc_temp(self, adc):
+        return self.base_temperature + adc * self.slope
     def calc_adc(self, temp):
         return (temp - self.base_temperature) / self.slope
     def calc_base(self, temp, adc):
@@ -91,9 +94,12 @@ class PrinterTemperatureMCU:
             self.base_temperature = self.calc_base(self.temp1, self.adc1)
         # Setup min/max checks
         arange = [self.calc_adc(t) for t in [self.min_temp, self.max_temp]]
+        min_adc, max_adc = sorted(arange)
         self.mcu_adc.setup_adc_sample(SAMPLE_TIME, SAMPLE_COUNT,
-                                      minval=min(arange), maxval=max(arange),
+                                      minval=min_adc, maxval=max_adc,
                                       range_check_count=RANGE_CHECK_COUNT)
+        self.diag_helper.setup_diag_minmax(self.min_temp, self.max_temp,
+                                           min_adc, max_adc)
     def config_unknown(self):
         raise self.printer.config_error("MCU temperature not supported on %s"
                                         % (self.mcu_type,))

--- a/klippy/extras/tsl1401cl_filament_width_sensor.py
+++ b/klippy/extras/tsl1401cl_filament_width_sensor.py
@@ -33,7 +33,7 @@ class FilamentWidthSensor:
         # Start adc
         self.ppins = self.printer.lookup_object('pins')
         self.mcu_adc = self.ppins.setup_pin('adc', self.pin)
-        self.mcu_adc.setup_minmax(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
+        self.mcu_adc.setup_adc_sample(ADC_SAMPLE_TIME, ADC_SAMPLE_COUNT)
         self.mcu_adc.setup_adc_callback(ADC_REPORT_TIME, self.adc_callback)
         # extrude factor updating
         self.extrude_factor_update_timer = self.reactor.register_timer(

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -22,13 +22,6 @@ command to reload the config and restart the host software.
 Printer is halted
 """
 
-message_mcu_connect_error = """
-Once the underlying issue is corrected, use the
-"FIRMWARE_RESTART" command to reset the firmware, reload the
-config, and restart the host software.
-Error configuring printer
-"""
-
 class Printer:
     config_error = configfile.error
     command_error = gcode.CommandError
@@ -152,8 +145,10 @@ class Printer:
             util.dump_mcu_build()
             return
         except mcu.error as e:
-            logging.exception("MCU error during connect")
-            self._set_state("%s%s" % (str(e), message_mcu_connect_error))
+            msg = "MCU error during connect"
+            logging.exception(msg)
+            self._set_state(msg)
+            self.send_event("klippy:notify_mcu_error", msg, {"error": str(e)})
             util.dump_mcu_build()
             return
         except Exception as e:

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1,6 +1,6 @@
 # Interface to Klipper micro-controller code
 #
-# Copyright (C) 2016-2023  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, zlib, logging, math
@@ -605,6 +605,7 @@ class MCU:
         self._mcu_tick_stddev = 0.
         self._mcu_tick_awake = 0.
         # Register handlers
+        printer.load_object(config, "error_mcu")
         printer.register_event_handler("klippy:firmware_restart",
                                        self._firmware_restart)
         printer.register_event_handler("klippy:mcu_identify",
@@ -631,13 +632,13 @@ class MCU:
         if clock is not None:
             self._shutdown_clock = self.clock32_to_clock64(clock)
         self._shutdown_msg = msg = params['static_string_id']
-        logging.info("MCU '%s' %s: %s\n%s\n%s", self._name, params['#name'],
+        event_type = params['#name']
+        self._printer.invoke_async_shutdown(
+            "MCU shutdown", {"reason": msg, "mcu": self._name,
+                             "event_type": event_type})
+        logging.info("MCU '%s' %s: %s\n%s\n%s", self._name, event_type,
                      self._shutdown_msg, self._clocksync.dump_debug(),
                      self._serial.dump_debug())
-        prefix = "MCU '%s' shutdown: " % (self._name,)
-        if params['#name'] == 'is_shutdown':
-            prefix = "Previous MCU '%s' shutdown: " % (self._name,)
-        self._printer.invoke_async_shutdown(prefix + msg + error_help(msg))
     def _handle_starting(self, params):
         if not self._is_shutdown:
             self._printer.invoke_async_shutdown("MCU '%s' spontaneous restart"
@@ -1007,34 +1008,6 @@ class MCU:
         last_stats = {k:(float(v) if '.' in v else int(v)) for k, v in parts}
         self._get_status_info['last_stats'] = last_stats
         return False, '%s: %s' % (self._name, stats)
-
-Common_MCU_errors = {
-    ("Timer too close",): """
-This often indicates the host computer is overloaded. Check
-for other processes consuming excessive CPU time, high swap
-usage, disk errors, overheating, unstable voltage, or
-similar system problems on the host computer.""",
-    ("Missed scheduling of next ",): """
-This is generally indicative of an intermittent
-communication failure between micro-controller and host.""",
-    ("ADC out of range",): """
-This generally occurs when a heater temperature exceeds
-its configured min_temp or max_temp.""",
-    ("Rescheduled timer in the past", "Stepper too far in past"): """
-This generally occurs when the micro-controller has been
-requested to step at a rate higher than it is capable of
-obtaining.""",
-    ("Command request",): """
-This generally occurs in response to an M112 G-Code command
-or in response to an internal error in the host software.""",
-}
-
-def error_help(msg):
-    for prefixes, help_msg in Common_MCU_errors.items():
-        for prefix in prefixes:
-            if msg.startswith(prefix):
-                return help_msg
-    return ""
 
 def add_printer_objects(config):
     printer = config.get_printer()

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -496,8 +496,8 @@ class MCU_adc:
         self._inv_max_adc = 0.
     def get_mcu(self):
         return self._mcu
-    def setup_minmax(self, sample_time, sample_count,
-                     minval=0., maxval=1., range_check_count=0):
+    def setup_adc_sample(self, sample_time, sample_count,
+                         minval=0., maxval=1., range_check_count=0):
         self._sample_time = sample_time
         self._sample_count = sample_count
         self._min_sample = minval


### PR DESCRIPTION
This PR adds a new error_mcu host module to facilitate error formatting.  It also attempts to report which ADC sensor is out of range on an "ADC out of range" mcu error.

Handling micro-controller errors is challenging because we really want the heaters to be disabled if an unexpected error occurs.  That means we don't want a lot of code complexity to analyze the source of the error in the code that needs to immediately handle that error.  This can lead to crytpic mcu error reports.

This PR creates a new error_mcu host module that can analyze the low-level error reports after the main shutdown processing has completed.  Thus, the error_mcu code is no longer on the "critical shutdown path" and can take more time and resources to format a more user friendly error message.

With this PR, the low-level MCU_adc code can identify if recent adc values were out of range, and then communicate that to the new error_mcu module.  This is then used in an "ADC out of range" error report.  For example:
```
MCU 'mcu' shutdown: ADC out of range

Sensor 'extruder' reporting out of range

This generally occurs when a heater temperature exceeds
its configured min_temp or max_temp.
Once the underlying issue is corrected, use the
"FIRMWARE_RESTART" command to reset the firmware, reload the
config, and restart the host software.
Printer is shutdown
```

This ADC check should work in most cases, but it is possible that an out-of-range error may occur while the host is unable to identify which module was out of range.

-Kevin

EDIT: The new module was renamed to "error_mcu.py"