### PR TITLE
Rewrite MCU I2C to support non blocking execution.

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -179,7 +179,7 @@ class MCU_I2C:
         self.i2c_read_cmd = self.mcu.lookup_query_command(
             "i2c_read oid=%c reg=%*s read_len=%u",
             "i2c_read_response oid=%c response=%*s", oid=self.oid,
-            cq=self.cmd_queue)
+            cq=self.cmd_queue, is_async=True)
         self.i2c_modify_bits_cmd = self.mcu.lookup_command(
             "i2c_modify_bits oid=%c reg=%*s clear_set_bits=%*s",
             cq=self.cmd_queue)

--- a/src/atsam/gpio.h
+++ b/src/atsam/gpio.h
@@ -2,6 +2,7 @@
 #define __ATSAM_GPIO_H
 
 #include <stdint.h> // uint32_t
+#include "sched.h"  // timer
 
 struct gpio_out {
     void *regs;
@@ -53,5 +54,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/atsamd/gpio.h
+++ b/src/atsamd/gpio.h
@@ -2,6 +2,7 @@
 #define __ATSAMD_GPIO_H
 
 #include <stdint.h>
+#include "sched.h" // timer
 
 struct gpio_out {
     void *regs;
@@ -54,5 +55,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/atsamd/i2c.c
+++ b/src/atsamd/i2c.c
@@ -9,6 +9,7 @@
 #include "command.h" // shutdown
 #include "gpio.h" // i2c_setup
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 
 #define TIME_RISE 125ULL // 125 nanoseconds
 #define I2C_FREQ 100000
@@ -143,4 +144,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
         // read received data byte
         *read++ = si->DATA.reg;
     }
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/avr/gpio.h
+++ b/src/avr/gpio.h
@@ -48,6 +48,7 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 
 struct i2c_config {
     uint8_t addr;
+    uint32_t pause;
 };
 
 struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);

--- a/src/avr/gpio.h
+++ b/src/avr/gpio.h
@@ -2,6 +2,7 @@
 #define __AVR_GPIO_H
 
 #include <stdint.h>
+#include "sched.h" // timer
 
 struct gpio_out {
     struct gpio_digital_regs *regs;
@@ -53,5 +54,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/avr/i2c.c
+++ b/src/avr/i2c.c
@@ -11,6 +11,7 @@
 #include "gpio.h" // i2c_setup
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 
 DECL_ENUMERATION("i2c_bus", "twi", 0);
 
@@ -120,4 +121,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
     while (read_len--)
         i2c_receive_byte(read++, timeout, read_len);
     i2c_stop(timeout);
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/i2c_software.c
+++ b/src/i2c_software.c
@@ -179,3 +179,35 @@ i2c_software_read(struct i2c_software *is, uint8_t reg_len, uint8_t *reg
     }
     i2c_software_stop(is);
 }
+
+uint_fast8_t i2c_software_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_software *is = alloc_chunk(sizeof(*is));
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_software_read(is, reg_len, reg, read_len, resp);
+
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++)
+        {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+
+        i2c_software_write(is, to_write, buf);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
+}

--- a/src/i2c_software.h
+++ b/src/i2c_software.h
@@ -5,11 +5,6 @@
 #include "sched.h" // struct timer
 
 struct i2c_software *i2c_software_oid_lookup(uint8_t oid);
-void i2c_software_write(struct i2c_software *sw_i2c
-                        , uint8_t write_len, uint8_t *write);
-void i2c_software_read(struct i2c_software *sw_i2c
-                       , uint8_t reg_len, uint8_t *reg
-                       , uint8_t read_len, uint8_t *read);
 uint_fast8_t i2c_software_async(struct timer *timer);
 
 #endif // i2c_software.h

--- a/src/i2c_software.h
+++ b/src/i2c_software.h
@@ -2,6 +2,7 @@
 #define __I2C_SOFTWARE_H
 
 #include <stdint.h> // uint8_t
