### PR TITLE
Allow any probes named eddy to perform rapid_scan

### DIFF
--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -865,8 +865,10 @@ class ProbeManager:
         can_scan = False
         pprobe = self.printer.lookup_object("probe", None)
         if pprobe is not None:
-            probe_name = pprobe.get_status(None).get("name", "")
-            can_scan = probe_name.startswith("probe_eddy_current")
+            pstatus = pprobe.get_status(None)
+            probe_name = pstatus.get("name", "")
+            can_scan = (pstatus.get("supports_rapid_scan", False) or
+                ("eddy" in probe_name))
         if method == "rapid_scan" and can_scan:
             self.rapid_scan_helper.perform_rapid_scan(gcmd)
         else:


### PR DESCRIPTION
[eddy-ng](https://github.com/vvuk/eddy-ng) currently has to patch `bed_mesh.py` in order to allow a `probe_eddy_ng` object to be used for rapid scan. This PR basically upstreams that change so that I don't have to ask people to patch bed_mesh, which can complicate klipper updates.

It allows any probe with "eddy" in its name can do rapid scan, or any probe that reports True for `rapid_scan_supported` in its status.