### PR TITLE
probe: Fixed premature firing of 'homing:homing_move_begin'

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -463,6 +463,10 @@ class ProbePointsHelper:
                 # Caller wants a "retry" - restart probing
                 probe_num = 0
             self._move_next(probe_num)
+            # Make sure that the toolhead is positoned before probing
+            # otherwise this will cause 'homing:homing_move_begin' to trigger
+            # while moving horizontally.
+            self.printer.lookup_object('toolhead').wait_moves()
             probe_session.run_probe(gcmd)
             probe_num += 1
         probe_session.end_probe_session()


### PR DESCRIPTION
When probing multiple points such as when calibrating a bed mesh, the ProbePointsHelper start_probe method initiates a horizontal repositioning move and then immediately begins to probe without waiting for the repositioning move to complete. This causes the 'homing:homing_move_begin' to trigger before the Z direction move has even began. This is problematic when running BED_MESH_CALIBRATE with [homing_heaters] configured since it means that the bed will never attempt to re-heat.

This fix addresses this issue simply by waiting for the moves to complete before begining the actual probe.