+#include "sched.h" // struct timer
 
 struct i2c_software *i2c_software_oid_lookup(uint8_t oid);
 void i2c_software_write(struct i2c_software *sw_i2c
@@ -9,5 +10,6 @@ void i2c_software_write(struct i2c_software *sw_i2c
 void i2c_software_read(struct i2c_software *sw_i2c
                        , uint8_t reg_len, uint8_t *reg
                        , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_software_async(struct timer *timer);
 
 #endif // i2c_software.h

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -10,12 +10,10 @@
 #include "command.h"  //sendf
 #include "sched.h" //DECL_COMMAND
 #include "board/gpio.h" //i2c_write/read/setup
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
 #include "i2c_software.h" // i2c_software_setup
 #include "i2ccmds.h"
-
-enum {
-    IF_SOFTWARE = 1, IF_HARDWARE = 2
-};
 
 void
 command_config_i2c(uint32_t *args)
@@ -37,7 +35,7 @@ command_i2c_set_bus(uint32_t *args)
     uint8_t addr = args[3] & 0x7f;
     struct i2cdev_s *i2c = i2cdev_oid_lookup(args[0]);
     i2c->i2c_config = i2c_setup(args[1], args[2], addr);
-    i2c->flags |= IF_HARDWARE;
+    i2c->timer.func = i2c_async;
 }
 DECL_COMMAND(command_i2c_set_bus,
              "i2c_set_bus oid=%c i2c_bus=%u rate=%u address=%u");
@@ -47,22 +45,92 @@ i2cdev_set_software_bus(struct i2cdev_s *i2c, struct i2c_software *is)
 {
     i2c->i2c_software = is;
     i2c->flags |= IF_SOFTWARE;
+    i2c->timer.func = i2c_software_async;
 }
 
-void
-command_i2c_write(uint32_t *args)
+void i2c_buf_write_b(struct i2cdev_s *i2c, uint8_t byte)
+{
+    i2c->buf[i2c->head] = byte;
+    i2c->head = (i2c->head + 1) % sizeof(i2c->buf);
+    i2c->size++;
+}
+
+uint8_t i2c_buf_read_b(struct i2cdev_s *i2c)
+{
+    uint8_t b = i2c->buf[i2c->tail];
+    i2c->tail = (i2c->tail + 1) % sizeof(i2c->buf);
+    i2c->size--;
+    return b;
+}
+
+// shift cmd buffer cmd[N] = cmd[N+1]
+void i2c_cmd_done(struct i2cdev_s *i2c)
+{
+    memmove(i2c->data_len, &i2c->data_len[1], sizeof(i2c->data_len) - 1);
+    i2c->data_len[sizeof(i2c->data_len) - 1] = 0;
+}
+
+void command_i2c_write(uint32_t *args)
 {
     uint8_t oid = args[0];
     struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
     uint8_t data_len = args[1];
     uint8_t *data = command_decode_ptr(args[2]);
-    uint_fast8_t flags = i2c->flags;
-    if (CONFIG_WANT_SOFTWARE_I2C && flags & IF_SOFTWARE)
-        i2c_software_write(i2c->i2c_software, data_len, data);
-    else
-        i2c_write(i2c->i2c_config, data_len, data);
+    uint8_t start = 0;
+
+    if (i2c->data_len[sizeof(i2c->data_len)-1]) {
+        shutdown("i2c_write: cmd buffer overload");
+    }
+
+    // write register -> read, write can be empty
+    if (i2c->flags & IF_RW) {
+        start = 1;
+    }
+
+    while (i2c->data_len[start]) {
+        start++;
+    }
+
+    if (data_len > sizeof(i2c->buf) - i2c->size)
+        shutdown("i2c_write: buffer overload - data too large");
+
+    i2c->data_len[start] = data_len;
+    for (uint8_t i = 0; i < data_len; i++) {
+        i2c_buf_write_b(i2c, data[i]);
+    }
+
+    if (i2c->flags & IF_ACTIVE)
+        return;
+
+    i2c->flags |= IF_ACTIVE;
+    irq_disable();
+    i2c->timer.waketime = timer_read_time() + timer_from_us(200);
+    sched_add_timer(&i2c->timer);
+    irq_enable();
 }
 DECL_COMMAND(command_i2c_write, "i2c_write oid=%c data=%*s");
+
+// Expects that i2c->read len is 0 and read_len = i2c->cur - i2c->tail;
+static uint_fast8_t
+i2c_read_response(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    uint8_t read_len = i2c->cur - i2c->tail;
+    sendf("i2c_read_response oid=%c response=%*s", i2c->oid, read_len
+          , &i2c->buf[i2c->tail]);
+    for (int i = 0; i < read_len; i++) {
+        i2c_buf_read_b(i2c);
+    }
+    i2c_cmd_done(i2c);
+
+    if (CONFIG_WANT_SOFTWARE_I2C && i2c->flags & IF_SOFTWARE)
+        i2c->timer.func = i2c_software_async;
+    else
+        i2c->timer.func = i2c_async;
+    i2c->flags &= ~(IF_RW);
+    i2c->timer.waketime = timer_read_time() + timer_from_us(50);
+    return SF_RESCHEDULE;
+}
 
 void
 command_i2c_read(uint32_t * args)
@@ -72,15 +140,75 @@ command_i2c_read(uint32_t * args)
     uint8_t reg_len = args[1];
     uint8_t *reg = command_decode_ptr(args[2]);
     uint8_t data_len = args[3];
-    uint8_t data[data_len];
-    uint_fast8_t flags = i2c->flags;
-    if (CONFIG_WANT_SOFTWARE_I2C && flags & IF_SOFTWARE)
-        i2c_software_read(i2c->i2c_software, reg_len, reg, data_len, data);
-    else
-        i2c_read(i2c->i2c_config, reg_len, reg, data_len, data);
-    sendf("i2c_read_response oid=%c response=%*s", oid, data_len, data);
+    if (i2c->flags & IF_ACTIVE)
+        // i2C is busy - silently drop this request (host should retransmit)
+        return;
+
+    // buffer is always empty here
+    if (reg_len + data_len > sizeof(i2c->buf))
+        shutdown("i2c_read: buffer overload - data too large");
+
+    i2c->oid = oid;
+    i2c->tail = 0;
+    i2c->head = 0;
+
+    i2c->data_len[0] = reg_len;
+    i2c->data_len[1] = data_len | I2C_R;
+    for (int i = 0; i < reg_len; i++) {
+        i2c_buf_write_b(i2c, reg[i]);
+    }
+    // reserve space
+    for (int i = 0; i < data_len; i++) {
+        i2c_buf_write_b(i2c, 0);
+    }
+
+    i2c->flags |= IF_ACTIVE | IF_RW;
+    i2c->callback = i2c_read_response;
+    irq_disable();
+    i2c->timer.waketime = timer_read_time() + timer_from_us(200);
+    sched_add_timer(&i2c->timer);
+    irq_enable();
 }
 DECL_COMMAND(command_i2c_read, "i2c_read oid=%c reg=%*s read_len=%u");
+
+static uint_fast8_t
+i2c_modify_bits(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    uint8_t read_len = i2c->cur - i2c->tail;
+    uint8_t buf[read_len];
+
+    for (int i = 0; i < read_len; i++) {
+        buf[i] = i2c_buf_read_b(i2c);
+    }
+    i2c_cmd_done(i2c);
+
+    for (int i = 0; i < read_len; i++) {
+        buf[i] &= i2c_buf_read_b(i2c);
+    }
+    i2c_cmd_done(i2c);
+
+    for (int i = 0; i < read_len; i++) {
+        buf[i] |= i2c_buf_read_b(i2c);
+    }
+    i2c_cmd_done(i2c);
+
+    // Because of FIFO next write is ours
+    uint8_t reg_len = i2c->data_len[0] - read_len;
+    i2c->cur = i2c->tail + reg_len;
+    for (int i = 0; i < read_len; i++) {
+        i2c->buf[i2c->cur] = buf[i];
+        i2c->cur++;
+    }
+
+    i2c->flags &= ~(IF_RW);
+    if (CONFIG_WANT_SOFTWARE_I2C && i2c->flags & IF_SOFTWARE)
+        timer->func = i2c_software_async;
+    else
+        timer->func = i2c_async;
+    timer->waketime = timer_read_time() + timer_from_us(200);
+    return SF_RESCHEDULE;
+}
 
 void
 command_i2c_modify_bits(uint32_t *args)
@@ -94,23 +222,57 @@ command_i2c_modify_bits(uint32_t *args)
         shutdown("i2c_modify_bits: Odd number of bits!");
     uint8_t data_len = clear_set_len/2;
     uint8_t *clear_set = command_decode_ptr(args[4]);
-    uint8_t receive_data[reg_len + data_len];
-    uint_fast8_t flags = i2c->flags;
-    memcpy(receive_data, reg, reg_len);
-    if (CONFIG_WANT_SOFTWARE_I2C && flags & IF_SOFTWARE)
-        i2c_software_read(
-            i2c->i2c_software, reg_len, reg, data_len, receive_data + reg_len);
-    else
-        i2c_read(
-            i2c->i2c_config, reg_len, reg, data_len, receive_data + reg_len);
-    for (int i = 0; i < data_len; i++) {
-        receive_data[reg_len + i] &= ~clear_set[i];
-        receive_data[reg_len + i] |= clear_set[data_len + i];
+
+    if (i2c->flags & IF_ACTIVE) {
+        shutdown("i2c_modify_bits: busy in process");
+        // i2c is busy - drop request for now
+        // I think there should be some sort of msg queue encoding,
+        // implemented again
+        // But every new supported RMW will complicate code.
+        return;
     }
-    if (CONFIG_WANT_SOFTWARE_I2C && flags & IF_SOFTWARE)
-        i2c_software_write(i2c->i2c_software, reg_len + data_len, receive_data);
-    else
-        i2c_write(i2c->i2c_config, reg_len + data_len, receive_data);
+
+    if (reg_len * 2 + data_len * 4 > sizeof(i2c->buf))
+        shutdown("i2c_modify_bits: buffer overload - data too large");
+
+    i2c->tail = 0;
+    i2c->head = 0;
+
+    i2c->data_len[0] = reg_len;
+    for (int i = 0; i < reg_len; i++) {
+        i2c_buf_write_b(i2c, reg[i]);
+    }
+
+    i2c->data_len[1] = data_len | I2C_R;
+    // reserve space for read
+    for (int i = 0; i < data_len; i++) {
+        i2c_buf_write_b(i2c, 0);
+    }
+
+    // save clear bits
+    i2c->data_len[2] = data_len | I2C_R;
+    for (int i = 0; i < data_len; i++) {
+        i2c_buf_write_b(i2c, ~clear_set[i]);
+    }
+
+    // save set bits
+    i2c->data_len[3] = data_len | I2C_R;
+    for (int i = 0; i < data_len; i++) {
+        i2c_buf_write_b(i2c, clear_set[data_len + i]);
+    }
+
+    // Reserve space for later write
+    i2c->data_len[4] = reg_len + data_len;
+    for (int i = 0; i < reg_len + data_len; i++) {
+        i2c_buf_write_b(i2c, reg[i]);
+    }
+
+    i2c->flags |= IF_ACTIVE | IF_RW;
+    i2c->callback = i2c_modify_bits;
+    irq_disable();
+    i2c->timer.waketime = timer_read_time() + timer_from_us(200);
+    sched_add_timer(&i2c->timer);
+    irq_enable();
 }
 DECL_COMMAND(command_i2c_modify_bits,
              "i2c_modify_bits oid=%c reg=%*s clear_set_bits=%*s");

--- a/src/i2ccmds.h
+++ b/src/i2ccmds.h
@@ -2,15 +2,38 @@
 #define __I2CCMDS_H
 
 #include <inttypes.h>
+#include "sched.h" // timer
 #include "board/gpio.h" // i2c_config
 
+enum {
+    IF_SOFTWARE = 1,
+    IF_ACTIVE = 1 << 2,
+    IF_RW = 1 << 7,
+    I2C_R = 1 << 7
+};
+
 struct i2cdev_s {
+    struct timer timer;
     struct i2c_config i2c_config;
     struct i2c_software *i2c_software;
+    uint8_t oid;
     uint8_t flags;
+    // MSB is W/R ops W is 0, R is 1
+    uint8_t data_len[8];
+    uint8_t buf[32];
+    uint8_t head;
+    uint8_t tail;
+    uint8_t size;
+    uint8_t cur;
+
+    // callback to return to
+    uint_fast8_t (*callback)(struct timer *timer);
 };
 
 struct i2cdev_s *i2cdev_oid_lookup(uint8_t oid);
 void i2cdev_set_software_bus(struct i2cdev_s *i2c, struct i2c_software *is);
+void i2c_buf_write_b(struct i2cdev_s *i2c, uint8_t byte);
+uint8_t i2c_buf_read_b(struct i2cdev_s *i2c);
+void i2c_cmd_done(struct i2cdev_s *i2c);
 
 #endif

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -47,6 +47,7 @@ void gpio_pwm_write(struct gpio_pwm g, uint16_t val);
 struct i2c_config {
     int fd;
     uint8_t addr;
+    int ret;
 };
 
 struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);

