### PR TITLE
Assorted minor hx71x changes

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -375,9 +375,10 @@ A request may look like:
 `{"id": 123, "method":"hx71x/dump_hx71x",
 "params": {"sensor": "load_cell", "response_template": {}}}`
 and might return:
-`{"id": 123,"result":{"header":["time","counts"]}}`
+`{"id": 123,"result":{"header":["time","counts","value"]}}`
 and might later produce asynchronous messages such as:
-`{"params":{"data":[[3292.432935, 562534], [3292.4394937, 5625322]]}}`
+`{"params":{"data":[[3292.432935, 562534, 0.067059278],
+[3292.4394937, 5625322, 0.670590639]]}}`
 
 ### ads1220/dump_ads1220
 
@@ -390,9 +391,10 @@ A request may look like:
 `{"id": 123, "method":"ads1220/dump_ads1220",
 "params": {"sensor": "load_cell", "response_template": {}}}`
 and might return:
-`{"id": 123,"result":{"header":["time","counts"]}}`
+`{"id": 123,"result":{"header":["time","counts","value"]}}`
 and might later produce asynchronous messages such as:
-`{"params":{"data":[[3292.432935, 562534], [3292.4394937, 5625322]]}}`
+`{"params":{"data":[[3292.432935, 562534, 0.067059278],
+[3292.4394937, 5625322, 0.670590639]]}}`
 
 ### pause_resume/cancel
 

--- a/klippy/extras/ads1220.py
+++ b/klippy/extras/ads1220.py
@@ -69,9 +69,9 @@ class ADS1220():
             self.printer, self._process_batch, self._start_measurements,
             self._finish_measurements, UPDATE_INTERVAL)
         # publish raw samples to the socket
+        hdr = {'header': ('time', 'counts', 'value')}
         self.batch_bulk.add_mux_endpoint("ads1220/dump_ads1220", "sensor",
-                                         self.name,
-                                         {'header': ('time', 'counts')})
+                                         self.name, hdr)
         # Command Configuration
         mcu.add_config_cmd(
             "config_ads1220 oid=%d spi_oid=%d data_ready_pin=%s"

--- a/klippy/extras/hx71x.py
+++ b/klippy/extras/hx71x.py
@@ -53,8 +53,8 @@ class HX71xBase():
             self._finish_measurements, UPDATE_INTERVAL)
         # publish raw samples to the socket
         dump_path = "%s/dump_%s" % (sensor_type, sensor_type)
-        self.batch_bulk.add_mux_endpoint(dump_path, "sensor", self.name,
-                                         {'header': ('time', 'counts')})
+        hdr = {'header': ('time', 'counts', 'value')}
+        self.batch_bulk.add_mux_endpoint(dump_path, "sensor", self.name, hdr)
         # Command Configuration
         self.query_hx71x_cmd = None
         mcu.add_config_cmd(


### PR DESCRIPTION
Hi @garethky,

I noticed a few minor things in the recent bulk_adc merge.

1. The bulk adc report includes the adc value as a float, but the header and docs weren't updated to reflect that.
2. I think it would be a little better to check for hx71x timing overflows via the timer handler.  This check should be a little more accurate as it includes the time needed to wake up the query task.  It should also be a little more efficient to check.
3. I wonder if we could automatically restart hx71x samples after an error if the code receives 4 valid looking samples.  The idea here is: In the event of a read overrun, it's likely the sample is bad and it should be discarded; the following sample is also likely bad as some leading bits may have been erroneously read in the previous sample; the next sample is also likely bad, because the gain/channel settings may have been altered; the next sample is likely okay, but prudent to discard as well; the following samples should be valid.  If the sensor fails to recover, the host will still automatically restart the sensor.

I don't actually have this hardware to test, so I'd appreciate feedback.

The 3rd commit is a bit speculative on my part, so I understand if it's not a good idea.

-Kevin