### PR TITLE
Manual stepper support multiple motors on a single rail

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -293,6 +293,13 @@ understands it).
 - `z_position_lower`: Last probe attempt just lower than the current height.
 - `z_position_upper`: Last probe attempt just greater than the current height.
 
+## manual_stepper
+
+The following information is available in the
+`manual_stepper` object:
+- `enabled`: Returns True if the stepper is currently enabled.
+- `position`: The requested position.
+
 ## mcu
 
 The following information is available in

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -104,6 +104,13 @@ class ManualStepper:
             self.do_move(movepos, speed, accel, sync)
         elif gcmd.get_int('SYNC', 0):
             self.sync_print_time()
+
+    def get_status(self, eventtime):
+        stepper_enable = self.printer.lookup_object('stepper_enable')
+        enable = stepper_enable.lookup_enable(self.steppers[0].get_name())
+        return {'position': self.rail.get_commanded_position(),
+                'enabled': enable.is_motor_enabled()}
+
     # Toolhead wrappers to support homing
     def flush_step_generation(self):
         self.sync_print_time()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -11,7 +11,7 @@ class ManualStepper:
         self.printer = config.get_printer()
         if config.get('endstop_pin', None) is not None:
             self.can_home = True
-            self.rail = stepper.PrinterRail(
+            self.rail = stepper.LookupMultiRail(
                 config, need_position_minmax=False, default_position_endstop=0.)
             self.steppers = self.rail.get_steppers()
         else:
@@ -132,5 +132,15 @@ class ManualStepper:
     def calc_position(self, stepper_positions):
         return [stepper_positions[self.rail.get_name()], 0., 0.]
 
+# Dummy object for multi stepper setup
+class DummyStepper():
+    def get_status(self, eventtime):
+        return {}
+
 def load_config_prefix(config):
+    name = config.get_name()
+    # Return a dummy if this is a secondary motor in a multi-motor setup.
+    for i in range(1,99):
+        if name.endswith(str(i)) and config.has_section(name[:-len(str(i))]):
+            return DummyStepper()
     return ManualStepper(config)

--- a/test/klippy/manual_stepper.cfg
+++ b/test/klippy/manual_stepper.cfg
@@ -16,6 +16,23 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PJ1
 
+[manual_stepper dual_motor_stepper]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+velocity: 7
+accel: 500
+
+[manual_stepper dual_motor_stepper1]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 40
+
 [mcu]
 serial: /dev/ttyACM0
 

--- a/test/klippy/manual_stepper.test
+++ b/test/klippy/manual_stepper.test
@@ -16,9 +16,16 @@ MANUAL_STEPPER STEPPER=homing_stepper SET_POSITION=0
 MANUAL_STEPPER STEPPER=homing_stepper MOVE=10 SPEED=100 ACCEL=1
 MANUAL_STEPPER STEPPER=homing_stepper ENABLE=0
 
+# Test dual motor
+MANUAL_STEPPER STEPPER=dual_motor_stepper ENABLE=1
+MANUAL_STEPPER STEPPER=dual_motor_stepper SET_POSITION=0
+MANUAL_STEPPER STEPPER=dual_motor_stepper MOVE=10 SPEED=100 ACCEL=1
+MANUAL_STEPPER STEPPER=dual_motor_stepper ENABLE=0
+
 # Test motor off
 M84
 
 # Verify stepper_buzz
 STEPPER_BUZZ STEPPER="manual_stepper basic_stepper"
 STEPPER_BUZZ STEPPER="manual_stepper homing_stepper"
+STEPPER_BUZZ STEPPER="manual_stepper dual_motor_stepper"


### PR DESCRIPTION
Allows multiple motors to run in sync as a manual stepper.

Tested with a tool dock lift.