### PR TITLE
angle: correct stepper position closer to zero while calibration

### DIFF
--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -178,6 +178,17 @@ class AngleCalibration:
         move(mcu_stepper, 2. * rotation_dist, move_speed)
         move(mcu_stepper, -2. * rotation_dist, move_speed)
         move(mcu_stepper, .5 * rotation_dist - full_step_dist, move_speed)
+        # Align stepper to zero
+        toolhead = self.printer.lookup_object('toolhead')
+        zero_offset = 0
+        mscnt_quant = 256 // microsteps
+        mscnt_min = (mscnt_quant // 2)
+        mscnt = self.tmc_module.mcu_tmc.get_register("MSCNT")
+        while mscnt != mscnt_min:
+            move(mcu_stepper, step_dist, move_speed)
+            zero_offset -= step_dist
+            toolhead.wait_moves()
+            mscnt = self.tmc_module.mcu_tmc.get_register("MSCNT")
         # Move to each full step position
         toolhead = self.printer.lookup_object('toolhead')
         times = []
@@ -194,6 +205,7 @@ class AngleCalibration:
                 move(mcu_stepper, -.5 * rotation_dist + samp_dist, move_speed)
                 samp_dist = -samp_dist
         move(mcu_stepper, .5*rotation_dist + align_dist, move_speed)
+        move(mcu_stepper, zero_offset, move_speed)
         toolhead.wait_moves()
         # Finish data collection
         is_finished = True


### PR DESCRIPTION
TMC drivers try to avoid stepper zero positions.
But stepper has different characteristics and precision depending on microstep position.
Consequently precision of angle sensor calibration will depend on the initial rotor position.

Fix that by moving the stepper to the minimal possible position.

This is a macro, I just copy-paste it 3 times, to get 3 results.
```
G28 X Y
CENTER
ANGLE_CALIBRATE CHIP=mt6826s
```

Before that change, I had different `stddev` between tests, like 14..22 (sometimes)
It feels like bad reproducibility.
```
# 64 microsteps
// angle: stddev=15.297 (0.367 forward / 0.197 reverse) in 49989 queries
// angle: stddev=14.616 (0.488 forward / 0.664 reverse) in 49991 queries
// angle: stddev=14.517 (0.580 forward / 0.679 reverse) in 49981 queries
# 128 microsteps 
// angle: stddev=14.692 (0.502 forward / 0.505 reverse) in 49990 queries
// angle: stddev=14.507 (0.595 forward / 0.601 reverse) in 49992 queries
// angle: stddev=14.337 (0.870 forward / 0.692 reverse) in 49994 queries
# 256 microsteps
// angle: stddev=14.745 (0.453 forward / 0.434 reverse) in 49992 queries
// angle: stddev=14.233 (0.600 forward / 0.590 reverse) in 49995 queries
// angle: stddev=14.412 (0.552 forward / 0.514 reverse) in 49988 queries
```

Now I have pretty stable results:
```
# 8 microsteps
// angle: stddev=15.913 (0.013 forward / 0.075 reverse) in 49990 queries
// angle: stddev=15.889 (0.041 forward / 0.078 reverse) in 49990 queries
// angle: stddev=15.806 (0.000 forward / 0.033 reverse) in 49991 queries
# 16 microsteps
// angle: stddev=14.328 (0.138 forward / 0.195 reverse) in 49989 queries
// angle: stddev=15.709 (0.044 forward / 0.075 reverse) in 49995 queries
// angle: stddev=15.678 (0.031 forward / 0.037 reverse) in 49990 queries
# 32 microsteps
// angle: stddev=15.441 (0.013 forward / 0.028 reverse) in 49989 queries
// angle: stddev=15.383 (0.025 forward / 0.000 reverse) in 49996 queries
// angle: stddev=15.342 (0.054 forward / 0.000 reverse) in 49994 queries
# 64 microsteps
// angle: stddev=15.235 (0.000 forward / 0.028 reverse) in 49991 queries
// angle: stddev=15.216 (0.075 forward / 0.025 reverse) in 49988 queries
// angle: stddev=15.216 (0.055 forward / 0.000 reverse) in 49993 queries
# 128 microsteps
// angle: stddev=15.255 (0.028 forward / 0.000 reverse) in 49990 queries
// angle: stddev=15.160 (0.033 forward / 0.000 reverse) in 49996 queries
// angle: stddev=15.148 (0.031 forward / 0.099 reverse) in 49989 queries
# 256 microsteps
// angle: stddev=14.973 (0.067 forward / 0.130 reverse) in 49994 queries
// angle: stddev=14.901 (0.079 forward / 0.000 reverse) in 49989 queries
// angle: stddev=15.012 (0.054 forward / 0.099 reverse) in 49995 queries
```

The solution is a little naive, better will be to detect the direction, and directly calculate the move.
For now, it is just short as possible.

Also, there are already `align_dist = step_dist * self.get_stepper_phase()`
This looks similar in the intention to do the same, but I may be wrong here.

Thanks