### PR TITLE
Add support of S parameter to Dwell command (G4)

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -7,7 +7,7 @@ commands that one may enter into the OctoPrint terminal tab.
 
 Klipper supports the following standard G-Code commands:
 - Move (G0 or G1): `G1 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>] [F<speed>]`
-- Dwell: `G4 P<milliseconds>`
+- Dwell: `G4 P<milliseconds>` or  `G4 S<seconds>`
 - Move to origin: `G28 [X] [Y] [Z]`
 - Turn off motors: `M18` or `M84`
 - Wait for current moves to finish: `M400`

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -610,7 +610,10 @@ class ToolHead:
         self.max_accel_to_decel = self.max_accel * (1. - self.min_cruise_ratio)
     def cmd_G4(self, gcmd):
         # Dwell
-        delay = gcmd.get_float('P', 0., minval=0.) / 1000.
+        if 'S' in gcmd.get_command_parameters():
+            delay = gcmd.get_float('S', 0., minval=0.)
+        else:
+            delay = gcmd.get_float('P', 0., minval=0.) / 1000.
         self.dwell(delay)
     def cmd_M400(self, gcmd):
         # Wait for current moves to finish


### PR DESCRIPTION
Add support of G4 S< seconds >

Inspired by https://github.com/Klipper3d/klipper/issues/6641

Signed-off-by: Michael Jäger michael@mjaeger.eu