### PR TITLE
tmc5160.py incorrectly calculates CS value to where it is always 31

### DIFF
--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -2,6 +2,8 @@
 #
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 #
+# Modified by Honest Brothers (C) 2024
+#
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
 from . import bus, tmc, tmc2130
@@ -260,7 +262,7 @@ FieldFormatters.update({
 ######################################################################
 
 VREF = 0.325
-MAX_CURRENT = 10.000 # Maximum dependent on board, but 10 is safe sanity check
+MAX_CURRENT = 10.000  # Maximum dependent on board, but 10 is a safe sanity check
 
 class TMC5160CurrentHelper:
     def __init__(self, config, mcu_tmc):
@@ -279,23 +281,24 @@ class TMC5160CurrentHelper:
         self.fields.set_field("ihold", ihold)
         self.fields.set_field("irun", irun)
     def _calc_globalscaler(self, current):
-        globalscaler = int((current * 256. * math.sqrt(2.)
-                            * self.sense_resistor / VREF) + .5)
+        cs = self._calc_current_bits(current)
+        globalscaler = int(
+            (current * 256.0 * math.sqrt(2.0) * self.sense_resistor * 32 / (
+                VREF * (1 + cs)))
+            + 0.5
+        )
         globalscaler = max(32, globalscaler)
         if globalscaler >= 256:
             globalscaler = 0
         return globalscaler
-    def _calc_current_bits(self, current, globalscaler):
-        if not globalscaler:
-            globalscaler = 256
-        cs = int((current * 256. * 32. * math.sqrt(2.) * self.sense_resistor)
-                 / (globalscaler * VREF)
-                 - 1. + .5)
-        return max(0, min(31, cs))
+    def _calc_current_bits(self, current):
+        cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(
+            1 - 2 * (current * math.sqrt(2)))
+        return max(16, min(31, cs))
     def _calc_current(self, run_current, hold_current):
         gscaler = self._calc_globalscaler(run_current)
-        irun = self._calc_current_bits(run_current, gscaler)
-        ihold = self._calc_current_bits(min(hold_current, run_current), gscaler)
+        irun = self._calc_current_bits(run_current)
+        ihold = self._calc_current_bits(min(hold_current, run_current))
         return gscaler, irun, ihold
     def _calc_current_from_field(self, field_name):
         globalscaler = self.fields.get_field("globalscaler")


### PR DESCRIPTION
TMC5160.py incorrectly implements CS values to where they are always 31.

The calculation of globalscaler in current Klipper code leaves out the CS values, and then calculates CS after globalscaler.

According to page 74 of the datasheet, Calculation of RMS Current, the end result of not specifying a CS value, automatically sets the CS to 31.

(CS+1)/32 = 1.

In the current code, globalscaler is calculated and then CS is back calculated using globalscaler, but the only value it can be set to is 31, which the globalscaler calculation has already determined by setting it to 1.

Analog Devices is less than forthcoming on how to calculate the CS value, as the equation used on page 74 has two unknowns and thus can not be calculated. However, the tuning spreadsheet TMC220x_TMC222x_Calculations.xlsx allows us to back calculate the CS value:

cs = int(100 * (current * math.sqrt(2)) * self.sense_resistor) - int(1 - 2 * (current * math.sqrt(2)))

Implementing this bug fix allows us to effectively set the CS value before globalscaler, and then set globalscaler based on the chosen CS value. Which is how I believe Analog Devices intended this driver to be tuned. This has the end result of CS being used to effectively scale Rsense, ie. when the driver is rated for more currrent than is being used, Rsense does not need to be changed and instead CS can scale the Rsense input.

The practical issue is that the way Klipper currrently calculates CS makes the motors hard to tune on high amp 5160 drivers, and high voltages practically impossible on some motors because the chopper parameters can not be correctly set. Current word around town is that 2804's don't do well above 24V and will result in VFAs if used at 48V.

I have implemented this fix on my own device and am using 2804's at 60V, which run at a cool 65C. Before implementing the motors were very noisy and melted my motor mounts. Now they are regular level of 1980's printer noisy.

The CS value is calculated automatically so it requires no user input. This fix should allow better motor tuning, the calc sheet to be used effectively, and certain motor, voltage, driver combos to be used where they could not before.

I apologize ahead of time for errors. I don't program often, just took a whirl at fixing this issue. Also sorry for reopening this, I made a hot mess of the last one. 

Signed off by: Brandon Smith honestbrotherstv@gmail.com