### PR TITLE
Update tmc5160.py

### DIFF
--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -254,7 +254,7 @@ VREF = 0.325
 MAX_CURRENT = 10.000  # Maximum dependent on board, but 10 is safe sanity check
 
 
-class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
+class TMC5160CurrentHelper:
     def __init__(self, config, mcu_tmc):
         super().__init__(config, mcu_tmc, MAX_CURRENT)
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -287,7 +287,6 @@ class TMC5160CurrentHelper:
             cs = 31
         cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(
             1 - 2 * (current * math.sqrt(2)))
-        self.cs = cs
         return max(16, min(31, cs))
     def _calc_current(self, run_current, hold_current):
         gscaler = self._calc_globalscaler(run_current)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -268,12 +268,13 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
         self.fields.set_field("globalscaler", gscaler)
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
-        
+
 
     def _calc_globalscaler(self, current):
-        cs = self._calc_current_bits(current, self.cs) #execute to find cs
+        cs = self._calc_current_bits(current, self.cs)
         globalscaler = int(
-            (current * 256.0 * math.sqrt(2.0) * self.sense_resistor * 32 / (VREF * (1 + cs))) #implement the correct calc using cs
+            (current * 256.0 * math.sqrt(2.0) * self.sense_resistor * 32 / (
+                VREF * (1 + cs)))
             + 0.5
         )
         globalscaler = max(32, globalscaler)
@@ -283,8 +284,9 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
 
     def _calc_current_bits(self, current, cs):
         if not cs:
-            globalscaler = 31
-        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(1 - 2 * (current * math.sqrt(2))) #cs from tuning spreadsheet allows useage of high amp drivers with low Rs
+            cs = 31
+        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - (
+            int(1 - 2 * (current * math.sqrt(2))))
         self.cs = cs
         return max(16, min(31, cs))
 

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -3,256 +3,247 @@
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import math, logging
-from . import bus, tmc, tmc2130
+#
+# Modified by Honest Brothers - 2024.
+#
+import math
+from . import tmc
+from . import tmc2130
 
