### PR TITLE
jinja2: Expand template syntax errors

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -49,6 +49,12 @@ class TemplateWrapper:
         self.create_template_context = gcode_macro.create_template_context
         try:
             self.template = env.from_string(script)
+        except jinja2.exceptions.TemplateSyntaxError as e:
+            lines = script.splitlines()
+            msg = "Error loading template '%s'\nline %s: %s # %s" % (
+                name, e.lineno, lines[e.lineno-1], e.message)
+            logging.exception(msg)
+            raise self.gcode.error(msg)
         except Exception as e:
             msg = "Error loading template '%s': %s" % (
                  name, traceback.format_exception_only(type(e), e)[-1])


### PR DESCRIPTION
Sometimes, writing macros is painful because jinja does not show adequate errors.

I tried to fix it, so now template syntax errors show that manner:
```
Internal error during connect: Error loading template 'temperature_fan octopus'
line 4: {%- set tmax = tt + 1. -%} # expected name or number
```

Thanks.

---
_Errors made me implement that fix while I was working on https://github.com/Klipper3d/klipper/pull/6837 and https://github.com/Klipper3d/klipper/pull/6840_