### PR TITLE
Fix getting wrong ADC value on PA0 of STM32G431

### DIFF
--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -92,7 +92,7 @@ static const uint8_t adc_pins[] = {
   #endif
     0,             //             VREFINT
 #elif CONFIG_MACH_STM32G4
-    0,                      // [0] vssa
+    0xFF,                   // [0] vssa
     GPIO('A', 0),           // [1]
     GPIO('A', 1),           // [2]
     GPIO('A', 2),           // [3]

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -12,6 +12,8 @@
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
 
+#define ADC_INVALID_PIN 0xFF
+
 #define ADC_TEMPERATURE_PIN 0xfe
 DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
 
@@ -24,8 +26,8 @@ DECL_CONSTANT("ADC_MAX", 4095);
 static const uint8_t adc_pins[] = {
 #if CONFIG_MACH_STM32H7
     // ADC1
-    0, // PA0_C                ADC12_INP0
-    0, // PA1_C                ADC12_INP1
+    ADC_INVALID_PIN, // PA0_C  ADC12_INP0
+    ADC_INVALID_PIN, // PA1_C  ADC12_INP1
     GPIO('F', 11), //           ADC1_INP2
     GPIO('A', 6),  //          ADC12_INP3
     GPIO('C', 4),  //          ADC12_INP4
@@ -45,8 +47,8 @@ static const uint8_t adc_pins[] = {
     GPIO('A', 4),  //         ADC12_INP18
     GPIO('A', 5),  //         ADC12_INP19
     // ADC2
-    0, // PA0_C                ADC12_INP0
-    0, // PA1_C                ADC12_INP1
+    ADC_INVALID_PIN, // PA0_C  ADC12_INP0
+    ADC_INVALID_PIN, // PA1_C  ADC12_INP1
     GPIO('F', 13), //           ADC2_INP2
     GPIO('A', 6),  //          ADC12_INP3
     GPIO('C', 4),  //          ADC12_INP4
@@ -61,13 +63,13 @@ static const uint8_t adc_pins[] = {
     GPIO('C', 3),  //         ADC12_INP13
     GPIO('A', 2),  //         ADC12_INP14
     GPIO('A', 3),  //         ADC12_INP15
-    0,             //            dac_out1
-    0,             //            dac_out2
+    ADC_INVALID_PIN,  //         dac_out1
+    ADC_INVALID_PIN,  //         dac_out2
     GPIO('A', 4),  //         ADC12_INP18
     GPIO('A', 5),  //         ADC12_INP19
     // ADC3
-    0, // PC2_C                 ADC3_INP0
-    0, // PC3_C                 ADC3_INP1
+    ADC_INVALID_PIN, // PC2_C   ADC3_INP0
+    ADC_INVALID_PIN, // PC3_C   ADC3_INP1
     GPIO('F', 9) , //           ADC3_INP2
     GPIO('F', 7),  //           ADC3_INP3
     GPIO('F', 5),  //           ADC3_INP4
@@ -85,14 +87,14 @@ static const uint8_t adc_pins[] = {
     GPIO('H', 5),  //          ADC3_INP16
   #if CONFIG_MACH_STM32H723
     ADC_TEMPERATURE_PIN,
-    0,
+    ADC_INVALID_PIN,
   #else
-    0,             //              Vbat/4
+    ADC_INVALID_PIN, //            Vbat/4
     ADC_TEMPERATURE_PIN,//         VSENSE
   #endif
-    0,             //             VREFINT
+    ADC_INVALID_PIN, //           VREFINT
 #elif CONFIG_MACH_STM32G4
-    0xFF,                   // [0] vssa
+    ADC_INVALID_PIN,        // [0] vssa
     GPIO('A', 0),           // [1]
     GPIO('A', 1),           // [2]
     GPIO('A', 2),           // [3]
@@ -105,14 +107,14 @@ static const uint8_t adc_pins[] = {
     GPIO('F', 0),           // [10]
     GPIO('B', 12),          // [11]
     GPIO('B', 1),           // [12]
-    0,                      // [13] opamp
+    ADC_INVALID_PIN,        // [13] opamp
     GPIO('B', 11),          // [14]
     GPIO('B', 0),           // [15]
     ADC_TEMPERATURE_PIN,    // [16] vtemp
-    0,                      // [17] vbat/3
-    0,                      // [18] vref
-    0,
-    0,                      // [0] vssa       ADC 2
+    ADC_INVALID_PIN,        // [17] vbat/3
+    ADC_INVALID_PIN,        // [18] vref
+    ADC_INVALID_PIN,
+    ADC_INVALID_PIN,        // [0] vssa       ADC 2
     GPIO('A', 0),           // [1]
     GPIO('A', 1),           // [2]
     GPIO('A', 6),           // [3]
@@ -128,11 +130,11 @@ static const uint8_t adc_pins[] = {
     GPIO('A', 5),           // [13]
     GPIO('B', 11),          // [14]
     GPIO('B', 15),          // [15]
-    0,                      // [16] opamp
+    ADC_INVALID_PIN,        // [16] opamp
     GPIO('A', 4),           // [17]
-    0,                      // [18] opamp
+    ADC_INVALID_PIN,        // [18] opamp
 #else // stm32l4
-    0,                      // vref
+    ADC_INVALID_PIN,        // vref
     GPIO('C', 0),           // ADC12_IN1 .. 16
     GPIO('C', 1),
     GPIO('C', 2),
@@ -150,7 +152,7 @@ static const uint8_t adc_pins[] = {
     GPIO('B', 0),
     GPIO('B', 1),
     ADC_TEMPERATURE_PIN,    // temp
-    0,                      // vbat
+    ADC_INVALID_PIN,        // vbat
 #endif
 };
 


### PR DESCRIPTION
I built my own 3D printer board with STM32G431 and flashed klipper firmware. I connected PA0 to heater bed sensor but always get random value. Finally I found that in array "adc_pins", the first element is 0 but GPIO('A', 0) equals 0, too. This causes the "gpio_adc_setup" functoin will get the wrong ADC channel of PA0. Here I changed it to 0xFF and it works fine.