### PR TITLE
STM32: Check for NACK

### DIFF
--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -97,6 +97,8 @@ i2c_wait(I2C_TypeDef *i2c, uint32_t set, uint32_t clear, uint32_t timeout)
         uint32_t sr1 = i2c->SR1;
         if ((sr1 & set) == set && (sr1 & clear) == 0)
             return sr1;
+        if (sr1 & I2C_SR1_AF)
+            shutdown("I2C NACK error encountered");
         if (!timer_is_before(timer_read_time(), timeout))
             shutdown("i2c timeout");
     }

--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -166,6 +166,8 @@ i2c_wait(I2C_TypeDef *i2c, uint32_t set, uint32_t timeout)
         uint32_t isr = i2c->ISR;
         if (isr & set)
             return isr;
+        if (isr & I2C_ISR_NACKF)
+            shutdown("I2C NACK error encountered");
         if (!timer_is_before(timer_read_time(), timeout))
             shutdown("i2c timeout");
     }


### PR DESCRIPTION
stm32f0_i2c - tested.
stm32/i2c - I do not have.

Currently, HW I2C ignores NACK bit in any case.
Valid case when this is the end of the transfer.
With this change, it will correctly report NACK instead of an empty read or timeout.

reproduce:
```
def _init_sht3x(self):
        ....
        logging.warning("sht3x: start read with stretching")
        self.i2c.i2c_read(SHT3X_CMD['MEASURE']['STRETCH_ENABLED']['HIGH_REP'], 6)
        logging.warning("sht3x: stop read with stretching")
        logging.warning("sht3x: start read without stretching")
        self.i2c.i2c_read(SHT3X_CMD['MEASURE']['STRETCH_DISABLED']['HIGH_REP'], 6)
        logging.warning("sht3x: stop read without stretching")
```

Output with patch:
```
Configured MCU 'host' (1024 moves)
sht3x: start read with stretching
sht3x: stop read with stretching
sht3x: start read without stretching
Transition to shutdown state: MCU shutdown
Dumping 7 requests for client 140733793436160
 .....
MCU 'mcu' shutdown: I2C NACK error encountered!
 .....
Printer is shutdown
```

Thanks.

---
#6674