### PR TITLE
Debounce gcode_button and filament_switch_sensor

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3278,6 +3278,10 @@ pin:
 #   A list of G-Code commands to execute when the button is released.
 #   G-Code templates are supported. The default is to not run any
 #   commands on a button release.
+#debounce_delay:
+#   A period of time in seconds to debounce events prior to running the
+#   button gcode. If the button is pressed and released during this
+#   delay, the entire button press is ignored. Default is 0.
 ```
 
 ### [output_pin]
@@ -4641,6 +4645,11 @@ more information.
 #   dispatch and execution of the runout_gcode. It may be useful to
 #   increase this delay if OctoPrint exhibits strange pause behavior.
 #   Default is 0.5 seconds.
+#debounce_delay:
+#   A period of time in seconds to debounce events prior to running the
+#   switch gcode. The switch must he held in a single state for at least
+#   this long to activate. If the switch is toggled on/off during this delay,
+#   the event is ignored. Default is 0.
 #switch_pin:
 #   The pin on which the switch is connected. This parameter must be
 #   provided.

--- a/klippy/extras/filament_motion_sensor.py
+++ b/klippy/extras/filament_motion_sensor.py
@@ -63,7 +63,7 @@ class EncoderSensor:
     def _extruder_pos_update_event(self, eventtime):
         extruder_pos = self._get_extruder_pos(eventtime)
         # Check for filament runout
-        self.runout_helper.note_filament_present(
+        self.runout_helper.note_filament_present(eventtime,
                 extruder_pos < self.filament_runout_pos)
         return eventtime + CHECK_RUNOUT_TIMEOUT
     def encoder_event(self, eventtime, state):
@@ -71,7 +71,7 @@ class EncoderSensor:
             self._update_filament_runout_pos(eventtime)
             # Check for filament insertion
             # Filament is always assumed to be present on an encoder event
-            self.runout_helper.note_filament_present(True)
+            self.runout_helper.note_filament_present(eventtime, True)
 
 def load_config_prefix(config):
     return EncoderSensor(config)

--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
+
 class GCodeButton:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -13,12 +14,13 @@ class GCodeButton:
         self.last_state = 0
         buttons = self.printer.load_object(config, "buttons")
         if config.get('analog_range', None) is None:
-            buttons.register_buttons([self.pin], self.button_callback)
+            buttons.register_debounce_button(self.pin, self.button_callback
+                                             , config)
         else:
             amin, amax = config.getfloatlist('analog_range', count=2)
             pullup = config.getfloat('analog_pullup_resistor', 4700., above=0.)
-            buttons.register_adc_button(self.pin, amin, amax, pullup,
-                                        self.button_callback)
+            buttons.register_debounce_adc_button(self.pin, amin, amax, pullup,
+                                        self.button_callback, config)
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.press_template = gcode_macro.load_template(config, 'press_gcode')
         self.release_template = gcode_macro.load_template(config,

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -125,7 +125,7 @@ class HallFilamentWidthSensor:
         # Update filament array for lastFilamentWidthReading
         self.update_filament_array(last_epos)
         # Check runout
-        self.runout_helper.note_filament_present(
+        self.runout_helper.note_filament_present(eventtime,
             self.runout_dia_min <= self.diameter <= self.runout_dia_max)
         # Does filament exists
         if self.diameter > 0.5:


### PR DESCRIPTION
This change adds a `debounce_delay` option to both `filament_switch_sensor` and `gcode_button`. This allows for much longer, user controllable, debouncing. Event cycles (off->on->off) that happen during the delay will be ignored. At the end of the delay, if the state transition is singular and maintained the event fires.

This is based on a request from a user that had issues with a fickle filament switch: https://klipper.discourse.group/t/proposal-button-debounce/22212

This allows printer owners to solve issues with less than optimal physical filament switch design. It also allows for ideas like "push and hold to execute" e.g. push and hold a button for 200ms to run `M112` so we know the user **_really_** meant it. Debouncing at this sort of timescale is widely used to add polish to user interfaces and input devices.

I argued in the thread that any sensing technology that converts its inputs into the equivalent of an on/off signal should get this treatment. This solves for spurious/hesitant/non-committal user inputs which could be seen as an event by a sensor (such as filament motion sensor) and still need to be ignored (e.g. user inserts and then quickly removes filament). But for now its limited to things that are driven by "physical switches".

This also has the minor change to set `event_delay` on a `filament_switch_sensor` to 0. Since the debounce delay can now essentially do what this option was trying to do I want users to disable this delay completely if they wish.