### PR TITLE
fix markup in Axis_Twist_Compensation.md

### DIFF
--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -42,7 +42,7 @@ SAMPLE_COUNT=<value>
 After completing the calibration, be sure to
 [adjust your Z offset](Probe_Calibrate.md#calibrating-probe-z-offset).
 
-4. **Perform Bed Leveling Operations:**
+3. **Perform Bed Leveling Operations:**
 Use probe-based operations as needed, such as:
   - [Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust)
   - [Z Tilt Adjust](G-Codes.md#z_tilt_adjust)

--- a/docs/Axis_Twist_Compensation.md
+++ b/docs/Axis_Twist_Compensation.md
@@ -1,6 +1,6 @@
 # Axis Twist Compensation
 
-This document describes the [axis_twist_compensation] module.
+This document describes the `[axis_twist_compensation]` module.
 
 Some printers may have a small twist in their X rail which can skew the results
 of a probe attached to the X carriage.
@@ -25,31 +25,31 @@ try to probe the bed without attaching the probe if you use it.
 > correctly set as they greatly influence calibration.
 
 ### Basic Usage: X-Axis Calibration
-1. After setting up the ```[axis_twist_compensation]``` module, run:
+1. After setting up the `[axis_twist_compensation]` module, run:
 ```
 AXIS_TWIST_COMPENSATION_CALIBRATE
 ```
 This command will calibrate the X-axis by default.
-    - The calibration wizard will prompt you to measure the probe Z offset at
+  - The calibration wizard will prompt you to measure the probe Z offset at
     several points along the bed.
-    - By default, the calibration uses 3 points, but you can specify a different
+  - By default, the calibration uses 3 points, but you can specify a different
     number with the option:
 ``
 SAMPLE_COUNT=<value>
 ``
 
 2. **Adjust Your Z Offset:**
-After completing the calibration, be sure to [adjust your Z offset]
-(Probe_Calibrate.md#calibrating-probe-z-offset).
+After completing the calibration, be sure to
+[adjust your Z offset](Probe_Calibrate.md#calibrating-probe-z-offset).
 
-3. **Perform Bed Leveling Operations:**
+4. **Perform Bed Leveling Operations:**
 Use probe-based operations as needed, such as:
-    - [Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust)
-    - [Z Tilt Adjust](G-Codes.md#z_tilt_adjust)
+  - [Screws Tilt Adjust](G-Codes.md#screws_tilt_adjust)
+  - [Z Tilt Adjust](G-Codes.md#z_tilt_adjust)
 
 4. **Finalize the Setup:**
-    - Home all axes, and perform a [Bed Mesh](Bed_Mesh.md) if necessary.
-    - Run a test print, followed by any
+  - Home all axes, and perform a [Bed Mesh](Bed_Mesh.md) if necessary.
+  - Run a test print, followed by any
     [fine-tuning](Axis_Twist_Compensation.md#fine-tuning)
     if needed.
 
@@ -75,8 +75,8 @@ In this mode, the calibration process will run for both axes automatically.
 
 ## [axis_twist_compensation] setup and commands
 
-Configuration options for [axis_twist_compensation] can be found in the
+Configuration options for `[axis_twist_compensation]` can be found in the
 [Configuration Reference](Config_Reference.md#axis_twist_compensation).
 
-Commands for [axis_twist_compensation] can be found in the
+Commands for `[axis_twist_compensation]` can be found in the
 [G-Codes Reference](G-Codes.md#axis_twist_compensation)


### PR DESCRIPTION
There's a broken (markdown) link; and various cleanups.