### PR TITLE
gcode: Improve handling of extended g-code commands with '*;#' characters

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,12 @@ All dates in this document are approximate.
 
 ## Changes
 
+20241201: In some cases Klipper may have ignored leading characters or
+spaces in a traditional G-Code command. For example, "99M123" may have
+been interpreted as "M123" and "M 321" may have been interpreted as
+"M321". Klipper will now report these cases with an "Unknown command"
+warning.
+
 20241112: Option `CHIPS=<chip_name>` in `TEST_RESONANCES` and
 `SHAPER_CALIBRATE` requires specifying the full name(s) of the accel
 chip(s). For example, `adxl345 rpi` instead of short name - `rpi`.

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -198,16 +198,14 @@ class GCodeDispatch:
                 line = line[:cpos]
             # Break line into parts and determine command
             parts = self.args_r.split(line.upper())
-            numparts = len(parts)
-            cmd = ""
-            if numparts >= 3 and parts[1] != 'N':
-                cmd = parts[1] + parts[2].strip()
-            elif numparts >= 5 and parts[1] == 'N':
+            if ''.join(parts[:2]) == 'N':
                 # Skip line number at start of command
-                cmd = parts[3] + parts[4].strip()
+                cmd = ''.join(parts[3:5]).strip()
+            else:
+                cmd = ''.join(parts[:3]).strip()
             # Build gcode "params" dictionary
             params = { parts[i]: parts[i+1].strip()
-                       for i in range(1, numparts, 2) }
+                       for i in range(1, len(parts), 2) }
             gcmd = GCodeCommand(self, cmd, origline, params, need_ack)
             # Invoke handler for command
             handler = self.gcode_handlers.get(cmd, self.cmd_default)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -35,7 +35,7 @@ class GCodeCommand:
             # Skip any gcode line-number and ignore any trailing checksum
             param_start += origline.upper().find(command)
             end = origline.rfind('*')
-            if end >= 0:
+            if end >= 0 and origline[end+1:].isdigit():
                 param_end = end
         if origline[param_start:param_start+1].isspace():
             param_start += 1

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -187,7 +187,7 @@ class GCodeDispatch:
         self._build_status_commands()
         self._respond_state("Ready")
     # Parse input into commands
-    args_r = re.compile('([A-Z_]+|[A-Z*/])')
+    args_r = re.compile('([A-Z_]+|[A-Z*])')
     def _process_commands(self, commands, need_ack=True):
         for line in commands:
             # Ignore comments and leading/trailing spaces
@@ -289,7 +289,7 @@ class GCodeDispatch:
         if ' ' in cmd:
             # Handle M117/M118 gcode with numeric and special characters
             realcmd = cmd.split()[0]
-            if realcmd in ["M117", "M118"]:
+            if realcmd in ["M117", "M118", "M23"]:
                 handler = self.gcode_handlers.get(realcmd, None)
                 if handler is not None:
                     gcmd._command = realcmd

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -133,6 +133,10 @@ class GCodeDispatch:
             raise self.printer.config_error(
                 "gcode command %s already registered" % (cmd,))
         if not self.is_traditional_gcode(cmd):
+            if (cmd.upper() != cmd or not cmd.replace('_', 'A').isalnum()
+                or cmd[0].isdigit() or cmd[1:2].isdigit()):
+                raise self.printer.config_error(
+                    "Can't register '%s' as it is an invalid name" % (cmd,))
             origfunc = func
             func = lambda params: origfunc(self._get_extended_params(params))
         self.ready_gcode_handlers[cmd] = func

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -28,18 +28,18 @@ class GCodeCommand:
         return self._params
     def get_raw_command_parameters(self):
         command = self._command
-        rawparams = self._commandline
-        urawparams = rawparams.upper()
-        if not urawparams.startswith(command):
+        origline = self._commandline
+        param_start = len(command)
+        param_end = len(origline)
+        if origline[:param_start].upper() != command:
             # Skip any gcode line-number and ignore any trailing checksum
-            rawparams = rawparams[urawparams.find(command):]
-            end = rawparams.rfind('*')
+            param_start += origline.upper().find(command)
+            end = origline.rfind('*')
             if end >= 0:
-                rawparams = rawparams[:end]
-        rawparams = rawparams[len(command):]
-        if rawparams.startswith(' '):
-            rawparams = rawparams[1:]
-        return rawparams
+                param_end = end
+        if origline[param_start:param_start+1].isspace():
+            param_start += 1
+        return origline[param_start:param_end]
     def ack(self, msg=None):
         if not self._need_ack:
             return False


### PR DESCRIPTION
The g-code command parser did not allow three characters to be passed as parameters to commands (asterisk, semicolon, pound sign).  Rework the parsing code to better leverage the python shlex package so that these characters can be supported.

In particular, this should allow better support for printing g-code files that have unusual characters in the filename.

-Kevin