### PR TITLE
Add support for output_pin and fan templates

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -476,6 +476,20 @@ enabled.
 `SET_FAN_SPEED FAN=config_name SPEED=<speed>` This command sets the
 speed of a fan. "speed" must be between 0.0 and 1.0.
 
+`SET_FAN_SPEED PIN=config_name TEMPLATE=<template_name>
+[<param_x>=<literal>]`: If `TEMPLATE` is specified then it assigns a
+[display_template](Config_Reference.md#display_template) to the given
+fan. For example, if one defined a `[display_template
+my_fan_template]` config section then one could assign
+`TEMPLATE=my_fan_template` here. The display_template should produce a
+string containing a floating point number with the desired value. The
+template will be continuously evaluated and the fan will be
+automatically set to the resulting speed. One may set display_template
+parameters to use during template evaluation (parameters will be
+parsed as Python literals). If TEMPLATE is an empty string then this
+command will clear any previous template assigned to the pin (one can
+then use `SET_FAN_SPEED` commands to manage the values directly).
+
 ### [filament_switch_sensor]
 
 The following command is available when a

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -857,6 +857,20 @@ output `VALUE`. VALUE should be 0 or 1 for "digital" output pins. For
 PWM pins, set to a value between 0.0 and 1.0, or between 0.0 and
 `scale` if a scale is configured in the output_pin config section.
 
+`SET_PIN PIN=config_name TEMPLATE=<template_name> [<param_x>=<literal>]`:
+If `TEMPLATE` is specified then it assigns a
+[display_template](Config_Reference.md#display_template) to the given
+pin. For example, if one defined a `[display_template
+my_pin_template]` config section then one could assign
+`TEMPLATE=my_pin_template` here. The display_template should produce a
+string containing a floating point number with the desired value. The
+template will be continuously evaluated and the pin will be
+automatically set to the resulting value. One may set display_template
+parameters to use during template evaluation (parameters will be
+parsed as Python literals). If TEMPLATE is an empty string then this
+command will clear any previous template assigned to the pin (one can
+then use `SET_PIN` commands to manage the values directly).
+
 ### [palette2]
 
 The following commands are available when the

--- a/klippy/extras/controller_fan.py
+++ b/klippy/extras/controller_fan.py
@@ -62,9 +62,7 @@ class ControllerFan:
             self.last_on += 1
         if speed != self.last_speed:
             self.last_speed = speed
-            curtime = self.printer.get_reactor().monotonic()
-            print_time = self.fan.get_mcu().estimated_print_time(curtime)
-            self.fan.set_speed(print_time + PIN_MIN_TIME, speed)
+            self.fan.set_speed(speed)
         return eventtime + 1.
 
 def load_config_prefix(config):

--- a/klippy/extras/dotstar.py
+++ b/klippy/extras/dotstar.py
@@ -1,9 +1,9 @@
 # Support for "dotstar" leds
 #
-# Copyright (C) 2019-2022  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import bus
+from . import bus, led
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
@@ -22,9 +22,8 @@ class PrinterDotstar:
         self.spi = bus.MCU_SPI(mcu, None, None, 0, 500000, sw_spi_pins)
         # Initialize color data
         self.chain_count = config.getint('chain_count', 1, minval=1)
-        pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds,
-                                            self.chain_count)
+        self.led_helper = led.LEDHelper(config, self.update_leds,
+                                        self.chain_count)
         self.prev_data = None
         # Register commands
         printer.register_event_handler("klippy:connect", self.handle_connect)

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -67,7 +67,7 @@ class Fan:
         self.last_fan_value = self.last_req_value = value
         self.mcu_fan.set_pwm(print_time, value)
     def set_speed(self, print_time, value):
-        self.gcrq.send_async_request(print_time, value)
+        self.gcrq.send_async_request(value, print_time)
     def set_speed_from_command(self, value):
         self.gcrq.queue_gcode_request(value)
     def _handle_request_restart(self, print_time):

--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -66,7 +66,7 @@ class Fan:
             return "delay", self.kick_start_time
         self.last_fan_value = self.last_req_value = value
         self.mcu_fan.set_pwm(print_time, value)
-    def set_speed(self, print_time, value):
+    def set_speed(self, value, print_time=None):
         self.gcrq.send_async_request(value, print_time)
     def set_speed_from_command(self, value):
         self.gcrq.queue_gcode_request(value)

--- a/klippy/extras/fan_generic.py
+++ b/klippy/extras/fan_generic.py
@@ -1,9 +1,9 @@
 # Support fans that are controlled by gcode
 #
-# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import fan
+from . import fan, output_pin
 
 class PrinterFanGeneric:
     cmd_SET_FAN_SPEED_help = "Sets the speed of a fan"
@@ -11,6 +11,9 @@ class PrinterFanGeneric:
         self.printer = config.get_printer()
         self.fan = fan.Fan(config, default_shutdown_speed=0.)
         self.fan_name = config.get_name().split()[-1]
+
+        # Template handling
+        self.template_eval = output_pin.lookup_template_eval(config)
 
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("SET_FAN_SPEED", "FAN",
@@ -20,8 +23,21 @@ class PrinterFanGeneric:
 
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)
+    def _template_update(self, text):
+        try:
+            value = float(text)
+        except ValueError as e:
+            logging.exception("fan_generic template render error")
+        self.fan.set_speed(value)
     def cmd_SET_FAN_SPEED(self, gcmd):
-        speed = gcmd.get_float('SPEED', 0.)
+        speed = gcmd.get_float('SPEED', None, 0.)
+        template = gcmd.get('TEMPLATE', None)
+        if (speed is None) == (template is None):
+            raise gcmd.error("SET_FAN_SPEED must specify SPEED or TEMPLATE")
+        # Check for template setting
+        if template is not None:
+            self.template_eval.set_template(gcmd, self._template_update)
+            return
         self.fan.set_speed_from_command(speed)
 
 def load_config_prefix(config):

--- a/klippy/extras/heater_fan.py
+++ b/klippy/extras/heater_fan.py
@@ -33,9 +33,7 @@ class PrinterHeaterFan:
                 speed = self.fan_speed
         if speed != self.last_speed:
             self.last_speed = speed
-            curtime = self.printer.get_reactor().monotonic()
-            print_time = self.fan.get_mcu().estimated_print_time(curtime)
-            self.fan.set_speed(print_time + PIN_MIN_TIME, speed)
+            self.fan.set_speed(speed)
         return eventtime + 1.
 
 def load_config_prefix(config):

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -3,11 +3,8 @@
 # Copyright (C) 2019-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, ast
-from .display import display
-
-# Time between each led template update
-RENDER_TIME = 0.500
+import logging
+from . import output_pin
 
 # Helper code for common LED initialization and control
 class LEDHelper:
@@ -23,7 +20,7 @@ class LEDHelper:
         white = config.getfloat('initial_WHITE', 0., minval=0., maxval=1.)
         self.led_state = [(red, green, blue, white)] * led_count
         # Support setting an led template
-        self.template_eval = lookup_template_eval(config)
+        self.template_eval = output_pin.lookup_template_eval(config)
         self.tcallbacks = [(lambda text, s=self, index=i:
                             s._template_update(index, text))
                            for i in range(led_count)]
@@ -99,94 +96,6 @@ class LEDHelper:
         else:
             for i in range(self.led_count):
                 set_template(gcmd, self.tcallbacks[i], self._check_transmit)
-
-# Main template evaluation code
-class PrinterTemplateEvaluator:
-    def __init__(self, config):
-        self.printer = config.get_printer()
-        self.active_templates = {}
-        self.render_timer = None
-        # Load templates
-        dtemplates = display.lookup_display_templates(config)
-        self.templates = dtemplates.get_display_templates()
-        gcode_macro = self.printer.load_object(config, "gcode_macro")
-        self.create_template_context = gcode_macro.create_template_context
-    def _activate_timer(self):
-        if self.render_timer is not None or not self.active_templates:
-            return
-        reactor = self.printer.get_reactor()
-        self.render_timer = reactor.register_timer(self._render, reactor.NOW)
-    def _activate_template(self, callback, template, lparams, flush_callback):
-        if template is not None:
-            uid = (template,) + tuple(sorted(lparams.items()))
-            self.active_templates[callback] = (
-                uid, template, lparams, flush_callback)
-            return
-        if callback in self.active_templates:
-            del self.active_templates[callback]
-    def _render(self, eventtime):
-        if not self.active_templates:
-            # Nothing to do - unregister timer
-            reactor = self.printer.get_reactor()
-            reactor.unregister_timer(self.render_timer)
-            self.render_timer = None
-            return reactor.NEVER
-        # Setup gcode_macro template context
-        context = self.create_template_context(eventtime)
-        def render(name, **kwargs):
-            return self.templates[name].render(context, **kwargs)
-        context['render'] = render
-        # Render all templates
-        flush_callbacks = {}
-        rendered = {}
-        template_info = self.active_templates.items()
-        for callback, (uid, template, lparams, flush_callback) in template_info:
-            text = rendered.get(uid)
-            if text is None:
-                try:
-                    text = template.render(context, **lparams)
-                except Exception as e:
-                    logging.exception("display template render error")
-                    text = ""
-                rendered[uid] = text
-            if flush_callback is not None:
-                flush_callbacks[flush_callback] = 1
-            callback(text)
-        context.clear() # Remove circular references for better gc
-        # Invoke optional flush callbacks
-        for flush_callback in flush_callbacks.keys():
-            flush_callback()
-        return eventtime + RENDER_TIME
-    def set_template(self, gcmd, callback, flush_callback=None):
-        template = None
-        lparams = {}
-        tpl_name = gcmd.get("TEMPLATE")
-        if tpl_name:
-            template = self.templates.get(tpl_name)
-            if template is None:
-                raise gcmd.error("Unknown display_template '%s'" % (tpl_name,))
-            tparams = template.get_params()
-            for p, v in gcmd.get_command_parameters().items():
-                if not p.startswith("PARAM_"):
-                    continue
-                p = p.lower()
-                if p not in tparams:
-                    raise gcmd.error("Invalid display_template parameter: %s"
-                                     % (p,))
-                try:
-                    lparams[p] = ast.literal_eval(v)
-                except ValueError as e:
-                    raise gcmd.error("Unable to parse '%s' as a literal" % (v,))
-        self._activate_template(callback, template, lparams, flush_callback)
-        self._activate_timer()
-
-def lookup_template_eval(config):
-    printer = config.get_printer()
-    te = printer.lookup_object("template_evaluator", None)
-    if te is None:
-        te = PrinterTemplateEvaluator(config)
-        printer.add_object("template_evaluator", te)
-    return te
 
 PIN_MIN_TIME = 0.100
 MAX_SCHEDULE_TIME = 5.0

--- a/klippy/extras/neopixel.py
+++ b/klippy/extras/neopixel.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
+from . import led
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
@@ -40,9 +41,7 @@ class PrinterNeoPixel:
         if len(self.color_map) > MAX_MCU_SIZE:
             raise config.error("neopixel chain too long")
         # Initialize color data
-        pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds,
-                                            chain_count)
+        self.led_helper = led.LEDHelper(config, self.update_leds, chain_count)
         self.color_data = bytearray(len(self.color_map))
         self.update_color_data(self.led_helper.get_status()['color_data'])
         self.old_color_data = bytearray([d ^ 1 for d in self.color_data])

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-from . import bus
+from . import bus, led
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
@@ -16,8 +16,7 @@ class PCA9533:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
-        pled = self.printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds, 1)
+        self.led_helper = led.LEDHelper(config, self.update_leds, 1)
         self.i2c.i2c_write([PCA9533_PWM0, 85])
         self.i2c.i2c_write([PCA9533_PWM1, 170])
         self.update_leds(self.led_helper.get_status()['color_data'], None)

