### PR TITLE
Use dotfiles for Klipper backup configuration

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -386,7 +386,7 @@ class ConfigAutoSave:
         self._disallow_include_conflicts(regular_fileconfig)
         # Determine filenames
         datestr = time.strftime("-%Y%m%d_%H%M%S")
-        backup_name = cfgname + datestr
+        backup_name = "." + cfgname + datestr
         temp_name = cfgname + "_autosave"
         if cfgname.endswith(".cfg"):
             backup_name = cfgname[:-4] + datestr + ".cfg"


### PR DESCRIPTION
This PR prepends a `.` to the name of the backup Klipper configuration file when `SAVE_CONFIG` is executed.  This greatly de-clutters the Klipper configuration directory.

Here is an example of `/etc/klipper` after many `SAVE_CONFIG` calls.  The backup files pollute the directory, and makes managing this directory difficult as a user.

```
$ ls /etc/klipper
klipper			     klipper-20250102_231643.cfg  klipper-20250108_201350.cfg  klipper-20250201_062042.cfg  klipper-20250204_092537.cfg
klipper-20241230_010002.cfg  klipper-20250102_232020.cfg  klipper-20250109_162625.cfg  klipper-20250201_063643.cfg  klipper-20250204_182142.cfg
klipper-20241230_011232.cfg  klipper-20250102_232556.cfg  klipper-20250109_172406.cfg  klipper-20250201_065344.cfg  klipper-20250204_183409.cfg
klipper-20241230_183238.cfg  klipper-20250102_235621.cfg  klipper-20250109_174713.cfg  klipper-20250201_071639.cfg  klipper-20250204_193018.cfg
klipper-20241230_184647.cfg  klipper-20250103_002034.cfg  klipper-20250111_133722.cfg  klipper-20250201_085324.cfg  klipper-20250204_194755.cfg
klipper-20241230_190858.cfg  klipper-20250103_233505.cfg  klipper-20250111_231710.cfg  klipper-20250201_085759.cfg  klipper-20250206_010314.cfg
klipper-20241230_193847.cfg  klipper-20250104_001433.cfg  klipper-20250112_002827.cfg  klipper-20250201_092728.cfg  klipper-20250206_010327.cfg
klipper-20241230_201524.cfg  klipper-20250104_003245.cfg  klipper-20250112_003101.cfg  klipper-20250201_094424.cfg  klipper-20250209_083342.cfg
klipper-20241230_201839.cfg  klipper-20250104_020937.cfg  klipper-20250120_215419.cfg  klipper-20250201_100913.cfg  klipper-20250209_085919.cfg
klipper-20241230_203903.cfg  klipper-20250105_181522.cfg  klipper-20250120_220518.cfg  klipper-20250202_082337.cfg  klipper-20250209_090526.cfg
klipper-20241231_144141.cfg  klipper-20250105_234452.cfg  klipper-20250121_220630.cfg  klipper-20250202_082927.cfg  klipper-20250209_093153.cfg
klipper-20241231_145323.cfg  klipper-20250106_135150.cfg  klipper-20250121_224252.cfg  klipper-20250202_085712.cfg  klipper-20250209_094548.cfg
klipper-20250101_191310.cfg  klipper-20250106_152108.cfg  klipper-20250131_133028.cfg  klipper-20250202_085929.cfg  klipper-20250209_101006.cfg
klipper-20250101_194524.cfg  klipper-20250106_233616.cfg  klipper-20250131_134838.cfg  klipper-20250202_090740.cfg  klipper-20250209_102219.cfg
klipper-20250101_233231.cfg  klipper-20250106_234352.cfg  klipper-20250201_025502.cfg  klipper-20250202_091204.cfg  klipper-20250210_010204.cfg
klipper-20250101_234316.cfg  klipper-20250107_112607.cfg  klipper-20250201_030006.cfg  klipper-20250202_092525.cfg  klipper.cfg
klipper-20250102_011046.cfg  klipper-20250107_145216.cfg  klipper-20250201_055142.cfg  klipper-20250203_000732.cfg  moonraker.conf
klipper-20250102_143420.cfg  klipper-20250107_160745.cfg  klipper-20250201_055731.cfg  klipper-20250203_045359.cfg
klipper-20250102_164936.cfg  klipper-20250107_161409.cfg  klipper-20250201_060051.cfg  klipper-20250203_050255.cfg
klipper-20250102_220506.cfg  klipper-20250108_020808.cfg  klipper-20250201_061048.cfg  klipper-20250204_082301.cfg
klipper-20250102_224536.cfg  klipper-20250108_153908.cfg  klipper-20250201_061547.cfg  klipper-20250204_085651.cfg
```

