### PR TITLE
Add a stale ticket tracker for github PRs

### DIFF
--- a/.github/workflows/stale-issue-bot.yaml
+++ b/.github/workflows/stale-issue-bot.yaml
@@ -11,16 +11,14 @@ jobs:
     steps:
     - uses: actions/stale@v8
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: |
+        stale-pr-message: |
           Hello,
 
           It looks like there hasn't been any recent updates on this
-          Klipper github issue.  If you created this issue and no
-          longer consider it open, then please login to github and
-          close the issue.  Otherwise, if there is no further activity
-          on this thread then it will be automatically closed in a few
-          days.
+          github ticket.  We prefer to only list tickets as "open" if
+          they are actively being worked on.  Feel free to provide an
+          update on this ticket.  Otherwise the ticket will be
+          automatically closed in a few days.
 
           Best regards,
 
@@ -29,10 +27,10 @@ jobs:
           PS: I'm just an automated script, not a human being.
 
         exempt-issue-labels: 'enhancement,bug'
-        days-before-stale: 35
+        days-before-stale: 60
         days-before-close: 7
-        days-before-pr-stale: -1
-        days-before-pr-close: -1
+        days-before-issue-stale: -1
+        days-before-issue-close: -1
   # Close tickets marked with "not on github" label
   close_not_on_github:
     if: github.repository == 'Klipper3d/klipper'
@@ -330,7 +328,7 @@ jobs:
             }
   # Lock closed issues after 6 months of inactivity and PRs after 1 year.
   lock:
-    name: Lock Closed Issues
+    name: Lock Closed Tickets
     if: github.repository == 'Klipper3d/klipper'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This change will mark any PR that hasn't been updated in 60 days with a stale label.  If there are no updates in 7 days after that, the PR will be closed.

There's quite a few open PRs right now - many of them are relevant and should be looked at.  However, quite a few are just stale and are unlikely to be followed up on.  Marking them as stale may help reduce the list of open tickets which could hopefully make it easier to identify which PRs need more attention.

-Kevin