--- a/src/linux/gpio.h
+++ b/src/linux/gpio.h
@@ -2,6 +2,7 @@
 #define __LINUX_GPIO_H
 
 #include <stdint.h> // uint8_t
+#include "sched.h" // timer
 
 struct gpio_out {
     struct gpio_line* line;
@@ -49,8 +50,9 @@ struct i2c_config {
 };
 
 struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
-void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
+void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *data);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/linux/i2c.c
+++ b/src/linux/i2c.c
@@ -13,6 +13,7 @@
 #include "command.h" // shutdown
 #include "internal.h" // report_errno
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 
 DECL_ENUMERATION_RANGE("i2c_bus", "i2c.0", 0, 15);
 
@@ -124,4 +125,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
     if(ret < 0) {
         try_shutdown("Unable to read i2c device");
     }
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/lpc176x/gpio.h
+++ b/src/lpc176x/gpio.h
@@ -2,6 +2,7 @@
 #define __LPC176X_GPIO_H
 
 #include <stdint.h>
+#include "sched.h" // timer
 
 struct gpio_out {
     void *regs;
@@ -54,5 +55,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/lpc176x/i2c.c
+++ b/src/lpc176x/i2c.c
@@ -9,6 +9,7 @@
 #include "gpio.h" // i2c_setup
 #include "internal.h" // gpio_peripheral
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 
 struct i2c_info {
     LPC_I2C_TypeDef *i2c;
@@ -159,4 +160,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
         read++;
     }
     i2c_stop(i2c, timeout);
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/rp2040/gpio.h
+++ b/src/rp2040/gpio.h
@@ -48,6 +48,8 @@ void spi_transfer(struct spi_config config, uint8_t receive_data
 struct i2c_config {
     void *i2c;
     uint8_t addr;
+    int i;
+    int to_read;
 };
 
 struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);

--- a/src/rp2040/gpio.h
+++ b/src/rp2040/gpio.h
@@ -2,6 +2,7 @@
 #define __RP2040_GPIO_H
 
 #include <stdint.h> // uint32_t
+#include "sched.h"
 
 struct gpio_out {
     uint32_t bit;
@@ -53,5 +54,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/rp2040/i2c.c
+++ b/src/rp2040/i2c.c
@@ -9,6 +9,7 @@
 #include "command.h" // shutdown
 #include "sched.h" // sched_shutdown
 #include "internal.h" // pclock, gpio_peripheral
+#include "i2ccmds.h" // struct i2cdev_s
 #include "hardware/regs/resets.h" // RESETS_RESET_I2C*_BITS
 #include "hardware/structs/i2c.h"
 
@@ -212,4 +213,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
         i2c_do_write(i2c, config.addr, reg_len, reg, 0, timeout);
     i2c_do_read(i2c, config.addr, read_len, read, timeout);
     i2c_stop(i2c);
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/stm32/gpio.h
+++ b/src/stm32/gpio.h
@@ -2,6 +2,7 @@
 #define __STM32_GPIO_H
 
 #include <stdint.h> // uint32_t
+#include "sched.h" // struct timer
 
 struct gpio_out {
     void *regs;
@@ -54,5 +55,6 @@ struct i2c_config i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr);
 void i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write);
 void i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
               , uint8_t read_len, uint8_t *read);