--- a/klippy/extras/pca9632.py
+++ b/klippy/extras/pca9632.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022  Ricardo Alcantara <ricardo@vulcanolabs.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import bus, mcp4018
+from . import bus, led, mcp4018
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
@@ -34,8 +34,7 @@ class PCA9632:
             raise config.error("Invalid color_order '%s'" % (color_order,))
         self.color_map = ["RGBW".index(c) for c in color_order]
         self.prev_regs = {}
-        pled = printer.load_object(config, "led")
-        self.led_helper = pled.setup_helper(config, self.update_leds, 1)
+        self.led_helper = led.LEDHelper(config, self.update_leds, 1)
         printer.register_event_handler("klippy:connect", self.handle_connect)
     def reg_write(self, reg, val, minclock=0):
         if self.prev_regs.get(reg) == val:

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -46,7 +46,7 @@ class TemperatureFan:
             self.cmd_SET_TEMPERATURE_FAN_TARGET,
             desc=self.cmd_SET_TEMPERATURE_FAN_TARGET_help)
 
-    def set_speed(self, read_time, value):
+    def set_tf_speed(self, read_time, value):
         if value <= 0.:
             value = 0.
         elif value < self.min_speed:
@@ -60,7 +60,7 @@ class TemperatureFan:
         speed_time = read_time + self.speed_delay
         self.next_speed_time = speed_time + 0.75 * MAX_FAN_TIME
         self.last_speed_value = value
