### PR TITLE
Refactor of probe ProbeSessionHelper into additional helpers

### DIFF
--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -191,9 +191,6 @@ class BLTouchProbe:
         self.verify_raise_probe()
         self.sync_print_time()
         self.multi = 'OFF'
-    def probing_move(self, pos, speed):
-        phoming = self.printer.lookup_object('homing')
-        return phoming.probing_move(self, pos, speed)
     def probe_prepare(self, hmove):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self.lower_probe()

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -64,7 +64,7 @@ class BLTouchProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.mcu_endstop.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeSessionHelper(config, self)
+        self.probe_session = probe.ProbeEndstopSessionHelper(config, self)
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -64,7 +64,11 @@ class BLTouchProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.mcu_endstop.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeEndstopSessionHelper(config, self)
+        self.param_helper = probe.ProbeParameterHelper(config)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self,
+                                                        self.param_helper)
+        self.probe_session = probe.ProbeSessionHelper(
+            config, self.param_helper, self.homing_helper.start_probe_session)
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,
@@ -75,7 +79,7 @@ class BLTouchProbe:
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
     def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
+        return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self):
         return self.probe_offsets.get_offsets()
     def get_status(self, eventtime):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -393,18 +393,6 @@ class ProbeSessionHelper:
         self.results = []
         return res
 
-# Helper for probes based purely on an endstop wrapper
-class ProbeEndstopSessionHelper:
-    def __init__(self, config, mcu_probe):
-        self.param_helper = ProbeParameterHelper(config)
-        self.homing_helper = HomingViaProbeHelper(config, mcu_probe,
-                                                  self.param_helper)
-        self.probe_session = ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
-        # Main printer probe session starting API
-        self.start_probe_session = self.probe_session.start_probe_session
-        self.get_probe_params = self.param_helper.get_probe_params
-
 # Helper to read the xyz probe offsets from the config
 class ProbeOffsetsHelper:
     def __init__(self, config):
@@ -606,9 +594,13 @@ class PrinterProbe:
         self.cmd_helper = ProbeCommandHelper(config, self,
                                              self.mcu_probe.query_endstop)
         self.probe_offsets = ProbeOffsetsHelper(config)
-        self.probe_session = ProbeEndstopSessionHelper(config, self.mcu_probe)
+        self.param_helper = ProbeParameterHelper(config)
+        self.homing_helper = HomingViaProbeHelper(config, self.mcu_probe,
+                                                  self.param_helper)
+        self.probe_session = ProbeSessionHelper(
+            config, self.param_helper, self.homing_helper.start_probe_session)
     def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
+        return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self):
         return self.probe_offsets.get_offsets()
     def get_status(self, eventtime):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -172,6 +172,14 @@ class ProbeCommandHelper:
         configfile = self.printer.lookup_object('configfile')
         configfile.set(self.name, 'z_offset', "%.3f" % (new_calibrate,))
 
+# Helper to lookup the minimum Z position for the printer
+def lookup_minimum_z(config):
+    if config.has_section('stepper_z'):
+        zconfig = config.getsection('stepper_z')
+        return zconfig.getfloat('position_min', 0., note_valid=False)
+    pconfig = config.getsection('printer')
+    return pconfig.getfloat('minimum_z_position', 0., note_valid=False)
+
 # Homing via probe:z_virtual_endstop
 class HomingViaProbeHelper:
     def __init__(self, config, mcu_probe):
@@ -241,14 +249,7 @@ class ProbeSessionHelper:
         gcode = self.printer.lookup_object('gcode')
         self.dummy_gcode_cmd = gcode.create_gcode_command("", "", {})
         # Infer Z position to move to during a probe
-        if config.has_section('stepper_z'):
-            zconfig = config.getsection('stepper_z')
-            self.z_position = zconfig.getfloat('position_min', 0.,
-                                               note_valid=False)
-        else:
-            pconfig = config.getsection('printer')
-            self.z_position = pconfig.getfloat('minimum_z_position', 0.,
-                                               note_valid=False)
+        self.z_position = lookup_minimum_z(config)
         # Configurable probing speeds
         self.speed = config.getfloat('speed', 5.0, above=0.)
         self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -423,6 +423,7 @@ class PrinterEddyProbe:
         sensor_type = config.getchoice('sensor_type', {s: s for s in sensors})
         self.sensor_helper = sensors[sensor_type](config, self.calibration)
         # Probe interface