-TMC_FREQUENCY=12000000.
+TMC_FREQUENCY = 12000000.0
 
 Registers = {
-    "GCONF":            0x00,
-    "GSTAT":            0x01,
-    "IFCNT":            0x02,
-    "SLAVECONF":        0x03,
-    "IOIN":             0x04,
-    "X_COMPARE":        0x05,
-    "OTP_READ":         0x07,
-    "FACTORY_CONF":     0x08,
-    "SHORT_CONF":       0x09,
-    "DRV_CONF":         0x0A,
-    "GLOBALSCALER":     0x0B,
-    "OFFSET_READ":      0x0C,
-    "IHOLD_IRUN":       0x10,
-    "TPOWERDOWN":       0x11,
-    "TSTEP":            0x12,
-    "TPWMTHRS":         0x13,
-    "TCOOLTHRS":        0x14,
-    "THIGH":            0x15,
-    "RAMPMODE":         0x20,
-    "XACTUAL":          0x21,
-    "VACTUAL":          0x22,
-    "VSTART":           0x23,
-    "A1":               0x24,
-    "V1":               0x25,
-    "AMAX":             0x26,
-    "VMAX":             0x27,
-    "DMAX":             0x28,
-    "D1":               0x2A,
-    "VSTOP":            0x2B,
-    "TZEROWAIT":        0x2C,
-    "XTARGET":          0x2D,
-    "VDCMIN":           0x33,
-    "SW_MODE":          0x34,
-    "RAMP_STAT":        0x35,
-    "XLATCH":           0x36,
-    "ENCMODE":          0x38,
-    "X_ENC":            0x39,
-    "ENC_CONST":        0x3A,
-    "ENC_STATUS":       0x3B,
-    "ENC_LATCH":        0x3C,
-    "ENC_DEVIATION":    0x3D,
-    "MSLUT0":           0x60,
-    "MSLUT1":           0x61,
-    "MSLUT2":           0x62,
-    "MSLUT3":           0x63,
-    "MSLUT4":           0x64,
-    "MSLUT5":           0x65,
-    "MSLUT6":           0x66,
-    "MSLUT7":           0x67,
-    "MSLUTSEL":         0x68,
-    "MSLUTSTART":       0x69,
-    "MSCNT":            0x6A,
-    "MSCURACT":         0x6B,
-    "CHOPCONF":         0x6C,
-    "COOLCONF":         0x6D,
-    "DCCTRL":           0x6E,
-    "DRV_STATUS":       0x6F,
-    "PWMCONF":          0x70,
-    "PWM_SCALE":        0x71,
-    "PWM_AUTO":         0x72,
-    "LOST_STEPS":       0x73,
+    "GCONF": 0x00,
+    "GSTAT": 0x01,
+    "IFCNT": 0x02,
+    "SLAVECONF": 0x03,
+    "IOIN": 0x04,
+    "X_COMPARE": 0x05,
+    "OTP_READ": 0x07,
+    "FACTORY_CONF": 0x08,
+    "SHORT_CONF": 0x09,
+    "DRV_CONF": 0x0A,
+    "GLOBALSCALER": 0x0B,
+    "OFFSET_READ": 0x0C,
+    "IHOLD_IRUN": 0x10,
+    "TPOWERDOWN": 0x11,
+    "TSTEP": 0x12,
+    "TPWMTHRS": 0x13,
+    "TCOOLTHRS": 0x14,
+    "THIGH": 0x15,
+    "RAMPMODE": 0x20,
+    "XACTUAL": 0x21,
+    "VACTUAL": 0x22,
+    "VSTART": 0x23,
+    "A1": 0x24,
+    "V1": 0x25,
+    "AMAX": 0x26,
+    "VMAX": 0x27,
+    "DMAX": 0x28,
+    "D1": 0x2A,
+    "VSTOP": 0x2B,
+    "TZEROWAIT": 0x2C,
+    "XTARGET": 0x2D,
+    "VDCMIN": 0x33,
+    "SW_MODE": 0x34,
+    "RAMP_STAT": 0x35,
+    "XLATCH": 0x36,
+    "ENCMODE": 0x38,
+    "X_ENC": 0x39,
+    "ENC_CONST": 0x3A,
+    "ENC_STATUS": 0x3B,
+    "ENC_LATCH": 0x3C,
+    "ENC_DEVIATION": 0x3D,
+    "MSLUT0": 0x60,
+    "MSLUT1": 0x61,
+    "MSLUT2": 0x62,
+    "MSLUT3": 0x63,
+    "MSLUT4": 0x64,
+    "MSLUT5": 0x65,
+    "MSLUT6": 0x66,
+    "MSLUT7": 0x67,
+    "MSLUTSEL": 0x68,
+    "MSLUTSTART": 0x69,
+    "MSCNT": 0x6A,
+    "MSCURACT": 0x6B,
+    "CHOPCONF": 0x6C,
+    "COOLCONF": 0x6D,
+    "DCCTRL": 0x6E,
+    "DRV_STATUS": 0x6F,
+    "PWMCONF": 0x70,
+    "PWM_SCALE": 0x71,
+    "PWM_AUTO": 0x72,
+    "LOST_STEPS": 0x73,
 }
 
 ReadRegisters = [
-    "GCONF", "CHOPCONF", "GSTAT", "DRV_STATUS", "FACTORY_CONF", "IOIN",
-    "LOST_STEPS", "MSCNT", "MSCURACT", "OTP_READ", "PWM_SCALE",
-    "PWM_AUTO", "TSTEP"
+    "GCONF",
+    "CHOPCONF",
+    "GSTAT",
+    "DRV_STATUS",
+    "FACTORY_CONF",
+    "IOIN",
+    "LOST_STEPS",
+    "MSCNT",
+    "MSCURACT",
+    "OTP_READ",
+    "PWM_SCALE",
+    "PWM_AUTO",
+    "TSTEP",
 ]
 
 Fields = {}
 Fields["COOLCONF"] = {
-    "semin":                    0x0F << 0,
-    "seup":                     0x03 << 5,
-    "semax":                    0x0F << 8,
-    "sedn":                     0x03 << 13,
-    "seimin":                   0x01 << 15,
-    "sgt":                      0x7F << 16,
-    "sfilt":                    0x01 << 24
+    "semin": 0x0F << 0,
+    "seup": 0x03 << 5,
+    "semax": 0x0F << 8,
+    "sedn": 0x03 << 13,
+    "seimin": 0x01 << 15,
+    "sgt": 0x7F << 16,
+    "sfilt": 0x01 << 24,
 }
 Fields["CHOPCONF"] = {
-    "toff":                     0x0F << 0,
-    "hstrt":                    0x07 << 4,
-    "hend":                     0x0F << 7,
-    "fd3":                      0x01 << 11,
-    "disfdcc":                  0x01 << 12,
-    "chm":                      0x01 << 14,
-    "tbl":                      0x03 << 15,
-    "vhighfs":                  0x01 << 18,
-    "vhighchm":                 0x01 << 19,
-    "tpfd":                     0x0F << 20, # midrange resonances
-    "mres":                     0x0F << 24,
-    "intpol":                   0x01 << 28,
-    "dedge":                    0x01 << 29,
-    "diss2g":                   0x01 << 30,
-    "diss2vs":                  0x01 << 31
+    "toff": 0x0F << 0,
+    "hstrt": 0x07 << 4,
+    "hend": 0x0F << 7,
+    "fd3": 0x01 << 11,
+    "disfdcc": 0x01 << 12,
+    "chm": 0x01 << 14,
+    "tbl": 0x03 << 15,
+    "vhighfs": 0x01 << 18,
+    "vhighchm": 0x01 << 19,
+    "tpfd": 0x0F << 20,  # midrange resonances
+    "mres": 0x0F << 24,
+    "intpol": 0x01 << 28,
+    "dedge": 0x01 << 29,
+    "diss2g": 0x01 << 30,
+    "diss2vs": 0x01 << 31,
 }
 Fields["DRV_CONF"] = {
-    "bbmtime":                  0x1F << 0,
-    "bbmclks":                  0x0F << 8,
-    "otselect":                 0x03 << 16,
-    "drvstrength":              0x03 << 18,
-    "filt_isense":              0x03 << 20,
+    "bbmtime": 0x1F << 0,
+    "bbmclks": 0x0F << 8,
+    "otselect": 0x03 << 16,
+    "drvstrength": 0x03 << 18,
+    "filt_isense": 0x03 << 20,
 }
 Fields["DRV_STATUS"] = {
-    "sg_result":                0x3FF << 0,
-    "s2vsa":                    0x01 << 12,
-    "s2vsb":                    0x01 << 13,
-    "stealth":                  0x01 << 14,
-    "fsactive":                 0x01 << 15,
-    "cs_actual":                0x1F << 16,
-    "stallguard":               0x01 << 24,
-    "ot":                       0x01 << 25,
-    "otpw":                     0x01 << 26,
-    "s2ga":                     0x01 << 27,
-    "s2gb":                     0x01 << 28,
-    "ola":                      0x01 << 29,
-    "olb":                      0x01 << 30,
-    "stst":                     0x01 << 31
+    "sg_result": 0x3FF << 0,
+    "s2vsa": 0x01 << 12,
+    "s2vsb": 0x01 << 13,
+    "stealth": 0x01 << 14,
+    "fsactive": 0x01 << 15,
+    "cs_actual": 0x1F << 16,
+    "stallguard": 0x01 << 24,
+    "ot": 0x01 << 25,
+    "otpw": 0x01 << 26,
+    "s2ga": 0x01 << 27,
+    "s2gb": 0x01 << 28,
+    "ola": 0x01 << 29,
+    "olb": 0x01 << 30,
+    "stst": 0x01 << 31,
 }
