### PR TITLE
Icm20948: Fix accelerometer readings, some changes

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1669,6 +1669,25 @@ cs_pin:
 #   measurements.
 ```
 
+### [icm20948]
+
+Support for icm20948 accelerometers.
+
+```
+[icm20948]
+#i2c_address:
+#   Default is 104 (0x68). If AD0 is high, it would be 0x69 instead.
+#i2c_mcu:
+#i2c_bus:
+#i2c_software_scl_pin:
+#i2c_software_sda_pin:
+#i2c_speed: 400000
+#   See the "common I2C settings" section for a description of the
+#   above parameters. The default "i2c_speed" is 400000.
+#axes_map: x, y, z
+#   See the "adxl345" section for information on this parameter.
+```
+
 ### [lis2dw]
 
 Support for LIS2DW accelerometers.

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -166,12 +166,12 @@ class AccelCommandHelper:
                           % (accel_x, accel_y, accel_z))
     cmd_ACCELEROMETER_DEBUG_READ_help = "Query register (for debugging)"
     def cmd_ACCELEROMETER_DEBUG_READ(self, gcmd):
-        reg = gcmd.get("REG", minval=0, maxval=126, parser=lambda x: int(x, 0))
+        reg = gcmd.get("REG", minval=0, maxval=127, parser=lambda x: int(x, 0))
         val = self.chip.read_reg(reg)
         gcmd.respond_info("Accelerometer REG[0x%x] = 0x%x" % (reg, val))
     cmd_ACCELEROMETER_DEBUG_WRITE_help = "Set register (for debugging)"
     def cmd_ACCELEROMETER_DEBUG_WRITE(self, gcmd):
-        reg = gcmd.get("REG", minval=0, maxval=126, parser=lambda x: int(x, 0))
+        reg = gcmd.get("REG", minval=0, maxval=127, parser=lambda x: int(x, 0))
         val = gcmd.get("VAL", minval=0, maxval=255, parser=lambda x: int(x, 0))
         self.chip.set_reg(reg, val)
 

--- a/klippy/extras/icm20948.py
+++ b/klippy/extras/icm20948.py
@@ -12,42 +12,40 @@
 import logging
 from . import bus, adxl345, bulk_sensor
 
-ICM20948_ADDR =      0x68
+ICM20948_ADDR =         0x68
 
 ICM_DEV_IDS = {
     0xEA: "icm-20948",
     #everything above are normal ICM IDs
-    }
-
+}
 
 # ICM20948 registers
-REG_DEVID =         0x00 # 0xEA
-REG_FIFO_EN =       0x67 # FIFO_EN_2
-REG_ACCEL_SMPLRT_DIV1 =    0x10 # MSB
-REG_ACCEL_SMPLRT_DIV2 =    0x11 # LSB
-REG_ACCEL_CONFIG    =    0x14
-REG_USER_CTRL =     0x03
-REG_PWR_MGMT_1 = 0x06
-REG_PWR_MGMT_2 = 0x07
-REG_INT_STATUS = 0x19
-REG_BANK_SEL =   0x7F
+REG_DEVID =             0x00 # 0xEA
+REG_FIFO_EN =           0x67 # FIFO_EN_2
+REG_ACCEL_SMPLRT_DIV1 = 0x10 # MSB
+REG_ACCEL_SMPLRT_DIV2 = 0x11 # LSB
+REG_ACCEL_CONFIG =      0x14
+REG_USER_CTRL =         0x03
+REG_PWR_MGMT_1 =        0x06
+REG_PWR_MGMT_2 =        0x07
+REG_INT_STATUS =        0x19
+REG_BANK_SEL =          0x7F
 
 SAMPLE_RATE_DIVS = { 4500: 0x00 }
 
-#SET_CONFIG =        0x01 # FIFO mode 'stream' style
-SET_BANK_0 = 0x00
-SET_BANK_1 = 0x10
-SET_BANK_2 = 0x20
-SET_BANK_3 = 0x30
-SET_ACCEL_CONFIG =  0x06 # 16g full scale, 1209Hz BW, ??? delay 4.5kHz samp rate
-SET_PWR_MGMT_1_WAKE =     0x01
-SET_PWR_MGMT_1_SLEEP=     0x41
+SET_BANK_0 =            0x00
+SET_BANK_1 =            0x10
+SET_BANK_2 =            0x20
+SET_BANK_3 =            0x30
+SET_ACCEL_CONFIG =      0x06 # 16g full scale, 1209Hz BW, 4.5kHz samp rate
+SET_PWR_MGMT_1_WAKE =   0x01
+SET_PWR_MGMT_1_SLEEP =  0x41
 SET_PWR_MGMT_2_ACCEL_ON = 0x07
-SET_PWR_MGMT_2_OFF  =     0x3F
-SET_USER_FIFO_RESET = 0x0E
-SET_USER_FIFO_EN    = 0x40
-SET_ENABLE_FIFO  = 0x10
-SET_DISABLE_FIFO = 0x00
+SET_PWR_MGMT_2_OFF =    0x3F
+SET_USER_FIFO_RESET =   0x0E
+SET_USER_FIFO_EN =      0x40
+SET_ENABLE_FIFO  =      0x10
+SET_DISABLE_FIFO =      0x00
 
 FREEFALL_ACCEL = 9.80665 * 1000.
 # SCALE = 1/2048 g/LSB @16g scale * Earth gravity in mm/s**2
@@ -129,7 +127,6 @@ class ICM20948:
                 % (dev_id))
         else:
             logging.info("Found %s with id %x"% (ICM_DEV_IDS[dev_id], dev_id))
-
         # Setup chip in requested query rate
         self.set_reg(REG_PWR_MGMT_1, SET_PWR_MGMT_1_WAKE)
         self.set_reg(REG_PWR_MGMT_2, SET_PWR_MGMT_2_ACCEL_ON)
@@ -137,7 +134,6 @@ class ICM20948:
         self.read_reg(REG_DEVID) # Dummy read to ensure queues flushed
         self.set_reg(REG_ACCEL_SMPLRT_DIV1, SAMPLE_RATE_DIVS[self.data_rate])
         self.set_reg(REG_ACCEL_SMPLRT_DIV2, SAMPLE_RATE_DIVS[self.data_rate])
-        # self.set_reg(REG_CONFIG, SET_CONFIG) # No config register
         self.set_reg(REG_BANK_SEL, SET_BANK_2)
         self.set_reg(REG_ACCEL_CONFIG, SET_ACCEL_CONFIG)
         self.set_reg(REG_BANK_SEL, SET_BANK_0)
@@ -146,7 +142,6 @@ class ICM20948:
         self.set_reg(REG_USER_CTRL, SET_USER_FIFO_RESET)
         self.set_reg(REG_USER_CTRL, SET_USER_FIFO_EN)
         self.read_reg(REG_INT_STATUS) # clear FIFO overflow flag
-
         # Start bulk reading
         rest_ticks = self.mcu.seconds_to_clock(4. / self.data_rate)
         self.query_icm20948_cmd.send([self.oid, rest_ticks])

--- a/klippy/extras/icm20948.py
+++ b/klippy/extras/icm20948.py
@@ -39,7 +39,7 @@ SET_BANK_0 = 0x00
 SET_BANK_1 = 0x10
 SET_BANK_2 = 0x20
 SET_BANK_3 = 0x30
-SET_ACCEL_CONFIG =  0x04 # 8g full scale, 1209Hz BW, ??? delay 4.5kHz samp rate
+SET_ACCEL_CONFIG =  0x06 # 16g full scale, 1209Hz BW, ??? delay 4.5kHz samp rate
 SET_PWR_MGMT_1_WAKE =     0x01
 SET_PWR_MGMT_1_SLEEP=     0x41
 SET_PWR_MGMT_2_ACCEL_ON = 0x07
@@ -50,8 +50,8 @@ SET_ENABLE_FIFO  = 0x10
 SET_DISABLE_FIFO = 0x00
 
 FREEFALL_ACCEL = 9.80665 * 1000.
-# SCALE = 1/4096 g/LSB @8g scale * Earth gravity in mm/s**2
-SCALE = 0.000244140625 * FREEFALL_ACCEL
+# SCALE = 1/2048 g/LSB @16g scale * Earth gravity in mm/s**2
+SCALE = 0.00048828125 * FREEFALL_ACCEL
 
 FIFO_SIZE = 512
 

--- a/klippy/extras/icm20948.py
+++ b/klippy/extras/icm20948.py
@@ -30,10 +30,15 @@ REG_USER_CTRL =     0x03
 REG_PWR_MGMT_1 = 0x06
 REG_PWR_MGMT_2 = 0x07
 REG_INT_STATUS = 0x19
+REG_BANK_SEL =   0x7F
 
 SAMPLE_RATE_DIVS = { 4500: 0x00 }
 
 #SET_CONFIG =        0x01 # FIFO mode 'stream' style
+SET_BANK_0 = 0x00
+SET_BANK_1 = 0x10
+SET_BANK_2 = 0x20
+SET_BANK_3 = 0x30
 SET_ACCEL_CONFIG =  0x04 # 8g full scale, 1209Hz BW, ??? delay 4.5kHz samp rate
 SET_PWR_MGMT_1_WAKE =     0x01
 SET_PWR_MGMT_1_SLEEP=     0x41
@@ -133,7 +138,9 @@ class ICM20948:
         self.set_reg(REG_ACCEL_SMPLRT_DIV1, SAMPLE_RATE_DIVS[self.data_rate])
         self.set_reg(REG_ACCEL_SMPLRT_DIV2, SAMPLE_RATE_DIVS[self.data_rate])
         # self.set_reg(REG_CONFIG, SET_CONFIG) # No config register
+        self.set_reg(REG_BANK_SEL, SET_BANK_2)
         self.set_reg(REG_ACCEL_CONFIG, SET_ACCEL_CONFIG)
+        self.set_reg(REG_BANK_SEL, SET_BANK_0)
         # Reset fifo
         self.set_reg(REG_FIFO_EN, SET_DISABLE_FIFO)
         self.set_reg(REG_USER_CTRL, SET_USER_FIFO_RESET)


### PR DESCRIPTION
-The accelerometer remained (by default) in accels scale 2g mode with a sampling rate of +-1125/s instead of setting the 8g and 4500 rate, since we did not switch to registers bank 2 before the 'accel config' configuration. Because of which it 'choked', and also incorrectly calculated its accels in ffreader.

I did some comparative experiments between adxl345 and Icm20948 (2g mode):
<div style="display: flex; gap: 10px;">
    <img src="https://github.com/user-attachments/assets/1abcfd9f-fb91-4ab0-92a1-bc1add104b46" width="300">
    <img src="https://github.com/user-attachments/assets/092ce08b-5bf6-4548-97cc-6e4b25363c32" width="300">
</div>

Measured the acceleration at idle on Icm20948:
<img src="https://github.com/user-attachments/assets/26f9a9f9-0045-43cc-b5ec-ccf76a16ce49b" width="600">

Сomparative experiments between adxl345 and Icm20948 (8g mode) after correcting the accelerometer configuration:
<div style="display: flex; gap: 10px;">
    <img src="https://github.com/user-attachments/assets/1abcfd9f-fb91-4ab0-92a1-bc1add104b46" width="300">
    <img src="https://github.com/user-attachments/assets/8bddaed7-d3fe-43c8-b30d-975cbdc8614e" width="300">
</div>
Measured the acceleration at idle on Icm20948:
<img src="https://github.com/user-attachments/assets/9b59ba29-b19c-4cec-8737-bf4be88cecf5" width="600">

The results have returned to normal, but it still seems like the accelerometer is reached the maximum acceleration threshold - the peak is too thick.

That's why I also compared adxl345 and Icm20948 in 16g mode:
<div style="display: flex; gap: 10px;">
    <img src="https://github.com/user-attachments/assets/1abcfd9f-fb91-4ab0-92a1-bc1add104b46" width="300">
    <img src="https://github.com/user-attachments/assets/1a248e00-fc68-44ec-ac59-afd10e344441" width="300">
</div>

Now it displays identically to adxl345. 

Measured the acceleration at idle on Icm20948:
<img src="https://github.com/user-attachments/assets/25afa76c-8a49-4952-bc7d-b1a29baf03dd" width="600">

-My suggestion is to switch from 8g mode to 16g, this change is also attached in a separate commit.
-Changes for adxl345 debug functions of read/write registers, the limit has been raised from 126 to 127 addresses, since Icm20948 has a maximum address of 127.
-Add icm20948 description to config reference.

I also have a question, i2c software bus is blocked at 100k rate, under such condition the samples rate of accelerometer will drop to about ~1800smp\s, and the calculation of accelerations will also be distorted. 
Perhaps we should add the functionality of the minimum bus rate for Icm20948 (and mpu chips too, by the way). Or perhaps we should perform calculations in ffreader differently? Or at least warn the user if his i2c bus has a low speed.
