### PR TITLE
Temperature combined: handle temp monitors and I2C sensors

### DIFF
--- a/klippy/extras/temperature_combined.py
+++ b/klippy/extras/temperature_combined.py
@@ -52,8 +52,10 @@ class PrinterSensorCombined:
 
     def _handle_ready(self):
         # Start temperature update timer
+        # There is a race condition with sensors where they can be not ready,
+        # and return 0 or None - initialize a little bit later.
         self.reactor.update_timer(self.temperature_update_timer,
-                                  self.reactor.NOW)
+                                  self.reactor.monotonic() + 1.)
 
     def setup_minmax(self, min_temp, max_temp):
         self.min_temp = min_temp


### PR DESCRIPTION
There are 2 patches:
1. Duct tape fix for race conditions with temperature combined sensor and other sensors during klippy initialization, where sensors can return 0. This may be by design, but it currently limits the minimum possible deviation between sensors.  Like there, it is adc + i2c: ![image](https://github.com/user-attachments/assets/1fa25fd9-1d7b-4822-be67-756d7db45e7d)
 
2. Temperature combined allows us to set "any" object in the sensor list, but with tmc2240, there is a corner case, it has a method `get_status()` and `temperature` field, but it has no value. So, it will crash Klippy cause max/min can't handle `None`. 

---
Should close: https://github.com/Klipper3d/klipper/pull/6675