### PR TITLE
[extruder*] config: Allow nonsequential extruders

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -309,6 +309,6 @@ def add_printer_objects(config):
         if i:
             section = 'extruder%d' % (i,)
         if not config.has_section(section):
-            break
+            continue
         pe = PrinterExtruder(config.getsection(section), i)
         printer.add_object(section, pe)


### PR DESCRIPTION
There are a myriad of toolchanger setups out there, but one common thing is they define the tools in individual files:

```
[include ./tool0.cfg]
[include ./tool1.cfg]
[include ./tool2.cfg]
```

Currently, commenting out tool1 from the config, causes a config validation (`invalid section: extruder2`) error and klipper shutdown.

This change allows for non sequential extruder definitions to exist and is specially useful when performing maintenance and one toolhead needs to be taken out of  config, like so:

```
[include ./tool0.cfg]
#[include ./tool1.cfg]
[include ./tool2.cfg]
```

I hope I'm not missing any side effects, I've been running a week without issues.