### PR TITLE
gcode_macro: Enable use of Python's math module

### DIFF
--- a/docs/Command_Templates.md
+++ b/docs/Command_Templates.md
@@ -101,6 +101,16 @@ gcode:
   RESTORE_GCODE_STATE NAME=clean_nozzle_state
 ```
 
+If more advanced math is required than Jinja2 offers natively,
+Python's [math module](https://docs.python.org/3/library/math.html)
+is available for use within Jinja2 expressions in G-Code macros:
+
+```
+[gcode_macro math_example]
+gcode:
+  REPLY MSG="The square root of 4 is {math.sqrt(4)}."
+```
+
 ### Macro parameters
 
 It is often useful to inspect parameters passed to the macro when

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import traceback, logging, ast, copy, json
 import jinja2
+import math
 
 
 ######################################################################
@@ -72,6 +73,7 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
+        self.env.globals['math'] = math
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:


### PR DESCRIPTION
Jinja2's native math functionality is fairly limited.

Python's math module includes many functions that are useful for calculations related to 3D printing.