### PR TITLE
Adjust default/generic config for printrboards

### DIFF
--- a/config/generic-printrboard.cfg
+++ b/config/generic-printrboard.cfg
@@ -19,20 +19,20 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PE3
 position_endstop: 0
-position_max: 200
+position_max: 150
 homing_speed: 50
 
 [stepper_y]
 step_pin: PA2
-dir_pin: PA3
+dir_pin: !PA3
 enable_pin: !PE6
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PB0
 # Printrboard RevF uses a different Y endstop pin.
 #endstop_pin: ^PB4
-position_endstop: 0
-position_max: 200
+position_endstop: 150
+position_max: 150
 homing_speed: 50
 
 [stepper_z]
@@ -43,7 +43,7 @@ microsteps: 16
 rotation_distance: 8
 endstop_pin: ^PE4
 position_endstop: 0.5
-position_max: 200
+position_max: 150
 
 [extruder]
 step_pin: PA6


### PR DESCRIPTION
Most Printrbot 3D printers that shipped with the printrboard (Printrbot simple, Simple Metal 1403, Simple Metal 2016 V2, Play, etc.) had the Y endstop on Y max, and the Y stepper direction reversed. Furthermore, the build volumes were more commonly 150mm. 

I have edited the relevant config file to reflect this. I have also tested the changes on a Printrbot Simple Metal 1403, and it works as expected.