+uint_fast8_t i2c_async(struct timer *timer);
 
 #endif // gpio.h

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -10,6 +10,7 @@
 #include "gpio.h" // i2c_setup
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 #include "board/irq.h" //irq_disable
 
 struct i2c_info {
@@ -180,4 +181,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
         read++;
     }
     i2c_wait(i2c, 0, I2C_SR1_RXNE, timeout);
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }

--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -9,6 +9,7 @@
 #include "gpio.h" // i2c_setup
 #include "internal.h" // GPIO
 #include "sched.h" // sched_shutdown
+#include "i2ccmds.h" // struct i2cdev_s
 
 struct i2c_info {
     I2C_TypeDef *i2c;
@@ -211,4 +212,38 @@ i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
         *read++ = i2c->RXDR;
     }
     i2c_wait(i2c, I2C_ISR_STOPF, timeout);
+}
+
+uint_fast8_t i2c_async(struct timer *timer)
+{
+    struct i2cdev_s *i2c = container_of(timer, struct i2cdev_s, timer);
+    struct i2c_config config = i2c->i2c_config;
+    if (i2c->data_len[1] & I2C_R) {
+        uint8_t reg_len = i2c->data_len[0];
+        uint8_t *reg = i2c->buf;
+        uint8_t read_len = i2c->data_len[1] & ~(I2C_R);
+        uint8_t *resp = &i2c->buf[reg_len];
+        i2c_read(config, reg_len, reg, read_len, resp);
+        for (int i = 0; i < reg_len; i++) {
+            i2c_buf_read_b(i2c);
+        }
+        i2c_cmd_done(i2c);
+        i2c->cur = i2c->tail + read_len;
+        timer->func = i2c->callback;
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    } else if (i2c->data_len[0]) {
+        uint8_t to_write = i2c->data_len[0];
+        uint8_t buf[to_write];
+        for (int i = 0; i < to_write; i++) {
+            buf[i] = i2c_buf_read_b(i2c);
+        }
+        i2c_write(config, to_write, buf);
+        i2c_cmd_done(i2c);
+        timer->waketime = timer_read_time() + timer_from_us(50);
+        return SF_RESCHEDULE;
+    }
+
+    i2c->flags &= ~IF_ACTIVE;
+    return SF_DONE;
 }