-Fields["FACTORY_CONF"] = {
-    "factory_conf":             0x1F << 0
-}
+Fields["FACTORY_CONF"] = {"factory_conf": 0x1F << 0}
+Fields["FACTORY_CONF"] = {"factory_conf": 0x1F << 0}
 Fields["GCONF"] = {
-    "recalibrate":              0x01 << 0,
-    "faststandstill":           0x01 << 1,
-    "en_pwm_mode":              0x01 << 2,
-    "multistep_filt":           0x01 << 3,
-    "shaft":                    0x01 << 4,
-    "diag0_error":              0x01 << 5,
-    "diag0_otpw":               0x01 << 6,
-    "diag0_stall":              0x01 << 7,
-    "diag1_stall":              0x01 << 8,
-    "diag1_index":              0x01 << 9,
-    "diag1_onstate":            0x01 << 10,
-    "diag1_steps_skipped":      0x01 << 11,
-    "diag0_int_pushpull":       0x01 << 12,
-    "diag1_poscomp_pushpull":   0x01 << 13,
-    "small_hysteresis":         0x01 << 14,
-    "stop_enable":              0x01 << 15,
-    "direct_mode":              0x01 << 16,
-    "test_mode":                0x01 << 17
+    "recalibrate": 0x01 << 0,
+    "faststandstill": 0x01 << 1,
+    "en_pwm_mode": 0x01 << 2,
+    "multistep_filt": 0x01 << 3,
+    "shaft": 0x01 << 4,
+    "diag0_error": 0x01 << 5,
+    "diag0_otpw": 0x01 << 6,
+    "diag0_stall": 0x01 << 7,
+    "diag1_stall": 0x01 << 8,
+    "diag1_index": 0x01 << 9,
+    "diag1_onstate": 0x01 << 10,
+    "diag1_steps_skipped": 0x01 << 11,
+    "diag0_int_pushpull": 0x01 << 12,
+    "diag1_poscomp_pushpull": 0x01 << 13,
+    "small_hysteresis": 0x01 << 14,
+    "stop_enable": 0x01 << 15,
+    "direct_mode": 0x01 << 16,
+    "test_mode": 0x01 << 17,
 }
