### PR TITLE
RFC: Cooperative Heaters predictive control

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5579,6 +5579,17 @@ cs_pin:
 #   above parameters.
 ```
 
+### [heater_pc]
+
+Heater prediction correction.
+To use this feature, define a config section with a "heater_pc" prefix
+followed by the name of the corresponding heater config section.
+For example `[heater_pc heater_bed]`
+```
+[heater_pc extruder]
+#macro_template: <display_template's name>
+```
+
 ## Common bus parameters
 
 ### Common SPI settings

--- a/klippy/extras/heater_pc.py
+++ b/klippy/extras/heater_pc.py
@@ -1,0 +1,71 @@
+# Klipper Heater Predictional Control
+#
+# Copyright (C) 2025  Timofey Titovets <nefelim4ag@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import logging
+import threading
+from . import output_pin
+
+class HeaterPredictControl:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.config = config
+        self.eval_time = 0.3
+        self.min_pwm = -1.0
+        self.max_pwm = 1.0
+        self.old_control = None
+        name_parts = config.get_name().split()
+        if len(name_parts) != 2:
+            raise config.error("Section name '%s' is not valid"
+                               % (config.get_name(),))
+        # Use lock to pass data to/from heater code
+        self.lock = threading.Lock()
+        self.output = .0
+        self.pwm_event_time = self.reactor.monotonic()
+        # Link template
+        self.template_name = config.get("macro_template")
+        # Template handling
+        self.template_eval = output_pin.lookup_template_eval(config)
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+    def handle_connect(self):
+        pheaters = self.printer.load_object(self.config, 'heaters')
+        heater_name = self.config.get_name().split()[-1]
+        heater = pheaters.heaters.get(heater_name)
+        if heater is None:
+            self.config.error("Heater %s is not registered" % (heater_name))
+        self.eval_time = heater.get_pwm_delay()
+        self.min_pwm = -heater.get_max_power()
+        self.max_pwm = heater.get_max_power()
+        self.old_control = heater.set_control(self)
+        gcode = self.printer.lookup_object('gcode')
+        params = {"TEMPLATE": self.template_name}
+        fo_gcmd = gcode.create_gcode_command("", "", params)
+        self.template_eval.set_template(fo_gcmd, self._adj_pwm)
+    def _adj_pwm(self, text):
+        try:
+            output = float(text) * self.max_pwm
+        except ValueError as e:
+            logging.exception("heater_pc template render error")
+            output = .0
+        output = max(self.min_pwm, min(self.max_pwm, output))
+        with self.lock:
+            self.output = output
+    def temperature_update(self, read_time, temp, target_temp):
+        output = .0
+        with self.lock:
+            output = self.output
+        # Returns +- max_power
+        co = self.old_control.temperature_update(read_time, temp, target_temp)
+        co += output
+        return co
+    def check_busy(self, eventtime, smoothed_temp, target_temp):
+        res = self.old_control.check_busy(eventtime, smoothed_temp,
+                                          target_temp)
+        return res
+
+def load_config_prefix(config):
+    return HeaterPredictControl(config)

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -89,7 +89,10 @@ class Heater:
             time_diff = read_time - self.last_temp_time
             self.last_temp = temp
             self.last_temp_time = read_time
-            self.control.temperature_update(read_time, temp, self.target_temp)
+            co = self.control.temperature_update(read_time, temp,
+                                                 self.target_temp)
+            bounded_co = max(.0, co)
+            self.set_pwm(read_time, bounded_co)
             temp_diff = temp - self.smoothed_temp
             adj_time = min(time_diff * self.inv_smooth_time, 1.)
             self.smoothed_temp += temp_diff * adj_time
@@ -175,9 +178,9 @@ class ControlBangBang:
         elif not self.heating and temp <= target_temp-self.max_delta:
             self.heating = True
         if self.heating:
-            self.heater.set_pwm(read_time, self.heater_max_power)
+            return self.heater_max_power
         else:
-            self.heater.set_pwm(read_time, 0.)
+            return 0.
     def check_busy(self, eventtime, smoothed_temp, target_temp):
         return smoothed_temp < target_temp-self.max_delta
 
@@ -221,14 +224,16 @@ class ControlPID:
         co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv
         #logging.debug("pid: %f@%.3f -> diff=%f deriv=%f err=%f integ=%f co=%d",
         #    temp, read_time, temp_diff, temp_deriv, temp_err, temp_integ, co)
-        bounded_co = max(0., min(self.heater_max_power, co))
-        self.heater.set_pwm(read_time, bounded_co)
+        max_power = self.heater_max_power
+        bounded_co = max(-max_power, min(max_power, co))
         # Store state for next measurement
         self.prev_temp = temp
         self.prev_temp_time = read_time
         self.prev_temp_deriv = temp_deriv
-        if co == bounded_co:
+        # Keep the previous wind-down behavior
+        if co == bounded_co and bounded_co >= 0:
             self.prev_temp_integ = temp_integ
+        return bounded_co
     def check_busy(self, eventtime, smoothed_temp, target_temp):
         temp_diff = target_temp - smoothed_temp
         return (abs(temp_diff) > PID_SETTLE_DELTA


### PR DESCRIPTION
Some time ago [I dug heaters a little on the Discourse](https://klipper.discourse.group/t/discussion-proposal-small-heater-control-improvements/19195)

I don't think PID is bad or needs to be replaced.
_I tried to do some fun stuff, like train DNN or write my own algo to control the power._
In the end, everything looks the same.

There are historically various topics, that try to replace it or tune it differently.
I think the only practical reason is to handle something important for that human being.

So, there is an ultimate solution, I think.
Pid is still under the control of a heater and is able to drive it.
The end-user has the ability to adjust it freely, like in my doc example - drive PWM in a feedforward way if the fan is suddenly enabled, like for bridges.

If it is needed, it is definitely possible to get the current chamber temperature, adjust to the fan curve, try to parse the extruder moving queue (IDK) and drive PWM higher before the temperature falls and PID will reactively compensate for that.
_I hope that will add enough flexibility to stop rituals like "how to do PID autotune properly"._

Another example, for some reason people do not insulate the heating beds, adding thermistors inside a thick aluminum plate and then want sort of PID control by two thermistors, and feel that combined sensor is not good enough.

Well, now it is possible to literally query the sensors and decide what to do, like return the `-N` value and decrease bed heater power on demand.

I hope it is made in a way to is safe and acceptable, leaves all existing safety measures in place, and mostly does not touch safety-critical code.

Thanks.

---
Btw, I will try to add templates to temperature FANs in a similar way, to fit most of the wishes, like curves, formulas & etc.

---
```
cd ~/klipper
git fetch origin pull/6837/head
git checkout FETCH_HEAD
sudo systemctl restart klipper
```