### PR TITLE
config: Lulzbot TAZ5 config, and TAZ6 and RAMBo config improvements

### DIFF
--- a/config/generic-rambo.cfg
+++ b/config/generic-rambo.cfg
@@ -78,6 +78,10 @@ pin: PH5
 #[heater_fan heatbreak_cooling_fan]
 #pin: PH3
 
+#[controller_fan controller_fan]
+#RAMBo labels this "FAN-2", and it is often used as the chassis fan.
+#pin: PE4
+
 [mcu]
 serial: /dev/ttyACM0
 

--- a/config/printer-lulzbot-taz5-dual-v3-2015.cfg
+++ b/config/printer-lulzbot-taz5-dual-v3-2015.cfg
@@ -1,0 +1,259 @@
+#This file contains pin mappings for the Lulzbot TAZ 5 circa 2015 using RAMBo and Dual v3 toolhead.
+#To use this config, the firmware should be compiled for the AVR atmega2560.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+#-------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------------
+# LULZBOT TAZ5 (RAMBo) with Dual v3 Extruder Master Config
+#-------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------------
+#Notes:
+# - The START_PRINT gcode macro uses parameters that should be passed from the slicer, although
+#   it has some reasonable defaults that might work for PLA.
+#
+# - Pressure Advance feature has been disabled and should be tuned if enabled.
+#
+# - All PID values pulled from Lulzbot Marlin 1.1.9.34, however, the PID calibration procedure
+#   should be done to tune these values to your specific hardware.
+#
+#-------------------------------------------------------------------------------------------------
+# LULZBOT TAZ5 Dual v3 Required Parameters
+#-------------------------------------------------------------------------------------------------
+[stepper_x]
+step_pin: PC0
+dir_pin: PL1
+enable_pin: !PA7
+microsteps: 16
+rotation_distance: 32
+endstop_pin: ^!PB6
+position_endstop: -17
+position_min: -17
+position_max: 265
+homing_speed: 50
+second_homing_speed: 5
+
+[stepper_y]
+step_pin: PC1
+dir_pin: !PL0
+enable_pin: !PA6
+microsteps: 16
+rotation_distance: 32
+endstop_pin: ^!PB5
+position_endstop: -10
+position_min: -10
+position_max: 306
+homing_speed: 50
+second_homing_speed: 5
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+enable_pin: !PA5
+microsteps: 16
+rotation_distance: 2
+endstop_pin: ^!PB4
+position_endstop: 0
+position_min: -2.0
+position_max: 270
+homing_speed: 10
+second_homing_speed: 1
+
+[extruder]
+# This is Extruder0 on the dual v3 (all -1 index in schematic)
+# The Dual v3 uses the same temp sensor as the single extruder
+# The Dual v3 uses 2x SOMEstruders with modified PID values
+step_pin: PC4
+dir_pin: !PL7
+enable_pin: !PA3
+microsteps: 16
+rotation_distance: 4.211
+nozzle_diameter: 0.500
+filament_diameter: 2.850
+heater_pin: PH4
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF1
+control: pid
+pid_Kp: 47.45
+pid_Ki: 4.83
+pid_Kd: 116.63
+min_temp: 0
+max_temp: 300
+min_extrude_temp: 120
+
+[extruder1]
+# This is Extruder1 on the dual v3 (all -0 index in schematic)
+# The Dual v3 uses the same temp sensor as the single extruder
+# The Dual v3 uses 2x SOMEstruders with modified PID values
+step_pin: PC3
+dir_pin: PL6
+enable_pin: !PA4
+microsteps: 16
+rotation_distance: 4.211
+nozzle_diameter: 0.500
+filament_diameter: 2.850
+heater_pin: PH6
+sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF0
+control: pid
+pid_Kp: 47.45
+pid_Ki: 4.83
+pid_Kd: 116.63
+min_temp: 0
+max_temp: 300
+min_extrude_temp: 120
+
+[heater_bed]
+#The Heater Bed uses Honeywell 100K 135-104LAG-J01 temp sensor and PID control
+heater_pin: PE5
+sensor_type: Honeywell 100K 135-104LAG-J01
+sensor_pin: PF2
+control: pid
+pid_Kp: 162.0
+pid_Ki: 17.0
+pid_Kd: 378.0
+min_temp: 0
+max_temp: 130
+
+[fan]
+#On Dual v3 heat break fan is connected to PH3 (part cooling fan on single extruder)
+pin: PH3
+
+[controller_fan controller_fan]
+pin: PE4
+
+[heater_fan heatbreak_cooling_fan]
+#On Dual v3 part fans are connected to PH5 (heat break fan on single extruder)
+pin: PH5
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 2
+max_z_accel: 10
+
+[ad5206 stepper_digipot]
+enable_pin: PD7
+# This scale value makes Lulzbot's intended amperage values align with
+# the register values they configured in Marlin and the comments in Marlin's
+# RAMBo board header.  That said, I can't work it out from the schematic and
+# datasheets,  but hey, I'm not an EE.
+scale: 1.35
+# Channel 1 is E0, 2 is E1, 3 is unused, 4 is Z, 5 is X, 6 is Y
+# Values taken from Marlin.
+channel_1: 0.75
+channel_2: 0.75
+channel_4: 1.275
+channel_5: 0.95
+channel_6: 0.95
+
+[static_digital_output stepper_config]
+# Enable 16 micro-steps on steppers X, Y, Z, E0, E1
+pins:
+    PG1, PG0,
+    PK7, PG2,
+    PK6, PK5,
+    PK3, PK4,
+    PK1, PK2
+
+[static_digital_output yellow_led]
+pins: !PB7
+
+[display]
+lcd_type: st7920
+cs_pin: PG4
+sclk_pin: PJ2
+sid_pin: PG3
+encoder_pins: ^PJ6,^PJ5
+click_pin: ^!PE2
+menu_timeout:5
+
+[bed_screws]
+# The Dual Extruder is super bulky, this is the best we can get at the corner
+# leveling screws with a normal allen key.  The back left is still pretty
+# inaccessible.
+screw1: 0, 0
+screw2: 252, 0
+screw3: 0, 255
+screw4: 230, 240
+
+[safe_z_home]
+#Needed to lift the Z to clear homing switch on bed
+# ---> WARNING! - Z_MAX limit switch not monitored in Klipper! <---
+# ---> This could potentially crash the toolhead if already at the top of Z travel! <---
+home_xy_position: 0, 0
+speed: 50.0
+z_hop: 10.0
+move_to_previous: False
+
+[gcode_macro T0]
+gcode:
+    SET_GCODE_OFFSET X=0
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+
+[gcode_macro T1]
+gcode:
+    SET_GCODE_OFFSET X=-13
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+
+[gcode_macro START_PRINT]
+gcode:
+    {% set EXTRUDERS_ENABLED_COUNT = params.EXTRUDERS_ENABLED_COUNT|default(1)|int %}
+    {% set MATERIAL_BED_TEMPERATURE_LAYER_0 = params.MATERIAL_BED_TEMPERATURE_LAYER_0|default(65)|float %}
+    {% set MATERIAL_PRINT_TEMPERATURE_LAYER_0_0 = params.MATERIAL_PRINT_TEMPERATURE_LAYER_0_0|default(210)|float %}
+    {% set MATERIAL_PRINT_TEMPERATURE_LAYER_0_1 = params.MATERIAL_PRINT_TEMPERATURE_LAYER_0_1|default(210)|float %}
+    ;This profile is designed specifically for LulzBot TAZ5 3D Printer with the Yellowfin Dual running Klipper
+    M140 S{MATERIAL_BED_TEMPERATURE_LAYER_0}    ; start bed heating up
+    G90        ;absolute positioning
+    M107       ;start with the fan off
+    G28        ;Klipper safe-home
+    M117 Heating...                     ; progress indicator message on LCD
+    {% if EXTRUDERS_ENABLED_COUNT|int == 2 %}
+        M104 S{MATERIAL_PRINT_TEMPERATURE_LAYER_0_1} T1 ; set extruder temp
+        M109 S{MATERIAL_PRINT_TEMPERATURE_LAYER_0_0} T0 ; set extruder temp and wait
+        M109 S{MATERIAL_PRINT_TEMPERATURE_LAYER_0_1} T1 ; set extruder temp and wait
+    {% else %}
+        M109 S{MATERIAL_PRINT_TEMPERATURE_LAYER_0_0} T0 ; set extruder temp and wait
+    {% endif %}
+    G1 Z15.0 F3000 ;move the platform down 15mm
+    {% if EXTRUDERS_ENABLED_COUNT|int == 2 %}
+        T1                      ;Switch to the 2nd extruder
+        G92 E0                  ;zero the extruded length
+        G1 F100 E10             ;extrude 10mm of feed stock
+        G92 E0                  ;zero the extruded length again
+        G1 F200 E-15
+    {% endif %}
+    T0                      ;Switch to the first extruder
+    G92 E0                  ;zero the extruded length
+    G1 F100 E10             ;extrude 10mm of feed stock
+    G92 E0                  ;zero the extruded length again
+    G1 F3000
+    M190 R{MATERIAL_BED_TEMPERATURE_LAYER_0}  ; wait for bed temperature
+    M117 Printing...
+
+[gcode_macro END_PRINT]
+gcode:
+    M400                                      ; wait for moves to finish
+    M140 S40 ; start bed cooling
+    M104 T0 S0                                   ; disable hotend
+    M104 T1 S0
+    M107                                      ; disable fans
+    G91                                       ; relative positioning
+    G1 E-1 F300                               ; filament retraction to release pressure
+    G1 Z20 E-5 X-20 Y-20 F3000                ; lift up and retract even more filament
+    G1 E6                                     ; re-prime extruder
+    M117 Cooling please wait                  ; progress indicator message on LCD
+    G90                                       ; absolute positioning
+    G1 Y0 F3000                               ; move to cooling position
+    M140 S0                                   ; cool down
+    TEMPERATURE_WAIT SENSOR=heater_bed MAXIMUM=40 ; wait for bed to cool down to removal temp
+    G1 Y280 F3000                             ; present finished print
+    M84                                       ; disable steppers
+    G90                                       ; absolute positioning
+    M117 Print Complete.                      ; print complete message

