### PR TITLE
Move from straight Ziegler-Nichols To Tyreus-Luyben variant

### DIFF
--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -118,10 +118,13 @@ class ControlAutoTune:
         amplitude = .5 * abs(temp_diff)
         Ku = 4. * self.heater_max_power / (math.pi * amplitude)
         Tu = time_diff
-        # Use Ziegler-Nichols method to generate PID parameters
-        Ti = 0.5 * Tu
-        Td = 0.125 * Tu
-        Kp = 0.6 * Ku * heaters.PID_PARAM_BASE
+        # Use Tyreus-Luyben variant of Ziegler-Nichols method to generate PID
+        # parameters. Ziegler-Nichols produces very aggressive gain, which
+        # tends to cause significant initial overshoot of large heater beds,
+        # and unneeded oscillation of hotends.
+        Ti = 2.2 * Tu
+        Td = Tu / 6.3
+        Kp = (Ku / 2.2) * heaters.PID_PARAM_BASE
         Ki = Kp / Ti
         Kd = Kp * Td
         logging.info("Autotune: raw=%f/%f Ku=%f Tu=%f  Kp=%f Ki=%f Kd=%f",


### PR DESCRIPTION
The Ziegler-Nichols method generates aggressive gain.

This is a well-known and understood issue to the degree it's even mentioned on the wikipedia page ("It yields an aggressive gain and overshoot – some applications wish to instead minimize or eliminate overshoot, and for these this method is inappropriate").

For Klipper, this tends to result in  overshoot on heater beds (especially large ones), and cause larger-than-needed oscillation on hotend temperatures.

This moves to a slightly different set of constants that does better at both of these things, without causing regressions for existing hotends (as far as i can tell)

I tested this on a number of different hotends and hotbeds.  On my magneto x, this consistently reduces initial overshoot of the heatbed (1000w heatbed) to 1C or less, whereas it was around 3-5C before.  For the hotend, the temperature range is about +-0.2C, and before it was about +-0.6C steady state.  This is representative of other results, and there were no regressions. 

This is about what you would expect as it produces less initial overshoot and better settling behavior that results in smaller oscillation due to less aggressive gain.

Not sure what the normal method of experimentation is here, but happy to make it a config option or whatever if folks are interested.

Depending how much people care, i could also implement one of the newer NN based PID techniques that are robust across basically everything we would care about (the biggest issue here seems to be time delayed thermal masses, which they handle remarkably well), which would eliminate the need for this kind of pid tuning, but be more computationally expensive (though a lot of the newer MCU cores are starting to get accelerators for this these days)