### PR TITLE
Update Dockerfile to use the official python2 image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -14,13 +14,13 @@
 #       /home/klippy/.config/
 # For more Dockerfile examples with Klipper (and Octoprint) see:
 # https://github.com/sillyfrog/OctoPrint-Klipper-mjpg-Dockerfile
-FROM ubuntu:18.04
+FROM python:2
 
 RUN apt-get update && \
     apt-get install -y sudo
 
 # Create user
-RUN useradd -ms /bin/bash klippy && adduser klippy dialout
+RUN useradd -ms /bin/sh klippy && adduser klippy dialout
 USER klippy
 
 #This fixes issues with the volume command setting wrong permissions
@@ -37,7 +37,7 @@ RUN echo 'klippy ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/klippy && \
 # This is to allow the install script to run without error
 RUN ln -s /bin/true /bin/systemctl
 USER klippy
-RUN ./klipper/scripts/install-ubuntu-18.04.sh
+RUN ./klipper/scripts/install-debian.sh
 # Clean up install script workaround
 RUN sudo rm -f /bin/systemctl
 


### PR DESCRIPTION
Switched the provided Dockerfile from unsupported for over a year ubuntu 18.04 image to official python2 image, based on Debian. This ensures that the python2 package is provided and the Debian base is supported.