### PR TITLE
sw spi bus: Added support for configured width and encoding

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4826,6 +4826,13 @@ SPI bus.
 #spi_software_sclk_pin:
 #spi_software_mosi_pin:
 #spi_software_miso_pin:
+#spi_software_bus_width: number of bits from `5` to `64` to send/receive per
+#                        transaction on the software SPI bus (default 8 bits).
+#spi_software_is_little_endian: `True`/`False` - if `True` and width above `8`
+#    bits, the least significant byte will be sent first, otherwise last
+#    (default `False`).
+#spi_software_is_lsb_first: `True`/`False` - if `True` then the least
+#    significant bit will be sent first (default `False`).
 #   Specify the above parameters to use "software based SPI". This
 #   mode does not require micro-controller hardware support (typically
 #   any general purpose pins may be used). The default is to not use

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -40,11 +40,22 @@ def resolve_bus_name(mcu, param, bus):
 # Helper code for working with devices connected to an MCU via an SPI bus
 class MCU_SPI:
     def __init__(self, mcu, bus, pin, mode, speed, sw_pins=None,
-                 cs_active_high=False):
+                 cs_active_high=False, sw_bus_width=8, is_little_endian=False,
+                 is_lsb_first=False):
         self.mcu = mcu
         self.bus = bus
         # Config SPI object (set all CS pins high before spi_set_bus commands)
         self.oid = mcu.create_oid()
+        self.width = sw_bus_width
+        self.is_little_endian = is_little_endian
+        self.is_lsb_first = is_lsb_first
+        # Limit the width to be 5 or more bits to ensure that multiple
+        # transactions can be differentiated from a single transaction.
+        # (e.g. for w=4 and then 1 byte might be 1 transaction and 4 spare bits
+        # or 2 transactions with 4 bits each)
+        if self.width < 5 or self.width > 64:
+            raise self.mcu.error("Unsupported spi bus width %d "
+                                 "(should be 5..64)" % (self.width,))
         if pin is None:
             mcu.add_config_cmd("config_spi_without_cs oid=%d" % (self.oid,))
         else:
@@ -54,8 +65,9 @@ class MCU_SPI:
         if sw_pins is not None:
             self.config_fmt = (
                 "spi_set_software_bus oid=%d"
-                " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d"
-                % (self.oid, sw_pins[0], sw_pins[1], sw_pins[2], mode, speed))
+                " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d width=%d"
+                % (self.oid, sw_pins[0], sw_pins[1], sw_pins[2],
+                mode, speed, self.width))
         else:
             self.config_fmt = (
                 "spi_set_bus oid=%d spi_bus=%%s mode=%d rate=%d"
@@ -86,27 +98,118 @@ class MCU_SPI:
             "spi_transfer_response oid=%c response=%*s", oid=self.oid,
             cq=self.cmd_queue)
     def spi_send(self, data, minclock=0, reqclock=0):
+        data_encoded = self.encode(data)
         if self.spi_send_cmd is None:
             # Send setup message via mcu initialization
-            data_msg = "".join(["%02x" % (x,) for x in data])
+            data_msg = "".join(["%02x" % (x,) for x in data_encoded])
             self.mcu.add_config_cmd("spi_send oid=%d data=%s" % (
                 self.oid, data_msg), is_init=True)
             return
