### PR TITLE
lib: fix rp2040_flash

### DIFF
--- a/lib/rp2040_flash/main.c
+++ b/lib/rp2040_flash/main.c
@@ -146,7 +146,7 @@ int picoboot_flash(libusb_device_handle *handle, struct flash_data *image, model
     }
 
     fprintf(stderr, "Rebooting device\n");
-    if (model == 2040) {
+    if (model == rp2040) {
         if (picoboot_reboot(handle, 0, 0, 500)) {
             return report_error(handle, "reboot");
         }


### PR DESCRIPTION
`model_t` is a enum value [here](https://github.com/Klipper3d/klipper/blob/master/lib/rp2040_flash/picoboot_connection.h#L44)

It should be `rp2040` (actual value is 0, `rp2350` is 1, and `unknown` is 2)
