### PR TITLE
Debian changed from python2 to python3

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -37,7 +37,7 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
 
     # Install/update dependencies
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt

--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -11,7 +11,7 @@ KLIPPER_GROUP=$KLIPPER_USER
 install_packages()
 {
     # Packages for python cffi
-    PKGLIST="virtualenv python-dev libffi-dev build-essential"
+    PKGLIST="virtualenv python3-dev libffi-dev build-essential"
     # kconfig requirements
     PKGLIST="${PKGLIST} libncurses-dev"
     # hub-ctrl


### PR DESCRIPTION
python-dev changed to python3-dev.  
python venv needs python3; tested with python 3.11, the current version in Debian Stable.