### PR TITLE
axis_twist_compensation: allow compensating both axis at once

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -45,21 +45,6 @@ class AxisTwistCompensation:
         self.zy_compensations = config.getlists('zy_compensations',
                                                 default=[], parser=float)
 
-        # Validate single compensation
-        valid_conditions = sum(
-            [
-                bool(self.z_compensations),
-                bool(self.zy_compensations)
-            ]
-        )
-
-        if valid_conditions > 1:
-            raise config.error(
-                """AXIS_TWIST_COMPENSATION: Only one type of compensation
-                can be present at a time:
-                either z_compensations or zy_compensations."""
-            )
-
         # setup calibrater
         self.calibrater = Calibrater(self, config)
         # register events


### PR DESCRIPTION
Restores the behavior before #6739 since people seemed to rely on it, even if the math is not exact.