### PR TITLE
Fix 0 values not being recognized in axis_twist_compensation

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -177,17 +177,15 @@ class Calibrater:
 
             self.compensation.clear_compensations('X')
 
-            if not all([
-                self.x_start_point[0],
-                self.x_end_point[0],
-                self.x_start_point[1]
-                ]):
+            if (self.x_start_point[0] is None or
+                self.x_end_point[0] is None or
+                self.x_start_point[1] is None):
                 raise self.gcmd.error(
                     """AXIS_TWIST_COMPENSATION for X axis requires
                     calibrate_start_x, calibrate_end_x and calibrate_y
                     to be defined
                     """
-                    )
+                )
 
             start_point = self.x_start_point
             end_point = self.x_end_point
@@ -204,17 +202,15 @@ class Calibrater:
 
             self.compensation.clear_compensations('Y')
 
-            if not all([
-                self.y_start_point[0],
-                self.y_end_point[0],
-                self.y_start_point[1]
-                ]):
+            if (self.y_start_point[0] is None or
+                self.y_end_point[0] is None or
+                self.y_start_point[1] is None):
                 raise self.gcmd.error(
                     """AXIS_TWIST_COMPENSATION for Y axis requires
                     calibrate_start_y, calibrate_end_y and calibrate_x
                     to be defined
                     """
-                    )
+                )
 
             start_point = self.y_start_point
             end_point = self.y_end_point
@@ -284,19 +280,16 @@ class Calibrater:
         return x_corrections, y_corrections
 
     def _start_autocalibration(self, sample_count):
-
-        if not all([
-                self.x_start_point[0],
-                self.x_end_point[0],
-                self.y_start_point[0],
-                self.y_end_point[0]
-                ]):
-                raise self.gcmd.error(
-                    """AXIS_TWIST_COMPENSATION_AUTOCALIBRATE requires
-                    calibrate_start_x, calibrate_end_x, calibrate_start_y
-                    and calibrate_end_y to be defined
-                    """
-                    )
+        if (self.x_start_point[0] is None or
+            self.x_end_point[0] is None or
+            self.y_start_point[0] is None or
+            self.y_end_point[0] is None):
+            raise self.gcmd.error(
+                """AXIS_TWIST_COMPENSATION_AUTOCALIBRATE requires
+                calibrate_start_x, calibrate_end_x, calibrate_start_y
+                and calibrate_end_y to be defined
+                """
+            )
 
         # check for valid sample_count
         if sample_count is None or sample_count < 2:


### PR DESCRIPTION
When following [the Axis Twist Compensation doc](https://www.klipper3d.org/Axis_Twist_Compensation.html), after calling `AXIS_TWIST_COMPENSATION_CALIBRATE`, I encountered an error that states:

> AXIS_TWIST_COMPENSATION for X axis requires
> calibrate_start_x, calibrate_end_x and calibrate_y
> to be defined

Following [the configuration reference](https://www.klipper3d.org/Config_Reference.html#axis_twist_compensation), I set my values like so:

```ini
[axis_twist_compensation]
speed: 2000
# X-axis compensation
calibrate_start_x: 0
calibrate_end_x: 230
calibrate_y: 115
# Y-axis compensation
calibrate_start_y: 0
calibrate_end_y: 181
calibrate_x: 115
```

This works for me, since the 0 X position and the 0 Y position both have my BL Touch sensor hovering over my print bed.  However, I still encountered the error back from the `AXIS_TWIST_COMPENSATION` GCode from above.

This bug is triggered from checks like these, because `0` makes `all()` return `False`:

https://github.com/Klipper3d/klipper/blob/fec3e685c92ef263a829a73510c74245d7772c03/klippy/extras/axis_twist_compensation.py?plain=1#L180-L190

For example:

```python
In [1]: all([None, 1])
Out[1]: False

In [2]: all([0, 1])
Out[2]: False

In [3]: all([0.1, 1])
Out[3]: True

In [4]: all([1, 1])
Out[4]: True
```

This PR replaces the `all()` calls with explicit `is None` checks to see if the value really is not present (as opposed to a value that casts to True).  I opted to use a few `is None` checks as opposed to building an array an enumerating with a `for` loop because the code is smaller and it reads better :+1: 