### PR TITLE
Implemented basic handler for USB GET STATUS requests

### DIFF
--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -524,9 +524,9 @@ usb_req_get_status(struct usb_ctrlrequest * req)
     // "Remote Wakeup Enabled" flags this message requests layout of descriptor
     // can be found in usb_20.pdf page 265, 266
     const status_t is_self_powered =
-            (cdc_config_descriptor.config.bmAttributes & (1<<6)) > 0;
+            (cdc_config_descriptor.config.bmAttributes & (1<<6)) != 0;
     const status_t remote_wakeup =
-            (cdc_config_descriptor.config.bmAttributes & (1<<5)) > 0;
+            (cdc_config_descriptor.config.bmAttributes & (1<<5)) != 0;
 
 
     // pack status data and send

--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -493,25 +493,8 @@ usb_req_set_line(struct usb_ctrlrequest *req)
 static void
 usb_req_get_status(struct usb_ctrlrequest * req)
 {
-    // zip file from https://www.usb.org/document-library/usb-20-specification
-    // filename: usb_20.pdf page 254 (9.4.5 Get Status)
-
-    // Verify request fields
-    // Special attention must be taken for bRequest
-    // if there are issues in the future.
-    // bRequest specifies the target of the status request.
-    // The USB spec mentions that the value may be "Device, Interface,
-    // or Endpoint"-number.
-    // For Interfaces (usb_interface_descriptor::bInterfaceNumber)
-    // status must always be zero.
-    // For Endpoints (usb_endpoint_descriptor::bEndpointAddress)
-    // the first bit indicates if the endpoint is halted.
-    // This isn't implemented and can be set to zero.
-    // For devices the self powered state and remote wakeup must be sent,
-    // but I'm not sure what bRequest number identifies a 'Device'.
-    // Experimenting with it, I only ever got zero.
-    // Referenced tinyusb https://github.com/hathach/tinyusb
-    // in src/device/usbd.c process_control_request()
+    // Basic implementation of GET STATUS. Doesn't handle status requests for 
+    // Interfaces or Endpoints
     typedef uint16_t status_t;
     if (req->wValue || req->wLength != sizeof(status_t) || req->wIndex
         || req->bRequest)
@@ -520,9 +503,8 @@ usb_req_get_status(struct usb_ctrlrequest * req)
         return;
     }
 
-    // config descriptor contains "Self Powered" and
-    // "Remote Wakeup Enabled" flags this message requests layout of descriptor
-    // can be found in usb_20.pdf page 265, 266
+    // config descriptor already contains "Self Powered" and
+    // "Remote Wakeup Enabled" flags. 
     const status_t is_self_powered =
             (cdc_config_descriptor.config.bmAttributes & (1<<6)) != 0;
     const status_t remote_wakeup =

--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -493,7 +493,7 @@ usb_req_set_line(struct usb_ctrlrequest *req)
 static void
 usb_req_get_status(struct usb_ctrlrequest * req)
 {
-    // Basic implementation of GET STATUS. Doesn't handle status requests for 
+    // Basic implementation of GET STATUS. Doesn't handle status requests for
     // Interfaces or Endpoints
     typedef uint16_t status_t;
     if (req->wValue || req->wLength != sizeof(status_t) || req->wIndex
@@ -504,7 +504,7 @@ usb_req_get_status(struct usb_ctrlrequest * req)
     }
 
     // config descriptor already contains "Self Powered" and
-    // "Remote Wakeup Enabled" flags. 
+    // "Remote Wakeup Enabled" flags.
     const status_t is_self_powered =
             (cdc_config_descriptor.config.bmAttributes & (1<<6)) != 0;
     const status_t remote_wakeup =


### PR DESCRIPTION
I'm currently working with a `BTT non-pro Octopus v1.1` with klippy running on my Linux Machine (Ubuntu 24.04, Kernel 6.8.0-45-generic amd64) and experienced erratic USB behavior. The board would connect normally but get kicked off the bus after starting klippy. Any attempt at configuring the serial device would yield the same behavior (e.g. connecting with gtkterm or screen)

`dmesg` would look like this 

```
[ 9350.139784] usb 1-2: new full-speed USB device number 37 using xhci_hcd
[ 9350.267874] usb 1-2: New USB device found, idVendor=1d50, idProduct=614e, bcdDevice= 1.00
[ 9350.267892] usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 9350.267901] usb 1-2: Product: stm32f446xx
[ 9350.267908] usb 1-2: Manufacturer: Klipper
[ 9350.267914] usb 1-2: SerialNumber: 240032000751323438353631
[ 9350.271220] cdc_acm 1-2:1.0: ttyACM0: USB ACM device
[ 9355.236947] usb 1-2: reset full-speed USB device number 37 using xhci_hcd
[ 9355.364256] usb 1-2: USB disconnect, device number 37
[ 9355.478658] usb 1-2: new full-speed USB device number 38 using xhci_hcd
[ 9355.606352] usb 1-2: New USB device found, idVendor=1d50, idProduct=614e, bcdDevice= 1.00
[ 9355.606357] usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 9355.606359] usb 1-2: Product: stm32f446xx
[ 9355.606361] usb 1-2: Manufacturer: Klipper
[ 9355.606362] usb 1-2: SerialNumber: 240032000751323438353631
[ 9355.608104] cdc_acm 1-2:1.0: ttyACM0: USB ACM device
``` 

I've spent some time debugging with Wireshark and usbmon and noticed that the GET STATUS device request was never answered by the device which probably caused it to be kicked off the bus.

In the PR I've implemented a basic handler for GET STATUS which fixed the erratic behavior for me. I've consulted the [USB 2.0 spec ](https://www.usb.org/document-library/usb-20-specification) and [tinyusb](https://github.com/hathach/tinyusb) . The USB Spec allows a host to ask for the status of the device, interface(s), or endpoint(s) via the `bRequest` field. It will contain some number corresponding to `usb_interface_descriptor::bInterfaceNumber` or `usb_endpoint_descriptor::bEndpointAddress` or just a zero for the device. The last part is a guess of mine as the spec. isn't very clear on that. Also, while debugging Linux only ever asked for `0` so :shrug:. 
If one would want to implement this fully, requests for interface status are simple, just send a 0; for endpoints however there needs to be some more work done on supporting *halting* of endpoints. Additionally USB can also request changes of the two device status flags (self-powered and remote-wakeup) via a config request. This isn't implemented either. It could maybe create some problems in the future.


I hope you find this useful.
Cheers!