### PR TITLE
add support for at32f415 and at32f413

### DIFF
--- a/lib/stm32f1/include/stm32f103xe.h
+++ b/lib/stm32f1/include/stm32f103xe.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *  
   ******************************************************************************
   * @attention
@@ -1447,6 +1447,18 @@ typedef struct
 #define RCC_CFGR_USBPRE_Pos                  (22U)                             
 #define RCC_CFGR_USBPRE_Msk                  (0x1UL << RCC_CFGR_USBPRE_Pos)     /*!< 0x00400000 */
 #define RCC_CFGR_USBPRE                      RCC_CFGR_USBPRE_Msk               /*!< USB Device prescaler */
+
+/* AT32 USB CLOCK  configuration */
+#define RCC_CFGR_USBPRE_DIV2                 0xC00000U                         /*!< USB Device prescaler 2 */
+#define RCC_CFGR_USBPRE_DIV2_5               0x800000U                         /*!< USB Device prescaler 2.5 */
+#define RCC_CFGR_USBPRE_DIV3                 0x8400000U                        /*!< USB Device prescaler 3 */
+#define RCC_CFGR_USBPRE_DIV3_5               0x8000000U                        /*!< USB Device prescaler 3.5 */
+#define RCC_CFGR_USBPRE_DIV4                 0x8800000U                        /*!< USB Device prescaler 4 */
+
+/* AT32F4X3 PLL RANGE */
+#define RCC_CFGR_PLLRANGE_Pos                (31U)                             
+#define RCC_CFGR_PLLRANGE_Msk                (0x1UL << RCC_CFGR_PLLRANGE_Pos)     /*!< 0x80000000 */
+#define RCC_CFGR_PLLRANGE                    RCC_CFGR_PLLRANGE_Msk               /*!< PLL RANGE GT 72MHZ */
 
 /*!< MCO configuration */
 #define RCC_CFGR_MCO_Pos                     (24U)                             

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -111,6 +111,12 @@ choice
         bool "Nation N32G455"
         select MACH_N32G45x
         select MACH_STM32F1
+    config MACH_AT32F415
+        bool "Artery AT32F415"
+        select MACH_STM32F1
+    config MACH_AT32F413
+        bool "Artery AT32F413"
+        select MACH_STM32F1
 endchoice
 
 config MACH_STM32F103x6
@@ -144,6 +150,10 @@ config MACH_STM32F4x5 # F405, F407, F429 series
 config MACH_STM32L4
     bool
 config MACH_N32G45x
+    bool
+config MACH_AT32F415
+    bool
+config MACH_AT32F413
     bool
 config HAVE_STM32_USBFS
     bool
@@ -190,6 +200,8 @@ config MCU
     default "stm32h750xx" if MACH_STM32H750
     default "stm32l412xx" if MACH_STM32L412
     default "stm32f103xe" if MACH_N32G45x
+    default "stm32f103xe" if MACH_AT32F415
+    default "stm32f103xe" if MACH_AT32F413
 
 config CLOCK_FREQ
     int
@@ -208,6 +220,9 @@ config CLOCK_FREQ
     default 80000000 if MACH_STM32L412
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
     default 128000000 if MACH_N32G45x
+    default 64000000 if MACH_AT32F415 && STM32_CLOCK_REF_INTERNAL
+    default 120000000 if MACH_AT32F415
+    default 120000000 if MACH_AT32F413
 
 config FLASH_SIZE
     hex
@@ -221,6 +236,8 @@ config FLASH_SIZE
     default 0x20000 if MACH_STM32H750
     default 0x200000 if MACH_STM32H743 || MACH_STM32F765
     default 0x20000 if MACH_N32G45x
+    default 0x20000 if MACH_AT32F415
+    default 0x20000 if MACH_AT32F413
 
 config FLASH_BOOT_ADDRESS
     hex
@@ -248,6 +265,8 @@ config RAM_SIZE
     default 0x24000 if MACH_STM32G0Bx
     default 0x20000 if MACH_STM32H7
     default 0x10000 if MACH_N32G45x
+    default 0x8000 if MACH_AT32F415
+    default 0x8000 if MACH_AT32F413
 
 config STACK_SIZE
     int

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -21,6 +21,8 @@ MCU_UPPER := $(shell echo $(CONFIG_MCU) | tr a-z A-Z | tr X x)
 CFLAGS-$(CONFIG_MACH_STM32F0) += -mcpu=cortex-m0 -Ilib/stm32f0/include
 CFLAGS-$(CONFIG_MACH_STM32F103) += -mcpu=cortex-m3
 CFLAGS-$(CONFIG_MACH_N32G45x) += -mcpu=cortex-m4 -Ilib/n32g45x/include
+CFLAGS-$(CONFIG_MACH_AT32F415) += -mcpu=cortex-m4
+CFLAGS-$(CONFIG_MACH_AT32F413) += -mcpu=cortex-m4
 CFLAGS-$(CONFIG_MACH_STM32F1) += -Ilib/stm32f1/include
 CFLAGS-$(CONFIG_MACH_STM32F2) += -mcpu=cortex-m3 -Ilib/stm32f2/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mcpu=cortex-m4 -Ilib/stm32f4/include
