### PR TITLE
resonance_tester: Added a new sweeping_vibrations resonance test method

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,14 @@ All dates in this document are approximate.
 
 ## Changes
 
+20241203: The resonance test has been changed to include slow sweeping
+moves. This change requires that testing point(s) have some clearance
+in X/Y plane (+/- 30 mm from the test point should suffice when using
+the default settings). The new test should generally produce more
+accurate and reliable test results. However, if required, the previous
+test behavior can be restored by adding options `sweeping_period: 0` and
+`accel_per_hz: 75` to the `[resonance_tester]` config section.
+
 20241201: In some cases Klipper may have ignored leading characters or
 spaces in a traditional G-Code command. For example, "99M123" may have
 been interpreted as "M123" and "M 321" may have been interpreted as

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1785,11 +1785,23 @@ section of the measuring resonances guide for more information on
 #   and on the toolhead (for X axis). These parameters have the same
 #   format as 'accel_chip' parameter. Only 'accel_chip' or these two
 #   parameters must be provided.
+#method: vibrations
+#   A test method to use for resonance testing. Valid choices are
+#   vibrations, sweeping_vibrations. The vibrations method tests
+#   different vibration frequencies at the designated test point.
+#   The sweeping_vibrations method tests different vibration frequencies
+#   while also moving the toolhead slowly around the test point, and
+#   thus may help, for example, if stiction of the toolhead (a force that
+#   must be be overcome to start toolhead motion) is too high.
+#   The default is vibrations, which is generally a recommended choice.
 #max_smoothing:
 #   Maximum input shaper smoothing to allow for each axis during shaper
 #   auto-calibration (with 'SHAPER_CALIBRATE' command). By default no
 #   maximum smoothing is specified. Refer to Measuring_Resonances guide
 #   for more details on using this feature.
+#move_speed: 50
+#   The speed (in mm/s) to move the toolhead to and between test points
+#   during the calibration. The default is 50.
 #min_freq: 5
 #   Minimum frequency to test for resonances. The default is 5 Hz.
 #max_freq: 133.33
@@ -1808,6 +1820,13 @@ section of the measuring resonances guide for more information on
 #   hz_per_sec. Small values make the test slow, and the large values
 #   will decrease the precision of the test. The default value is 1.0
 #   (Hz/sec == sec^-2).
+#motion_accel: 400
+#   An acceleration of slow moves. Available only for sweeping_vibrations
+#   test method. The default is 400 mm/sec^2.
+#motion_period: 1.2
+#   A period of slow moves. Must not be set to a too small value in order
+#   to not poison the measurements. Available only for sweeping_vibrations
+#   test method. The default is 1.2 sec which is a good all-round choice.
 ```
 
 ## Config file helpers

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1785,15 +1785,6 @@ section of the measuring resonances guide for more information on
 #   and on the toolhead (for X axis). These parameters have the same
 #   format as 'accel_chip' parameter. Only 'accel_chip' or these two
 #   parameters must be provided.
-#method: vibrations
-#   A test method to use for resonance testing. Valid choices are
-#   vibrations, sweeping_vibrations. The vibrations method tests
-#   different vibration frequencies at the designated test point.
-#   The sweeping_vibrations method tests different vibration frequencies
-#   while also moving the toolhead slowly around the test point, and
-#   thus may help, for example, if stiction of the toolhead (a force that
-#   must be be overcome to start toolhead motion) is too high.
-#   The default is vibrations, which is generally a recommended choice.
 #max_smoothing:
 #   Maximum input shaper smoothing to allow for each axis during shaper
 #   auto-calibration (with 'SHAPER_CALIBRATE' command). By default no
@@ -1806,7 +1797,7 @@ section of the measuring resonances guide for more information on
 #   Minimum frequency to test for resonances. The default is 5 Hz.
 #max_freq: 133.33
 #   Maximum frequency to test for resonances. The default is 133.33 Hz.
-#accel_per_hz: 75
+#accel_per_hz: 60
 #   This parameter is used to determine which acceleration to use to
 #   test a specific frequency: accel = accel_per_hz * freq. Higher the
 #   value, the higher is the energy of the oscillations. Can be set to
@@ -1821,13 +1812,12 @@ section of the measuring resonances guide for more information on
 #   will decrease the precision of the test. The default value is 1.0
 #   (Hz/sec == sec^-2).
 #sweeping_accel: 400
-#   An acceleration of slow sweeping moves. Available only for
-#   sweeping_vibrations test method. The default is 400 mm/sec^2.
+#   An acceleration of slow sweeping moves. The default is 400 mm/sec^2.
 #sweeping_period: 1.2
-#   A period of slow sweeping moves. Must not be set to a too small
-#   value in order to not poison the measurements. Available only for
-#   sweeping_vibrations test method. The default is 1.2 sec which is
-#   a good all-round choice.
+#   A period of slow sweeping moves. Setting this parameter to 0
+#   disables slow sweeping moves. Avoid setting it to a too small
+#   non-zero value in order to not poison the measurements.
+#   The default is 1.2 sec which is a good all-round choice.
 ```
 
 ## Config file helpers

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1820,13 +1820,14 @@ section of the measuring resonances guide for more information on
 #   hz_per_sec. Small values make the test slow, and the large values
 #   will decrease the precision of the test. The default value is 1.0
 #   (Hz/sec == sec^-2).
