### PR TITLE
Fix minor transmit stall race when in USB to CAN bridge mode

### DIFF
--- a/src/generic/usb_canbus.c
+++ b/src/generic/usb_canbus.c
@@ -335,7 +335,7 @@ canbus_send(struct canbus_msg *msg)
     int ret = send_frame(msg);
     if (ret < 0)
         goto retry_later;
-    if (UsbCan.notify_local && UsbCan.host_status)
+    if (UsbCan.host_status)
         canbus_notify_tx();
     UsbCan.notify_local = 0;
     return msg->dlc;


### PR DESCRIPTION
There was a small race condition that could allow transmit "echo" frames to become briefly stalled when in USB to CAN bridge mode.  This would likely only effect some controllers - potentially the stm32 usbotg (stm32f4 and stm32h7 devices).

The PR also contains a couple of commits intended to better organize the usb_canbus.c code.

-Kevin