### PR TITLE
screws_tilt_adjust: initialize status result as a dictionary

### DIFF
--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -12,7 +12,7 @@ class ScrewsTiltAdjust:
         self.config = config
         self.printer = config.get_printer()
         self.screws = []
-        self.results = []
+        self.results = {}
         self.max_diff = None
         self.max_diff_error = False
         # Read config


### PR DESCRIPTION
On [my previous PR](https://github.com/Klipper3d/klipper/pull/5992) to make this an object I forgot to correctly initialize `results` as an object; this PR fixed that.