### PR TITLE
Update OctoPrint.md - wrong serial address

### DIFF
--- a/docs/OctoPrint.md
+++ b/docs/OctoPrint.md
@@ -52,7 +52,7 @@ Navigate to the Settings tab (the wrench icon at the top of the page).
 Under "Serial Connection" in "Additional serial ports" add:
 
 ```
-~/printer_data/comms/klippy.sock
+~/printer_data/comms/klippy.serial
 ```
 Then click "Save".
 


### PR DESCRIPTION
This PR corrects a simple mistake where I gave the Unix socket not the serial pts.

Thanks
James