### PR TITLE
Queue and collate fan requests (and output_pin and servo)

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,15 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240912: `SET_PIN`, `SET_SERVO`, `SET_FAN_SPEED`, `M106`, and `M107`
+commands are now collated. Previously, if many updates to the same
+object were issued faster than the minimum scheduling time (typically
+100ms) then actual updates could be queued far into the future. Now if
+many updates are issued in rapid succession then it is possible that
+only the latest request will be applied. If the previous behavior is
+requried then consider adding explicit `G4` delay commands between
+updates.
+
 20240912: Support for `maximum_mcu_duration` and `static_value`
 parameters in `[output_pin]` config sections have been removed. These
 options have been deprecated since 20240123.

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20240912: Support for `maximum_mcu_duration` and `static_value`
+parameters in `[output_pin]` config sections have been removed. These
+options have been deprecated since 20240123.
+
 20240415: The `on_error_gcode` parameter in the `[virtual_sdcard]`
 config section now has a default. If this parameter is not specified
 it now defaults to `TURN_OFF_HEATERS`. If the previous behavior is

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -1,17 +1,14 @@
 # Printer cooling fan
 #
-# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import pulse_counter
-
-FAN_MIN_TIME = 0.100
+from . import pulse_counter, output_pin
 
 class Fan:
     def __init__(self, config, default_shutdown_speed=0.):
         self.printer = config.get_printer()
         self.last_fan_value = 0.