-Fields["GSTAT"] = {
-    "reset":                    0x01 << 0,
-    "drv_err":                  0x01 << 1,
-    "uv_cp":                    0x01 << 2
-}
-Fields["GLOBALSCALER"] = {
-    "globalscaler":             0xFF << 0
-}
+Fields["GSTAT"] = {"reset": 0x01 << 0, "drv_err": 0x01 << 1, "uv_cp": 0x01 << 2}
+Fields["GLOBALSCALER"] = {"globalscaler": 0xFF << 0}
 Fields["IHOLD_IRUN"] = {
-    "ihold":                    0x1F << 0,
-    "irun":                     0x1F << 8,
-    "iholddelay":               0x0F << 16
+    "ihold": 0x1F << 0,
+    "irun": 0x1F << 8,
+    "iholddelay": 0x0F << 16,
 }
 Fields["IOIN"] = {
-    "refl_step":                0x01 << 0,
-    "refr_dir":                 0x01 << 1,
-    "encb_dcen_cfg4":           0x01 << 2,
-    "enca_dcin_cfg5":           0x01 << 3,
-    "drv_enn":                  0x01 << 4,
-    "enc_n_dco_cfg6":           0x01 << 5,
-    "sd_mode":                  0x01 << 6,
-    "swcomp_in":                0x01 << 7,
-    "version":                  0xFF << 24
+    "refl_step": 0x01 << 0,
+    "refr_dir": 0x01 << 1,
+    "encb_dcen_cfg4": 0x01 << 2,
+    "enca_dcin_cfg5": 0x01 << 3,
+    "drv_enn": 0x01 << 4,
+    "enc_n_dco_cfg6": 0x01 << 5,
+    "sd_mode": 0x01 << 6,
+    "swcomp_in": 0x01 << 7,
+    "version": 0xFF << 24,
 }