--- a/config/printer-lulzbot-taz6-2017.cfg
+++ b/config/printer-lulzbot-taz6-2017.cfg
@@ -100,6 +100,10 @@ pin: PH5
 [heater_fan heatbreak_cooling_fan]
 pin: PH3
 
+[controller_fan controller_fan]
+#The chassis fan ("FAN-2" on the RAMBo) cools the stepper drivers and is connected to PE4.
+pin: PE4
+
 [mcu]
 serial: /dev/ttyACM0
 

--- a/config/printer-lulzbot-taz6-dual-v3-2017.cfg
+++ b/config/printer-lulzbot-taz6-dual-v3-2017.cfg
@@ -132,6 +132,10 @@ pin: PH3
 #On Dual v3 part fans are connected to PH5 (heat break fan on single extruder)
 pin: PH5
 
+[controller_fan controller_fan]
+#The chassis fan ("FAN-2" on the RAMBo) cools the stepper drivers and is connected to PE4.
+pin: PE4
+
 [mcu]
 serial: /dev/ttyACM0
 

--- a/config/printer-lulzbot-taz6-dual-v3-2017.cfg
+++ b/config/printer-lulzbot-taz6-dual-v3-2017.cfg
@@ -206,6 +206,16 @@ move_to_previous: False
 gcode:
     BED_TILT_CALIBRATE
 
