### PR TITLE
Allow homing only some of the axes in homing_override

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250315: `SET_KINEMATIC_POSITION` now forces the toolhead position
+only for the explicitly specified axes. Other axes will not assume
+homed state by default.
+
 20250308: The `AUTO` parameter of the
 `AXIS_TWIST_COMPENSATION_CALIBRATE` command has been removed.
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,8 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250315: `[homing_override]` is permitted to home only some axes.
+
 20250315: `SET_KINEMATIC_POSITION` now forces the toolhead position
 only for the explicitly specified axes. Other axes will not assume
 homed state by default.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1319,14 +1319,21 @@ gcode:
 #   found in the normal g-code input. See docs/Command_Templates.md
 #   for G-Code format. If a G28 is contained in this list of commands
 #   then it will invoke the normal homing procedure for the printer.
-#   The commands listed here must home all axes. This parameter must
-#   be provided.
+#   For simplicity, it is recommended to always home all printer axes.
+#   However, in order to speed up the homing process, it is possible
+#   to write the gcode that homes only some axes. The commands listed
+#   here must home at least all requested axes, which are passed from
+#   the original G28 invocation via the params pseudo-variable, as well
+#   as all axes, for which the position is forced via set_position_?
+#   parameters (see below). If no specific axis is requested to home, the
+#   commands here must home all axes. This parameter must be provided.
 #axes: xyz
 #   The axes to override. For example, if this is set to "z" then the
 #   override script will only be run when the z axis is homed (eg, via
 #   a "G28" or "G28 Z0" command). Note, the override script should
-#   still home all axes. The default is "xyz" which causes the
-#   override script to be run in place of all G28 commands.
+#   still home all required axes as described above. The default is
+#   "xyz" which causes the override script to be run in place of all
+#   G28 commands.
 #set_position_x:
 #set_position_y:
 #set_position_z:
@@ -1334,7 +1341,13 @@ gcode:
 #   position prior to running the above g-code commands. Setting this
 #   disables homing checks for that axis. This may be useful if the
 #   head must move prior to invoking the normal G28 mechanism for an
-#   axis. The default is to not force a position for an axis.
+#   axis. If specified for some of the axes, the homing override gcode
+#   must home those axes, otherwise the printer will assume an incorrect
+#   location after homing. An alternative to these parameters is to use
+#   SET_KINEMATIC_POSITION in the homing override gcode (potentially
+#   followed by another invocation of SET_KINEMATIC_POSITION with CLEAR
+#   parameter to reset homing state of some axes).
+#   The default is to not force a position for an axis.
 ```
 
 ### [endstop_phase]

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -583,14 +583,14 @@ intended for low-level diagnostics and debugging.
 [CLEAR=<[X][Y][Z]>]`: Force the low-level kinematic code to believe the
 toolhead is at the given cartesian position. This is a diagnostic and
 debugging command; use SET_GCODE_OFFSET and/or G92 for regular axis
