### PR TITLE
Updating homing speed for sensorless homing

### DIFF
--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -187,12 +187,12 @@ the end of the rail. However, the TMC drivers can't reliably detect a
 stall at very slow speeds.
 
 A good starting point for the homing speed is for the stepper motor to
-make a full rotation every two seconds. For many axes this will be the
-`rotation_distance` divided by two. For example:
+make a full rotation every second. For many axes this will be equal to the
+`rotation_distance`. For example:
 ```
 [stepper_x]
 rotation_distance: 40
-homing_speed: 20
+homing_speed: 40
 ...
 ```
 


### PR DESCRIPTION
Hello there, 

Update homing speed for sensorless homing
The TMC 2209 documention recommends a higher speed.
Currently the recommended starting homing speed is half as rotation speed, which would equal half a rotation per second and that is in my thinking well below one revolution per second as the documentation is stating. 


```
StallGuard4 operates best at medium motor velocities. Very low motor velocities (for many motors
well below one revolution per second) [...]
```
https://www.analog.com/media/en/technical-documentation/data-sheets/TMC2209_datasheet_rev1.08.pdf S.59 Section 11.5

If there are any objections please let me know. 