### PR TITLE
homing_heaters: Added ability to re-heat within a threshold

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2352,6 +2352,15 @@ Tool to disable heaters when homing or probing an axis.
 #   A comma separated list of heaters to disable during homing/probing
 #   moves. The default is to disable all heaters.
 #   Typical example: extruder, heater_bed
+#threshold:
+#   If this is set then the printer will wait until the heaters have 
+#   reached their target temperatures before continuing. If set then the
+#   number indicates the threshold (+/-) before needing to re-heat.
+#   This is useful for when performing bed mesh calinbration probing for
+#   probes that are sensitive to EMI, while still allowing the bed to
+#   maintain a constant temperature.
+#   Note that it is typically more convenient to set this via the
+#   SET_HOMING_HEATERS [gcode command](G-Codes.md#set_homing_heaters)
 ```
 
 ### [thermistor]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -736,6 +736,13 @@ above the supplied MINIMUM and/or at or below the supplied MAXIMUM.
 [TARGET=<target_temperature>]`: Sets the target temperature for a
 heater. If a target temperature is not supplied, the target is 0.
 
+### [homing_heaters]
+
+#### SET_HOMING_HEATERS [THRESHOLD=<temperature_threshold>]
+`SET_HOMING_HEATERS [THRESHOLD=<temperature_threshold>]`: Setting this to any value at all causes homing procedures to wait until the heaters have reached
+thier target temperatures AFTER probing has occurred.
+This is helpful during bed mesh calibration in the event that the probe is sensitive to the EMI caused by the bed but the bed temperature must be maintained during probing. To disable this, simply run the `SET_HOMING_HEATERS` command while omitting the `THRESHOLD` parameter.
+
 ### [idle_timeout]
 
 The idle_timeout module is automatically loaded.


### PR DESCRIPTION
This PR allows bed mesh calibration to work well with probes that are sensitive to EMI coming from the bed heater while still being able to maintain the bed temperature.
This works through adding an additional configuration setting to the
```[homing_heaters]``` section that will cause homing to wait for the
heaters to re-heat if they are outside the threshold AFTER homing has
occurred.
Note that in order to work properly this feature PR relies on the bugfix
in PR #6779.