### PR TITLE
probe_eddy_current: Fix "z-offset" did not apply as expected

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2020,6 +2020,10 @@ sensor_type: ldc1612
 #z_offset:
 #   The nominal distance (in mm) between the nozzle and bed that a
 #   probing attempt should stop at. This parameter must be provided.
+#position_endstop:
+#   The nominal distance (in mm) between the nozzle and bed that a
+#   homing attempt should stop at. The recommended parameter is 1.0
+#   This parameter must be provided.
 #i2c_address:
 #i2c_mcu:
 #i2c_bus:

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -300,6 +300,7 @@ class EddyEndstopWrapper:
         self._mcu = sensor_helper.get_mcu()
         self._calibration = calibration
         self._z_offset = config.getfloat('z_offset', minval=0.)
+        self.position_endstop = config.getfloat('position_endstop', minval=0.)
         self._dispatch = mcu.TriggerDispatch(self._mcu)
         self._trigger_time = 0.
         self._gather = None
@@ -313,7 +314,7 @@ class EddyEndstopWrapper:
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
         self._trigger_time = 0.
-        trigger_freq = self._calibration.height_to_freq(self._z_offset)
+        trigger_freq = self._calibration.height_to_freq(self.position_endstop)
         trigger_completion = self._dispatch.start(print_time)
         self._sensor_helper.setup_home(
             print_time, trigger_freq, self._dispatch.get_oid(),


### PR DESCRIPTION
Currently, many users have reported fine-tuning the z-offset during printing to make the first layer perfect. After printing is completed, `SAVE_CONFIG` and restart to print again. The z-offset does not take effect and still needs to be adjusted.

This is because when using Eddy as the z-axis endstop, the parameter of z-offset is applied to the homing, and the actual height of the z-axis at which the homing stops varies depending on the value of z-offset. So it is necessary to fix a homing height so that z-offset can take effect as expected.

In theory, the correspondence between the frequency and distance of Eddy is obtained through Paper test and calibration, and theoretically, z-offset does not need to be adjusted at all. But in reality, there are indeed many users who need the z-offset function.

The [ldctap ](https://github.com/KevinOConnor/klipper-dev/tree/work-ldctap-20240430) you previously implemented can also solve this problem. 
