### PR TITLE
spi_flash: New flash-sdcard board definitions for Creality v4.5.x motherboards

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -156,6 +156,8 @@ BOARD_ALIASES = {
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],
     'creality-v4.2.7': BOARD_DEFS['creality-v4.2.2'],
+    'creality-v4.5.2': BOARD_DEFS['creality-v4.2.2'],
+    'creality-v4.5.3': BOARD_DEFS['creality-v4.2.2'],
     'btt-skr-2-f407': BOARD_DEFS['btt-octopus-f407-v1'],
     'btt-skr-2-f429': BOARD_DEFS['btt-octopus-f429-v1'],
     'btt-octopus-f407-v1.0': BOARD_DEFS['btt-octopus-f407-v1'],


### PR DESCRIPTION
This pull request adds two board definitions for Creality v4.5.2 and v4.5.3 motherboards found in Creality CR-6 SE printers. These definitions are actually aliases pointing to the existing `creality-v4.2.2` definition, which has the same MCU and SDIO pinout as the v4.5.x boards.