-        self.spi_send_cmd.send([self.oid, data],
+        self.spi_send_cmd.send([self.oid, data_encoded],
                                minclock=minclock, reqclock=reqclock)
     def spi_transfer(self, data, minclock=0, reqclock=0):
-        return self.spi_transfer_cmd.send([self.oid, data],
+        data_encoded = self.encode(data)
+        recv = self.spi_transfer_cmd.send([self.oid, data_encoded],
                                           minclock=minclock, reqclock=reqclock)
+        return self.decode(recv)
+
     def spi_transfer_with_preface(self, preface_data, data,
                                   minclock=0, reqclock=0):
-        return self.spi_transfer_cmd.send_with_preface(
+        recv = self.spi_transfer_cmd.send_with_preface(
             self.spi_send_cmd, [self.oid, preface_data], [self.oid, data],
             minclock=minclock, reqclock=reqclock)
+        return self.decode(recv)
+
+    def encode(self, data):
+        if self.width == 8 and not self.is_lsb_first:
+            return data
+        encoded_bytes = []
+        accumulator = 0  # To accumulate bits
+        acc_bits = 0  # Count of bits in the accumulator
+        format_str = '0{}b'.format(self.width)
+        append_from_left = self.is_little_endian
+        if self.is_lsb_first:
+            append_from_left = not append_from_left
+        for number in data:
+            if self.is_lsb_first:
+                # rotate all bits of the byte msb<->lsb
+                number = int(''.join(reversed(format(number, format_str))), 2)
+            if append_from_left:
+                # Shift the current number into the accumulator from the left
+                accumulator |= number << acc_bits
+            else:
+                # Shift the current number into the accumulator from the right
+                accumulator = (accumulator << self.width) | number
+            acc_bits += self.width
+            # While we have at least 8 bits, form a byte and append it
+            while acc_bits >= 8:
+                acc_bits -= 8  # Decrease bit count by 8
+                if append_from_left:
+                    # Extract the 8 least significant bits to form a byte
+                    byte = accumulator & 0xFF
+                    # Remove lsb 8 bits from the accumulator
+                    accumulator >>= 8
+                else:
+                    # Extract the 8 most significant bits to form a byte
+                    byte = (accumulator >> acc_bits) & 0xFF
+                    # Remove msb 8 bits from the accumulator
+                    accumulator &= (1 << acc_bits) - 1
+                encoded_bytes.append(byte)
+        # Handle any remaining bits by padding them on the right to byte
+        if acc_bits > 0:
+            last_byte = (accumulator << (8 - acc_bits)) & 0xFF
+            encoded_bytes.append(last_byte)
+        return encoded_bytes
+
+    def decode(self, encoded_data):
+        if self.width == 8 and not self.is_lsb_first:
+            return encoded_data
+        decoded_data = []
+        accumulator = 0
+        acc_bits = 0
+        format_str = '0{}b'.format(self.width)
+        append_from_left = self.is_little_endian
+        if self.is_lsb_first:
+            append_from_left = not append_from_left
+        if append_from_left:
+            # shift the last byte right if it is not full to simplify decoding
+            # as leftovers always stay in the msb side of this byte
+            last_byte = encoded_data[-1]
+            left_overs = len(encoded_data) * 8 % self.width
+            encoded_data[-1] = last_byte >> (8 - left_overs)
+        for byte in encoded_data:
+            # Adjust byte order based on endianness
+            if append_from_left:
+                # Shift the bytes into the accumulator from the left
+                accumulator |= byte << acc_bits
+            else:
+                # Shift the bytes into the accumulator from the right
+                accumulator = (accumulator << 8) | byte
+            acc_bits += 8
+            # Decode numbers from the accumulator
+            while acc_bits >= self.width:
+                acc_bits -= self.width
+                num = 0
+                if append_from_left:
+                    num = accumulator & ((1 << self.width) - 1)
+                    accumulator >>= self.width
+                else:
+                    num = (accumulator >> acc_bits) & ((1 << self.width) - 1)
+                    accumulator &= (1 << acc_bits) - 1
+                # Apply lsb-first rotation if required
+                if self.is_lsb_first:
+                    num = int(''.join(reversed(format(num, format_str))), 2)
+                # Append the decoded number
+                decoded_data.append(num)
+        # as byte array may have leftover bits (len*width % 8 != 0),
+        # it is ok to ignore acc_bits and drop remaining accumulated bits
+        return decoded_data
 
 # Helper to setup an spi bus from settings in a config section
 def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
                         default_speed=100000, share_type=None,
-                        cs_active_high=False):
+                        cs_active_high=False, sw_bus_width=8,
+                        is_little_endian=False, is_lsb_first=False):
     # Determine pin from config
     ppins = config.get_printer().lookup_object("pins")
     cs_pin = config.get(pin_option)
@@ -118,6 +221,12 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
     # Load bus parameters
     mcu = cs_pin_params['chip']
     speed = config.getint('spi_speed', default_speed, minval=100000)
+    sw_bus_width = config.getint('spi_software_bus_width', sw_bus_width,
+                                 minval=5, maxval=64)
+    sw_bus_is_little_endian=config.getboolean('spi_software_is_little_endian',
+                                              is_little_endian)
+    sw_bus_is_lsb_first=config.getboolean('spi_software_is_lsb_first',
+                                          is_lsb_first)
     if config.get('spi_software_sclk_pin', None) is not None:
         sw_pin_names = ['spi_software_%s_pin' % (name,)
                         for name in ['miso', 'mosi', 'sclk']]
@@ -133,8 +242,9 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
         bus = config.get('spi_bus', None)
         sw_pins = None
     # Create MCU_SPI object
-    return MCU_SPI(mcu, bus, pin, mode, speed, sw_pins, cs_active_high)
-
+    return MCU_SPI(mcu, bus, pin, mode, speed, sw_pins,
+                   cs_active_high, sw_bus_width, sw_bus_is_little_endian,
+                   sw_bus_is_lsb_first)
 
 ######################################################################
 # I2C

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -114,7 +114,7 @@ SPI_CFG_CMDS = (
 )
 SPI_BUS_CMD = "spi_set_bus oid=%d spi_bus=%s mode=%d rate=%d"
 SW_SPI_BUS_CMD = "spi_set_software_bus oid=%d " \
-    "miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d"
+    "miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d width=%d"
 SPI_SEND_CMD = "spi_send oid=%c data=%*s"
 SPI_XFER_CMD = "spi_transfer oid=%c data=%*s"
 SPI_XFER_RESPONSE = "spi_transfer_response oid=%c response=%*s"
@@ -1289,7 +1289,7 @@ class MCUConnection:
                 if p not in pin_enums:
                     raise SPIFlashError(pin_err_msg)
             bus_cmd = SW_SPI_BUS_CMD % (SPI_OID, pins[0], pins[1], pins[2],
-                                        SPI_MODE, SD_SPI_SPEED)
+                                        SPI_MODE, SD_SPI_SPEED, 8)
         else:
             if bus not in bus_enums:
                 raise SPIFlashError("Invalid SPI Bus: %s" % (bus,))

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -14,14 +14,18 @@ struct spi_software {
     struct gpio_in miso;
     struct gpio_out mosi, sclk;
     uint8_t mode;
+    uint8_t width;
 };
 
 void
 command_spi_set_software_bus(uint32_t *args)
 {
     uint8_t mode = args[4];
-    if (mode > 3)
+    uint8_t width = args[6];
+    if (mode > 3 || width < 5 || width > 64) {
+        output("command_spi_set_software_bus width=%c mode=%c", width, mode);
         shutdown("Invalid spi config");
+    }
 
     struct spidev_s *spi = spidev_oid_lookup(args[0]);
     struct spi_software *ss = alloc_chunk(sizeof(*ss));
@@ -29,11 +33,12 @@ command_spi_set_software_bus(uint32_t *args)
     ss->mosi = gpio_out_setup(args[2], 0);
     ss->sclk = gpio_out_setup(args[3], 0);
     ss->mode = mode;
+    ss->width = width;
     spidev_set_software_bus(spi, ss);
 }
 DECL_COMMAND(command_spi_set_software_bus,
              "spi_set_software_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
-             " mode=%u rate=%u");
+             " mode=%u rate=%u width=%u");
 
 void
 spi_software_prepare(struct spi_software *ss)
