### PR TITLE
z_tilt: return done when max retries is 0

### DIFF
--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -108,7 +108,7 @@ class RetryHelper:
         return self.increasing > 1
     def check_retry(self, z_positions):
         if self.max_retries == 0:
-            return
+            return "done"
         error = round(max(z_positions) - min(z_positions),6)
         self.gcode.respond_info(
             "Retries: %d/%d %s: %0.6f tolerance: %0.6f" % (


### PR DESCRIPTION
- Set `printer.z_tilt.applied = True` when max_retries is 0
- and then raises error when `[z_tilt] retry_tolerance = 0` 


[Discourse Link](https://klipper.discourse.group/t/possible-bug-printer-z-tilt-applied-not-true-if-no-retries-in-config/20584/2)

