### PR TITLE
stm32: Add SPI6 support for PB3-PB5 on STM32H723

### DIFF
--- a/src/stm32/stm32h7_spi.c
+++ b/src/stm32/stm32h7_spi.c
@@ -54,7 +54,7 @@ DECL_CONSTANT_STR("BUS_PINS_spi5a", "PH7,PF11,PH6");
 DECL_ENUMERATION("spi_bus", "spi6", __COUNTER__);
 DECL_CONSTANT_STR("BUS_PINS_spi6", "PG12,PG14,PG13");
 DECL_ENUMERATION("spi_bus", "spi6a", __COUNTER__);
-DECL_CONSTANT_STR("BUS_PINS_spi6a", "PB3,PB4,PB5");
+DECL_CONSTANT_STR("BUS_PINS_spi6a", "PB4,PB5,PB3");
 #endif
 
 
@@ -78,7 +78,7 @@ static const struct spi_info spi_bus[] = {
 #endif
 #ifdef SPI6
     { SPI6, GPIO('G', 12), GPIO('G', 14), GPIO('G', 13), GPIO_FUNCTION(5)},
-    { SPI6, GPIO('B', 3), GPIO('B', 4), GPIO('B', 5), GPIO_FUNCTION(8)},
+    { SPI6, GPIO('B', 4), GPIO('B', 5), GPIO('B', 3), GPIO_FUNCTION(8)},
 #endif
 };
 

--- a/src/stm32/stm32h7_spi.c
+++ b/src/stm32/stm32h7_spi.c
@@ -53,6 +53,8 @@ DECL_CONSTANT_STR("BUS_PINS_spi5a", "PH7,PF11,PH6");
 #ifdef SPI6
 DECL_ENUMERATION("spi_bus", "spi6", __COUNTER__);
 DECL_CONSTANT_STR("BUS_PINS_spi6", "PG12,PG14,PG13");
+DECL_ENUMERATION("spi_bus", "spi6a", __COUNTER__);
+DECL_CONSTANT_STR("BUS_PINS_spi6a", "PB3,PB4,PB5");
 #endif
 
 
@@ -76,6 +78,7 @@ static const struct spi_info spi_bus[] = {
 #endif
 #ifdef SPI6
     { SPI6, GPIO('G', 12), GPIO('G', 14), GPIO('G', 13), GPIO_FUNCTION(5)},
+    { SPI6, GPIO('B', 3), GPIO('B', 4), GPIO('B', 5), GPIO_FUNCTION(8)},
 #endif
 };
 


### PR DESCRIPTION
The STM32H723 hardware SPI on pins PB3-PB5 supports alternate functions for SPI1, SPI3, and SPI6. Currently, these pins work only with SPI1 (spi1a config) and cannot be used with the hardware driver since SPI1 is already utilized by the onboard MAX PT100 amplifier (on PA5-7 pins).

This commit introduces SPI6 hardware support for PB3-PB5 using the spi6a configuration.

Signed-off-by: Andrey Melnikov Aam335@gmail.com