### PR TITLE
Asynchronous temperature setting, and cancel of temperature wait

### DIFF
--- a/docs/API_Server.md
+++ b/docs/API_Server.md
@@ -282,6 +282,22 @@ window" interface. Parsing content from the G-Code terminal output is
 discouraged. Use the "objects/subscribe" endpoint to obtain updates on
 Klipper's state.
 
+### heaters/set_target_temperature
+
+This endpoint is used to asynchronously set the target temperature for
+a heater. For example:
+`{"id": 123, "method": "heaters/set_target_temperature", "params":
+{"heater":"heater_generic my_heater", "target": 100.3}}`
+
+This endpoint is similar to the `SET_HEATER_TEMPERATURE` G-Code
+command, but the target temperature takes effect immediately.  It does
+not wait for pending G-Code commands to complete.
+
+If this endpoint is issued for a heater while a `WAIT_TEMPERATURE`
+command (or `M109`, `M190`) is pending for that heater, then the
+requested target temperature will be set and the `WAIT_TEMPERATURE`
+command will exit with an error.
+
 ### motion_report/dump_stepper
 
 This endpoint is used to subscribe to Klipper's internal stepper

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -256,6 +256,11 @@ object is available if any heater is defined):
   e.g. `["tmc2240 stepper_x"]`.  While a temperature sensor is always
   available to read, a temperature monitor may not be available and
   will return null in such case.
+- `temperature_wait`: Indicates if G-Code processing is stalled
+  waiting for a requested temperature (typically via
+  `TEMPERATURE_WAIT`, `M109`, or `M190` commands). The value will
+  contain the name of the sensor that is causing the stall or `None`
+  if no wait is in progress.
 
 ## idle_timeout
 

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -1,6 +1,6 @@
 # Tracking of PWM controlled heaters and their temperature control
 #
-# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, logging, threading
@@ -38,6 +38,7 @@ class Heater:
         self.smooth_time = config.getfloat('smooth_time', 1., above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
         self.is_shutdown = False
+        self.set_temp_count = 0
         self.lock = threading.Lock()
         self.last_temp = self.smoothed_temp = self.target_temp = 0.
         self.last_temp_time = 0.
@@ -63,6 +64,9 @@ class Heater:
         gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER",
                                    short_name, self.cmd_SET_HEATER_TEMPERATURE,
                                    desc=self.cmd_SET_HEATER_TEMPERATURE_help)
+        wh = self.printer.lookup_object('webhooks')
+        wh.register_mux_endpoint("heaters/set_target_temperature", "heater",
+                                 self.name, self._api_set_target_temperature)
         self.printer.register_event_handler("klippy:shutdown",
                                             self._handle_shutdown)
     def set_pwm(self, read_time, value):
@@ -106,6 +110,7 @@ class Heater:
             raise self.printer.command_error(
                 "Requested temperature (%.1f) out of range (%.1f:%.1f)"
                 % (degrees, self.min_temp, self.max_temp))
+        self.set_temp_count += 1
         with self.lock:
             self.target_temp = degrees
     def get_temp(self, eventtime):
@@ -143,9 +148,15 @@ class Heater:
             last_pwm_value = self.last_pwm_value
         return {'temperature': round(smoothed_temp, 2), 'target': target_temp,
                 'power': last_pwm_value}
+    def get_set_temp_count(self):
+        return self.set_temp_count
     cmd_SET_HEATER_TEMPERATURE_help = "Sets a heater temperature"
     def cmd_SET_HEATER_TEMPERATURE(self, gcmd):
         temp = gcmd.get_float('TARGET', 0.)
+        pheaters = self.printer.lookup_object('heaters')
+        pheaters.set_temperature(self, temp)
+    def _api_set_target_temperature(self, web_request):
+        temp = web_request.get_float('target')
         pheaters = self.printer.lookup_object('heaters')
         pheaters.set_temperature(self, temp)
 
@@ -339,6 +350,7 @@ class PrinterHeaters:
         if self.printer.get_start_args().get('debugoutput') is not None:
             return
         full_name = heater.get_name()
+        set_temp_count = heater.get_set_temp_count()
         toolhead = self.printer.lookup_object("toolhead")
         gcode = self.printer.lookup_object("gcode")
         reactor = self.printer.get_reactor()
@@ -348,6 +360,11 @@ class PrinterHeaters:
             print_time = toolhead.get_last_move_time()
             gcode.respond_raw(self._get_temp(eventtime))
             eventtime = reactor.pause(eventtime + 1.)
+            if heater.get_set_temp_count() != set_temp_count:
+                self.in_temperature_wait = None
+                raise self.printer.command_error(
+                    "Heater '%s' target temperature changed during wait"
+                    % (full_name,))
         self.in_temperature_wait = None
     def set_temperature(self, heater, temp, wait=False):
         toolhead = self.printer.lookup_object('toolhead')
@@ -368,9 +385,11 @@ class PrinterHeaters:
         if self.printer.get_start_args().get('debugoutput') is not None:
             return
         full_name = sensor_name
+        set_temp_count = None
         if sensor_name in self.heaters:
             sensor = self.heaters[sensor_name]
             full_name = sensor.get_name()
+            set_temp_count = sensor.get_set_temp_count()
         else:
             sensor = self.printer.lookup_object(sensor_name)
         toolhead = self.printer.lookup_object("toolhead")
@@ -384,6 +403,12 @@ class PrinterHeaters:
             print_time = toolhead.get_last_move_time()
             gcmd.respond_raw(self._get_temp(eventtime))
             eventtime = reactor.pause(eventtime + 1.)
+            if (set_temp_count is not None
+                and sensor.get_set_temp_count() != set_temp_count):
+                self.in_temperature_wait = None
+                raise self.printer.command_error(
+                    "Heater '%s' target temperature changed during wait"
+                    % (full_name,))
         self.in_temperature_wait = None
 
 def load_config(config):


### PR DESCRIPTION
This PR adds a new `heaters/set_target_temperature` API endpoint.  It allows the frontends to asynchronously set a new target temperature.  Currently, temperatures are set via `M109`, `M104`, `M190`, `M140`, and `SET_HEATER_TEMPERATURE` commands.  However, these commands wait in the G-Code command queue, which can be delayed - in particular if the printer is waiting for another temperature to be met.  In contrast, the new API call sets the requested target temperature as soon as it is received.

To avoid conflicts, if a heater target temperature is set asynchronously through the API while a command is actively waiting for that heater to reach a temperature (`TEMPERATURE_WAIT`, `M109`, `M190`) then the new asynchronous temperature will be accepted and the waiting command will raise an error.  So, for example, if the user ran `M190 S200` and then issued a `{"method": "heaters/set_target_temperature", "params":
{"heater":"heater_bed", "target": 60.0}}` then the target temperature will be set to 60 and the `M190` command will report an error.  (If the command was issued from a virtual_sdcard based print then that error would cause the `on_gcode_error` code to run which may change the target temperature again.)

To alert API users of this conflict, this PR also introduces new `printer.heaters.temperature_wait` status information.  If Klipper is actively waiting for a temperature (`TEMPERATURE_WAIT`, `M109`, `M190`) it will report that heater (or sensor) involved in the wait.  It will report `null` in the common case where no temperature wait is in progress.

These two mechanisms can also be utilized to "cancel a heater wait".  An API session could determine if the code is waiting on a temperature and then purposely issue an asynchronous temperature assignment to cause the waiting command to exit early (with an error).

FYI, @meteyou , @pedrolamas , @Arksine .

Thoughts?
-Kevin