### PR TITLE
Update board_defs.py - BTT Octopus Max EZ

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -130,6 +130,13 @@ BOARD_DEFS = {
         "cs_pin": "PA4",
         "current_firmware_path": "OLD.BIN"
     },
+    'btt-octopus-max-ez': {
+        'mcu': "stm32h723xx",
+        'spi_bus': "swspi",
+        'spi_pins': "PE13,PE14,PE12",
+        'cs_pin': "PB12",
+        'skip_verify': True
+    },
     'btt-skrat': {
         'mcu': "stm32g0b1xx",
         'spi_bus': "spi1",


### PR DESCRIPTION
Addition to the board_defs file for the BTT Octopus Max EZ, written and confirmed by discord user Nikki @winningfaith81

Thanks
James

Signed-off-by: James Hartley <james@hartleyns.com>