### PR TITLE
Supports retrieving the name of the currently loaded skew correction …

### DIFF
--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -20,7 +20,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
-        self.cur_skew_profiles_name = ""
+        self.cur_skew_prof_name = ""
         self.toolhead = None
         self.xy_factor = 0.
         self.xz_factor = 0.
@@ -33,7 +33,8 @@ class PrinterSkew:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('GET_CURRENT_SKEW', self.cmd_GET_CURRENT_SKEW,
                                desc=self.cmd_GET_CURRENT_SKEW_help)
-        gcode.register_command('GET_CURRENT_SKEW_NAME', self.cmd_GET_CURRENT_SKEW_NAME,
+        gcode.register_command('GET_CURRENT_SKEW_NAME',
+                               self.cmd_GET_CURRENT_SKEW_NAME,
                                desc=self.cmd_GET_CURRENT_SKEW_NAME_help)
         gcode.register_command('CALC_MEASURED_SKEW',
                                self.cmd_CALC_MEASURED_SKEW,
@@ -90,7 +91,7 @@ class PrinterSkew:
         gcmd.respond_info(out)
     cmd_GET_CURRENT_SKEW_NAME_help = "Report current printer skew name"
     def cmd_GET_CURRENT_SKEW_NAME(self, gcmd):
-        out = self.cur_skew_profiles_name
+        out = self.cur_skew_prof_name
         gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
@@ -124,7 +125,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')
-            self.cur_skew_profiles_name = name
+            self.cur_skew_prof_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -20,7 +20,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
-        self.cur_skew_name = ""
+        self.cur_skew_profiles_name = ""
         self.toolhead = None
         self.xy_factor = 0.
         self.xz_factor = 0.
@@ -90,7 +90,7 @@ class PrinterSkew:
         gcmd.respond_info(out)
     cmd_GET_CURRENT_SKEW_NAME_help = "Report current printer skew name"
     def cmd_GET_CURRENT_SKEW_NAME(self, gcmd):
-        out = self.cur_skew_name
+        out = self.cur_skew_profiles_name
         gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
@@ -124,7 +124,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')
-            self.cur_skew_name = name
+            self.cur_skew_profiles_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -20,6 +20,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
+        self.cur_skew_name = ""
         self.toolhead = None
         self.xy_factor = 0.
         self.xz_factor = 0.
@@ -32,6 +33,8 @@ class PrinterSkew:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('GET_CURRENT_SKEW', self.cmd_GET_CURRENT_SKEW,
                                desc=self.cmd_GET_CURRENT_SKEW_help)
+        gcode.register_command('GET_CURRENT_SKEW_NAME', self.cmd_GET_CURRENT_SKEW_NAME,
+                               desc=self.cmd_GET_CURRENT_SKEW_NAME_help)
         gcode.register_command('CALC_MEASURED_SKEW',
                                self.cmd_CALC_MEASURED_SKEW,
                                desc=self.cmd_CALC_MEASURED_SKEW_help)
@@ -85,6 +88,10 @@ class PrinterSkew:
             out += " Skew: %.6f radians, %.2f degrees" % (
                 fac, math.degrees(fac))
         gcmd.respond_info(out)
+    cmd_GET_CURRENT_SKEW_NAME_help = "Report current printer skew name"
+    def cmd_GET_CURRENT_SKEW_NAME(self, gcmd):
+        out = self.cur_skew_name
+        gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
         ac = gcmd.get_float("AC", above=0.)
@@ -117,6 +124,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')
+            self.cur_skew_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(


### PR DESCRIPTION
Added a command to retrieve the name of the current tilt correction configuration.

In some cases (such as enabling filament cutter or nozzle wipe), activating tilt correction may cause the tool head to exceed its range of motion. By retrieving the current tilt correction name, it is possible to get the tilt configuration name before execution, unload tilt correction, execute the command (cut filament or wipe nozzle), and then reload tilt correction using the obtained name.