### PR TITLE
Simplify kinematic set_position() and clear_homing_state() calls

### DIFF
--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -131,11 +131,10 @@ class ForceMove:
         x = gcmd.get_float('X', curpos[0])
         y = gcmd.get_float('Y', curpos[1])
         z = gcmd.get_float('Z', curpos[2])
-        clear = gcmd.get('CLEAR', '').upper()
-        axes = ['X', 'Y', 'Z']
-        clear_axes = [axes.index(a) for a in axes if a in clear]
+        clear = gcmd.get('CLEAR', '').lower()
+        clear_axes = "".join([a for a in "xyz" if a in clear])
         logging.info("SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f clear=%s",
-                     x, y, z, ','.join((axes[i] for i in clear_axes)))
+                     x, y, z, clear_axes)
         toolhead.set_position([x, y, z, curpos[3]], homing_axes="xyz")
         toolhead.get_kinematics().clear_homing_state(clear_axes)
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -136,7 +136,7 @@ class ForceMove:
         clear_axes = [axes.index(a) for a in axes if a in clear]
         logging.info("SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f clear=%s",
                      x, y, z, ','.join((axes[i] for i in clear_axes)))
-        toolhead.set_position([x, y, z, curpos[3]], homing_axes=(0, 1, 2))
+        toolhead.set_position([x, y, z, curpos[3]], homing_axes="xyz")
         toolhead.get_kinematics().clear_homing_state(clear_axes)
 
 def load_config(config):

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -187,7 +187,8 @@ class Homing:
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
         # Alter kinematics class to think printer is at forcepos
-        homing_axes = [axis for axis in range(3) if forcepos[axis] is not None]
+        force_axes = [axis for axis in range(3) if forcepos[axis] is not None]
+        homing_axes = "".join(["xyz"[i] for i in force_axes])
         startpos = self._fill_coord(forcepos)
         homepos = self._fill_coord(movepos)
         self.toolhead.set_position(startpos, homing_axes=homing_axes)
@@ -231,7 +232,7 @@ class Homing:
                                        + self.adjust_pos.get(s.get_name(), 0.))
                         for s in kin.get_steppers()}
             newpos = kin.calc_position(kin_spos)
-            for axis in homing_axes:
+            for axis in force_axes:
                 homepos[axis] = newpos[axis]
             self.toolhead.set_position(homepos)
 

--- a/klippy/extras/homing_override.py
+++ b/klippy/extras/homing_override.py
@@ -46,11 +46,11 @@ class HomingOverride:
         # Calculate forced position (if configured)
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
-        homing_axes = []
+        homing_axes = ""
         for axis, loc in enumerate(self.start_pos):
             if loc is not None:
                 pos[axis] = loc
-                homing_axes.append(axis)
+                homing_axes += "xyz"[axis]
         toolhead.set_position(pos, homing_axes=homing_axes)
         # Perform homing
         context = self.template.create_template_context()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -109,7 +109,7 @@ class ManualStepper:
         self.sync_print_time()
     def get_position(self):
         return [self.rail.get_commanded_position(), 0., 0., 0.]
-    def set_position(self, newpos, homing_axes=()):
+    def set_position(self, newpos, homing_axes=""):
         self.do_set_position(newpos[0])
     def get_last_move_time(self):
         self.sync_print_time()

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -40,7 +40,7 @@ class SafeZHoming:
                 toolhead.set_position(pos, homing_axes="z")
                 toolhead.manual_move([None, None, self.z_hop],
                                      self.z_hop_speed)