### PR DESCRIPTION
I'm not a hardcore embedded guy - I can have wrong assumptions or understanding here.

If I understood correctly.
For now, SPI/I2C is working in synchronous mode, which may shift other events in the scheduler queue.
I2C is slower in general because it is used with speeds: of 100kHz and 400kHz.
According to #6141, we can easily calculate timings, 5us per pulse, 18 pulses per byte + ack.
The average read request looks like 2 bytes write 6 byte read.
1 byte ~ 18 * 5 = 90 us
8 byte ~ 90 * 8 = 720 us

400kHz is 4x faster, so 22.5us and 180us with same load.
SPI is freaking fast, SW works as fast as pins go, HW looks like expected to run at 4Mhz.
So, 10 times faster, 1 pulse per bit ~ 0.25us.
0.25 * 8 = 2 us, scheduling per byte looks not so good here.

The toolhead moved at a speed of 200 mm/s, 40mm rotational distance and 32 micro steps should have 32us between steps:  `1 / ((200 / 40) * 200 * 32)) ~ 31.25 us`

Because i2c is blocking it will affect other timings occasionally.
It feels important to me to honor TSTEP timing for TMC because they are used for interpolation/thresholds (stealth/coolstep).
I cannot argue that those timings create interpolation position lag or that is a reason why switching stealth/spread modes is unstable.

