### PR TITLE
stm32f0/i2c.c: calculate correct bus frequency

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5001,8 +5001,9 @@ Most Klipper micro-controller implementations only support an
 micro-controller supports a 400000 speed (*fast mode*, 400kbit/s), but it must be
 [set in the operating system](RPi_microcontroller.md#optional-enabling-i2c)
 and the `i2c_speed` parameter is otherwise ignored. The Klipper
-"RP2040" micro-controller and ATmega AVR family support a rate of 400000
-via the `i2c_speed` parameter. All other Klipper micro-controllers use a
+"RP2040" micro-controller and ATmega AVR family and some STM32
+(F0, G0, G4, L4, F7, H7) support a rate of 400000 via the `i2c_speed` parameter.
+All other Klipper micro-controllers use a
 100000 rate and ignore the `i2c_speed` parameter.
 
 ```

--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -153,6 +153,13 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         uint32_t sclh = 32; // 32 * 125ns = 4us
         uint32_t sdadel = 4; // 4 * 125ns = 500ns
         uint32_t scldel = 10; // 10 * 125ns = 1250ns
+        // Clamp the rate to 400Khz
+        if (rate >= 400000) {
+            scll = 10; // 10 * 125ns = 1250ns
+            sclh = 4; // 4 * 125 = 500ns
+            sdadel = 3; // 3 * 125 = 375ns
+            scldel = 4; // 4 * 125 = 500ns
+        }
 
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
         uint32_t presc = DIV_ROUND_UP(pclk, nom_i2c_clock);


### PR DESCRIPTION
Right now i2c frequency is hardcoded, I think for stm32f0.
STM32f0 pclk is 48Mhz.
My STM32H7 has 400Mhz -> 100Mhz pclk.
it runs faster at around 200kHz
https://klipper.discourse.group/t/stm32h7-wrong-i2c-timings-200khz/18676
```
>>> 44 / 9
4.88
>>> 1 / 0.0000048
208333.33
>>> 208333.33 / 100 * 48
99999.99
```

I added some actual timing calculations, but I can't get them precise.
100kHz, 1 / 0.0000085= 117647 
![stm32-freq-100kHz](https://github.com/user-attachments/assets/64b489c2-0b34-4f12-aabe-405717506014)

400kHz, 1 / 0.0000025 = 400000
![stm32-freq-400kHz](https://github.com/user-attachments/assets/313c9ca8-1150-4369-959a-ba6a5903b833)

1000kHz, 1 / 0.0000013 = 769230
![stm32-freq-1Mhz](https://github.com/user-attachments/assets/14354614-af0f-41a1-a1e6-3847bcb40a15)

This is as close, as I can get to target values.