-                toolhead.get_kinematics().clear_homing_state((2,))
+                toolhead.get_kinematics().clear_homing_state("z")
             elif pos[2] < self.z_hop:
                 # If the Z axis is homed, and below z_hop, lift it to z_hop
                 toolhead.manual_move([None, None, self.z_hop],

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -37,7 +37,7 @@ class SafeZHoming:
             if 'z' not in kin_status['homed_axes']:
                 # Always perform the z_hop if the Z axis is not homed
                 pos[2] = 0
-                toolhead.set_position(pos, homing_axes=[2])
+                toolhead.set_position(pos, homing_axes="z")
                 toolhead.manual_move([None, None, self.z_hop],
                                      self.z_hop_speed)
                 toolhead.get_kinematics().clear_homing_state((2,))

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -94,6 +94,7 @@ class PrinterStepperEnable:
         print_time = toolhead.get_last_move_time()
         for el in self.enable_lines.values():
             el.motor_disable(print_time)
+        toolhead.get_kinematics().clear_homing_state((0, 1, 2))
         self.printer.send_event("stepper_enable:motor_off", print_time)
         toolhead.dwell(DISABLE_STALL_TIME)
     def motor_debug_enable(self, stepper, enable):

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -94,7 +94,7 @@ class PrinterStepperEnable:
         print_time = toolhead.get_last_move_time()
         for el in self.enable_lines.values():
             el.motor_disable(print_time)
-        toolhead.get_kinematics().clear_homing_state((0, 1, 2))
+        toolhead.get_kinematics().clear_homing_state("xyz")
         self.printer.send_event("stepper_enable:motor_off", print_time)
         toolhead.dwell(DISABLE_STALL_TIME)
     def motor_debug_enable(self, stepper, enable):

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -40,8 +40,6 @@ class CartKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler("stepper_enable:motor_off",
-                                            self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,
@@ -97,8 +95,6 @@ class CartKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -65,7 +65,8 @@ class CartKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -72,10 +72,10 @@ class CartKinematics:
             else:
                 rail = self.rails[axis]
             self.limits[axis] = rail.get_range()
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
     def home_axis(self, homing_state, axis, rail):
         # Determine movement
         position_min, position_max = rail.get_range()

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -39,7 +39,7 @@ class CoreXYKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
+            if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
     def clear_homing_state(self, axes):
         for i, _ in enumerate(self.limits):

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -21,8 +21,6 @@ class CoreXYKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -63,8 +61,6 @@ class CoreXYKinematics:
                 forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -41,10 +41,10 @@ class CoreXYKinematics:
             rail.set_position(newpos)
             if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
     def home(self, homing_state):
         # Each axis is homed independently and in order
         for axis in homing_state.get_axes():

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -41,10 +41,10 @@ class CoreXZKinematics:
             rail.set_position(newpos)
             if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
     def home(self, homing_state):
         # Each axis is homed independently and in order
         for axis in homing_state.get_axes():

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -39,7 +39,7 @@ class CoreXZKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-            if i in homing_axes:
+            if "xyz"[i] in homing_axes:
                 self.limits[i] = rail.get_range()
     def clear_homing_state(self, axes):
         for i, _ in enumerate(self.limits):

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -21,8 +21,6 @@ class CoreXZKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -63,8 +61,6 @@ class CoreXZKinematics:
                 forcepos[axis] += 1.5 * (position_max - hi.position_endstop)
             # Perform homing
             homing_state.home_rails([rail], forcepos, homepos)
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -23,8 +23,6 @@ class DeltaKinematics:
             stepper_configs[2], need_position_minmax = False,
             default_position_endstop=a_endstop)
         self.rails = [rail_a, rail_b, rail_c]
-        config.get_printer().register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup max velocity
         self.max_velocity, self.max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -116,8 +114,6 @@ class DeltaKinematics:
         forcepos = list(self.home_position)
         forcepos[2] = -1.5 * math.sqrt(max(self.arm2)-self.max_xy2)
         homing_state.home_rails(self.rails, forcepos, self.home_position)
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def check_move(self, move):
         end_pos = move.end_pos
         end_xy2 = end_pos[0]**2 + end_pos[1]**2

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -88,7 +88,7 @@ class DeltaKinematics:
                         math.sqrt(self.very_slow_xy2)))
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.)
-        self.set_position([0., 0., 0.], ())
+        self.set_position([0., 0., 0.], "")
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def _actuator_to_cartesian(self, spos):
@@ -101,7 +101,7 @@ class DeltaKinematics:
         for rail in self.rails:
             rail.set_position(newpos)
         self.limit_xy2 = -1.
-        if tuple(homing_axes) == (0, 1, 2):
+        if homing_axes == "xyz":
             self.need_home = False
     def clear_homing_state(self, axes):
         # Clearing homing state for each axis individually is not implemented

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -103,9 +103,9 @@ class DeltaKinematics:
         self.limit_xy2 = -1.
         if homing_axes == "xyz":
             self.need_home = False
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         # Clearing homing state for each axis individually is not implemented
-        if 0 in axes or 1 in axes or 2 in axes:
+        if clear_axes:
             self.limit_xy2 = -1
             self.need_home = True
     def home(self, homing_state):

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -116,10 +116,10 @@ class DeltesianKinematics:
         for axis_name in homing_axes:
             axis = "xyz".index(axis_name)
             self.homed_axis[axis] = True
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.homed_axis[i] = False
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.homed_axis[axis] = False
     def home(self, homing_state):
         homing_axes = homing_state.get_axes()
         home_xz = 0 in homing_axes or 2 in homing_axes

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -87,7 +87,7 @@ class DeltesianKinematics:
         self.axes_min = toolhead.Coord(*[l[0] for l in self.limits], e=0.)
         self.axes_max = toolhead.Coord(*[l[1] for l in self.limits], e=0.)
         self.homed_axis = [False] * 3
