### PR TITLE
temperature_probe: add 'max_valid_temp' option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2458,6 +2458,10 @@ postfix for both sections.
 #   "calibration_extruder_temp" option is set.  Its recommended to heat
 #   the extruder some distance from the bed to minimize its impact on
 #   the probe coil temperature.  The default is 50.
+#max_validation_temp: 60.
+#   The maximum temperature used to validate the calibration.  It is
+#   recommended to set this to a value between 100 and 120 for enclosed
+#   printers.  The default is 60.
 ```
 
 ## Temperature sensors

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -78,7 +78,9 @@ for further details on how to configure a `temperature_probe`.  It is
 advised to configure the `calibration_position`,
 `calibration_extruder_temp`, `extruder_heating_z`, and
 `calibration_bed_temp` options, as doing so will automate some of the
-steps outlined below.
+steps outlined below.  If the printer to be calibrated is enclosed, it
+is strongly recommended to set the `max_validation_temp` option to a value
+between 100 and 120.
 
 Eddy probe manufacturers may offer a stock drift calibration that can be
 manually added to `drift_calibration` option of the `[probe_eddy_current]`


### PR DESCRIPTION
This pull request addresses an issue with users unable to calibrate across a wide coil temperature range.  Specifically, unenclosed printers commonly achieve a maximum temperature between 50-55C.  The result is a calibration with polynomials that intersect at higher temperatures.  The `temperature_probe` module checks for this condition post-calibration, and said users are experiencing failures.

This patch introduces the `max_valid_temp` config option, which replaces the hard coded maximum validation temperature of 120C.  This option will not impact current calibrations.