### PR TITLE
tmc: add missing freewheel config options 2208/2209/2130

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3533,6 +3533,7 @@ run_current:
 #driver_PWM_FREQ: 1
 #driver_PWM_GRAD: 4
 #driver_PWM_AMPL: 128
+#driver_FREEWHEEL: 0
 #driver_SGT: 0
 #driver_SEMIN: 0
 #driver_SEUP: 0
@@ -3613,6 +3614,7 @@ run_current:
 #driver_PWM_FREQ: 1
 #driver_PWM_GRAD: 14
 #driver_PWM_OFS: 36
+#driver_FREEWHEEL: 0
 #   Set the given register during the configuration of the TMC2208
 #   chip. This may be used to set custom motor parameters. The
 #   defaults for each parameter are next to the parameter name in the
@@ -3662,6 +3664,7 @@ run_current:
 #driver_PWM_FREQ: 1
 #driver_PWM_GRAD: 14
 #driver_PWM_OFS: 36
+#driver_FREEWHEEL: 0
 #driver_SGTHRS: 0
 #driver_SEMIN: 0
 #driver_SEUP: 0

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -323,6 +323,7 @@ class TMC2130:
         set_config_field(config, "pwm_grad", 4)
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
+        set_config_field(config, "freewheel", 0)
         # TPOWERDOWN
         set_config_field(config, "tpowerdown", 0)
 

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -215,6 +215,7 @@ class TMC2208:
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
         # TPOWERDOWN

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -98,6 +98,7 @@ class TMC2209:
         set_config_field(config, "pwm_freq", 1)
         set_config_field(config, "pwm_autoscale", True)
         set_config_field(config, "pwm_autograd", True)
+        set_config_field(config, "freewheel", 0)
         set_config_field(config, "pwm_reg", 8)
         set_config_field(config, "pwm_lim", 12)
         # TPOWERDOWN


### PR DESCRIPTION
This PR simply adds missing config options from TMC drivers.

The intended use is to define the default value.
This can then be used to passively brake the Z axis instead of disabling motors for printers where appropriate.
Example: Voron 2.4, probably some deltas.

[Discourse link with suggested macros](https://klipper.discourse.group/t/example-how-to-make-passive-breaking-work-for-z/22861)

Thanks.