-Fields["LOST_STEPS"] = {
-    "lost_steps":               0xfffff << 0
-}
-Fields["MSLUT0"] = { "mslut0": 0xffffffff }
-Fields["MSLUT1"] = { "mslut1": 0xffffffff }
-Fields["MSLUT2"] = { "mslut2": 0xffffffff }
-Fields["MSLUT3"] = { "mslut3": 0xffffffff }
-Fields["MSLUT4"] = { "mslut4": 0xffffffff }
-Fields["MSLUT5"] = { "mslut5": 0xffffffff }
-Fields["MSLUT6"] = { "mslut6": 0xffffffff }
-Fields["MSLUT7"] = { "mslut7": 0xffffffff }
+Fields["LOST_STEPS"] = {"lost_steps": 0xFFFFF << 0}
+Fields["MSLUT0"] = {"mslut0": 0xFFFFFFFF}
+Fields["MSLUT1"] = {"mslut1": 0xFFFFFFFF}
+Fields["MSLUT2"] = {"mslut2": 0xFFFFFFFF}
+Fields["MSLUT3"] = {"mslut3": 0xFFFFFFFF}
+Fields["MSLUT4"] = {"mslut4": 0xFFFFFFFF}
+Fields["MSLUT5"] = {"mslut5": 0xFFFFFFFF}
+Fields["MSLUT6"] = {"mslut6": 0xFFFFFFFF}
+Fields["MSLUT7"] = {"mslut7": 0xFFFFFFFF}
 Fields["MSLUTSEL"] = {
-    "x3":                       0xFF << 24,
-    "x2":                       0xFF << 16,
-    "x1":                       0xFF << 8,
-    "w3":                       0x03 << 6,
-    "w2":                       0x03 << 4,
-    "w1":                       0x03 << 2,
-    "w0":                       0x03 << 0,
+    "x3": 0xFF << 24,
+    "x2": 0xFF << 16,
+    "x1": 0xFF << 8,
+    "w3": 0x03 << 6,
+    "w2": 0x03 << 4,
+    "w1": 0x03 << 2,
+    "w0": 0x03 << 0,
 }
 Fields["MSLUTSTART"] = {
-    "start_sin":                0xFF << 0,
-    "start_sin90":              0xFF << 16,
+    "start_sin": 0xFF << 0,
+    "start_sin90": 0xFF << 16,
 }
-Fields["MSCNT"] = {
-    "mscnt":                    0x3ff << 0
-}
-Fields["MSCURACT"] = {
-    "cur_a":                    0x1ff << 0,
-    "cur_b":                    0x1ff << 16
-}
+Fields["MSCNT"] = {"mscnt": 0x3FF << 0}
+Fields["MSCURACT"] = {"cur_a": 0x1FF << 0, "cur_b": 0x1FF << 16}
+Fields["LOST_STEPS"] = {"lost_steps": 0xFFFFF << 0}
+Fields["MSCNT"] = {"mscnt": 0x3FF << 0}
+Fields["MSCURACT"] = {"cur_a": 0x1FF << 0, "cur_b": 0x1FF << 16}
 Fields["OTP_READ"] = {
-    "otp_fclktrim":             0x1f << 0,
-    "otp_s2_level":             0x01 << 5,
-    "otp_bbm":                  0x01 << 6,
-    "otp_tbl":                  0x01 << 7
+    "otp_fclktrim": 0x1F << 0,
+    "otp_s2_level": 0x01 << 5,
+    "otp_bbm": 0x01 << 6,
+    "otp_tbl": 0x01 << 7,
 }
