### PR TITLE
Add support for gd32f303xe MCU temperature used on Creality K1 Max (and others)

### DIFF
--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -80,6 +80,7 @@ class PrinterTemperatureMCU:
             ('stm32l4', self.config_stm32g0),
             ('stm32h723', self.config_stm32h723),
             ('stm32h7', self.config_stm32h7),
+            ('gd32f303xe', self.config_gd32f303xe),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -164,6 +165,9 @@ class PrinterTemperatureMCU:
         cal_adc_110 = self.read16(0x1FF1E840) / 65535.
         self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
+    def config_gd32f303xe(self):
+        self.slope = 3.3 / -.004100
+        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
     def read16(self, addr):
         params = self.debug_read_cmd.send([1, addr])
         return params['val']


### PR DESCRIPTION
### Summary
This PR adds support for the gd32f303xe MCU, which is used in the Creality K1 Max and other printers, by adding necessary code into temperature_mcu.py.

### Background
I recently converted my Creality K1 Max printer to mainline Klipper, moving away from Creality's forked version. However, I discovered that the gd32f303xe MCU—which is used for the toolhead or temperature sensor MCU—is not currently supported in upstream Klipper.

Error message upon starting: **MCU temperature not supported on gd32f303xe**

![image](https://github.com/user-attachments/assets/1459b6cf-1737-4b3c-b35c-3499df184f46)

### Changes Made

- Modified temperature_mcu.py to add support for the gd32f303xe MCU.
- Only 4 lines of code were added to include this MCU in the supported list.

### Testing

- Verified functionality by ensuring correct temperature readings and general toolhead operation.
- Printed multiple test models without issues.
- No other functionality is affected beyond enabling this MCU.

Signed-off-by: Serge Latulippe <happytechcanada@gmail.com>