+[gcode_macro T0]
+gcode:
+    SET_GCODE_OFFSET X=0
+    ACTIVATE_EXTRUDER EXTRUDER=extruder
+
+[gcode_macro T1]
+gcode:
+    SET_GCODE_OFFSET X=-13
+    ACTIVATE_EXTRUDER EXTRUDER=extruder1
+
 #-------------------------------------------------------------------------------------------------
 # Macros to Support TAZ6 START and END Blocks
 #-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds a new config for TAZ5 with a DualExtruder v3.

The TAZ6 has mostly the same guts (same mainboard for sure), so I started from that.  In the process I made some fixes to the TAZ6 configs:

* Added missing chassis fans for the TAZ6 configs.
* Added a commented out chassis fan for the generic RAMBo config.
* Added T0 and T1 macros for the TAZ6 dual extruder.

The chassis fan was verified from the [RAMBo schematic](https://github.com/ultimachine/RAMBo-1.4/blob/1.4/Project%20Outputs/Schematic%20Prints_RAMBo_1.4a.PDF) and the [wiring instructions for the TAZ6](https://download.lulzbot.com/TAZ/6.0/production_docs/OHAI/03_ControlBoxWiring-OHAI-T6.pdf).

The TAZ5 config is tested and works on a real machine.  The machine is stock in all the ways that matter for this config.

Differences TAZ5 -> TAZ6 differences were largely about homing.  These I things changed:

* Two endstop pins were different.
* `[bed_screws]` section
* Homing location and some axis extents.
* Reworked START_PRINT and END_PRINT from Lulzbot's Cura profiles.

The stepper digipot is reconfigured, and I think it's more accurate, but since I don't have enough knowledge to fully confirm it, I didn't change TAZ6 or RAMBo.  If I'm right, the TAZ6 and RAMBo configs are underpowering their steppers.