-Fields["PWM_AUTO"] = {
-    "pwm_ofs_auto":             0xff << 0,
-    "pwm_grad_auto":            0xff << 16
-}
+Fields["PWM_AUTO"] = {"pwm_ofs_auto": 0xFF << 0, "pwm_grad_auto": 0xFF << 16}
 Fields["PWMCONF"] = {
-    "pwm_ofs":                  0xFF << 0,
-    "pwm_grad":                 0xFF << 8,
-    "pwm_freq":                 0x03 << 16,
-    "pwm_autoscale":            0x01 << 18,
-    "pwm_autograd":             0x01 << 19,
-    "freewheel":                0x03 << 20,
-    "pwm_reg":                  0x0F << 24,
-    "pwm_lim":                  0x0F << 28
+    "pwm_ofs": 0xFF << 0,
+    "pwm_grad": 0xFF << 8,
+    "pwm_freq": 0x03 << 16,
+    "pwm_autoscale": 0x01 << 18,
+    "pwm_autograd": 0x01 << 19,
+    "freewheel": 0x03 << 20,
+    "pwm_reg": 0x0F << 24,
+    "pwm_lim": 0x0F << 28,
 }
 Fields["PWM_SCALE"] = {
-    "pwm_scale_sum":            0xff << 0,
-    "pwm_scale_auto":           0x1ff << 16
+    "pwm_scale_sum": 0xFF << 0,
+    "pwm_scale_auto": 0x1FF << 16,
 }
-Fields["TPOWERDOWN"] = {
-    "tpowerdown":               0xff << 0
-}
-Fields["TPWMTHRS"] = {
-    "tpwmthrs":                 0xfffff << 0
-}
-Fields["TCOOLTHRS"] = {
-    "tcoolthrs":                0xfffff << 0
-}
-Fields["TSTEP"] = {
-    "tstep":                    0xfffff << 0
-}
-Fields["THIGH"] = {
-    "thigh":                    0xfffff << 0
-}
+Fields["TPOWERDOWN"] = {"tpowerdown": 0xFF << 0}
+Fields["TPWMTHRS"] = {"tpwmthrs": 0xFFFFF << 0}
+Fields["TCOOLTHRS"] = {"tcoolthrs": 0xFFFFF << 0}
+Fields["TSTEP"] = {"tstep": 0xFFFFF << 0}
 
 SignedFields = ["cur_a", "cur_b", "sgt", "xactual", "vactual", "pwm_scale_auto"]
 
 FieldFormatters = dict(tmc2130.FieldFormatters)
-FieldFormatters.update({
-    "s2vsa":            (lambda v: "1(ShortToSupply_A!)" if v else ""),
-    "s2vsb":            (lambda v: "1(ShortToSupply_B!)" if v else ""),
-})
+FieldFormatters.update(
+    {
+        "s2vsa": (lambda v: "1(ShortToSupply_A!)" if v else ""),
+        "s2vsb": (lambda v: "1(ShortToSupply_B!)" if v else ""),
+    }
+)
 
 
 ######################################################################