-        self.fan.set_speed(speed_time, value)
+        self.fan.set_speed(value, speed_time)
     def temperature_callback(self, read_time, temp):
         self.last_temp = temp
         self.control.temperature_callback(read_time, temp)
@@ -128,10 +128,10 @@ class ControlBangBang:
               and temp <= target_temp-self.max_delta):
             self.heating = True
         if self.heating:
-            self.temperature_fan.set_speed(read_time, 0.)
+            self.temperature_fan.set_tf_speed(read_time, 0.)
         else:
-            self.temperature_fan.set_speed(read_time,
-                                           self.temperature_fan.get_max_speed())
+            self.temperature_fan.set_tf_speed(
+                read_time, self.temperature_fan.get_max_speed())
 
 ######################################################################
 # Proportional Integral Derivative (PID) control algo
@@ -171,7 +171,7 @@ class ControlPID:
         # Calculate output
         co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
         bounded_co = max(0., min(self.temperature_fan.get_max_speed(), co))
-        self.temperature_fan.set_speed(
+        self.temperature_fan.set_tf_speed(
             read_time, max(self.temperature_fan.get_min_speed(),
                            self.temperature_fan.get_max_speed() - bounded_co))
         # Store state for next measurement


### PR DESCRIPTION
This PR adds support for specifying a math formula for output_pin and fan_generic objects.  This works similarly to the "led template" support - one can specify a `[display_template my_template]` config section that contains a Jinja2 macro providing a formula, and that formula will then be evaluated periodically to determine the pin/fan setting to apply.

The settings from the formula do not pass through the g-code command queue, so the updates are applied even during homing and other long running commands.

This should make it possible to define more flexible pin and fan control schemes.

-Kevin