### PR TITLE
Modify Ender3 V2 config comments to warn users to disconnect the display

### DIFF
--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -12,7 +12,8 @@
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware
 # filename must end in ".bin" and must not match the last filename
-# that was flashed.
+# that was flashed. You may need to remove the display in order to
+# succesfully flash firmware on some controller boards
 
 # See docs/Config_Reference.md for a description of parameters.
 


### PR DESCRIPTION
I spent about three hours chasing firmware issues caused by this issue, and wanted to save others from wasting their time. 

See also https://youtu.be/gfZ9Lbyh8qU?t=422

Should this note be applied to other Creality Printers? I'm pretty sure the E3V2 isn't the only printer that ships with this screen, and it's available as an upgrade module too.