-#motion_accel: 400
-#   An acceleration of slow moves. Available only for sweeping_vibrations
-#   test method. The default is 400 mm/sec^2.
-#motion_period: 1.2
-#   A period of slow moves. Must not be set to a too small value in order
-#   to not poison the measurements. Available only for sweeping_vibrations
-#   test method. The default is 1.2 sec which is a good all-round choice.
+#sweeping_accel: 400
+#   An acceleration of slow sweeping moves. Available only for
+#   sweeping_vibrations test method. The default is 400 mm/sec^2.
+#sweeping_period: 1.2
+#   A period of slow sweeping moves. Must not be set to a too small
+#   value in order to not poison the measurements. Available only for
+#   sweeping_vibrations test method. The default is 1.2 sec which is
+#   a good all-round choice.
 ```
 
 ## Config file helpers

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -694,6 +694,38 @@ If you are doing a shaper re-calibration and the reported smoothing for the
 suggested shaper configuration is almost the same as what you got during the
 previous calibration, this step can be skipped.
 
+### Unreliable measurements of resonance frequencies
+
+Sometimes the resonance measurements can produce bogus results, leading to
+the incorrect suggestions for the input shapers. This can be caused by a
+variety of reasons, including running fans on the toolhead, incorrect
+position or non-rigid mounting of the accelerometer, or mechanical problems
+such as loose belts or binding or bumpy axis. Keep in mind that all fans
+should be disabled for resonance testing, especially the noisy ones, and
+that the accelerometer should be rigidly mounted on the corresponding
+moving part (e.g. on the bed itself for the bed slinger, or on the extruder
+of the printer itself and not the carriage, and some people get better
+results by mounting the accelerometer on the nozzle itself). As for
+mechanical problems, the user should inspect if there is any fault that
+can be fixed with a moving axis (e.g. linear guide rails cleaned up and
+lubricated and V-slot wheels tension adjusted correctly). However, if
+the axis has too high stiction (a force that must be be overcome to start
+toolhead motion over that axis) and thus binds, or if the user gets
+recommended shapers that do not eliminate the echo well on the prints
+and troubleshooting did not help, the user may try to use a different
+resonance test method that can be activated by adding
+```
+[resonance_tester]
+method: sweeping_vibrations
+```
+option to the Klipper config, restarting Klipper, and reruning the resonance
+test again. Note that this test moves the toolhead slowly around the test
+point, thus requiring some clearance around the test point over the tested
+axis. Since this method may produce higher amplitude vibrations compared to
+the default method, it is avised to monitor the printer closely during the
+test, and if the vibrations get too strong, the user may need to reduce
+`accel_per_hz` value in `[resonance_tester]` section from its default value.
+
 ### Testing custom axes
 
 `TEST_RESONANCES` command supports custom axes. While this is not really

--- a/docs/Measuring_Resonances.md
+++ b/docs/Measuring_Resonances.md
@@ -708,23 +708,9 @@ of the printer itself and not the carriage, and some people get better
 results by mounting the accelerometer on the nozzle itself). As for
 mechanical problems, the user should inspect if there is any fault that
 can be fixed with a moving axis (e.g. linear guide rails cleaned up and
-lubricated and V-slot wheels tension adjusted correctly). However, if
-the axis has too high stiction (a force that must be be overcome to start
-toolhead motion over that axis) and thus binds, or if the user gets
-recommended shapers that do not eliminate the echo well on the prints
-and troubleshooting did not help, the user may try to use a different
-resonance test method that can be activated by adding
-```
-[resonance_tester]
-method: sweeping_vibrations
-```
-option to the Klipper config, restarting Klipper, and reruning the resonance
-test again. Note that this test moves the toolhead slowly around the test
-point, thus requiring some clearance around the test point over the tested
-axis. Since this method may produce higher amplitude vibrations compared to
-the default method, it is avised to monitor the printer closely during the
-test, and if the vibrations get too strong, the user may need to reduce
-`accel_per_hz` value in `[resonance_tester]` section from its default value.
+lubricated and V-slot wheels tension adjusted correctly). If none of that
+helps, a user may try the other shapers from the produced list besides the
+one recommended by default.
 
 ### Testing custom axes
 

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -100,12 +100,12 @@ class VibrationsWithMotionTestGenerator:
                                             self.motion_period, above=0.)
     def gen_test(self):
         test_seq = self.vibration_generator.gen_test()
-        accel_fraction = 0.125
+        accel_fraction = math.sqrt(2.0) * 0.125
         t_rem = self.motion_period * accel_fraction
         res = []
         last_t = 0.
         sig = 1.
-        accel_fraction = 0.375
+        accel_fraction += 0.25
         for next_t, accel in test_seq:
             t_seg = next_t - last_t
             while t_rem <= t_seg:
@@ -187,10 +187,10 @@ class ResonanceTestExecutor:
             last_v = v
             last_accel = accel
         if last_v:
-            d_decel = -.5 * last_v2 / max_accel
+            d_decel = -.5 * last_v2 / old_max_accel
             decel_X, decel_Y = axis.get_point(d_decel)
             toolhead.cmd_M204(self.gcode.create_gcode_command(
-                "M204", "M204", {"S": max_accel}))
+                "M204", "M204", {"S": old_max_accel}))
             toolhead.move([X + decel_X, Y + decel_Y, Z, E], abs(last_v))
         # Restore the original acceleration values
         self.gcode.run_script_from_command(

--- a/klippy/extras/shaper_calibrate.py
+++ b/klippy/extras/shaper_calibrate.py
@@ -48,7 +48,9 @@ class CalibrationData:
             # Avoid division by zero errors
             psd /= self.freq_bins + .1
             # Remove low-frequency noise
-            psd[self.freq_bins < MIN_FREQ] = 0.
+            low_freqs = self.freq_bins < 2. * MIN_FREQ
+            psd[low_freqs] *= self.numpy.exp(
+                    -(2. * MIN_FREQ / (self.freq_bins[low_freqs] + .1))**2 + 1.)
     def get_psd(self, axis='all'):
         return self._psd_map[axis]
 

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -47,6 +47,7 @@ class Move:
         self.delta_v2 = 2.0 * move_d * self.accel
         self.max_smoothed_v2 = 0.
         self.smooth_delta_v2 = 2.0 * move_d * toolhead.max_accel_to_decel
+        self.junction_v2 = 999999999.9
     def limit_speed(self, speed, accel):
         speed2 = speed**2
         if speed2 < self.max_cruise_v2:
@@ -55,6 +56,8 @@ class Move:
         self.accel = min(self.accel, accel)
         self.delta_v2 = 2.0 * self.move_d * self.accel
         self.smooth_delta_v2 = min(self.smooth_delta_v2, self.delta_v2)
+    def limit_junction(self, junction_v2):
+        self.junction_v2 = min(self.junction_v2, junction_v2)
     def move_error(self, msg="Move out of range"):
         ep = self.end_pos
         m = "%s: %.3f %.3f %.3f [%.3f]" % (msg, ep[0], ep[1], ep[2], ep[3])
@@ -66,7 +69,7 @@ class Move:
         extruder_v2 = self.toolhead.extruder.calc_junction(prev_move, self)
         max_start_v2 = min(
             extruder_v2, self.max_cruise_v2, prev_move.max_cruise_v2,
-            prev_move.max_start_v2 + prev_move.delta_v2)
+            self.junction_v2, prev_move.max_start_v2 + prev_move.delta_v2)
         # Find max velocity using "approximated centripetal velocity"
         axes_r = self.axes_r
         prev_axes_r = prev_move.axes_r
@@ -462,7 +465,7 @@ class ToolHead:
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")
-    def move(self, newpos, speed):
+    def move(self, newpos, speed, max_junction_v2=None):
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
             return
@@ -470,6 +473,8 @@ class ToolHead:
             self.kin.check_move(move)
         if move.axes_d[3]:
             self.extruder.check_move(move)
+        if max_junction_v2 is not None:
+            move.limit_junction(max_junction_v2)
         self.commanded_pos[:] = move.end_pos
         self.lookahead.add_move(move)
         if self.print_time > self.need_check_pause:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -47,7 +47,7 @@ class Move:
         self.delta_v2 = 2.0 * move_d * self.accel
         self.max_smoothed_v2 = 0.
         self.smooth_delta_v2 = 2.0 * move_d * toolhead.max_accel_to_decel
-        self.junction_v2 = 999999999.9
+        self.next_junction_v2 = 999999999.9
     def limit_speed(self, speed, accel):
         speed2 = speed**2
         if speed2 < self.max_cruise_v2:
@@ -56,8 +56,8 @@ class Move:
         self.accel = min(self.accel, accel)
         self.delta_v2 = 2.0 * self.move_d * self.accel
         self.smooth_delta_v2 = min(self.smooth_delta_v2, self.delta_v2)
-    def limit_junction(self, junction_v2):
-        self.junction_v2 = min(self.junction_v2, junction_v2)
+    def limit_next_junction_speed(self, speed):
+        self.next_junction_v2 = min(self.next_junction_v2, speed**2)
     def move_error(self, msg="Move out of range"):
         ep = self.end_pos
         m = "%s: %.3f %.3f %.3f [%.3f]" % (msg, ep[0], ep[1], ep[2], ep[3])
@@ -67,9 +67,9 @@ class Move:
             return
         # Allow extruder to calculate its maximum junction
         extruder_v2 = self.toolhead.extruder.calc_junction(prev_move, self)
-        max_start_v2 = min(
-            extruder_v2, self.max_cruise_v2, prev_move.max_cruise_v2,
-            self.junction_v2, prev_move.max_start_v2 + prev_move.delta_v2)
+        max_start_v2 = min(extruder_v2, self.max_cruise_v2,
+                           prev_move.max_cruise_v2, prev_move.next_junction_v2,
+                           prev_move.max_start_v2 + prev_move.delta_v2)
         # Find max velocity using "approximated centripetal velocity"
         axes_r = self.axes_r
         prev_axes_r = prev_move.axes_r
@@ -465,7 +465,11 @@ class ToolHead:
         self.commanded_pos[:] = newpos
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")
-    def move(self, newpos, speed, max_junction_v2=None):
+    def limit_next_junction_speed(self, speed):
+        last_move = self.lookahead.get_last()
+        if last_move is not None:
+            last_move.limit_next_junction_speed(speed)
+    def move(self, newpos, speed):
         move = Move(self, self.commanded_pos, newpos, speed)
         if not move.move_d:
             return
@@ -473,8 +477,6 @@ class ToolHead:
             self.kin.check_move(move)
         if move.axes_d[3]:
             self.extruder.check_move(move)
-        if max_junction_v2 is not None:
-            move.limit_junction(max_junction_v2)
         self.commanded_pos[:] = move.end_pos
         self.lookahead.add_move(move)
         if self.print_time > self.need_check_pause:


### PR DESCRIPTION
This adds a new resonance test method that can help if a user has some mechanical problems with the printer. The new method is not enabled by default and can be activated via a config option.

Signed-off-by: Dmitry Butyugin <dmbutyugin@google.com>