### PR TITLE
temperature_combined: Handle None in combined temp sensor values

### DIFF
--- a/klippy/extras/temperature_combined.py
+++ b/klippy/extras/temperature_combined.py
@@ -70,7 +70,8 @@ class PrinterSensorCombined:
         for sensor in self.sensors:
             sensor_status = sensor.get_status(eventtime)
             sensor_temperature = sensor_status['temperature']
-            values.append(sensor_temperature)
+            if sensor_temperature is not None:
+                values.append(sensor_temperature)
 
         # check if values are out of max_deviation range
         if (max(values) - min(values)) > self.max_deviation:


### PR DESCRIPTION
Improves `temperature_combined` so it handles undefined values (by ignoring them).

This allows `temperature_combined` to use for example the temps reported by tmc2240 stepper drivers, currently if these are included there is a crash on boot up.