### PR TITLE
stm32: Add support for USART6 on STM32F401

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -434,6 +434,12 @@ choice
         bool "Serial (on USART5 PD2/PD3)" if LOW_LEVEL_OPTIONS
         depends on MACH_STM32G0Bx
         select SERIAL
+    config STM32_SERIAL_USART6
+        bool "Serial (on USART6 PA12/PA11)" if LOW_LEVEL_OPTIONS && MACH_STM32F401
+        select SERIAL
+    config STM32_SERIAL_USART6_ALT_PC7_PC6
+        bool "Serial (on USART6 PC7/PC6)" if LOW_LEVEL_OPTIONS && MACH_STM32F401
+        select SERIAL
     config STM32_CANBUS_PA11_PA12
         bool "CAN bus (on PA11/PA12)"
         depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS

--- a/src/stm32/serial.c
+++ b/src/stm32/serial.c
@@ -16,38 +16,58 @@
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA10,PA9");
   #define GPIO_Rx GPIO('A', 10)
   #define GPIO_Tx GPIO('A', 9)
+  #define GPIO_AF_MODE 7
   #define USARTx USART1
   #define USARTx_IRQn USART1_IRQn
 #elif CONFIG_STM32_SERIAL_USART1_ALT_PB7_PB6
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PB7,PB6");
   #define GPIO_Rx GPIO('B', 7)
   #define GPIO_Tx GPIO('B', 6)
+  #define GPIO_AF_MODE 7
   #define USARTx USART1
   #define USARTx_IRQn USART1_IRQn
 #elif CONFIG_STM32_SERIAL_USART2
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA3,PA2");
   #define GPIO_Rx GPIO('A', 3)
   #define GPIO_Tx GPIO('A', 2)
+  #define GPIO_AF_MODE 7
   #define USARTx USART2
   #define USARTx_IRQn USART2_IRQn
 #elif CONFIG_STM32_SERIAL_USART2_ALT_PD6_PD5
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PD6,PD5");
   #define GPIO_Rx GPIO('D', 6)
   #define GPIO_Tx GPIO('D', 5)
+  #define GPIO_AF_MODE 7
   #define USARTx USART2
   #define USARTx_IRQn USART2_IRQn
 #elif CONFIG_STM32_SERIAL_USART3
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PB11,PB10");
   #define GPIO_Rx GPIO('B', 11)
   #define GPIO_Tx GPIO('B', 10)
+  #define GPIO_AF_MODE 7
   #define USARTx USART3
   #define USARTx_IRQn USART3_IRQn
 #elif CONFIG_STM32_SERIAL_USART3_ALT_PD9_PD8
   DECL_CONSTANT_STR("RESERVE_PINS_serial", "PD9,PD8");
   #define GPIO_Rx GPIO('D', 9)
   #define GPIO_Tx GPIO('D', 8)
+  #define GPIO_AF_MODE 7
   #define USARTx USART3
   #define USARTx_IRQn USART3_IRQn
+#elif CONFIG_STM32_SERIAL_USART6
+  DECL_CONSTANT_STR("RESERVE_PINS_serial", "PA12,PA11");
+  #define GPIO_Rx GPIO('A', 12)
+  #define GPIO_Tx GPIO('A', 11)
+  #define GPIO_AF_MODE 8
+  #define USARTx USART6
+  #define USARTx_IRQn USART6_IRQn
+#elif CONFIG_STM32_SERIAL_USART6_ALT_PC7_PC6
+  DECL_CONSTANT_STR("RESERVE_PINS_serial", "PC7,PC6");
+  #define GPIO_Rx GPIO('C', 7)
+  #define GPIO_Tx GPIO('C', 6)
+  #define GPIO_AF_MODE 8
+  #define USARTx USART6
+  #define USARTx_IRQn USART6_IRQn
 #endif
 
 #define CR1_FLAGS (USART_CR1_UE | USART_CR1_RE | USART_CR1_TE   \
@@ -90,7 +110,7 @@ serial_init(void)
     USARTx->CR1 = CR1_FLAGS;
     armcm_enable_irq(USARTx_IRQHandler, USARTx_IRQn, 0);
 
-    gpio_peripheral(GPIO_Rx, GPIO_FUNCTION(7), 1);
-    gpio_peripheral(GPIO_Tx, GPIO_FUNCTION(7), 0);
+    gpio_peripheral(GPIO_Rx, GPIO_FUNCTION(GPIO_AF_MODE), 1);
+    gpio_peripheral(GPIO_Tx, GPIO_FUNCTION(GPIO_AF_MODE), 0);
 }
 DECL_INIT(serial_init);


### PR DESCRIPTION
STM32F401 has USART6 on PA12/PA11 and PC7/PC6 with alternate function mapping AF08. This can be used, for example, to connect to the Elegoo Neptune 3 without soldering to the main board or even opening the case, where PA12/PA11 are wired to a convenient RJ10 plug going to the stock screen.

See the datasheet (Page 45, Table 9. Alternate function mapping):

https://www.st.com/resource/en/datasheet/stm32f401re.pdf

See the Neptune 3's schematic:

https://github.com/TheFeralEngineer/Elegoo-Neptune-board-schematics/blob/main/ZNP%20Robin%20Nano_DW%20V21_001%20SCH_加水印pdf%20·%20version%201_230115_223844.pdf

I only tested this on my Neptune 3. It might work for other STM32s that have USART6, if there are any others, but I only added a Kconfig entry for STM32F401, since that's what I have access to for testing.