### PR TITLE
klippy: Fixup dictionary parameter parsing.

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -248,9 +248,6 @@ def import_test():
 
 def arg_dictionary(option, opt_str, value, parser):
     key, fname = "dictionary", value
-    if '=' in value:
-        mcu_name, fname = value.split('=', 1)
-        key = "dictionary_" + mcu_name
     if parser.values.dictionary is None:
         parser.values.dictionary = {}
     parser.values.dictionary[key] = fname

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -661,7 +661,7 @@ class MCU:
             dict_fname = start_args.get('dictionary')
         else:
             out_fname = start_args.get('debugoutput') + "-" + self._name
-            dict_fname = start_args.get('dictionary_' + self._name)
+            dict_fname = start_args.get('dictionary') + "-" + self._name
         outfile = open(out_fname, 'wb')
         dfile = open(dict_fname, 'rb')
         dict_data = dfile.read()


### PR DESCRIPTION
mcu: Fixup using of multiple controller dictionaries.

Uneeded spliting of dictionary parameter value by '=' symbol removed. Wrong naming of additional mcu dictionary file fixed.

These errors came from the distant 2017. Tested with two mcus. It works as expected.

> commit 3ccecc568dbfd505fe3bdc46b4d16bf7a4528996
> Author: Kevin O'Connor <kevin@koconnor.net>
> Date:   Mon Aug 14 11:46:35 2017 -0400
> 
>     mcu: Initial support for multiple micro-controllers
>     
>     Add initial support for controlling multiple independent
>     micro-controllers from a single Klippy host instance.  Add basic
>     support for synchronizing the clocks of the additional mcus to the
>     main mcu's clock.
>     
>     Signed-off-by: Kevin O'Connor <kevin@koconnor.net>
> 