### PR TITLE
tmc: Add `overvoltage_threshold` and `overtemperature_warning_threshold` for TMC2240

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3718,6 +3718,16 @@ run_current:
 #   velocity" threshold (THIGH) to. This is typically used to disable
 #   the "CoolStep" feature at high speeds. The default is to not set a
 #   TMC "high velocity" threshold.
+#overvoltage_threshold: 37.735
+#   The threshold voltage (in V) of overvoltage protection. The decelerating
+#   stepper motor can cause a raise of V_supply of the driver. When the V_supply
+#   is higher than overvoltage_threshold, the mosfet is turned on and dump the
+#   excess energy into the power resistor, keep the supply voltage below
+#   the threshold.
+#overtemperature_warning_threshold: 120.0
+#   The threshold temperature (in ℃) of the overtemperature warning.
+#   When the temperature of the driver is higher than this threshold,
+#   a warning will be reported.
 #driver_MSLUT0: 2863314260
 #driver_MSLUT1: 1251300522
 #driver_MSLUT2: 608774441

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -336,6 +336,34 @@ class TMC2240CurrentHelper:
         val = self.fields.set_field("irun", irun)
         self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
 
+######################################################################
+# TMC stepper overvoltage config helper
+######################################################################
+
+def TMC2240OvervoltageHelper(config, mcu_tmc):
+    fields = mcu_tmc.get_fields()
+    ov_thres = config.getfloat(
+        'overvoltage_threshold',
+        37.735, # 0xF25 by default
+        maxval = 40.0,
+    )
+    overvoltage_vth = int(ov_thres / 0.009732)
+    fields.set_field("overvoltage_vth", overvoltage_vth)
+
+######################################################################
+# TMC stepper overtemperature warning config helper
+######################################################################
+
+def TMC2240OvertemperatureWarningHelper(config, mcu_tmc):
+    fields = mcu_tmc.get_fields()
+    otw_thres = config.getfloat(
+        'overtemperature_warning_threshold',
+        120.0, # 0xB92 by default
+        maxval = 120.0,
+    )
+    overtempprewarning_vth = int((otw_thres * 7.7) + 2038)
+    fields.set_field("overtempprewarning_vth", overtempprewarning_vth)
+
 
 ######################################################################
 # TMC2240 printer object
@@ -357,6 +385,8 @@ class TMC2240:
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
         # Register commands
         current_helper = TMC2240CurrentHelper(config, self.mcu_tmc)
+        TMC2240OvervoltageHelper(config, self.mcu_tmc)
+        TMC2240OvertemperatureWarningHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters)
         self.get_phase_offset = cmdhelper.get_phase_offset


### PR DESCRIPTION
This PR adds `overvoltage_threshold` and `overtemperature_warning_threshold` to the config of tmc2240 driver.

## overvoltage_threshold
Accroding to tmc2240 datasheet:
> A stepper motor application can generate significant overvoltage, especially when the motor becomes quickly decelerated from a high velocity, or when the motor stalls 
To protect the driver as well as connected circuitry, the TMC2240 has an overvoltage detection and protection
mechanism.
The OV output allows attaching an NPN or MOSFET with a power resistor (brake resistor) to dump the excess energy
into the resistor.
The transistor chops with approximately 3kHz to 4kHz (depending on the clock frequency) to keep the supply within the limits.

By setting the `overvoltage_threshold` in config, we can determine the the threshold of the overvoltage detection of tmc2240 to adapt different supply voltage.

## overtemperature_warning_threshold
This config sets the threshold of overtemperature warning. When the temperature of tmc2240 reaches this threshold, a overtemperature warning will be reported.

## Example config
```
[tmc2240 stepper_x]
...
overvoltage_threshold: 13.0 
# 13V overvoltage threshold for a 12V system.

overtemperature_warning_threshold: 100
# When temperature reaches 100℃, a warning will be reported.
...
```

