### PR TITLE
Add spi0e bus for rp2040, used on pitb v2 by fysetc

### DIFF
--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -11,6 +11,26 @@
 #include "hardware/structs/spi.h" // spi_hw_t
 #include "hardware/regs/resets.h" // RESETS_RESET_SPI*_BITS
 
+
+DECL_ENUMERATION("spi_bus", "spi0_gpio0_gpio3_gpio2", 0);
+DECL_CONSTANT_STR("BUS_PINS_spi0_gpio0_gpio3_gpio2", "gpio0,gpio3,gpio2");
+DECL_ENUMERATION("spi_bus", "spi0_gpio4_gpio7_gpio6", 1);
+DECL_CONSTANT_STR("BUS_PINS_spi0_gpio4_gpio7_gpio6", "gpio4,gpio7,gpio6");
+DECL_ENUMERATION("spi_bus", "spi0_gpio16_gpio19_gpio18", 2);
+DECL_CONSTANT_STR("BUS_PINS_spi0_gpio16_gpio19_gpio18", "gpio16,gpio19,gpio18");
+DECL_ENUMERATION("spi_bus", "spi0_gpio20_gpio23_gpio22", 3);
+DECL_CONSTANT_STR("BUS_PINS_spi0_gpio20_gpio23_gpio22", "gpio20,gpio23,gpio22");
+DECL_ENUMERATION("spi_bus", "spi0_gpio4_gpio3_gpio2", 4);
+DECL_CONSTANT_STR("BUS_PINS_spi0_gpio4_gpio3_gpio2", "gpio4,gpio3,gpio2");
+
+DECL_ENUMERATION("spi_bus", "spi1_gpio8_gpio11_gpio10", 5);
+DECL_CONSTANT_STR("BUS_PINS_spi1_gpio8_gpio11_gpio10", "gpio8,gpio11,gpio10");
+DECL_ENUMERATION("spi_bus", "spi1_gpio12_gpio15_gpio14", 6);
+DECL_CONSTANT_STR("BUS_PINS_spi1_gpio12_gpio15_gpio14", "gpio12,gpio15,gpio14");
+DECL_ENUMERATION("spi_bus", "spi1_gpio24_gpio27_gpio26", 7);
+DECL_CONSTANT_STR("BUS_PINS_spi1_gpio24_gpio27_gpio26", "gpio24,gpio27,gpio26");
+
+//Deprecated "spi0a" style mappings
 DECL_ENUMERATION("spi_bus", "spi0a", 0);
 DECL_CONSTANT_STR("BUS_PINS_spi0a", "gpio0,gpio3,gpio2");
 DECL_ENUMERATION("spi_bus", "spi0b", 1);
@@ -20,11 +40,11 @@ DECL_CONSTANT_STR("BUS_PINS_spi0c", "gpio16,gpio19,gpio18");
 DECL_ENUMERATION("spi_bus", "spi0d", 3);
 DECL_CONSTANT_STR("BUS_PINS_spi0d", "gpio20,gpio23,gpio22");
 
-DECL_ENUMERATION("spi_bus", "spi1a", 4);
+DECL_ENUMERATION("spi_bus", "spi1a", 5);
 DECL_CONSTANT_STR("BUS_PINS_spi1a", "gpio8,gpio11,gpio10");
-DECL_ENUMERATION("spi_bus", "spi1b", 5);
+DECL_ENUMERATION("spi_bus", "spi1b", 6);
 DECL_CONSTANT_STR("BUS_PINS_spi1b", "gpio12,gpio15,gpio14");
-DECL_ENUMERATION("spi_bus", "spi1c", 6);
+DECL_ENUMERATION("spi_bus", "spi1c", 7);
 DECL_CONSTANT_STR("BUS_PINS_spi1c", "gpio24,gpio27,gpio26");
 
 struct spi_info {
@@ -38,6 +58,7 @@ static const struct spi_info spi_bus[] = {
     {spi0_hw, 4,  7,  6,  RESETS_RESET_SPI0_BITS},
     {spi0_hw, 16, 19, 18, RESETS_RESET_SPI0_BITS},
     {spi0_hw, 20, 23, 22, RESETS_RESET_SPI0_BITS},
+    {spi0_hw, 4,  3,  2,  RESETS_RESET_SPI0_BITS},
 
     {spi1_hw, 8,  11, 10, RESETS_RESET_SPI1_BITS},
     {spi1_hw, 12, 15, 14, RESETS_RESET_SPI1_BITS},


### PR DESCRIPTION
I purchased the fysetc PITB v2 board, which is not functioning via software spi, and I'm not 100% sure why.  

The issue with hardware spi, is that this board is wired such that:
SCK: gpio2
MOSI: gpio3
MISO: gpio4

however, the spi0 configuration currently in the klipper codebase, only allows an spi permutation of:
SCK: 2
MOSI: 3
MISO: 0

However, that said, I've seen a few cases around the internet in troubleshooting this, that show people using the rp2040 spi bus configured this way, as well as the PITB v2 board.  The rp2040 datasheet (page 13: [here](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf)) shows it as a supported configuration, so I added spi0e as an option, and everything now started up and works.   

I'd almost suggest perhaps a more configurable way of managing these spi buses for this chip, as many gpio can be used for spi0 for example, but I'm not familiar enough with the klipper code to realize it. This solved my immediate issue so I offer it up for the masses to accept or not :)

Once this is done, the config looks like this for that board:
```
[stepper_x]
step_pin: PITB:gpio6
dir_pin: PITB:gpio5
enable_pin: !PITB:gpio20
rotation_distance: 40
microsteps: 16
full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
endstop_pin: EBB:PB8
position_min: 0
position_endstop: 350
position_max: 350
homing_speed: 25   #Max 100
homing_retract_dist: 5
homing_positive_dir: true

[tmc5160 stepper_x]
spi_bus: spi0e
cs_pin: PITB:gpio1
interpolate: False
diag1_pin: PITB:gpio7
run_current: 0.800 

[stepper_y]
step_pin: PITB:gpio13
dir_pin: PITB:gpio23
enable_pin: !PITB:gpio22
rotation_distance: 40
microsteps: 16
full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
endstop_pin: PG6
position_min: 0
position_endstop: 350
position_max: 350
homing_speed: 25  #Max 100
homing_retract_dist: 5
homing_positive_dir: true

[tmc5160 stepper_y] 
spi_bus: spi0e
cs_pin: PITB:gpio21
diag1_pin: PITB:^gpio14
interpolate: False
run_current: 0.8

```