### PR TITLE
Adding LIS3DH support

### DIFF
--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -12,6 +12,8 @@ REG_LIS2DW_WHO_AM_I_ADDR = 0x0F
 REG_LIS2DW_CTRL_REG1_ADDR = 0x20
 REG_LIS2DW_CTRL_REG2_ADDR = 0x21
 REG_LIS2DW_CTRL_REG3_ADDR = 0x22
+REG_LIS2DW_CTRL_REG4_ADDR = 0x23
+REG_LIS2DW_CTRL_REG5_ADDR = 0x24
 REG_LIS2DW_CTRL_REG6_ADDR = 0x25
 REG_LIS2DW_STATUS_REG_ADDR = 0x27
 REG_LIS2DW_OUT_XL_ADDR = 0x28
@@ -26,9 +28,11 @@ REG_MOD_READ = 0x80
 # REG_MOD_MULTI = 0x40
 
 LIS2DW_DEV_ID = 0x44
+LIS3DH_DEV_ID = 0x33
 
 FREEFALL_ACCEL = 9.80665
 SCALE = FREEFALL_ACCEL * 1.952 / 4
+SCALE_IIS3DH = FREEFALL_ACCEL * 1 / 4096 * 1000
 
 BATCH_UPDATES = 0.100
 
@@ -37,20 +41,34 @@ class LIS2DW:
     def __init__(self, config):
         self.printer = config.get_printer()
         adxl345.AccelCommandHelper(config, self)
-        self.axes_map = adxl345.read_axes_map(config, SCALE, SCALE, SCALE)
+        self.is_lis3dh = config.getboolean('is_lis3dh', False)
+        self.axes_map = None
+        if self.is_lis3dh:
+            self.axes_map = adxl345.read_axes_map(config, SCALE_IIS3DH, SCALE_IIS3DH, SCALE_IIS3DH)
+        else:
+            self.axes_map = adxl345.read_axes_map(config, SCALE, SCALE, SCALE)
+        
         self.data_rate = 1600
+        self.data_rate_lis3dh = 1344
+
         # Setup mcu sensor_lis2dw bulk query code
         self.spi = bus.MCU_SPI_from_config(config, 3, default_speed=5000000)
         self.mcu = mcu = self.spi.get_mcu()
         self.oid = oid = mcu.create_oid()
         self.query_lis2dw_cmd = None
-        mcu.add_config_cmd("config_lis2dw oid=%d spi_oid=%d"
-                           % (oid, self.spi.get_oid()))
+                # Read config
+        
+        mcu.add_config_cmd("config_lis2dw oid=%d spi_oid=%d lis3dh=%d"
+                           % (oid, self.spi.get_oid(), self.is_lis3dh))
         mcu.add_config_cmd("query_lis2dw oid=%d rest_ticks=0"
                            % (oid,), on_restart=True)
         mcu.register_config_callback(self._build_config)
         # Bulk sample message reading
-        chip_smooth = self.data_rate * BATCH_UPDATES * 2
+        chip_smooth = None
+        if self.is_lis3dh:
+            chip_smooth = self.data_rate_lis3dh * BATCH_UPDATES * 2
+        else:
+            chip_smooth = self.data_rate * BATCH_UPDATES * 2
         self.ffreader = bulk_sensor.FixedFreqReader(mcu, chip_smooth, "<hhh")
         self.last_error_count = 0
         # Process messages in batches
@@ -72,6 +90,7 @@ class LIS2DW:
         params = self.spi.spi_transfer([reg | REG_MOD_READ, 0x00])
         response = bytearray(params['response'])
         return response[1]
+    
     def set_reg(self, reg, val, minclock=0):
         self.spi.spi_send([reg, val & 0xFF], minclock=minclock)
         stored_val = self.read_reg(reg)
@@ -102,26 +121,42 @@ class LIS2DW:
         # noise or wrong signal as a correctly initialized device
         dev_id = self.read_reg(REG_LIS2DW_WHO_AM_I_ADDR)
         logging.info("lis2dw_dev_id: %x", dev_id)
-        if dev_id != LIS2DW_DEV_ID:
+        if dev_id != LIS2DW_DEV_ID and dev_id != LIS3DH_DEV_ID:
             raise self.printer.command_error(
-                "Invalid lis2dw id (got %x vs %x).\n"
+                "Invalid lis2dw id (got %x vs %x or %x).\n"
                 "This is generally indicative of connection problems\n"
                 "(e.g. faulty wiring) or a faulty lis2dw chip."
-                % (dev_id, LIS2DW_DEV_ID))
-        # Setup chip in requested query rate
-        # ODR/2, +-16g, low-pass filter, Low-noise abled
-        self.set_reg(REG_LIS2DW_CTRL_REG6_ADDR, 0x34)
-        # Continuous mode: If the FIFO is full
-        # the new sample overwrites the older sample.
-        self.set_reg(REG_LIS2DW_FIFO_CTRL, 0xC0)
-        # High-Performance / Low-Power mode 1600/200 Hz
-        # High-Performance Mode (14-bit resolution)
-        self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0x94)
+                % (dev_id, LIS2DW_DEV_ID, LIS3DH_DEV_ID))
+        if dev_id == LIS2DW_DEV_ID:
+            # Setup chip in requested query rate
+            # ODR/2, +-16g, low-pass filter, Low-noise abled
+            self.set_reg(REG_LIS2DW_CTRL_REG6_ADDR, 0x34)
+            # Continuous mode: If the FIFO is full
+            # the new sample overwrites the older sample.
+            self.set_reg(REG_LIS2DW_FIFO_CTRL, 0xC0)
+            # High-Performance / Low-Power mode 1600/200 Hz
+            # High-Performance Mode (14-bit resolution)
+            self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0x94)
 