@@ -260,57 +251,76 @@ FieldFormatters.update({
 ######################################################################
 
 VREF = 0.325
-MAX_CURRENT = 10.000 # Maximum dependent on board, but 10 is safe sanity check
+MAX_CURRENT = 10.000  # Maximum dependent on board, but 10 is safe sanity check
 
-class TMC5160CurrentHelper:
+
+class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def __init__(self, config, mcu_tmc):
-        self.printer = config.get_printer()
-        self.name = config.get_name().split()[-1]
-        self.mcu_tmc = mcu_tmc
-        self.fields = mcu_tmc.get_fields()
-        run_current = config.getfloat('run_current',
-                                      above=0., maxval=MAX_CURRENT)
-        hold_current = config.getfloat('hold_current', MAX_CURRENT,
-                                       above=0., maxval=MAX_CURRENT)
-        self.req_hold_current = hold_current
-        self.sense_resistor = config.getfloat('sense_resistor', 0.075, above=0.)
-        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
+        super().__init__(config, mcu_tmc, MAX_CURRENT)
+
+        self.sense_resistor = config.getfloat(
+            "sense_resistor", 0.075, above=0.0
+        )
+        self.cs = 31
+        gscaler, irun, ihold = self._calc_current(
+            self.req_run_current, self.req_hold_current
+        )
         self.fields.set_field("globalscaler", gscaler)
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
+        
+
     def _calc_globalscaler(self, current):
-        globalscaler = int((current * 256. * math.sqrt(2.)
-                            * self.sense_resistor / VREF) + .5)
+        cs = self._calc_current_bits(current, self.cs) #execute to find cs
+        globalscaler = int(
+            (current * 256.0 * math.sqrt(2.0) * self.sense_resistor * 32 / (VREF * (1 + cs))) #implement the correct calc using cs
+            + 0.5
+        )
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0
         return globalscaler
-    def _calc_current_bits(self, current, globalscaler):
-        if not globalscaler:
-            globalscaler = 256
-        cs = int((current * 256. * 32. * math.sqrt(2.) * self.sense_resistor)
-                 / (globalscaler * VREF)
-                 - 1. + .5)
-        return max(0, min(31, cs))
+
+    def _calc_current_bits(self, current, cs):
+        if not cs:
+            globalscaler = 31
+        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(1 - 2 * (current * math.sqrt(2))) #cs from tuning spreadsheet allows useage of high amp drivers with low Rs
+        self.cs = cs
+        return max(16, min(31, cs))
+
     def _calc_current(self, run_current, hold_current):
         gscaler = self._calc_globalscaler(run_current)
         irun = self._calc_current_bits(run_current, gscaler)
         ihold = self._calc_current_bits(min(hold_current, run_current), gscaler)
         return gscaler, irun, ihold
+
     def _calc_current_from_field(self, field_name):
         globalscaler = self.fields.get_field("globalscaler")
         if not globalscaler:
             globalscaler = 256
         bits = self.fields.get_field(field_name)
-        return (globalscaler * (bits + 1) * VREF
-                / (256. * 32. * math.sqrt(2.) * self.sense_resistor))
+        return (
+            globalscaler
+            * (bits + 1)
+            * VREF
+            / (256.0 * 32.0 * math.sqrt(2.0) * self.sense_resistor)
+        )
+
     def get_current(self):
         run_current = self._calc_current_from_field("irun")
         hold_current = self._calc_current_from_field("ihold")
-        return run_current, hold_current, self.req_hold_current, MAX_CURRENT
-    def set_current(self, run_current, hold_current, print_time):
-        self.req_hold_current = hold_current
-        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
+        return (
+            run_current,
+            hold_current,
+            self.req_hold_current,
+            MAX_CURRENT,
+            self.req_home_current,
+        )
+
+    def apply_current(self, print_time):
+        gscaler, irun, ihold = self._calc_current(
+            self.actual_current, self.req_hold_current
+        )
         val = self.fields.set_field("globalscaler", gscaler)
         self.mcu_tmc.set_register("GLOBALSCALER", val, print_time)
         self.fields.set_field("ihold", ihold)
@@ -322,12 +332,14 @@ class TMC5160CurrentHelper:
 # TMC5160 printer object
 ######################################################################
 
+
 class TMC5160:
     def __init__(self, config):
         # Setup mcu communication
         self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
-        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
-                                           TMC_FREQUENCY)
+        self.mcu_tmc = tmc2130.MCU_TMC_SPI(
+            config, Registers, self.fields, TMC_FREQUENCY
+        )
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
@@ -338,10 +350,7 @@ class TMC5160:
         self.get_status = cmdhelper.get_status
         # Setup basic register values
         tmc.TMCWaveTableHelper(config, self.mcu_tmc)
-        tmc.TMCStealthchopHelper(config, self.mcu_tmc)
-        tmc.TMCVcoolthrsHelper(config, self.mcu_tmc)
-        tmc.TMCVhighHelper(config, self.mcu_tmc)
-        # Allow other registers to be set from the config
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc, TMC_FREQUENCY)
         set_config_field = self.fields.set_config_field
         #   GCONF
         set_config_field(config, "multistep_filt", True)