Current implementation often blocks and waits for each byte (HW)/bit(SW) just wasting CPU time.
Those graphs when my machine is at a standstill:
Current implementation BME680 on host, SHT3x on mcu. *HW i2c decreased mcu load to ~5.6%
![image](https://github.com/user-attachments/assets/b5a6bd38-5f64-41af-a97f-54ea39d27f7a)
Current implementation with disabled i2c sensors.
![image](https://github.com/user-attachments/assets/0ba2fb53-3554-4813-a537-90d9c2c24c10)
Such a difference in load is unexpected for me. I can guess it is calculated from time drift.
Because the actual Awake time difference is in the expected range (less than 1%).

Patched async I2C (MCU software):
![image](https://github.com/user-attachments/assets/f111d47f-1fda-48f9-bcc3-63b7ef25739b)
mcu hw i2c bus:
![image](https://github.com/user-attachments/assets/5f2369e0-6f77-4e6f-83bb-8b6e7f3dfc55)
Host MCU pthread:
![image](https://github.com/user-attachments/assets/5fb4f613-818f-4780-908b-f8a0d4f80eb4)

---
Current master SW: `mcu_awake=0.006 mcu_task_avg=0.000013 mcu_task_stddev=0.000114`
Async I2C SW: `mcu: mcu_awake=0.001 mcu_task_avg=0.000001 mcu_task_stddev=0.000001`

---
![image](https://github.com/user-attachments/assets/71061f4a-6ac1-4990-9176-cc4daaccdf6c)
![image](https://github.com/user-attachments/assets/73e120c3-1761-41a8-b02d-03b484563871)

New I2C SW timings with default 100k.
It looks like 6-7 us per pulse originated to a safe way of switching.
https://github.com/Klipper3d/klipper/pull/6141#discussion_r1201492770

The transition between bytes is a little suboptimal.

---
![image](https://github.com/user-attachments/assets/2868f12c-8f33-4643-bc75-566e696851cd)
With bit time correction at 100kHz.
I was able to drive the bus around 500kHz, it looks like there is a limit on the GPIO toggle speed.

---
The main question is it worth it?
I tried different approaches, but for now, this is something more or less simple.

*Current i2c_read/write works as before.

The high-level Idea is to buffer klippy i2c requests and execute them in the background.
There is a new infrastructure defined around it.
Because i2c_read is currently used in different places, there is the possibility of defining a callback for i2c_async.
There is the ability to change ldc1612 and mpu9250, to use it with the nonblocking API.

Correct nonblocking HW i2c is written for stm32f0_i2c.c
Others I didn't touch for now, but I can also rewrite them - the event loop is the same.
Software i2c is tricky, I tried to not overcomplicate things and still emulate the bit-banging approach in tmcuart.c
(I unintentionally reinvented it somehow, with function overrides :D)

For now, the event loop is stored in each HW i2p implementation because it is easier to overcome specific restrictions, like:
- Linux HW i2s can only be made in one ioctl.
- AVR can be slow and such a thing will not work, so there count of jumps can be reduced.

This is not ready for merge.
TODO:
- ~~Make i2c_modify_bits async. There is Write-Read-Modify-Write cycle here.~~ - Done
- Write HW for other MCUs.
- i2c bus is shared, there is the possibility to send 2 async requests to the same bus - it will not work
- If there are decisions to get rid of old synchronous code here. I have a bad understanding of time measurements for i2c bulk data and how it will cooperate with async approach.
- ~~Does it make sense to have io pthread on Host MCU?~~ - that one reduce jitter
- ~~Commit mess should be fixed (I leave it for now as a history of thoughts).~~

---
MCU: Octopus Pro - stm32h723
Host: RPI 5