### PR TITLE
install-debian.sh: Highlight "NOT" in root check

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -86,7 +86,7 @@ report_status()
 verify_ready()
 {
     if [ "$EUID" -eq 0 ]; then
-        echo "This script must not run as root"
+        echo "This script must NOT run as root"
         exit -1
     fi
 }


### PR DESCRIPTION
Got confused by that, the console is sometimes hard to read over serial.