### PR TITLE
Create generic-bigtreetech-32spi-v1.0.cfg

### DIFF
--- a/config/generic-bigtreetech-32spi-v1.0.cfg
+++ b/config/generic-bigtreetech-32spi-v1.0.cfg
@@ -1,0 +1,100 @@
+# This file contains common pin mappings for the BIGTREETECH 32SPI V1.0
+# board. To use this config, the firmware should be compiled:
+# Micro-controller Architecture (LPC176x (Smoothieboard))
+# Processor model (lpc1768 (100 MHz))
+# Bootloader offset (16KiB bootloader (Smoothieware bootloader))
+# Communication interface (Serial (on UART0 P0.3/P0.2))
+# Rename klipper.bin to firmware.bin and place on SD Card
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: P2.0
+dir_pin: !P0.5
+enable_pin: !P0.4
+microsteps: 16
+rotation_distance: 40
+endstop_pin: P1.24 
+# P1.25 for X-max
+position_endstop: 0
+position_max: 320
+homing_speed: 50
+
+[stepper_y]
+step_pin: P2.1
+dir_pin: !P0.11
+enable_pin: !P0.10
+microsteps: 16
+rotation_distance: 40
+endstop_pin: P1.26  
+# P1.27 for Y-max
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+
+[stepper_z]
+step_pin: P2.2
+dir_pin: P0.20
+enable_pin: !P0.19
+microsteps: 16
+rotation_distance: 8
+endstop_pin: P1.28  
+# P1.29 for Z-max
+position_endstop: 0.5
+position_max: 400
+
+[extruder]
+step_pin: P2.3
+dir_pin: !P0.22
+enable_pin: !P0.21
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: P2.7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: P0.24
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 260
+
+#[extruder1]
+#step_pin: P0.1
+#dir_pin: P0.0
+#enable_pin: !P0.10
+#heater_pin: P2.4
+#sensor_pin: P0.25
+#...
+
+[heater_bed]
+heater_pin: P2.5
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: P0.23
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[fan]
+#On printhead
+pin: P2.4
+
+#FAN0 and #FAN1 are not controlled
+
+[mcu]
+serial: /dev/serial/by-path/platform-1c1b400.usb-usb-0:1:1.0-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 200
+max_accel: 2000
+max_z_velocity: 25
+max_z_accel: 100
+
+#======UNDISCOVERD PINS========
+#BL pin
+#AUX-1 header
+#ICSP header
+#Extruder 1 driver


### PR DESCRIPTION
Made a configuration of this old board. Not all pins are known, but this is enough to run the printer with this board.