### PR TITLE
lis3dh: increase scale from 8g to 16g

### DIFF
--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -34,7 +34,7 @@ LIS_I2C_ADDR = 0x19
 # Right shift for left justified registers.
 FREEFALL_ACCEL = 9.80665
 LIS2DW_SCALE = FREEFALL_ACCEL * 1.952 / 4
-LIS3DH_SCALE = FREEFALL_ACCEL * 3.906 / 16
+LIS3DH_SCALE = FREEFALL_ACCEL * 11.718 / 16
 
 BATCH_UPDATES = 0.100
 
@@ -167,8 +167,8 @@ class LIS2DW:
             self.set_reg(REG_LIS2DW_CTRL_REG1_ADDR, 0x97)
             # Disable all filtering
             self.set_reg(REG_LIS2DW_CTRL_REG2_ADDR, 0)
-            # Set +-8g, High Resolution mode
-            self.set_reg(REG_LIS2DW_CTRL_REG4_ADDR, 0x28)
+            # Set +-16g, High Resolution mode
+            self.set_reg(REG_LIS2DW_CTRL_REG4_ADDR, 0x38)
             # Enable FIFO
             self.set_reg(REG_LIS2DW_CTRL_REG5_ADDR, 0x40)
             # Stream mode


### PR DESCRIPTION
This change bumps the scale on the LIS3DH from 8g to 16g due to observations made in #6868.