### PR TITLE
Add Ender 3 V2 UART crossing note

### DIFF
--- a/config/printer-creality-ender3-v2-2020.cfg
+++ b/config/printer-creality-ender3-v2-2020.cfg
@@ -7,7 +7,7 @@
 # select "Enable extra low-level configuration options" and select
 # serial (on USART3 PB11/PB10), which is broken out on the 10 pin IDC
 # cable used for the LCD module as follows:
-# 3: Tx, 4: Rx, 9: GND, 10: VCC
+# 3: Tx, 4: Rx, 9: GND, 10: VCC (pins 3 & 4 may need to be crossed depending on host board)
 
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware


### PR DESCRIPTION
On some boards (for example, the Raspberry Pi 4) the pinout diagram may lead some end-users to improperly connect the UART pins. For example, some users may connect pin 3 (TX) of the IDC to pin 8 (TX) of the RPI4 and pin 4 (RX) of the IDC to pin 10 (RX). This is incorrect but it isn't immediately obvious to some users. Instead users should connect TX-RX and vice versa.

This note should help relieve this issue.