### PR TITLE
Update generic-bigtreetech-skr-v1.4.cfg with mcu working baud rate 11…

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -2,6 +2,9 @@
 # board. To use this config, the firmware should be compiled for the
 # LPC1768 or LPC1769(Turbo).
 
+# IMPORTANT: if this is the first time flashing Klipper to the mcu
+# See https://www.klipper3d.org/SDCard_Updates.html?h=btt#sdcard-updates
+
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
@@ -78,6 +81,7 @@ pin: P2.3
 
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
+baud: 115200
 
 [printer]
 kinematics: cartesian


### PR DESCRIPTION
Hello there.

This PR aims to fix 2 issues I encountered while flashing klipper onto a skr v1.4 turbo board today:

1. The default speed of 200000 won't work for this board. It is specified to use a [baud rate of 115200 by the manufacturer](https://github.com/bigtreetech/docs/blob/master/docs/SKR%20V1.4.md#:~:text=baud%20rate%20of-,115200,-Expand%20the%20interface)

If this option is missing from the printer.cfg file, the Raspi will hang when trying to connect to the board.

2. I wasted a few hours trying to flash the firmware via a USB until I found a documentation page explaining that this board can only use this method TO UPDATE the firmware. So I added a link pointing to this doc page so the next person coming here knows what to do.

Thank you!