### PR TITLE
Fixed incorrect spelling in Config_Reference.md

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5061,7 +5061,7 @@ Octoprint as they will conflict, and 1 will fail to initialize
 properly likely aborting your print.
 
 If you use Octoprint and stream gcode over the serial port instead of
-printing from virtual_sd, then remo **M1** and **M0** from *Pausing commands*
+printing from virtual_sd, then remove **M1** and **M0** from *Pausing commands*
 in *Settings > Serial Connection > Firmware & protocol* will prevent
 the need to start print on the Palette 2 and unpausing in Octoprint
 for your print to begin.


### PR DESCRIPTION
module: Fixed incorrect spelling in Config_Reference.md

changed spelling of "remo" to "remove", assuming it was a simple mistype and should say "remove".

Signed-off-by: Nicholas Parry <rounded-gully-5r@icloud.com>