-        self.set_position([0., 0., 0.], ())
+        self.set_position([0., 0., 0.], "")
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def _actuator_to_cartesian(self, sp):
@@ -113,8 +113,9 @@ class DeltesianKinematics:
     def set_position(self, newpos, homing_axes):
         for rail in self.rails:
             rail.set_position(newpos)
-        for n in homing_axes:
-            self.homed_axis[n] = True
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
+            self.homed_axis[axis] = True
     def clear_homing_state(self, axes):
         for i, _ in enumerate(self.limits):
             if i in axes:

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -41,8 +41,6 @@ class DeltesianKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler(
-            "stepper_enable:motor_off", self._motor_off)
         self.limits = [(1.0, -1.0)] * 3
         # X axis limits
         min_angle = config.getfloat('min_angle', MIN_ANGLE,
@@ -146,8 +144,6 @@ class DeltesianKinematics:
             else:
                 forcepos[1] += 1.5 * (position_max - hi.position_endstop)
             homing_state.home_rails([self.rails[2]], forcepos, homepos)
-    def _motor_off(self, print_time):
-        self.homed_axis = [False] * 3
     def check_move(self, move):
         limits = list(map(list, self.limits))
         spos, epos = move.start_pos, move.end_pos

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -74,10 +74,10 @@ class HybridCoreXYKinematics:
             else:
                 rail = self.rails[axis]
             self.limits[axis] = rail.get_range()
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()
         hi = rail.get_homing_info()

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -67,7 +67,8 @@ class HybridCoreXYKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -42,8 +42,6 @@ class HybridCoreXYKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -97,8 +95,6 @@ class HybridCoreXYKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -74,10 +74,10 @@ class HybridCoreXZKinematics:
             else:
                 rail = self.rails[axis]
             self.limits[axis] = rail.get_range()
-    def clear_homing_state(self, axes):
-        for i, _ in enumerate(self.limits):
-            if i in axes:
-                self.limits[i] = (1.0, -1.0)
+    def clear_homing_state(self, clear_axes):
+        for axis, axis_name in enumerate("xyz"):
+            if axis_name in clear_axes:
+                self.limits[axis] = (1.0, -1.0)
     def home_axis(self, homing_state, axis, rail):
         position_min, position_max = rail.get_range()
         hi = rail.get_homing_info()

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -42,8 +42,6 @@ class HybridCoreXZKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        self.printer.register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -97,8 +95,6 @@ class HybridCoreXZKinematics:
                 self.dc_module.home(homing_state)
             else:
                 self.home_axis(homing_state, axis, self.rails[axis])
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def _check_endstops(self, move):
         end_pos = move.end_pos
         for i in (0, 1, 2):

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -67,7 +67,8 @@ class HybridCoreXZKinematics:
     def set_position(self, newpos, homing_axes):
         for i, rail in enumerate(self.rails):
             rail.set_position(newpos)
-        for axis in homing_axes:
+        for axis_name in homing_axes:
+            axis = "xyz".index(axis_name)
             if self.dc_module and axis == self.dc_module.axis:
                 rail = self.dc_module.get_primary_rail().get_rail()
             else:

--- a/klippy/kinematics/none.py
+++ b/klippy/kinematics/none.py
@@ -13,7 +13,7 @@ class NoneKinematics:
         return [0, 0, 0]
     def set_position(self, newpos, homing_axes):
         pass
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         pass
     def home(self, homing_state):
         pass

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -45,9 +45,9 @@ class PolarKinematics:
     def set_position(self, newpos, homing_axes):
         for s in self.steppers:
             s.set_position(newpos)
-        if 2 in homing_axes:
+        if "z" in homing_axes:
             self.limit_z = self.rails[1].get_range()
-        if 0 in homing_axes and 1 in homing_axes:
+        if "x" in homing_axes and "y" in homing_axes:
             self.limit_xy2 = self.rails[0].get_range()[1]**2
     def clear_homing_state(self, axes):
         if 0 in axes or 1 in axes:

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -22,8 +22,6 @@ class PolarKinematics:
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)
-        config.get_printer().register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(
@@ -88,8 +86,6 @@ class PolarKinematics:
             self._home_axis(homing_state, 0, self.rails[0])
         if home_z:
             self._home_axis(homing_state, 2, self.rails[1])
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def check_move(self, move):
         end_pos = move.end_pos
         xy2 = end_pos[0]**2 + end_pos[1]**2

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -49,11 +49,11 @@ class PolarKinematics:
             self.limit_z = self.rails[1].get_range()
         if "x" in homing_axes and "y" in homing_axes:
             self.limit_xy2 = self.rails[0].get_range()[1]**2
-    def clear_homing_state(self, axes):
-        if 0 in axes or 1 in axes:
+    def clear_homing_state(self, clear_axes):
+        if "x" in clear_axes or "y" in clear_axes:
             # X and Y cannot be cleared separately
             self.limit_xy2 = -1.
-        if 2 in axes:
+        if "z" in clear_axes:
             self.limit_z = (1.0, -1.0)
     def _home_axis(self, homing_state, axis, rail):
         # Determine movement

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -86,9 +86,9 @@ class RotaryDeltaKinematics:
         self.limit_xy2 = -1.
         if homing_axes == "xyz":
             self.need_home = False
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         # Clearing homing state for each axis individually is not implemented
-        if 0 in axes or 1 in axes or 2 in axes:
+        if clear_axes:
             self.limit_xy2 = -1
             self.need_home = True
     def home(self, homing_state):

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -74,7 +74,7 @@ class RotaryDeltaKinematics:
         max_xy = math.sqrt(self.max_xy2)
         self.axes_min = toolhead.Coord(-max_xy, -max_xy, self.min_z, 0.)
         self.axes_max = toolhead.Coord(max_xy, max_xy, self.max_z, 0.)
-        self.set_position([0., 0., 0.], ())
+        self.set_position([0., 0., 0.], "")
     def get_steppers(self):
         return [s for rail in self.rails for s in rail.get_steppers()]
     def calc_position(self, stepper_positions):
@@ -84,7 +84,7 @@ class RotaryDeltaKinematics:
         for rail in self.rails:
             rail.set_position(newpos)
         self.limit_xy2 = -1.
-        if tuple(homing_axes) == (0, 1, 2):
+        if homing_axes == "xyz":
             self.need_home = False
     def clear_homing_state(self, axes):
         # Clearing homing state for each axis individually is not implemented

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -21,8 +21,6 @@ class RotaryDeltaKinematics:
             stepper_configs[2], need_position_minmax=False,
             default_position_endstop=a_endstop, units_in_radians=True)
         self.rails = [rail_a, rail_b, rail_c]
