### PR TITLE
sht3x: use periodic report mode

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -192,6 +192,9 @@ class MCU_I2C:
             return
         self.i2c_write_cmd.send([self.oid, data],
                                 minclock=minclock, reqclock=reqclock)
+    def i2c_write_wait_ack(self, data, minclock=0, reqclock=0):
+        self.i2c_write_cmd.send_wait_ack([self.oid, data],
+                                minclock=minclock, reqclock=reqclock)
     def i2c_read(self, write, read_len):
         return self.i2c_read_cmd.send([self.oid, write, read_len])
     def i2c_modify_bits(self, reg, clear_bits, set_bits,


### PR DESCRIPTION
SHT3X supports periodic mode, which allows us to completely skip the "write" phase and wait, and just read data in one command.

Also, I corrected reactor pauses to the right numeric order (they are also wrong in htu21.py).

Thanks.