### PR TITLE
axis_twist_compensation: Fix AttributeError on klippy connect state

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -125,9 +125,8 @@ class Calibrater:
 
     def _handle_connect(self):
         self.probe = self.printer.lookup_object('probe', None)
-        if (self.probe is None):
-            config = self.printer.lookup_object('configfile')
-            raise config.error(
+        if self.probe is None:
+            raise self.printer.config_error(
                 "AXIS_TWIST_COMPENSATION requires [probe] to be defined")
         self.lift_speed = self.probe.get_probe_params()['lift_speed']
         self.probe_x_offset, self.probe_y_offset, _ = \


### PR DESCRIPTION
axis_twist_compensation on klippy:connect state checks for the presence of the 'probe' object, but if it is missing, it causes an error in the 'PrinterConfig' object, which does not have such an attribute.