### PR TITLE
Fix hx71x on python2

### DIFF
--- a/klippy/extras/ads1220.py
+++ b/klippy/extras/ads1220.py
@@ -24,7 +24,7 @@ def hexify(byte_array):
     return "[%s]" % (", ".join([hex(b) for b in byte_array]))
 
 
-class ADS1220():
+class ADS1220:
     def __init__(self, config):
         self.printer = printer = config.get_printer()
         self.name = config.get_name().split()[-1]

--- a/klippy/extras/hx71x.py
+++ b/klippy/extras/hx71x.py
@@ -14,7 +14,7 @@ SAMPLE_ERROR_DESYNC = -0x80000000
 SAMPLE_ERROR_LONG_READ = 0x40000000
 
 # Implementation of HX711 and HX717
-class HX71xBase():
+class HX71xBase:
     def __init__(self, config, sensor_type,
                  sample_rate_options, default_sample_rate,
                  gain_options, default_gain):
@@ -145,23 +145,21 @@ class HX71xBase():
                 'overflows': self.ffreader.get_last_overflows()}
 
 
-class HX711(HX71xBase):
-    def __init__(self, config):
-        super(HX711, self).__init__(config, "hx711",
-                                    # HX711 sps options
-                                    {80: 80, 10: 10}, 80,
-                                    # HX711 gain/channel options
-                                    {'A-128': 1, 'B-32': 2, 'A-64': 3}, 'A-128')
+def HX711(config):
+    return HX71xBase(config, "hx711",
+                     # HX711 sps options
+                     {80: 80, 10: 10}, 80,
+                     # HX711 gain/channel options
+                     {'A-128': 1, 'B-32': 2, 'A-64': 3}, 'A-128')
 
 
-class HX717(HX71xBase):
-    def __init__(self, config):
-        super(HX717, self).__init__(config, "hx717",
-                                    # HX717 sps options
-                                    {320: 320, 80: 80, 20: 20, 10: 10}, 320,
-                                    # HX717 gain/channel options
-                                    {'A-128': 1, 'B-64': 2, 'A-64': 3,
-                                     'B-8': 4}, 'A-128')
+def HX717(config):
+    return HX71xBase(config, "hx717",
+                     # HX717 sps options
+                     {320: 320, 80: 80, 20: 20, 10: 10}, 320,
+                     # HX717 gain/channel options
+                     {'A-128': 1, 'B-64': 2, 'A-64': 3,
+                      'B-8': 4}, 'A-128')
 
 
 HX71X_SENSOR_TYPES = {

--- a/test/klippy/load_cell.cfg
+++ b/test/klippy/load_cell.cfg
@@ -1,0 +1,23 @@
+# Test config for load_cell
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: none
+max_velocity: 300
+max_accel: 3000
+
+[load_cell my_ads1220]
+sensor_type: ads1220
+cs_pin: PA0
+data_ready_pin: PA1
+
+[load_cell my_hx711]
+sensor_type: hx711
+sclk_pin: PA2
+dout_pin: PA3
+
+[load_cell my_hx717]
+sensor_type: hx717
+sclk_pin: PA4
+dout_pin: PA5

--- a/test/klippy/load_cell.test
+++ b/test/klippy/load_cell.test
@@ -1,0 +1,5 @@
+# Tests for loadcell sensors
+DICTIONARY atmega2560.dict
+CONFIG load_cell.cfg
+
+G4 P1000


### PR DESCRIPTION
This minor code change should fix the hx71x support on python2 installations.  It also adds a load_cell regression test case.

@garethky , @alchemyEngine - fyi.

-Kevin