-        config.get_printer().register_event_handler("stepper_enable:motor_off",
-                                                    self._motor_off)
         # Read config
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,
@@ -101,8 +99,6 @@ class RotaryDeltaKinematics:
         #forcepos[2] = self.calibration.actuator_to_cartesian(min_angles)[2]
         forcepos[2] = -1.
         homing_state.home_rails(self.rails, forcepos, self.home_position)
-    def _motor_off(self, print_time):
-        self.clear_homing_state((0, 1, 2))
     def check_move(self, move):
         end_pos = move.end_pos
         end_xy2 = end_pos[0]**2 + end_pos[1]**2

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -26,7 +26,7 @@ class WinchKinematics:
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.)
         self.axes_max = toolhead.Coord(*[max(a) for a in acoords], e=0.)
-        self.set_position([0., 0., 0.], ())
+        self.set_position([0., 0., 0.], "")
     def get_steppers(self):
         return list(self.steppers)
     def calc_position(self, stepper_positions):

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -36,7 +36,7 @@ class WinchKinematics:
     def set_position(self, newpos, homing_axes):
         for s in self.steppers:
             s.set_position(newpos)
-    def clear_homing_state(self, axes):
+    def clear_homing_state(self, clear_axes):
         # XXX - homing not implemented
         pass
     def home(self, homing_state):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -457,7 +457,7 @@ class ToolHead:
     # Movement commands
     def get_position(self):
         return list(self.commanded_pos)
-    def set_position(self, newpos, homing_axes=()):
+    def set_position(self, newpos, homing_axes=""):
         self.flush_step_generation()
         ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.trapq_set_position(self.trapq, self.print_time,


### PR DESCRIPTION
Now that clear_homing_state() has been implemented, there is no longer a need for each kinematic class to manually register for the "motor_off" event, as the stepper_enable class can directly call clear_homing_state().

Also this changes the homing_axes and clear_axes parameters of the set_position() and clear_homing_state() to pass strings (eg, "xyz") instead of a list of numbers.

@twelho - fyi.

-Kevin