@@ -359,7 +368,7 @@ class TMC5160:
         set_config_field(config, "diss2g", 0)
         set_config_field(config, "diss2vs", 0)
         #   COOLCONF
-        set_config_field(config, "semin", 0)    # page 52
+        set_config_field(config, "semin", 0)  # page 52
         set_config_field(config, "seup", 0)
         set_config_field(config, "semax", 0)
         set_config_field(config, "sedn", 0)
@@ -384,6 +393,7 @@ class TMC5160:
         set_config_field(config, "pwm_lim", 12)
         #   TPOWERDOWN
         set_config_field(config, "tpowerdown", 10)
+
 
 def load_config_prefix(config):
     return TMC5160(config)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -274,7 +274,7 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
         cs = self._calc_current_bits(current, self.cs)
         globalscaler = int(
             (current * 256.0 * math.sqrt(2.0) * self.sense_resistor * 32 / (
-                VREF * (1 + cs)))
+            VREF * (1 + cs)))
             + 0.5
         )
         globalscaler = max(32, globalscaler)
@@ -285,8 +285,8 @@ class TMC5160CurrentHelper(tmc.BaseTMCCurrentHelper):
     def _calc_current_bits(self, current, cs):
         if not cs:
             cs = 31
-        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - (
-            int(1 - 2 * (current * math.sqrt(2))))
+        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(
+            1 - 2 * (current * math.sqrt(2)))
         self.cs = cs
         return max(16, min(31, cs))
 


### PR DESCRIPTION
TMC5160.py incorrectly implements CS values to where they are always 31. 

The calculation of globalscaler in current Klipper code leaves out the CS values, and then calculates CS after globalscaler.

According to page 74 of the datasheet, Calculation of RMS Current, the end result of not specifying a CS value, automatically sets the CS to 31. 

(CS+1)/32 = 1. 

In the current code, globalscaler is calculated and then CS is back calculated using globalscaler, but the only value it can be set to is 31, which the globalscaler calculation has already determined by setting it to 1. 

Analog Devices is less than forthcoming on how to calculate the CS value, as the equation used on page 74 has two unknowns and thus can not be calculated. However, the tuning spreadsheet TMC220x_TMC222x_Calculations.xlsx allows us to back calculate the CS value:

cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(1 - 2 * (current * math.sqrt(2)))

Implementing this bug fix allows us to effectively set the CS value before globalscaler, and then set globalscaler based on the chosen CS value. Which is how I believe Analog Devices intended this driver to be tuned. This has the end result of CS being used to effectively scale Rsense, ie. when the driver is rated for more currrent than is being used, Rsense does not need to be changed and instead CS can scale the Rsense input. 

The practical issue is that the way Klipper currrently calculates CS makes the motors hard to tune on high amp 5160 drivers, and high voltages practically impossible on some motors because the chopper parameters can not be correctly set. Current word around town is that 2804's don't do well above 24V and will result in VFAs if used at 48V.

I have implemented this fix on my own device and am using 2804's at 60V, which run at a cool 65C. Before implementing the motors were very noisy and melted my motor mounts. Now they are regular level of 1980's printer noisy. 

The CS value is calculated automatically so it requires no user input. This fix should allow better motor tuning, the calc sheet to be used effectively, and certain motor, voltage, driver combos to be used where they could not before. 

Signed off by: Brandon Smith honestbrotherstv@gmail.com