### PR TITLE
Warning Fix: Current code produces warnings for possible value overflows.

### DIFF
--- a/src/sensor_ads1220.c
+++ b/src/sensor_ads1220.c
@@ -86,7 +86,9 @@ ads1220_read_adc(struct ads1220_adc *ads1220, uint8_t oid)
     barrier();
 
     // create 24 bit int from bytes
-    int32_t counts = (msg[0] << 16) | (msg[1] << 8) | msg[2];
+    uint32_t counts = ((uint32_t)msg[0] << 16)
+                    | ((uint32_t)msg[1] << 8)
+                    | ((uint32_t)msg[2]);
 
     // extend 2's complement 24 bits to 32bits
     if (counts & 0x800000)

--- a/src/sensor_hx71x.c
+++ b/src/sensor_hx71x.c
@@ -27,8 +27,8 @@ struct hx71x_adc {
 };
 
 #define BYTES_PER_SAMPLE 4
-#define SAMPLE_ERROR_DESYNC 1 << 31
-#define SAMPLE_ERROR_READ_TOO_LONG 1 << 30
+#define SAMPLE_ERROR_DESYNC 1L << 31
+#define SAMPLE_ERROR_READ_TOO_LONG 1L << 30
 
 static struct task_wake wake_hx71x;
 

--- a/src/sensor_ldc1612.c
+++ b/src/sensor_ldc1612.c
@@ -180,7 +180,10 @@ ldc1612_query(struct ldc1612 *ld, uint8_t oid)
     ld->sb.data_count += BYTES_PER_SAMPLE;
 
     // Check for endstop trigger
-    uint32_t data = (d[0] << 24L) | (d[1] << 16L) | (d[2] << 8) | d[3];
+    uint32_t data =   ((uint32_t)d[0] << 24)
+                    | ((uint32_t)d[1] << 16)
+                    | ((uint32_t)d[2] << 8)
+                    | ((uint32_t)d[3]);
     check_home(ld, data);
 
     // Flush local buffer if needed


### PR DESCRIPTION
As the input values are uint8_t types, any shift may result in value loss.
Explicit promotion to the output type (uint32_t) keeps things safe.

Have also changed the int32_t in ads1220_read_adc to uint32_t, type promotion and bit manipulation are a bit 'weird' on signed integers, so keep it as an unsigned to align with following function call parameter type.
Have retained the prior explicit sign extension logic however.