### PR TITLE
Improve suggestions on bytes_invalid in CANBUS_Troubleshooting.md

### DIFF
--- a/docs/CANBUS_Troubleshooting.md
+++ b/docs/CANBUS_Troubleshooting.md
@@ -37,20 +37,36 @@ hours or more frequently) then it is an indication of a severe
 problem.
 
 Incrementing `bytes_invalid` on a CAN bus connection is a symptom of
-reordered messages on the CAN bus. There are two known causes of
-reordered messages:
-1. Old versions of the popular candlight_firmware for USB CAN adapters
-   had a bug that could cause reordered messages. If using a USB CAN
-   adapter running this firmware then make sure to update to the
-   latest firmware if incrementing `bytes_invalid` is observed.
-2. Some Linux kernel builds for embedded devices have been known to
-   reorder CAN bus messages. It may be necessary to use an alternative
-   Linux kernel or to use alternative hardware that supports
-   mainstream Linux kernels that do not exhibit this problem.
+reordered messages on the CAN bus. If seen, make sure to:
+* Use a Linux kernel version 6.6.0 or later.
+* If using a USB-to-CANBUS adapter running candlelight firmware, use
+  v2.0 or later of candleLight_fw.
+* If using Klipper's USB-to-CANBUS bridge mode, make sure the bridge
+  node is flashed with Klipper v0.12.0 or later.
 
 Reordered messages is a severe problem that must be fixed. It will
 result in unstable behavior and can lead to confusing errors at any
-part of a print.
+part of a print. An incrementing `bytes_invalid` is not caused by
+wiring or similar hardware issues and can only be fixed by identifying
+and updating the faulty software.
+
+Older versions of the Linux kernel had a bug in the gs_usb canbus
+driver code that could cause reordered canbus packets.  The issue is
+thought to be fixed in
+[Linux commit 24bc41b4](https://github.com/torvalds/linux/commit/24bc41b4558347672a3db61009c339b1f5692169)
+which was released in v6.6.0. In some cases, older Linux versions may
+not show the problem (due to how hardware interrupts are configured),
+however if problems are seen the recommended solution is to upgrade to
+a newer kernel.
+
+Older versions of candlelight firmware could reorder canbus packets,
+and the issue is thought to be fixed in
+[candlelight_fw commit 8b3a7b45](https://github.com/candle-usb/candleLight_fw/commit/8b3a7b4565a3c9521b762b154c94c72c5acb2bcf).
+
+Older versions of Klipper's USB-to-CANBUS bridge code could
+incorrectly drop canbus messages. This is not as severe as reordering
+messages, but it should still be fixed. It is thought to be fixed with
+[Klipper PR #6175](https://github.com/Klipper3d/klipper/pull/6175).
 
 ## Use an appropriate txqueuelen setting
 


### PR DESCRIPTION
Reword the section on "incrementing bytes_invalid" to hopefully be more clear on steps that need to be taken if the issue is encountered.

I did some research on the known cases of reordered canbus packets and I think we can make some simple recommendations (Linux kernel >v6.5.0 and candlelight_fw >v2.0).

This was also discussed at https://klipper.discourse.group/t/canbus-missed-scheduling-of-next-digital-out-event/21757

@meteyou - FYI there are reports that the mainsail OS images are using Linux kernels <v6.5.0 and that those installations can show the reordered canbus packet problem.

-Kevin