### PR TITLE
stm32: h7 spi support reload mode & frequency

### DIFF
--- a/src/stm32/gpio.h
+++ b/src/stm32/gpio.h
@@ -38,7 +38,13 @@ void gpio_adc_cancel_sample(struct gpio_adc g);
 
 struct spi_config {
     void *spi;
-    uint32_t spi_cr1;
+    union {
+        uint32_t spi_cr1;
+        struct {
+            uint8_t div;
+            uint8_t mode;
+        };
+    };
 };
 struct spi_config spi_setup(uint32_t bus, uint8_t mode, uint32_t rate);
 void spi_prepare(struct spi_config config);

--- a/src/stm32/stm32h7_spi.c
+++ b/src/stm32/stm32h7_spi.c
@@ -100,19 +100,27 @@ spi_setup(uint32_t bus, uint8_t mode, uint32_t rate)
     while ((pclk >> (div + 1)) > rate && div < 7)
         div++;
 
-    uint32_t cr1 = SPI_CR1_SPE;
     spi->CFG1 |= (div << SPI_CFG1_MBR_Pos) | (7 << SPI_CFG1_DSIZE_Pos);
     CLEAR_BIT(spi->CFG1, SPI_CFG1_CRCSIZE);
     spi->CFG2 |= ((mode << SPI_CFG2_CPHA_Pos) | SPI_CFG2_MASTER | SPI_CFG2_SSM
                    | SPI_CFG2_AFCNTR | SPI_CFG2_SSOE);
     spi->CR1 |= SPI_CR1_SSI;
 
-    return (struct spi_config){ .spi = spi, .spi_cr1 = cr1 };
+    return (struct spi_config){ .spi = spi, .div = div, .mode = mode };
 }
 
 void
 spi_prepare(struct spi_config config)
 {
+    uint32_t div = config.div;
+    uint32_t mode = config.mode;
+    SPI_TypeDef *spi = config.spi;
+    // Reload frequency
+    spi->CFG1 = (spi->CFG1 & ~SPI_CFG1_MBR_Msk);
+    spi->CFG1 |= (div << SPI_CFG1_MBR_Pos);
+    // Reload mode
+    spi->CFG2 = (spi->CFG2 & ~SPI_CFG2_CPHA_Msk);
+    spi->CFG2 |= (mode << SPI_CFG2_CPHA_Pos);
 }
 
 void


### PR DESCRIPTION
Currently, there is an issue with spi bus frequency and possibly mode.
If several different devices are present on the bus because of the logical `OR` gate on CFG registers, mode and div will be merged.
So, if they share mode speed will be lower, in my specific case 4Mhz TMC (MBR 6) + 10Mhz encoder (MBR 5), causes div to be 6|5 = 7.

So, this is a simple fix to allow a proper reload of CFG registers.
STM32H7 (at 480Mhz) so expected frequencies:
- 480_000_000 >> (5 + 1) = 7500000
- 480_000_000 >> (6 + 1) = 3750000

There are oscilloscope probes, while both are running:
![image](https://github.com/user-attachments/assets/9e9f6904-f4ab-492c-b240-bab92ee52644)
![image](https://github.com/user-attachments/assets/4cb4abe7-a6ca-4981-8737-69ba9b6c8a48)

Thanks.