@@ -45,10 +50,26 @@ void
 spi_software_transfer(struct spi_software *ss, uint8_t receive_data
                       , uint8_t len, uint8_t *data)
 {
+    uint16_t num_values = (uint16_t)len * 8 / ss->width;
+    uint8_t  extra_bits = (uint16_t)len * 8 % ss->width;
+
+    if (num_values < 1) {
+        output("spi_software_transfer width=%c len=%c num_values=%hu, " \
+               "extra_bits=%c", ss->width, len, num_values, extra_bits);
+        shutdown("Invalid spi transfer: not enough data for at least 1 value");
+    }
+
+    if (extra_bits > 7) {
+        output("spi_software_transfer width=%c len=%c num_values=%hu, " \
+               "extra_bits=%c", ss->width, len, num_values, extra_bits);
+        shutdown("Invalid spi transfer: unused bytes at the end of data");
+    }
+
     while (len--) {
         uint8_t outbuf = *data;
         uint8_t inbuf = 0;
-        for (uint_fast8_t i = 0; i < 8; i++) {
+        uint_fast8_t end = (len) ? 8 : 8 - extra_bits;
+        for (uint_fast8_t i = 0; i < end; i++) {
             if (ss->mode & 0x01) {
                 // MODE 1 & 3
                 gpio_out_toggle(ss->sclk);


### PR DESCRIPTION
Adds option to work with any device/sensor unrelated to HW SPI bus width.
Implemented to work with `YHCB2004` display on `Geeetech A10/M/T` printers that require 9-bit SPI commands.

## Test results
### 5 bit command (less than byte)
![5](https://github.com/Klipper3d/klipper/assets/63168142/6c8034f6-e869-4aae-b3eb-e52ed1ab32cb)
### 12 bit command (non integer number of bytes)
![12](https://github.com/Klipper3d/klipper/assets/63168142/0346062a-22a8-4261-9bbc-702475aa21e3)
### 32 bit command (standard for many sensors)
![32](https://github.com/Klipper3d/klipper/assets/63168142/17cb17a7-a37f-4613-ab3c-898eea3cc2cd)
### 64 bit command (artifitially set max)
![64](https://github.com/Klipper3d/klipper/assets/63168142/eb03a41b-34a8-4c4e-bc47-b318311225c6)
### transmitting 20 bits `0x80f05`
![ff0](https://github.com/Klipper3d/klipper/assets/63168142/7c187f6c-7cfd-494f-8edb-a055583d0e51)
### testing all 4 options of encoding of `0x80f05`
**big/little-endian**
**lsb/msb bit first**
![4 opt4](https://github.com/Klipper3d/klipper/assets/63168142/8e3b6cb5-75a2-477b-b864-7d9e23cd986f)