+        self.param_helper = probe.ProbeParameterHelper(config)
         self.mcu_probe = EddyEndstopWrapper(config, self.sensor_helper,
                                             self.calibration)
         self.cmd_helper = probe.ProbeCommandHelper(
@@ -430,12 +431,13 @@ class PrinterEddyProbe:
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe)
         self.probe_session = probe.ProbeSessionHelper(
-            config, self.mcu_probe, self.mcu_probe.probing_move)
+            config, self.mcu_probe, self.param_helper,
+            self.mcu_probe.probing_move)
         self.printer.add_object('probe', self)
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)
     def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
+        return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self):
         return self.probe_offsets.get_offsets()
     def get_status(self, eventtime):

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -438,8 +438,7 @@ class PrinterEddyProbe:
         self.param_helper = probe.ProbeParameterHelper(config)
         self.mcu_probe = EddyEndstopWrapper(
             config, self.sensor_helper, self.calibration, self.param_helper)
-        self.cmd_helper = probe.ProbeCommandHelper(
-            config, self, self.mcu_probe.query_endstop)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe,
                                                         self.param_helper)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -428,6 +428,7 @@ class PrinterEddyProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.mcu_probe.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe)
         self.probe_session = probe.ProbeSessionHelper(
             config, self.mcu_probe, self.mcu_probe.probing_move)
         self.printer.add_object('probe', self)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -428,7 +428,8 @@ class PrinterEddyProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.mcu_probe.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeSessionHelper(config, self.mcu_probe)
+        self.probe_session = probe.ProbeSessionHelper(
+            config, self.mcu_probe, self.mcu_probe.probing_move)
         self.printer.add_object('probe', self)
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -302,7 +302,7 @@ class EddyGatherSamples:
         self._check_samples()
 
 # Helper for implementing PROBE style commands (descend until trigger)
-class EddyEndstopWrapper:
+class EddyDescend:
     REASON_SENSOR_ERROR = mcu.MCU_trsync.REASON_COMMS_TIMEOUT + 1
     def __init__(self, config, sensor_helper, calibration, param_helper):
         self._printer = config.get_printer()
@@ -315,11 +315,8 @@ class EddyEndstopWrapper:
         self._dispatch = mcu.TriggerDispatch(self._mcu)
         self._trigger_time = 0.
         self._gather = None
