### PR TITLE
hall_filament_width_sensor: Add filament switch values to status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -242,6 +242,8 @@ The following information is available in the `gcode_move` object
 The following information is available in the
 [hall_filament_width_sensor](Config_Reference.md#hall_filament_width_sensor)
 object:
+- all items from
+  [filament_switch_sensor](Status_Reference.md#filament_switch_sensor)
 - `is_active`: Returns True if the sensor is currently active.
 - `Diameter`: The last reading from the sensor in mm.
 - `Raw`: The last raw ADC reading from the sensor.

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -209,10 +209,12 @@ class HallFilamentWidthSensor:
                       +self.lastFilamentWidthReading2))
         gcmd.respond_info(response)
     def get_status(self, eventtime):
-        return {'Diameter': self.diameter,
+        status = self.runout_helper.get_status(eventtime)
+        status.update({'Diameter': self.diameter,
                 'Raw':(self.lastFilamentWidthReading+
                  self.lastFilamentWidthReading2),
-                'is_active':self.is_active}
+                'is_active':self.is_active})
+        return status
     def cmd_log_enable(self, gcmd):
         self.is_log = True
         gcmd.respond_info("Filament width logging Turned On")


### PR DESCRIPTION
`hall_filament_width_sensor` contains a runout sensor object internally. This exposes those values in the API status result.

```
SEND: {"id":123,"method":"objects/query","params":{"objects":{"hall_filament_width_sensor":["enabled","filament_detected","is_active","Diameter","Raw"]}}}
GOT: b'{"id":123,"result":{"eventtime":199567.823596603,"status":{"hall_filament_width_sensor":{"enabled":true,"filament_detected":true,"is_active":true,"Diameter":1.9499999999999986,"Raw":6113}}}}'
```

The duplication of `is_active` and `enabled` seems confusing, but both of these can be independently manipulated by GCode:

```
SEND: {"id":123,"method":"gcode/script","params":{"script":"DISABLE_FILAMENT_WIDTH_SENSOR"}}
GOT: b'{"id":123,"result":{}}'
SEND: {"id":123,"method":"objects/query","params":{"objects":{"hall_filament_width_sensor":["enabled","is_active"]}}}
GOT: b'{"id":123,"result":{"eventtime":199770.446013297,"status":{"hall_filament_width_sensor":{"enabled":true,"is_active":false}}}}'

SEND: {"id":123,"method":"gcode/script","params":{"script":"SET_FILAMENT_SENSOR SENSOR=hall_filament_width_sensor ENABLE=0"}}
GOT: b'{"id":123,"result":{}}'
SEND: {"id":123,"method":"objects/query","params":{"objects":{"hall_filament_width_sensor":["enabled","is_active"]}}}
GOT: b'{"id":123,"result":{"eventtime":199847.927726196,"status":{"hall_filament_width_sensor":{"enabled":false,"is_active":false}}}}'
```