### PR TITLE
screws_tilt_adjust: add option to compute probe-relative points automatically, as well as raise z at the end

### DIFF
--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -15,6 +15,41 @@ class ScrewsTiltAdjust:
         self.results = []
         self.max_diff = None
         self.max_diff_error = False
+        self.end_z = config.getfloat("end_z", None)
+
+        use_bed_screws = config.get("use_bed_screws", "no").lower()
+        if use_bed_screws == "yes" or use_bed_screws == "true" or use_bed_screws == "1":
+            self.need_probe_offsets = True
+            self._load_screws_from_bed_screws()
+        else:
+            self.need_probe_offsets = False
+            self._load_screws(self.config)
+        self.threads = {'CW-M3': 0, 'CCW-M3': 1, 'CW-M4': 2, 'CCW-M4': 3,
+                        'CW-M5': 4, 'CCW-M5': 5, 'CW-M6': 6, 'CCW-M6': 7}
+        self.thread = config.getchoice('screw_thread', self.threads,
+                                       default='CW-M3')
+        # Initialize ProbePointsHelper
+        self.probe_helper = probe.ProbePointsHelper(self.config,
+                                                    self.probe_finalize,
+                                                    default_points=[(0,0)])
+        # Register command
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command("SCREWS_TILT_CALCULATE",
+                                    self.cmd_SCREWS_TILT_CALCULATE,
+                                    desc=self.cmd_SCREWS_TILT_CALCULATE_help)
+    cmd_SCREWS_TILT_CALCULATE_help = "Tool to help adjust bed leveling " \
+                                     "screws by calculating the number " \
+                                     "of turns to level it."
+
+    def _load_screws_from_bed_screws(self):
+        config = self.config
+        if not config.has_section('bed_screws'):
+            raise config.error("screws_tilt_adjust: must have bed_screws "
+                    "if use_bed_screws is set")
+        bed_screws = config.getsection('bed_screws')
+        self._load_screws(bed_screws)
+
+    def _load_screws(self, config):
         # Read config
         for i in range(99):
             prefix = "screw%d" % (i + 1,)
@@ -26,25 +61,31 @@ class ScrewsTiltAdjust:
             self.screws.append((screw_coord, screw_name))
         if len(self.screws) < 3:
             raise config.error("screws_tilt_adjust: Must have "
-                               "at least three screws")
-        self.threads = {'CW-M3': 0, 'CCW-M3': 1, 'CW-M4': 2, 'CCW-M4': 3,
-                        'CW-M5': 4, 'CCW-M5': 5, 'CW-M6': 6, 'CCW-M6': 7}
-        self.thread = config.getchoice('screw_thread', self.threads,
-                                       default='CW-M3')
-        # Initialize ProbePointsHelper
-        points = [coord for coord, name in self.screws]
-        self.probe_helper = probe.ProbePointsHelper(self.config,
-                                                    self.probe_finalize,
-                                                    default_points=points)
-        self.probe_helper.minimum_points(3)
-        # Register command
-        self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command("SCREWS_TILT_CALCULATE",
-                                    self.cmd_SCREWS_TILT_CALCULATE,
-                                    desc=self.cmd_SCREWS_TILT_CALCULATE_help)
-    cmd_SCREWS_TILT_CALCULATE_help = "Tool to help adjust bed leveling " \
-                                     "screws by calculating the number " \
-                                     "of turns to level it."
+                           "at least three screws")
+
+    def _offset_screws(self, gcmd):
+        if not self.need_probe_offsets:
+            return
+        th = self.printer.lookup_object('toolhead')
+        xrange = th.get_kinematics().rails[0].get_range()
+        yrange = th.get_kinematics().rails[1].get_range()
+        probe = self.printer.lookup_object('probe')
+        probe_x, probe_y, _ = probe.get_offsets()
+        for i in range(len(self.screws)):
+            screw_coord, screw_name = self.screws[i]
+            sx, sy = screw_coord
+            sx -= probe_x
+            sy -= probe_y
+            if xrange[0] >= sx or sx >= xrange[1]:
+                sx = max(xrange[0]+1.0, min(sx, xrange[1]-1.0))
+                gcmd.respond_info(f"screws_tilt_adjust: screw {screw_name} X"
+                        f"out of range, adjusting to {sx}")
+            if yrange[0] >= sy or sy >= yrange[1]:
+                sy = max(yrange[0]+1.0, min(sy, yrange[1]-1.0))
+                gcmd.respond_info(f"screws_tilt_adjust: screw {screw_name} Y"
+                        f"out of range, adjusting to {sy}")
+            self.screws[i] = ((sx, sy), screw_name)
+        self.need_probe_offsets = False
 
     def cmd_SCREWS_TILT_CALCULATE(self, gcmd):
         self.max_diff = gcmd.get_float("MAX_DEVIATION", None)
@@ -57,6 +98,9 @@ class ScrewsTiltAdjust:
                     "Error on '%s': DIRECTION must be either CW or CCW" % (
                         gcmd.get_commandline(),))
         self.direction = direction
+        self._offset_screws(gcmd)
+        points = [coord for coord, name in self.screws]
+        self.probe_helper.update_probe_points(points, 3)
         self.probe_helper.start_probe(gcmd)
 
     def get_status(self, eventtime):
@@ -65,6 +109,9 @@ class ScrewsTiltAdjust:
             'results': self.results}
 
     def probe_finalize(self, offsets, positions):
+        if self.end_z is not None:
+            th = self.printer.lookup_object('toolhead')
+            th.manual_move([None, None, self.end_z], 10)
         self.results = {}
         self.max_diff_error = False
         # Factors used for CW-M3, CCW-M3, CW-M4, CCW-M4, CW-M5, CCW-M5, CW-M6


### PR DESCRIPTION
`screws_tilt_adjust` expects screw points as probe-relative, while `bed_screws` is nozzle-relative. This is a bit silly (and confusing) -- the system's got the probe offsets, it can do the math faster than I can. In order to maintain backwards compat, this adds a `use_bed_screws` option to `screws_tilt_adjust`. If it's set (`yes`, `true`, `1`), then the screw positions are read from `bed_screws`, and are offset by the probe offset.

It can't use the ProbePointsHelper's `use_xy_offsets`, because that may put the points outside of range; it applies the offsets manually, and pushes them within x/y range if they're outside. (It would be nice if `ProbePointsHelper` had a "and push points in range" option, maybe also a "skip out of range" option.) Also ran into a weird issue that if `default_points` wasn't specified, `ProbePointsHelper` suddenly required a `points` config option; didn't investigate why, from my reading of the code it shouldn't be required.

This patch also adds a `end_z` option to `screws_tilt_adjust` to give a z to raise the toolhead to after probing the last point. Otherwise it leaves the toolhead right over top of the last screw you may need to modify; you can manually move and run it again, but if we're trying to be helpful... 

(Also -- why do `bed_screws` and `screws_tilt_adjust` both exist? They're doing 99% the same work, except one uses a probe and gives you turn instructions, both of which could be optional.. e.g. manual probe, and if you don't know screw info, then it can just give you the relative heights.)
