### PR TITLE
save_variables: Check lowercase variable names

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250131: Option `VARIABLE=<name>` in `SAVE_VARIABLE` requires lowercase
+value. For example, `extruder` instead of mixedcase `Extruder` or
+uppercase `EXTRUDER`. Using any uppercase letter will raise an error.
+
 20241203: The resonance test has been changed to include slow sweeping
 moves. This change requires that testing point(s) have some clearance
 in X/Y plane (+/- 30 mm from the test point should suffice when using

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1201,8 +1201,9 @@ has been enabled.
 
 #### SAVE_VARIABLE
 `SAVE_VARIABLE VARIABLE=<name> VALUE=<value>`: Saves the variable to
-disk so that it can be used across restarts. All stored variables are
-loaded into the `printer.save_variables.variables` dict at startup and
+disk so that it can be used across restarts. The VARIABLE must be lowercase.
+All stored variables are loaded into the
+`printer.save_variables.variables` dict at startup and
 can be used in gcode macros. The provided VALUE is parsed as a Python
 literal.
 

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -36,6 +36,8 @@ class SaveVariables:
     cmd_SAVE_VARIABLE_help = "Save arbitrary variables to disk"
     def cmd_SAVE_VARIABLE(self, gcmd):
         varname = gcmd.get('VARIABLE')
+        if (varname.lower() != varname):
+            raise gcmd.error("VARIABLE must not contain upper case")
         value = gcmd.get('VALUE')
         try:
             value = ast.literal_eval(value)


### PR DESCRIPTION
This is a follow up on [this Discorse topic](https://klipper.discourse.group/t/save-variable-only-works-with-lower-case-variable-names/21032), ensuring the variable name is converted to lowercase before saving and documenting this change to fix the incorrect behavior.