### PR TITLE
Probe position skew warning and ldc1612 irq fix

### DIFF
--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -1,6 +1,6 @@
 # Helper code for implementing homing operations
 #
-# Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
@@ -29,10 +29,17 @@ class StepperPosition:
         self.endstop_name = endstop_name
         self.stepper_name = stepper.get_name()
         self.start_pos = stepper.get_mcu_position()
+        self.start_cmd_pos = stepper.mcu_to_commanded_position(self.start_pos)
         self.halt_pos = self.trig_pos = None
     def note_home_end(self, trigger_time):
         self.halt_pos = self.stepper.get_mcu_position()
         self.trig_pos = self.stepper.get_past_mcu_position(trigger_time)
+    def verify_no_probe_skew(self, haltpos):
+        new_start_pos = self.stepper.get_mcu_position(self.start_cmd_pos)
+        if new_start_pos != self.start_pos:
+            logging.warning(
+                "Stepper '%s' position skew after probe: pos %d now %d",
+                self.stepper.get_name(), self.start_pos, new_start_pos)
 
 # Implementation of homing/probing moves
 class HomingMove:
@@ -121,6 +128,9 @@ class HomingMove:
             haltpos = trigpos = self.calc_toolhead_pos(kin_spos, trig_steps)
             if trig_steps != halt_steps:
                 haltpos = self.calc_toolhead_pos(kin_spos, halt_steps)
+            self.toolhead.set_position(haltpos)
+            for sp in self.stepper_positions:
+                sp.verify_no_probe_skew(haltpos)
         else:
             haltpos = trigpos = movepos
             over_steps = {sp.stepper_name: sp.halt_pos - sp.trig_pos
@@ -130,7 +140,7 @@ class HomingMove:
                 halt_kin_spos = {s.get_name(): s.get_commanded_position()
                                  for s in kin.get_steppers()}
                 haltpos = self.calc_toolhead_pos(halt_kin_spos, over_steps)
-        self.toolhead.set_position(haltpos)
+            self.toolhead.set_position(haltpos)
         # Signal homing/probing move complete
         try:
             self.printer.send_event("homing:homing_move_end", self)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -138,8 +138,10 @@ class MCU_stepper:
     def get_commanded_position(self):
         ffi_main, ffi_lib = chelper.get_ffi()
         return ffi_lib.itersolve_get_commanded_pos(self._stepper_kinematics)
-    def get_mcu_position(self):
-        mcu_pos_dist = self.get_commanded_position() + self._mcu_position_offset
+    def get_mcu_position(self, cmd_pos=None):
+        if cmd_pos is None:
+            cmd_pos = self.get_commanded_position()
+        mcu_pos_dist = cmd_pos + self._mcu_position_offset
         mcu_pos = mcu_pos_dist / self._step_dist
         if mcu_pos >= 0.:
             return int(mcu_pos + 0.5)

--- a/src/trsync.c
+++ b/src/trsync.c
@@ -1,6 +1,6 @@
 // Handling of synchronized "trigger" dispatch
 //
-// Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -23,13 +23,14 @@ enum { TSF_CAN_TRIGGER=1<<0, TSF_REPORT=1<<2 };
 
 static struct task_wake trsync_wake;
 
-// Activate a trigger (caller must disable IRQs)
+// Activate a trigger
 void
 trsync_do_trigger(struct trsync *ts, uint8_t reason)
 {
+    irqstatus_t flag = irq_save();
     uint8_t flags = ts->flags;
     if (!(flags & TSF_CAN_TRIGGER))
-        return;
+        goto done;
     ts->trigger_reason = reason;
     ts->flags = (flags & ~TSF_CAN_TRIGGER) | TSF_REPORT;
     // Dispatch signals
@@ -42,6 +43,8 @@ trsync_do_trigger(struct trsync *ts, uint8_t reason)
         func(tss, reason);
     }
     sched_wake_task(&trsync_wake);
+done:
+    irq_restore(flag);
 }
 
 // Timeout handler


### PR DESCRIPTION
During a probe attempt, the internal tracking of positions should not change.  Verify this after each probe and log a warning if the post-probe position tracking does not match the pre-probe position tracking.

Also, fix an error in the ldc1612 probe trigger notification - it should have called `trsync_do_trigger()` with irqs disabled.  Fix by changing `trsync_do_trigger()` to internally disable irqs to avoid issues like this in the future.

-Kevin

EDIT: This was discussed at: https://klipper.discourse.group/t/z-stepper-microstep-shift-on-multi-mcu-homing-loadcell-ldc1612/19524/