### PR TITLE
Add stm32g0b0xx to board_defs.py

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -31,6 +31,11 @@ BOARD_DEFS = {
         'spi_bus': "spi1",
         "cs_pin": "PA4"
     },
+    'btt-skr-mini-v3-b0': {
+        'mcu': "stm32g0b0xx",
+        'spi_bus': "spi1",
+        "cs_pin": "PA4"
+    },
     'flyboard-mini': {
         'mcu': "stm32f103xe",
         'spi_bus': "spi2",
@@ -152,6 +157,7 @@ BOARD_ALIASES = {
     'btt-skr-mini-e3-v1.2': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-mini-e3-v2': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-mini-e3-v3': BOARD_DEFS['btt-skr-mini-v3'],
+    'btt-skr-mini-e3-v3-b0': BOARD_DEFS['btt-skr-mini-v3-b0'],
     'btt-skr-mini-mz': BOARD_DEFS['btt-skr-mini'],
     'btt-skr-e3-dip': BOARD_DEFS['btt-skr-mini'],
     'btt002-v1': BOARD_DEFS['btt-skr-mini'],


### PR DESCRIPTION
Added board definition for stm32g0b0xx variant of the SKR Mini v3.0.

I couldn't flash this variant of the board with the flash_sdcard.sh script and had to add an additional definition.