### PR TITLE
Docs: Update for some extra adaptive info

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -410,9 +410,12 @@ adaptive_margin: 5
   ![adaptive_bedmesh_margin](img/adaptive_bed_mesh_margin.svg)
 
 By nature, adaptive bed meshes use the objects defined by the Gcode file being printed.
-Therefore, it is expected that each Gcode file will generate a mesh that probes a different
-area of the print bed. Therefore, adapted bed meshes should not be re-used. The expectation
-is that a new mesh will be generated for each print if adaptive meshing is used.
+EXCLUDE_OBJECT_DEFINE gcode needs to be present in the Gcode file, which can be procesed in
+with a slicer plugin, moonraker or by slicer specific functions, see [Slicers.md](Slicers.md),
+also [exclude_object] should be in the configuration.It is expected that each Gcode file
+will generate a mesh that probes a different area of the print bed. Therefore, adapted bed
+meshes should not be re-used. The expectation is that a new mesh will be generated for each
+print if adaptive meshing is used.
 
 It is also important to consider that adaptive bed meshing is best used on machines that can
 normally probe the entire bed and achieve a maximum variance less than or equal to 1 layer

--- a/docs/Slicers.md
+++ b/docs/Slicers.md
@@ -2,13 +2,15 @@
 
 This document provides some tips for configuring a "slicer"
 application for use with Klipper. Common slicers used with Klipper are
-Slic3r, Cura, Simplify3D, etc.
+Slic3r, Cura, Simplify3D, PrusaSlicer, SuperSlicer, OrcaSlicer etc.
 
 ## Set the G-Code flavor to Marlin
 
 Many slicers have an option to configure the "G-Code flavor". The
 default is frequently "Marlin" and that works well with Klipper. The
-"Smoothieware" setting also works well with Klipper.
+"Smoothieware" setting also works well with Klipper. Some slicers
+may have an actual "Klipper" flavor, which you should use over
+"Marlin" or "Smoothieware" if available.
 
 ## Klipper gcode_macro
 
@@ -87,6 +89,28 @@ Klipper's maximum extrusion cross-section check.
 
 In contrast, it is okay (and often helpful) to use a slicer's
 "retract" setting, "wipe" setting, and/or "wipe on retract" setting.
+
+## Disable arc generating features of OrcaSlicer
+
+OrcaSlicer uses "Arc fitting" and "Spiral Z-Lift", these will produce
+errors in the console if used without enabling gcode_arcs in Klipper
+config. These options can also produce timing errors due to how Klipper
+deals with arcs and can cause the step rate to be massively increased,
+overloading the hardware.
+
+## Object labelling and exclude_object
+
+Some slicers, like the Slic3r forks: PrusaSlicer and OrcaSlicer can
+automatically produce the gcode needed for exclude_object support with no
+need for external processing. This slicer option should be enabled when
+using exclude_object support. The flavor should be set to Klipper and the
+label object setting set to "Firmware Specific", making sure all options
+for Label Object and Exclude Object are enabled.
+Other slicers that dont have this functionality can be processed through a
+plugin or via Moonraker Object Processing. In all cases this will insert an
+EXCLUDE_OBJECT_DEFINE gcode into the first commands in the Gcode file that
+will inform Klipper of the object details, to be used for adaptive functions
+and object cancelling.
 
 ## START_PRINT macros
 


### PR DESCRIPTION
Small PR to clarify and add some points about exclude_object and properly defined gcode being needed for adaptive meshing.

Also some extra info in Slicers.md to clarify other slicers, and Orca arc features(i can split these out if needed)

Thanks

James

Signed-off-by: James Hartley <james@hartleyns.com>