### PR TITLE
Update generic-bigtreetech-skr-mini-e3-v3.0.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
@@ -85,11 +85,12 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.650
-stealthchop_threshold: 999999
+# Adding stealth to extruder motor caused under extrusion
+# stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: ATC Semitec 104GT-2
+sensor_type: EPCOS 100K B57560G104F # Ender 3 Sensor is EPCOS not ATC
 sensor_pin: PC4
 control: pid
 pid_Kp: 54.027

--- a/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
+++ b/config/generic-bigtreetech-skr-mini-e3-v3.0.cfg
@@ -85,12 +85,10 @@ uart_pin: PC11
 tx_pin: PC10
 uart_address: 3
 run_current: 0.650
-# Adding stealth to extruder motor caused under extrusion
-# stealthchop_threshold: 999999
 
 [heater_bed]
 heater_pin: PC9
-sensor_type: EPCOS 100K B57560G104F # Ender 3 Sensor is EPCOS not ATC
+sensor_type: EPCOS 100K B57560G104F
 sensor_pin: PC4
 control: pid
 pid_Kp: 54.027


### PR DESCRIPTION
SKR Mini E3 V3 Config Corrections

I have made some changes to the current SKR Mini E3 V3 config example that helps to eliminate some troubles I was facing after installation, and using the sample config:

- Removed stealth from the extruder motor to stop under-extrusion issues
- Changed bed sensor to correct stock Ender 3 sensor

Signed-off-by: Miles Pawar slab.paged-0p@icloud.com