### PR TITLE
Update Measuring_Resonances.md for some NumPY version issues

### DIFF
--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -212,12 +212,20 @@ sudo apt install python3-numpy python3-matplotlib libatlas-base-dev libopenblas-
 
 Next, in order to install NumPy in the Klipper environment, run the command:
 ```
-~/klippy-env/bin/pip install -v numpy
+~/klippy-env/bin/pip install -v numpy==1.25.2
 ```
 Note that, depending on the performance of the CPU, it may take *a lot*
 of time, up to 10-20 minutes. Be patient and wait for the completion of
 the installation. On some occasions, if the board has too little RAM
-the installation may fail and you will need to enable swap.
+the installation may fail and you will need to enable swap. Also note
+the forced version, due to newer versions of NumPY having requirements
+that may not be satisfied in some klipper python environments.
+
+Once installed please check that no errors show from the command:
+```
+~/klippy-env/bin/python -c 'import numpy;'
+```
+The correct output should simply be a new line.
 
 #### Configure ADXL345 With RPi
 


### PR DESCRIPTION
It has been noted over the last six to eight months that some versions of Numpy have issues with the klipper python environment on some machines. This PR introduces a fixed version that is known to work and a small test for people to do to make sure there are no output issues from the get go. These have been pulled from the pinned posts in the discord, from a time when 1.26 was causing issue, and now it seems v2 is also having some issues, hence the change. 

Thanks
James