### PR TITLE
Improve timer vs task priority check

### DIFF
--- a/src/avr/timer.c
+++ b/src/avr/timer.c
@@ -197,7 +197,7 @@ ISR(TIMER1_COMPA_vect)
             uint16_t now = timer_get();
             if ((int16_t)(next - now) < (int16_t)(-timer_from_us(1000)))
                 try_shutdown("Rescheduled timer in the past");
-            if (sched_tasks_busy()) {
+            if (sched_check_set_tasks_busy()) {
                 timer_repeat_set(now + TIMER_REPEAT_TICKS);
                 next = now + TIMER_DEFER_REPEAT_TICKS;
                 goto done;

--- a/src/generic/armcm_timer.c
+++ b/src/generic/armcm_timer.c
@@ -137,7 +137,7 @@ timer_dispatch_many(void)
             // Check if there are too many repeat timers
             if (diff < (int32_t)(-timer_from_us(1000)))
                 try_shutdown("Rescheduled timer in the past");
-            if (sched_tasks_busy()) {
+            if (sched_check_set_tasks_busy()) {
                 timer_repeat_until = now + TIMER_REPEAT_TICKS;
                 return TIMER_DEFER_REPEAT_TICKS;
             }

--- a/src/generic/timer_irq.c
+++ b/src/generic/timer_irq.c
@@ -55,7 +55,7 @@ timer_dispatch_many(void)
             // Check if there are too many repeat timers
             if (diff < (int32_t)(-timer_from_us(1000)))
                 try_shutdown("Rescheduled timer in the past");
-            if (sched_tasks_busy()) {
+            if (sched_check_set_tasks_busy()) {
                 timer_repeat_until = now + TIMER_REPEAT_TICKS;
                 return now + TIMER_DEFER_REPEAT_TICKS;
             }

--- a/src/linux/timer.c
+++ b/src/linux/timer.c
@@ -152,7 +152,7 @@ timer_dispatch(void)
             // Check if there are too many repeat timers
             if (diff < (int32_t)(-timer_from_us(100000)))
                 try_shutdown("Rescheduled timer in the past");
-            if (sched_tasks_busy())
+            if (sched_check_set_tasks_busy())
                 return;
             repeat_count = TIMER_IDLE_REPEAT_COUNT;
         }

--- a/src/sched.h
+++ b/src/sched.h
@@ -31,7 +31,7 @@ void sched_del_timer(struct timer *del);
 unsigned int sched_timer_dispatch(void);
 void sched_timer_reset(void);
 void sched_wake_tasks(void);
-uint8_t sched_tasks_busy(void);
+uint8_t sched_check_set_tasks_busy(void);
 void sched_wake_task(struct task_wake *w);
 uint8_t sched_check_wake(struct task_wake *w);
 uint8_t sched_is_shutdown(void);


### PR DESCRIPTION
Rename `sched_tasks_busy()` to `sched_check_set_tasks_busy()` and change it to only return true if tasks are active (running or requested) for two consecutive calls.  This makes it less likely that timers will yield to tasks except when tasks really are notably backlogged.

This also makes it less likely that multiple steppers controlling the same rail will be interrupted by tasks mid-step.  This should slightly improve the timing, and make it less likely that a halt during homing/probing will occur with these steppers taking a different number of total steps.

This was discussed at: https://klipper.discourse.group/t/z-stepper-microstep-shift-on-multi-mcu-homing-loadcell-ldc1612/19524/

-Kevin