### PR TITLE
docs: Fix broken link to MainsailOS

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -61,7 +61,7 @@ their own Klipper-centric images.
 
 The two main Moonraker based front ends are [Fluidd](https://docs.fluidd.xyz/)
 and [Mainsail](https://docs.mainsail.xyz/), the latter of which has a premade install
-image ["MainsailOS"](http://docs.mainsailOS.xyz), this has the option for Raspberry Pi
+image ["MainsailOS"](https://docs-os.mainsail.xyz/), this has the option for Raspberry Pi
 and some OrangePi varianta.
 
 Fluidd can be installed via KIAUH(Klipper Install And Update Helper), which


### PR DESCRIPTION
The documentation install page has a link to the old mainsail OS site, which is no longer available