-transformations. If an axis is not specified then it will default to the
-position that the head was last commanded to. Setting an incorrect or
-invalid position may lead to internal software errors. Use the CLEAR
-parameter to forget the homing state for the given axes. Note that CLEAR
-will not override the previous functionality; if an axis is not specified
-to CLEAR it will have its kinematic position set as per above. This
-command may invalidate future boundary checks; issue a G28 afterwards to
-reset the kinematics.
+transformations. If an axis is not specified then its state will not
+be altered. Setting an incorrect or invalid position may lead to internal
+software errors. This command may invalidate future boundary checks on the
+affected axes; issue a G28 afterwards to reset the kinematics.
+
+Use the CLEAR parameter to forget the homing state for the given axes. Note
+that CLEAR will not override the previous functionality; if an axis is not
+specified to CLEAR it will have its kinematic position set as per above.
 
 ### [gcode]
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -127,15 +127,19 @@ class ForceMove:
     def cmd_SET_KINEMATIC_POSITION(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.get_last_move_time()
-        curpos = toolhead.get_position()
-        x = gcmd.get_float('X', curpos[0])
-        y = gcmd.get_float('Y', curpos[1])
-        z = gcmd.get_float('Z', curpos[2])
+        pos = toolhead.get_position()
+        homing_axes = ''
+        for i, axis in enumerate('xyz'):
+            loc = gcmd.get_float(axis.upper(), None)
+            if loc is not None:
+                pos[i] = loc
+                homing_axes += axis
         clear = gcmd.get('CLEAR', '').lower()
         clear_axes = "".join([a for a in "xyz" if a in clear])
-        logging.info("SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f clear=%s",
-                     x, y, z, clear_axes)
-        toolhead.set_position([x, y, z, curpos[3]], homing_axes="xyz")
+        logging.info(
+                "SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f homed=%s clear=%s",
+                pos[0], pos[1], pos[2], homing_axes, clear_axes)
+        toolhead.set_position(pos, homing_axes=homing_axes)
         toolhead.get_kinematics().clear_homing_state(clear_axes)
 
 def load_config(config):

--- a/test/klippy/homing_override.cfg
+++ b/test/klippy/homing_override.cfg
@@ -1,0 +1,104 @@
+# This file is an example config file for cartesian style printers.
+# One may copy and edit this file to configure a new cartesian
+# printer.
+
+# DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
+# FIRST. Incorrectly configured parameters may cause damage.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PD3
+position_endstop: 0.5
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.500
+nozzle_diameter: 0.500
+filament_diameter: 3.500
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 210
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 110
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 25
+max_z_accel: 30
+
+[force_move]
+enable_force_move: true
+
+[homing_override]
+gcode:
+    {% set home_all = not ('X' in params or 'Y' in params or 'Z' in params) %}
+    {% set z_was_homed = 'z' in printer.toolhead.homed_axes %}
+    {% if not z_was_homed %}
+        SET_KINEMATIC_POSITION Z=0
+    {% endif %}
+    SAVE_GCODE_STATE NAME=homing_override
+    ; Perform Z hop
+    G91
+    G0 Z{(10, printer.toolhead.axis_maximum.z-printer.toolhead.position.z)|min}
+    RESTORE_GCODE_STATE NAME=homing_override MOVE=0
+    {% if not z_was_homed %}
+        SET_KINEMATIC_POSITION CLEAR=Z
+    {% endif %}
+    ; Home axes in specific order
+    {% if 'Y' in params or home_all %}
+        G28 Y
+    {% endif %}
+    ; Home axis X before Z to avoid collisions of the hotend with the bed
+    {% if 'X' in params or 'Z' in params or home_all %}
+        G28 X
+    {% endif %}
+    {% if 'Z' in params or home_all %}
+        G28 Z
+    {% endif %}

--- a/test/klippy/homing_override.test
+++ b/test/klippy/homing_override.test
@@ -1,0 +1,17 @@
+# Test cases of the homing_override
+CONFIG homing_override.cfg
+DICTIONARY atmega2560.dict
+
+G90
+G28 Y
+G0 Y50
+G28 X
+G0 X100
+G28 Z
+G0 Z20
+M84
+G28 Z
+G0 Z10
+G0 X50
+M84
+G28


### PR DESCRIPTION
The PR actually makes two independent, but related changes:

- allows homing only some of the axes in `homing_override` rather than all axes
- changes SET_KINEMATIC_POSITION to change homing state only for the specified axes

The background for both changes is that as a part of #6815 I'm trying to adapt the proposal from the discourse - namely explicit homing of IDEX axes, which requires a user to define `[homing_override]`. However, I find the currently documented requirements for it rather inflexible, as they require a user to home all axes. This may considerably degrade user experience vs the current `cartesian` kinematics and alike, since they allow partial homing of the printer axes. The corresponding change in this PR addresses this shortcoming by explicitly permitting partial homing of the axes and instead adds a validation that such homing happened indeed. FWIW, this particular change should be fully backwards-compatible, as any previously valid `[homing_override]` would still be valid with additional validations added.

As for the second change to `SET_KINEMATIC_POSITION`, I find it to be a bit of an overlook as it makes all axes homed even those that were not explicitly modified by the command. The proposed change addresses it by only updating the homed state of the axes that were explicitly mentioned in the parameters of the command. This one is not fully backwards-compatible, but since the previous behavior was in fact rather surprising, and the tool itself was positioned as mostly for debugging purposes, I consider such a change acceptable, but I anyways documented it in Config_Changes.md.

Please let me know what you think. I think this would be particularly useful for the upcoming `generic_cartesian` kinematics and potential deprecation of other IDEX configurations, as this would allow users to maintain the same level of convenience as before.