### PR TITLE
Update ender 3 v2 re: GD32F303 variants.

### DIFF
--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -3,6 +3,12 @@
 # STM32F103 with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.
 
+# It should be noted that newer variations of this printer shipping in
+# 2022 may have GD32F303 chips installed and not STM32F103. You may
+# have to inspect the mainboard to ascertain which one you have. If it
+# is the GD32F303 then please select Disable SWD at startup in the
+# "make menuconfig" along with the same settings for STM32F103.
+
 # If you prefer a direct serial connection, in "make menuconfig"
 # select "Enable extra low-level configuration options" and select
 # serial (on USART3 PB11/PB10), which is broken out on the 10 pin IDC


### PR DESCRIPTION
Ender started shipping GD32F303 based mainboards sometime in 2022. These require "Disable SWD at startup" to be toggled. This PR adds a note regarding this setting. The note is lifted from the ender3pro-2020 config file, but I changed GD32F**1**03 to GD32F**3**03 as I believe this is the chip used in these models. 