-        self.last_fan_time = 0.
         # Read config
         self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
         self.kick_start_time = config.getfloat('kick_start_time', 0.1,
@@ -36,6 +33,10 @@ class Fan:
             self.enable_pin = ppins.setup_pin('digital_out', enable_pin)
             self.enable_pin.setup_max_duration(0.)
 
+        # Create gcode request queue
+        self.gcrq = output_pin.GCodeRequestQueue(config, self.mcu_fan.get_mcu(),
+                                                 self._apply_speed)
+
         # Setup tachometer
         self.tachometer = FanTachometer(config)
 
@@ -45,13 +46,12 @@ class Fan:
 
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
-    def set_speed(self, print_time, value):
+    def _apply_speed(self, print_time, value):
         if value < self.off_below:
             value = 0.
         value = max(0., min(self.max_power, value * self.max_power))
         if value == self.last_fan_value:
-            return
-        print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
+            return (True, 0.)
         if self.enable_pin:
             if value > 0 and self.last_fan_value == 0:
                 self.enable_pin.set_digital(print_time, 1)
@@ -60,15 +60,16 @@ class Fan:
         if (value and value < self.max_power and self.kick_start_time
             and (not self.last_fan_value or value - self.last_fan_value > .5)):
             # Run fan at full speed for specified kick_start_time
+            self.last_fan_value = self.max_power
             self.mcu_fan.set_pwm(print_time, self.max_power)
-            print_time += self.kick_start_time
-        self.mcu_fan.set_pwm(print_time, value)
-        self.last_fan_time = print_time
+            return (False, self.kick_start_time)
         self.last_fan_value = value
+        self.mcu_fan.set_pwm(print_time, value)
+        return (True, 0.)
+    def set_speed(self, print_time, value):
+        self.gcrq.queue_request(print_time, value)
     def set_speed_from_command(self, value):
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.register_lookahead_callback((lambda pt:
-                                              self.set_speed(pt, value)))
+        self.gcrq.queue_gcode_request(value)
     def _handle_request_restart(self, print_time):
         self.set_speed(print_time, 0.)
 

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 PIN_MIN_TIME = 0.100
-RESEND_HOST_TIME = 0.300 + PIN_MIN_TIME
 MAX_SCHEDULE_TIME = 5.0
 
 class PrinterOutputPin:
@@ -24,29 +23,13 @@ class PrinterOutputPin:
         else:
             self.mcu_pin = ppins.setup_pin('digital_out', config.get('pin'))
             self.scale = 1.
+        self.mcu_pin.setup_max_duration(0.)
         self.last_print_time = 0.
-        # Support mcu checking for maximum duration
-        self.reactor = self.printer.get_reactor()
-        self.resend_timer = None
-        self.resend_interval = 0.
-        max_mcu_duration = config.getfloat('maximum_mcu_duration', 0.,
-                                           minval=0.500,
-                                           maxval=MAX_SCHEDULE_TIME)
-        self.mcu_pin.setup_max_duration(max_mcu_duration)
-        if max_mcu_duration:
-            config.deprecate('maximum_mcu_duration')
-            self.resend_interval = max_mcu_duration - RESEND_HOST_TIME
         # Determine start and shutdown values
-        static_value = config.getfloat('static_value', None,
-                                       minval=0., maxval=self.scale)
-        if static_value is not None:
-            config.deprecate('static_value')
-            self.last_value = self.shutdown_value = static_value / self.scale
-        else:
-            self.last_value = config.getfloat(
-                'value', 0., minval=0., maxval=self.scale) / self.scale
-            self.shutdown_value = config.getfloat(
-                'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
+        self.last_value = config.getfloat(
+            'value', 0., minval=0., maxval=self.scale) / self.scale
+        self.shutdown_value = config.getfloat(
+            'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
         self.mcu_pin.setup_start_value(self.last_value, self.shutdown_value)
         # Register commands
         pin_name = config.get_name().split()[1]
@@ -56,8 +39,8 @@ class PrinterOutputPin:
                                    desc=self.cmd_SET_PIN_help)
     def get_status(self, eventtime):
         return {'value': self.last_value}
-    def _set_pin(self, print_time, value, is_resend=False):
-        if value == self.last_value and not is_resend:
+    def _set_pin(self, print_time, value):
+        if value == self.last_value:
             return
         print_time = max(print_time, self.last_print_time + PIN_MIN_TIME)
         if self.is_pwm:
@@ -66,9 +49,6 @@ class PrinterOutputPin:
             self.mcu_pin.set_digital(print_time, value)
         self.last_value = value
         self.last_print_time = print_time
-        if self.resend_interval and self.resend_timer is None:
-            self.resend_timer = self.reactor.register_timer(
-                self._resend_current_val, self.reactor.NOW)
     cmd_SET_PIN_help = "Set the value of an output pin"
     def cmd_SET_PIN(self, gcmd):
         # Read requested value
@@ -80,21 +60,6 @@ class PrinterOutputPin:
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_lookahead_callback(
             lambda print_time: self._set_pin(print_time, value))
-
-    def _resend_current_val(self, eventtime):
-        if self.last_value == self.shutdown_value:
-            self.reactor.unregister_timer(self.resend_timer)
-            self.resend_timer = None
-            return self.reactor.NEVER
-
-        systime = self.reactor.monotonic()
-        print_time = self.mcu_pin.get_mcu().estimated_print_time(systime)
-        time_diff = (self.last_print_time + self.resend_interval) - print_time
-        if time_diff > 0.:
-            # Reschedule for resend time
-            return systime + time_diff
-        self._set_pin(print_time + PIN_MIN_TIME, self.last_value, True)
-        return systime + self.resend_interval
 
 def load_config_prefix(config):
     return PrinterOutputPin(config)

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -7,6 +7,46 @@
 PIN_MIN_TIME = 0.100
 MAX_SCHEDULE_TIME = 5.0
 
+# Helper code to queue g-code requests
+class GCodeRequestQueue:
+    def __init__(self, config, mcu, callback):
+        self.printer = printer = config.get_printer()
+        self.mcu = mcu
+        self.callback = callback
+        self.rqueue = []
+        self.next_min_flush_time = 0.
+        self.toolhead = None
+        mcu.register_flush_callback(self._flush_notification)
+        printer.register_event_handler("klippy:connect", self._handle_connect)
+    def _handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+    def _flush_notification(self, print_time, clock):
+        rqueue = self.rqueue
+        if not rqueue:
+            return
+        next_time = max(rqueue[0][0], self.next_min_flush_time)
+        if next_time > print_time:
+            return
+        # Skip requests that have been overridden with a following request
+        pos = 0
+        while pos + 1 < len(rqueue) and rqueue[pos + 1][0] <= next_time:
+            pos += 1
+        req_pt, req_val = rqueue[pos]
+        # Invoke callback for the request
+        want_dequeue, min_wait_time = self.callback(next_time, req_val)
+        self.next_min_flush_time = next_time + max(min_wait_time, PIN_MIN_TIME)
+        if want_dequeue:
+            pos += 1
+        del rqueue[:pos]
+        # Ensure following queue items are flushed
+        self.toolhead.note_mcu_movequeue_activity(self.next_min_flush_time)
+    def queue_request(self, print_time, value):
+        self.rqueue.append((print_time, value))
+        self.toolhead.note_mcu_movequeue_activity(print_time)
+    def queue_gcode_request(self, value):
+        self.toolhead.register_lookahead_callback(
+            (lambda pt: self.queue_request(pt, value)))
+
 class PrinterOutputPin:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -24,13 +64,15 @@ class PrinterOutputPin:
             self.mcu_pin = ppins.setup_pin('digital_out', config.get('pin'))
             self.scale = 1.
         self.mcu_pin.setup_max_duration(0.)
-        self.last_print_time = 0.
         # Determine start and shutdown values
         self.last_value = config.getfloat(
             'value', 0., minval=0., maxval=self.scale) / self.scale
         self.shutdown_value = config.getfloat(
             'shutdown_value', 0., minval=0., maxval=self.scale) / self.scale
         self.mcu_pin.setup_start_value(self.last_value, self.shutdown_value)
+        # Create gcode request queue
+        self.gcrq = GCodeRequestQueue(config, self.mcu_pin.get_mcu(),
+                                      self._set_pin)
         # Register commands
         pin_name = config.get_name().split()[1]
         gcode = self.printer.lookup_object('gcode')
@@ -40,15 +82,13 @@ class PrinterOutputPin:
     def get_status(self, eventtime):
         return {'value': self.last_value}
     def _set_pin(self, print_time, value):
-        if value == self.last_value:
-            return
-        print_time = max(print_time, self.last_print_time + PIN_MIN_TIME)
-        if self.is_pwm:
-            self.mcu_pin.set_pwm(print_time, value)
-        else:
-            self.mcu_pin.set_digital(print_time, value)
-        self.last_value = value
-        self.last_print_time = print_time
+        if value != self.last_value:
+            self.last_value = value
+            if self.is_pwm:
+                self.mcu_pin.set_pwm(print_time, value)
+            else:
+                self.mcu_pin.set_digital(print_time, value)
+        return (True, 0.)
     cmd_SET_PIN_help = "Set the value of an output pin"
     def cmd_SET_PIN(self, gcmd):
         # Read requested value
@@ -56,10 +96,8 @@ class PrinterOutputPin:
         value /= self.scale
         if not self.is_pwm and value not in [0., 1.]:
             raise gcmd.error("Invalid pin value")
-        # Obtain print_time and apply requested settings
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.register_lookahead_callback(
-            lambda print_time: self._set_pin(print_time, value))
+        # Queue requested value
+        self.gcrq.queue_gcode_request(value)
 
 def load_config_prefix(config):
     return PrinterOutputPin(config)


### PR DESCRIPTION
This PR adds a new mechanism for queuing of fan updates.  (It also applies to output_pin and servo objects.)  Due to the low-level mechanism used to transmit updates to the mcus, it is necessary for each update to apply for a minimum amount of time - typically 100ms.  Previously, if one were to send many fan updates in rapid succession, the code would batch up those updates and apply them in succession.  (With each update running for at least 100ms.)  This could result in the fan updates becoming out of sync with the toolhead.

This PR adds new code to collect fan updates in the host and only send the latest fan update to the mcu.  For example, in the following sequence:
```
G4 P2000
M106 S100
M106 S101
M106 S102
M106 S103
M106 S104
G1 X100
```
The old code would apply four fan speed changes spaced over 500ms.  The new code will send just a single update (`M106 S104`).

This change should make Klipper a little more resilient with buggy slicers.  It is also part of a series of changes I have been working on to add support for asynchronous pin changes.

-Kevin