### PR TITLE
fan_generic: fixes missing logging import

### DIFF
--- a/klippy/extras/fan_generic.py
+++ b/klippy/extras/fan_generic.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 from . import fan, output_pin
 
 class PrinterFanGeneric:


### PR DESCRIPTION
At the moment, using `SET_FAN_SPEED` with a display template that does not resolve to a string that can get converted to a valid float will cause a crash as the `import logging` is missing.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>