### PR TITLE
docs: Clarify sensorless homing moves mode selection in TMC_Drivers.md

### DIFF
--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -83,6 +83,10 @@ setting `stealthchop_threshold` to 999999). Unfortunately, the drivers
 often produce poor and confusing results if the mode changes while the
 motor is at a non-zero velocity.
 
+When sensorless homing is enabled the homing moves will always
+automatically temporarily switch to the mode required by stallGuard,
+regardless of `stealthchop_threshold` setting.
+
 ## TMC interpolate setting introduces small position deviation
 
 The TMC driver `interpolate` setting may reduce the audible noise of


### PR DESCRIPTION
Hi,

Reading the docs I was really puzzled about the right way to configure stealthChop vs. spreadCycle knowing my tmc2209 drivers only support stallGuard in spreadCycle mode. Reading the code answered my question and I hope I can make it easier for the next confused person.