### PR TITLE
Update generic-creality-v4.2.7.cfg

### DIFF
--- a/config/generic-creality-v4.2.7.cfg
+++ b/config/generic-creality-v4.2.7.cfg
@@ -16,8 +16,8 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
-step_pin: PB9
-dir_pin: PC2
+step_pin: PC2
+dir_pin: PB9
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
@@ -27,8 +27,8 @@ position_max: 235
 homing_speed: 50
 
 [stepper_y]
-step_pin: PB7
-dir_pin: PB8
+step_pin: PB8
+dir_pin: PB7
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 40
@@ -38,8 +38,8 @@ position_max: 235
 homing_speed: 50
 
 [stepper_z]
-step_pin: PB5
-dir_pin: !PB6
+step_pin: PB6
+dir_pin: !PB5
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 8
@@ -49,8 +49,8 @@ position_max: 250
 
 [extruder]
 max_extrude_only_distance: 100.0
-step_pin: PB3
-dir_pin: PB4
+step_pin: PB4
+dir_pin: PB3
 enable_pin: !PC3
 microsteps: 16
 rotation_distance: 33.500


### PR DESCRIPTION
Corrected pinoutss for the 4 stepper motor on the 4.2.7 board. The correct ones can also be found on the klipper/config/printer-creality-ender3-v2-neo-2022.cfg

I am using this on my v4.2.7 board . 
The step_pin and dir_pin are are inverted in the original. 
Thanks to whoever looks these over. 
Louis