### PR TITLE
fix(gc): freeze gc objects after startup 

### DIFF
--- a/klippy/extras/garbage_collection.py
+++ b/klippy/extras/garbage_collection.py
@@ -1,0 +1,31 @@
+# Garbage collection optimizations
+#
+# Copyright (C) 2025  Branden Cash <ammmze@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import gc
+import logging
+
+class GarbageCollection:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        # feature check ... freeze/unfreeze is only available in python 3.7+
+        can_freeze = hasattr(gc, 'freeze') and hasattr(gc, 'unfreeze')
+        if can_freeze:
+            self.printer.register_event_handler("klippy:ready",
+                                                self._handle_ready)
+            self.printer.register_event_handler("klippy:disconnect",
+                                                self._handle_disconnect)
+
+    def _handle_ready(self):
+        logging.debug("Running full garbage collection and freezing")
+        for n in range(3):
+            gc.collect(n)
+        gc.freeze()
+
+    def _handle_disconnect(self):
+        logging.debug("Unfreezing garbage collection")
+        gc.unfreeze()
+
+def load_config(config):
+    return GarbageCollection(config)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -290,7 +290,7 @@ class ToolHead:
                                             self._handle_shutdown)
         # Load some default modules
         modules = ["gcode_move", "homing", "idle_timeout", "statistics",
-                   "manual_probe", "tuning_tower"]
+                   "manual_probe", "tuning_tower", "garbage_collection"]
         for module_name in modules:
             self.printer.load_object(config, module_name)
     # Print time and flush tracking


### PR DESCRIPTION
This is my attempt to address Timer Too Close errors on some slower machines. Through some debugging that started with something @KevinOConnor pointed out in #6784, I observed a correlation between generation 2 collection happening at the same time as homing moves (in particular during happy hare drip/homing moves...with happy hare the user will experience many more "homing" moves than a standard non-mmu enabled printer because it "homes" filament to various sensors each time filament is swapped. I found that on my Orange Pi CM4, the generation 2 garbage collection takes between ~150-300ms depending on whether I have the shake and tune module enabled. Based on the discussion in #6784, those homing moves require low latency (<100ms) communication. So having gc that takes longer than this 100ms (which would block all other threads) is problematic. More details about my setup can be found [here](https://gist.github.com/ammmze/5770bb4833de3aafc63ab589e46cd371).

~What I am doing here in this PR is tracking how long each generation garbage collection takes (with a cap of 90% of the largest free time we've seen). With this information, we can prevent doing garbage collection if there's a possibility that gc will take us past the next scheduled timer.~

What I am doing here in this PR is performing a full garbage collection after klipper has finished loading and then performing a garbage collection freeze. This will move all the remaining mostly static objects to the "permanent" generation, leaving a lot less data for future gen 2 collections to process, making gen 2 collections much faster.

I am open to other ideas if you've got any. I don't think my solution is in any way bullet proof...there's still a possibility that a long running garbage collection could take too long and take us past the next timer, but I think it will be less likely.

I will acknowledge that standard klipper does do garbage collection much less frequently, but the reality is many people have extra modules like cartographer, led effects, happy hare, etc. While it would be nice if these all did their best to avoid leaving garbage for the garbage collector, the reality is that it would be a large effort and different communities have varying levels of knowledge to make this happen. So I think we should try to accommodate the best we can.