### PR TITLE
Supports retrieving the name of the currently loaded skew correction …

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -451,7 +451,7 @@ The following information is available in
 
 The following information is available in the `skew_correction` object (this
 object is available if any skew_correction is defined):
-- `cur_prof_name`: Returns the name of the currently loaded SKEW_PROFILE.
+- `current_profile_name`: Returns the name of the currently loaded SKEW_PROFILE.
 
 ## stepper_enable
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -451,8 +451,7 @@ The following information is available in
 
 The following information is available in the `skew_correction` object (this
 object is available if any skew_correction is defined):
-- `printer.skew_correction.cur_prof_name`: Returns the name of the 
-  currently loaded SKEW_PROFILE.
+- `cur_prof_name`: Returns the name of the currently loaded SKEW_PROFILE.
 
 ## stepper_enable
 

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -447,6 +447,13 @@ The following information is available in
 - `printer["servo <config_name>"].value`: The last setting of the PWM
   pin (a value between 0.0 and 1.0) associated with the servo.
 
+## skew_correction.py
+
+The following information is available in the `skew_correction` object (this
+object is available if any skew_correction is defined):
+- `printer.skew_correction.cur_prof_name`: Returns the name of the 
+  currently loaded SKEW_PROFILE.
+
 ## stepper_enable
 
 The following information is available in the `stepper_enable` object (this

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -20,7 +20,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
-        self.cur_skew_prof_name = ""
+        self.current_profile_name = ""
         self.toolhead = None
         self.xy_factor = 0.
         self.xz_factor = 0.
@@ -118,7 +118,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')
-            self.cur_skew_prof_name = name
+            self.current_profile_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(
@@ -160,7 +160,7 @@ class PrinterSkew:
                     % (name))
     def get_status(self, eventtime):
         return {
-            'cur_prof_name': self.cur_skew_prof_name
+            'current_profile_name': self.current_profile_name
         }
 
 def load_config(config):

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -20,6 +20,7 @@ class PrinterSkew:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name()
+        self.cur_skew_prof_name = ""
         self.toolhead = None
         self.xy_factor = 0.
         self.xz_factor = 0.
@@ -32,6 +33,9 @@ class PrinterSkew:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('GET_CURRENT_SKEW', self.cmd_GET_CURRENT_SKEW,
                                desc=self.cmd_GET_CURRENT_SKEW_help)
+        gcode.register_command('GET_CURRENT_SKEW_NAME',
+                               self.cmd_GET_CURRENT_SKEW_NAME,
+                               desc=self.cmd_GET_CURRENT_SKEW_NAME_help)
         gcode.register_command('CALC_MEASURED_SKEW',
                                self.cmd_CALC_MEASURED_SKEW,
                                desc=self.cmd_CALC_MEASURED_SKEW_help)
@@ -85,6 +89,10 @@ class PrinterSkew:
             out += " Skew: %.6f radians, %.2f degrees" % (
                 fac, math.degrees(fac))
         gcmd.respond_info(out)
+    cmd_GET_CURRENT_SKEW_NAME_help = "Report current printer skew name"
+    def cmd_GET_CURRENT_SKEW_NAME(self, gcmd):
+        out = self.cur_skew_prof_name
+        gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
         ac = gcmd.get_float("AC", above=0.)
@@ -117,6 +125,7 @@ class PrinterSkew:
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')
+            self.cur_skew_prof_name = name
             prof = self.skew_profiles.get(name)
             if prof is None:
                 gcmd.respond_info(

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -33,9 +33,6 @@ class PrinterSkew:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('GET_CURRENT_SKEW', self.cmd_GET_CURRENT_SKEW,
                                desc=self.cmd_GET_CURRENT_SKEW_help)
-        gcode.register_command('GET_CURRENT_SKEW_NAME',
-                               self.cmd_GET_CURRENT_SKEW_NAME,
-                               desc=self.cmd_GET_CURRENT_SKEW_NAME_help)
         gcode.register_command('CALC_MEASURED_SKEW',
                                self.cmd_CALC_MEASURED_SKEW,
                                desc=self.cmd_CALC_MEASURED_SKEW_help)
@@ -88,10 +85,6 @@ class PrinterSkew:
             out += '\n' + plane
             out += " Skew: %.6f radians, %.2f degrees" % (
                 fac, math.degrees(fac))
-        gcmd.respond_info(out)
-    cmd_GET_CURRENT_SKEW_NAME_help = "Report current printer skew name"
-    def cmd_GET_CURRENT_SKEW_NAME(self, gcmd):
-        out = self.cur_skew_prof_name
         gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
@@ -165,7 +158,10 @@ class PrinterSkew:
                 gcmd.respond_info(
                     "skew_correction: No profile named [%s] to remove"
                     % (name))
-
+    def get_status(self, eventtime):
+        return {
+            'cur_prof_name': self.cur_skew_prof_name
+        }
 
 def load_config(config):
     return PrinterSkew(config)


### PR DESCRIPTION
Added a command to retrieve the name of the current tilt correction configuration.

In some cases (such as enabling filament cutter or nozzle wipe), activating tilt correction may cause the tool head to exceed its range of motion. By retrieving the current tilt correction name, it is possible to get the tilt configuration name before execution, unload tilt correction, execute the command (cut filament or wipe nozzle), and then reload tilt correction using the obtained name.

Signed-off-by: Zhang Gaofan <zhanggaofan0827@gmail.com>