@@ -47,6 +49,10 @@ src-$(CONFIG_MACH_STM32F103) += ../lib/stm32f1/system_stm32f1xx.c
 src-$(CONFIG_MACH_STM32F103) += stm32/adc.c
 src-$(CONFIG_MACH_N32G45x) += ../lib/stm32f1/system_stm32f1xx.c
 src-$(CONFIG_MACH_N32G45x) += ../lib/n32g45x/n32g45x_adc.c stm32/n32g45x_adc.c
+src-$(CONFIG_MACH_AT32F415) += ../lib/stm32f1/system_stm32f1xx.c
+src-$(CONFIG_MACH_AT32F415) += stm32/adc.c
+src-$(CONFIG_MACH_AT32F413) += ../lib/stm32f1/system_stm32f1xx.c
+src-$(CONFIG_MACH_AT32F413) += stm32/adc.c
 src-$(CONFIG_MACH_STM32F1) += stm32/stm32f1.c generic/armcm_timer.c stm32/i2c.c
 src-$(CONFIG_MACH_STM32F2) += ../lib/stm32f2/system_stm32f2xx.c
 src-$(CONFIG_MACH_STM32F2) += stm32/stm32f4.c generic/armcm_timer.c

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -73,7 +73,8 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     if (!is_enabled_pclock((uint32_t)i2c)) {
         // Enable i2c clock and gpio
         enable_pclock((uint32_t)i2c);
-        i2c_busy_errata(ii->scl_pin, ii->sda_pin);
+        if (! CONFIG_MACH_AT32F415 && ! CONFIG_MACH_AT32F413)
+            i2c_busy_errata(ii->scl_pin, ii->sda_pin);
         gpio_peripheral(ii->scl_pin, GPIO_FUNCTION(4) | GPIO_OPEN_DRAIN, 1);
         gpio_peripheral(ii->sda_pin, GPIO_FUNCTION(4) | GPIO_OPEN_DRAIN, 1);
         i2c->CR1 = I2C_CR1_SWRST;
@@ -82,8 +83,14 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         // Set 100Khz frequency and enable
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
         i2c->CR2 = pclk / 1000000;
-        i2c->CCR = pclk / 100000 / 2;
-        i2c->TRISE = (pclk / 1000000) + 1;
+        if ( (CONFIG_MACH_AT32F415 || CONFIG_MACH_AT32F413) && rate == 400000) {
+            i2c->CCR = pclk / 400000 / 3;
+            i2c->CCR |= I2C_CCR_FS;
+            i2c->TRISE = (pclk / 1000000) * 3 / 10 + 1;
+        } else {
+            i2c->CCR = pclk / 100000 / 2;
+            i2c->TRISE = (pclk / 1000000) + 1;
+        }
         i2c->CR1 = I2C_CR1_PE;
     }
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -74,6 +74,8 @@ clock_setup(void)
                 | ((div2 - 2) << RCC_CFGR_PLLMULL_Pos));
     }
     cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_ADCPRE_DIV8;
+    if (CONFIG_MACH_AT32F413 && CONFIG_CLOCK_FREQ == 120000000)
+        cfgr |= RCC_CFGR_PLLRANGE | RCC_CFGR_USBPRE_DIV2_5;
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 

--- a/src/stm32/usbfs.c
+++ b/src/stm32/usbfs.c
@@ -265,7 +265,8 @@ usb_send_bulk_in(void *data, uint_fast8_t len)
             // buffering mode, so wait for second packet before starting.
             if (bipp == (BI_START | 1)) {
                 bulk_in_push_pos = 0;
-                writel(&bulk_in_pop_flag, USB_EP_KIND); // Dummy flag
+                if (! CONFIG_MACH_AT32F413)
+                    writel(&bulk_in_pop_flag, USB_EP_KIND); // Dummy flag
                 USB_EPR[ep] = calc_epr_bits(epr, USB_EPTX_STAT
                                             , USB_EP_TX_VALID);
             }


### PR DESCRIPTION
This PR add support for artery at32f415 and at32f413 . They are almost fully compatible with stm32f103 ,but have higher clock and little difference. The at32f413 need to set RCC_CFGR_PLLRANGE in RCC_CFGR register when PLL range great than 72Mhz . The RCC_CFGR_PLLRANGE bit is reserved in stm32f103 series .  While at32f415 do not need to set RCC_CFGR_PLLRANGE bit .  They can run stably  at 120Mhz . The RCC_CFGR_USBPRE_DIV2_5 use bit 23 which is also reserved in stm32f103 series .
at32f413 can run usb and canbus ，but need to make small change in usbfs.c . 
at32f415 can only run canbus at now .
There are some changes in i2c.c for at32f413/at32f415 running i2c at the speed of 100k and 400k . 

signed-off-by: Albert Lin  <vcore85@gmail.com>