### PR TITLE
Expose slope_control field on TMC2240.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3846,6 +3846,7 @@ run_current:
 #driver_SEIMIN: 0
 #driver_SFILT: 0
 #driver_SG4_ANGLE_OFFSET: 1
+#driver_SLOPE_CONTROL: 2
 #   Set the given register during the configuration of the TMC2240
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -408,6 +408,8 @@ class TMC2240:
         set_config_field(config, "tpowerdown", 10)
         #   SG4_THRS
         set_config_field(config, "sg4_angle_offset", 1)
+        #   DRV_CONF
+        set_config_field(config, "slope_control", 2)
 
 def load_config_prefix(config):
     return TMC2240(config)


### PR DESCRIPTION
The chip has a default value of 0, corresponding to 100V/µs. The default is overridden with 2 here, corresponding to 400V/µs to approximately match the TMC2209. This should also solve some overheating issues as it lowers the power dissipation at a 50kHz chopper frequency by around 1W.

This is currently untested.