### PR TITLE
ruff: init

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+target-version = "py38"


### PR DESCRIPTION
### What?
This PR exists to discuss/create/add a configuration file for [ruff](https://docs.astral.sh/ruff/), "An extremely fast Python linter and code formatter, written in Rust".

### Why?
To avoid commonly occurring mistakes in python code, and establish a baseline of code quality.

### How?
Run `ruff check` in the project's root, or [integrate the ruff language server in your editor](https://docs.astral.sh/ruff/editors/setup/).
Before any merging or code changes are done, we have to devise a list of warnings that we care about, and a list of irrelevant ones.

### to-be-discussed rules:
- [E401](https://docs.astral.sh/ruff/rules/multiple-imports-on-one-line/): Multiple imports on one line
- [E402](https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/): Module level import not at top of file
- [E701](https://docs.astral.sh/ruff/rules/multiple-statements-on-one-line-colon/): Multiple statements on one line (colon)
- [E703](https://docs.astral.sh/ruff/rules/useless-semicolon/): Statement ends with an unnecessary semicolon
- [E711](https://docs.astral.sh/ruff/rules/none-comparison/): Comparison to `None` should be `cond is not None`
- [E713](https://docs.astral.sh/ruff/rules/not-in-test/): Test for membership should be `not in`
- [E721](https://docs.astral.sh/ruff/rules/type-comparison/): Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
- [E722](https://docs.astral.sh/ruff/rules/bare-except/): Do not use bare `except`
- [E731](https://docs.astral.sh/ruff/rules/lambda-assignment/): Do not assign a `lambda` expression, use a `def`
- [E741](https://docs.astral.sh/ruff/rules/ambiguous-variable-name/): Ambiguous variable name: `l`
- [F401](https://docs.astral.sh/ruff/rules/unused-import/): imported but unused
- [F402](https://docs.astral.sh/ruff/rules/import-shadowed-by-loop-var/): Import {name} from {row} shadowed by loop variable
- [F811](https://docs.astral.sh/ruff/rules/redefined-while-unused/): Redefinition of unused {name} from {row}
- [F821](https://docs.astral.sh/ruff/rules/undefined-name/): Undefined name
- [F841](https://docs.astral.sh/ruff/rules/unused-variable/): Local variable is assigned to but never used

### `select`ed rules:
- none yet

### `ignore`d rules:
- none yet

### Extra info
Explanation of the rules can be found at https://docs.astral.sh/ruff/rules/
Discourse thread: https://klipper.discourse.group/t/static-analysis-for-python-code-ie-ruff/17697