-        # Start bulk reading
-        rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
-        self.query_lis2dw_cmd.send([self.oid, rest_ticks])
-        self.set_reg(REG_LIS2DW_FIFO_CTRL, 0xC0)
+            # Start bulk reading
+            rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
+            self.query_lis2dw_cmd.send([self.oid, rest_ticks])
+            self.set_reg(REG_LIS2DW_FIFO_CTRL, 0xC0)
+        else:
+            self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0x97)
+            self.set_reg(REG_LIS2DW_CTRL_REG2_ADDR, 0)
+            self.set_reg(REG_LIS2DW_CTRL_REG3_ADDR, 0)
+            self.set_reg(REG_LIS2DW_CTRL_REG4_ADDR, 0x38)
+            self.set_reg(REG_LIS2DW_CTRL_REG5_ADDR, 0x40)
+            self.set_reg(REG_LIS2DW_CTRL_REG6_ADDR, 0)
+            self.set_reg(REG_LIS2DW_FIFO_CTRL, 0)
+            self.set_reg(REG_LIS2DW_FIFO_CTRL, 0x80)
+            # Start bulk reading
+            rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate_lis3dh)
+            self.query_lis2dw_cmd.send([self.oid, rest_ticks])
+            self.set_reg(REG_LIS2DW_FIFO_CTRL, 0x80)
+
+
         logging.info("LIS2DW starting '%s' measurements", self.name)
         # Initialize clock tracking
         self.ffreader.note_start()
@@ -133,6 +168,8 @@ class LIS2DW:
         self.ffreader.note_end()
         logging.info("LIS2DW finished '%s' measurements", self.name)
         self.set_reg(REG_LIS2DW_FIFO_CTRL, 0x00)
+        self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0)
+
     def _process_batch(self, eventtime):
         samples = self.ffreader.pull_samples()
         self._convert_samples(samples)

--- a/src/sensor_lis2dw.c
+++ b/src/sensor_lis2dw.c
@@ -20,12 +20,16 @@
 
 #define BYTES_PER_SAMPLE 6
 
+#define LIS2DW_MODEL 0
+#define LIS3DH_MODEL 1
+
 struct lis2dw {
     struct timer timer;
     uint32_t rest_ticks;
     struct spidev_s *spi;
     uint8_t flags;
     struct sensor_bulk sb;
+    uint8_t model;  
 };
 
 enum {
@@ -51,8 +55,9 @@ command_config_lis2dw(uint32_t *args)
                                    , sizeof(*ax));
     ax->timer.func = lis2dw_event;
     ax->spi = spidev_oid_lookup(args[1]);
+    ax->model = args[2];
 }
-DECL_COMMAND(command_config_lis2dw, "config_lis2dw oid=%c spi_oid=%c");
+DECL_COMMAND(command_config_lis2dw, "config_lis2dw oid=%c spi_oid=%c lis3dh=%c");
 
 // Helper code to reschedule the lis2dw_event() timer
 static void
@@ -75,18 +80,44 @@ lis2dw_query(struct lis2dw *ax, uint8_t oid)
     msg[0] = LIS_AR_DATAX0 | LIS_AM_READ ;
     uint8_t *d = &ax->sb.data[ax->sb.data_count];
 
-    spidev_transfer(ax->spi, 1, sizeof(msg), msg);
-
     spidev_transfer(ax->spi, 1, sizeof(fifo), fifo);
     fifo_empty = fifo[1]&0x3F;
     fifo_ovrn = fifo[1]&0x40;
 
-    d[0] = msg[1]; // x low bits
-    d[1] = msg[2]; // x high bits
-    d[2] = msg[3]; // y low bits
-    d[3] = msg[4]; // y high bits
-    d[4] = msg[5]; // z low bits
-    d[5] = msg[6]; // z high bits
+    if(ax->model == LIS2DW_MODEL){
+        
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        
+        d[0] = msg[1]; // x low bits
+        d[1] = msg[2]; // x high bits
+        d[2] = msg[3]; // y low bits
+        d[3] = msg[4]; // y high bits
+        d[4] = msg[5]; // z low bits
+        d[5] = msg[6]; // z high bits
+
+    }else{
+
+        msg[0] = 0x28 | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[0] = msg[1]; // x low bits
+        msg[0] = 0x29 | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[1] = msg[1]; // x high bits
+        msg[0] = 0x2A | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[2] = msg[1]; // y low bits
+        msg[0] = 0x2B | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[3] = msg[1]; // y high bits
+        msg[0] = 0x2C | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[4] = msg[1]; // z low bits
+        msg[0] = 0x2D | LIS_AM_READ ;
+        spidev_transfer(ax->spi, 1, sizeof(msg), msg);
+        d[5] = msg[1]; // z high bits
+
+    }
+
 
     ax->sb.data_count += BYTES_PER_SAMPLE;
     if (ax->sb.data_count + BYTES_PER_SAMPLE > ARRAY_SIZE(ax->sb.data))


### PR DESCRIPTION
Based on the code from [pull request [#6477](https://github.com/Klipper3d/klipper/pull/6477) , the code has been merged into lis2dw.py and lis2dw.c.
When using lis3dh, only need to add :

is_lis3dh: True 

[lis2dw]
is_lis3dh:True
cs_pin: SHT36:gpio9
spi_software_sclk_pin: SHT36:gpio10
spi_software_mosi_pin: SHT36:gpio11
spi_software_miso_pin: SHT36:gpio12