-    # Interface for MCU_endstop
-    def get_mcu(self):
-        return self._mcu
-    def add_stepper(self, stepper):
-        self._dispatch.add_stepper(stepper)
+        probe.LookupZSteppers(config, self._dispatch.add_stepper)
+    # Interface for phoming.probing_move()
     def get_steppers(self):
         return self._dispatch.get_steppers()
     def home_start(self, print_time, sample_time, sample_count, rest_time,
@@ -346,11 +343,10 @@ class EddyEndstopWrapper:
             return home_end_time
         self._trigger_time = trigger_time
         return trigger_time
-    def query_endstop(self, print_time):
-        return False # XXX
     # Probe session interface
     def start_probe_session(self, gcmd):
-        self.multi_probe_begin()
+        self._gather = EddyGatherSamples(self._printer, self._sensor_helper,
+                                         self._calibration, self._z_offset)
         return self
     def run_probe(self, gcmd):
         toolhead = self._printer.lookup_object('toolhead')
@@ -370,20 +366,43 @@ class EddyEndstopWrapper:
     def pull_probed_results(self):
         return self._gather.pull_probed()
     def end_probe_session(self):
-        self.multi_probe_end()
-    # Interface for ProbeEndstopWrapper
-    def multi_probe_begin(self):
-        self._gather = EddyGatherSamples(self._printer, self._sensor_helper,
-                                         self._calibration, self._z_offset)
-    def multi_probe_end(self):
         self._gather.finish()
         self._gather = None
+
+# Wrapper to emulate mcu_endstop for probe:z_virtual_endstop
+# Note that this does not provide accurate results
+class EddyEndstopWrapper:
+    def __init__(self, sensor_helper, eddy_descend):
+        self._sensor_helper = sensor_helper
+        self._eddy_descend = eddy_descend
+        self._hw_probe_session = None
+    # Interface for MCU_endstop
+    def get_mcu(self):
+        return self._sensor_helper.get_mcu()
+    def add_stepper(self, stepper):
+        pass
+    def get_steppers(self):
+        return self._eddy_descend.get_steppers()
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        return self._eddy_descend.home_start(
+            print_time, sample_time, sample_count, rest_time, triggered)
+    def home_wait(self, home_end_time):
+        return self._eddy_descend.home_wait(home_end_time)
+    def query_endstop(self, print_time):
+        return False # XXX
+    # Interface for HomingViaProbeHelper
+    def multi_probe_begin(self):
+        self._hw_probe_session = self._eddy_descend.start_probe_session(None)
+    def multi_probe_end(self):
+        self._hw_probe_session.end_probe_session()
+        self._hw_probe_session = None
     def probe_prepare(self, hmove):
         pass
     def probe_finish(self, hmove):
         pass
     def get_position_endstop(self):
-        return self._z_offset
+        return self._eddy_descend._z_offset
 
 # Implementing probing with "METHOD=scan"
 class EddyScanningProbe:
@@ -436,14 +455,14 @@ class PrinterEddyProbe:
         self.sensor_helper = sensors[sensor_type](config, self.calibration)
         # Probe interface
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.mcu_probe = EddyEndstopWrapper(
+        self.eddy_descend = EddyDescend(
             config, self.sensor_helper, self.calibration, self.param_helper)
         self.cmd_helper = probe.ProbeCommandHelper(config, self)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe,
-                                                        self.param_helper)
         self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.mcu_probe.start_probe_session)
+            config, self.param_helper, self.eddy_descend.start_probe_session)
+        mcu_probe = EddyEndstopWrapper(self.sensor_helper, self.eddy_descend)
+        probe.HomingViaProbeHelper(config, mcu_probe, self.param_helper)
         self.printer.add_object('probe', self)
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -69,7 +69,7 @@ class SmartEffectorProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.probe_wrapper.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeSessionHelper(config, self)
+        self.probe_session = probe.ProbeEndstopSessionHelper(config, self)
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -92,9 +92,6 @@ class SmartEffectorProbe:
         return self.cmd_helper.get_status(eventtime)
     def start_probe_session(self, gcmd):
         return self.probe_session.start_probe_session(gcmd)
-    def probing_move(self, pos, speed):
-        phoming = self.printer.lookup_object('homing')
-        return phoming.probing_move(self, pos, speed)
     def probe_prepare(self, hmove):
         toolhead = self.printer.lookup_object('toolhead')
         self.probe_wrapper.probe_prepare(hmove)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -69,7 +69,11 @@ class SmartEffectorProbe:
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.probe_wrapper.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = probe.ProbeEndstopSessionHelper(config, self)
+        self.param_helper = probe.ProbeParameterHelper(config)
+        self.homing_helper = probe.HomingViaProbeHelper(config, self,
+                                                        self.param_helper)
+        self.probe_session = probe.ProbeSessionHelper(
+            config, self.param_helper, self.homing_helper.start_probe_session)
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:
@@ -85,7 +89,7 @@ class SmartEffectorProbe:
                                     self.cmd_SET_SMART_EFFECTOR,
                                     desc=self.cmd_SET_SMART_EFFECTOR_help)
     def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
+        return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self):
         return self.probe_offsets.get_offsets()
     def get_status(self, eventtime):


### PR DESCRIPTION
This PR separates the probe.ProbeSessionHelper class into several additional "helper" classes.  This makes it easier for code to use just parts of the existing probe code.

This was discussed at #6871.

@garethky - fyi.

This would be something to look at merging after tagging v0.13.0 .

-Kevin