Here is what :point_up: would look like with the changes in this PR:

```
$ ls /etc/klipper
klipper  klipper.cfg  moonraker.conf
```

...and of course, the dotfiles can be viewed with `-a`, along with other dotfiles that carry a similar nature:

```
$ ls -a /etc/klipper
.			      .klipper-20250102_224536.cfg  .klipper-20250108_201350.cfg  .klipper-20250201_063643.cfg	.klipper-20250204_183409.cfg
..			      .klipper-20250102_231643.cfg  .klipper-20250109_162625.cfg  .klipper-20250201_065344.cfg	.klipper-20250204_193018.cfg
.git			      .klipper-20250102_232020.cfg  .klipper-20250109_172406.cfg  .klipper-20250201_071639.cfg	.klipper-20250204_194755.cfg
.klipper-20241230_010002.cfg  .klipper-20250102_232556.cfg  .klipper-20250109_174713.cfg  .klipper-20250201_085324.cfg	.klipper-20250206_010314.cfg
.klipper-20241230_011232.cfg  .klipper-20250102_235621.cfg  .klipper-20250111_133722.cfg  .klipper-20250201_085759.cfg	.klipper-20250206_010327.cfg
.klipper-20241230_183238.cfg  .klipper-20250103_002034.cfg  .klipper-20250111_231710.cfg  .klipper-20250201_092728.cfg	.klipper-20250209_083342.cfg
.klipper-20241230_184647.cfg  .klipper-20250103_233505.cfg  .klipper-20250112_002827.cfg  .klipper-20250201_094424.cfg	.klipper-20250209_085919.cfg
.klipper-20241230_190858.cfg  .klipper-20250104_001433.cfg  .klipper-20250112_003101.cfg  .klipper-20250201_100913.cfg	.klipper-20250209_090526.cfg
.klipper-20241230_193847.cfg  .klipper-20250104_003245.cfg  .klipper-20250120_215419.cfg  .klipper-20250202_082337.cfg	.klipper-20250209_093153.cfg
.klipper-20241230_201524.cfg  .klipper-20250104_020937.cfg  .klipper-20250120_220518.cfg  .klipper-20250202_082927.cfg	.klipper-20250209_094548.cfg
.klipper-20241230_201839.cfg  .klipper-20250105_181522.cfg  .klipper-20250121_220630.cfg  .klipper-20250202_085712.cfg	.klipper-20250209_101006.cfg
.klipper-20241230_203903.cfg  .klipper-20250105_234452.cfg  .klipper-20250121_224252.cfg  .klipper-20250202_085929.cfg	.klipper-20250209_102219.cfg
.klipper-20241231_144141.cfg  .klipper-20250106_135150.cfg  .klipper-20250131_133028.cfg  .klipper-20250202_090740.cfg	.klipper-20250210_010204.cfg
.klipper-20241231_145323.cfg  .klipper-20250106_152108.cfg  .klipper-20250131_134838.cfg  .klipper-20250202_091204.cfg	.klipper.cfg.un~
.klipper-20250101_191310.cfg  .klipper-20250106_233616.cfg  .klipper-20250201_025502.cfg  .klipper-20250202_092525.cfg	.moonraker.conf.bkp
.klipper-20250101_194524.cfg  .klipper-20250106_234352.cfg  .klipper-20250201_030006.cfg  .klipper-20250203_000732.cfg	klipper
.klipper-20250101_233231.cfg  .klipper-20250107_112607.cfg  .klipper-20250201_055142.cfg  .klipper-20250203_045359.cfg	klipper.cfg
.klipper-20250101_234316.cfg  .klipper-20250107_145216.cfg  .klipper-20250201_055731.cfg  .klipper-20250203_050255.cfg	moonraker.conf
.klipper-20250102_011046.cfg  .klipper-20250107_160745.cfg  .klipper-20250201_060051.cfg  .klipper-20250204_082301.cfg
.klipper-20250102_143420.cfg  .klipper-20250107_161409.cfg  .klipper-20250201_061048.cfg  .klipper-20250204_085651.cfg
.klipper-20250102_164936.cfg  .klipper-20250108_020808.cfg  .klipper-20250201_061547.cfg  .klipper-20250204_092537.cfg
.klipper-20250102_220506.cfg  .klipper-20250108_153908.cfg  .klipper-20250201_062042.cfg  .klipper-20250204_182142.cfg
```