### PR TITLE
Amend octoprint install instructions with `klippy.serial`

### DIFF
--- a/docs/OctoPrint.md
+++ b/docs/OctoPrint.md
@@ -52,12 +52,12 @@ Navigate to the Settings tab (the wrench icon at the top of the page).
 Under "Serial Connection" in "Additional serial ports" add:
 
 ```
-~/printer_data/comms/klippy.sock
+~/printer_data/comms/klippy.serial
 ```
+
 Then click "Save".
 
-_In some older setups this address may be `/tmp/printer`_
-
+_In some older setups this address may be `/tmp/printer`, depending on your setup, you may need to keep this line as well_
 
 Enter the Settings tab again and under "Serial Connection" change the "Serial Port"
 setting to the one added above.


### PR DESCRIPTION
The OctoPrint install instructions say 'add ~/printer_data/comms/klippy.sock' but it actually appears to be `~/printer_data/comms/klippy.serial`, so I have updated this.

I also seemed to have issues connecting without `/tmp/printer` in additional ports, so added more information on this.