### PR TITLE
RFC: temperature_monitor - define as a separate config object.

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2491,6 +2491,19 @@ temperature sensors that are reported via the M105 command.
 #   parameter.
 ```
 
+### [temperature_monitor]
+
+Special temperature sensors, which could fail and/or
+report temperature under specific circumstances.
+
+```
+[temperature_monitor my_sensor]
+#monitor: tmc
+#  The only currently supported is TMC for TMC2240.
+#stepper: stepper_N
+#  The postfix of TMC2240 definition.
+```
+
 ### [temperature_probe]
 
 Reports probe coil temperature.  Includes optional thermal drift

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -274,9 +274,9 @@ object is available if any heater is defined):
   "temperature_sensor electronics_temp"]`.
 - `available_monitors`: Returns a list of all currently available
   temperature monitors by their full config section names,
-  e.g. `["tmc2240 stepper_x"]`.  While a temperature sensor is always
-  available to read, a temperature monitor may not be available and
-  will return null in such case.
+  e.g. `["temperature_monitor stepper_x"]`.
+  While a temperature sensor is always available to read,
+  a temperature monitor may not be available and will return null in such case.
 
 ## idle_timeout
 

--- a/klippy/extras/temperature_monitor/__init__.py
+++ b/klippy/extras/temperature_monitor/__init__.py
@@ -1,0 +1,19 @@
+# Support generic temperature monitor
+#
+# Copyright (C) 2025  Timofey Titovets <nefelim4ag@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from . import tmc
+
+MONITORS = {
+    'tmc': tmc.TMCMonitor
+}
+
+def load_config_prefix(config):
+    printer = config.get_printer()
+    monitor = config.getchoice('monitor', MONITORS)(config)
+
+    pheater = printer.lookup_object("heaters")
+    pheater.register_monitor(config)
+    return monitor

--- a/klippy/extras/temperature_monitor/tmc.py
+++ b/klippy/extras/temperature_monitor/tmc.py
@@ -1,0 +1,81 @@
+# Support generic TMC Temperature Monitor
+#
+# Copyright (C) 2025  Timofey Titovets <nefelim4ag@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2209", "tmc2240", "tmc2660",
+    "tmc5160"]
+
+class TMCMonitor:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.stepper_name = config.get('stepper')
+        self.driver_name = ""
+        self.adc_temp = None
+        self.mcu_tmc = None
+        self.sample_timer = None
+        self.printer.register_event_handler("klippy:connect", self.connect)
+
+    def lookup_tmc(self):
+        for driver in TRINAMIC_DRIVERS:
+            self.driver_name = "%s %s" % (driver, self.stepper_name)
+            module = self.printer.lookup_object(self.driver_name, None)
+            if module is not None:
+                return module
+        raise self.printer.config_error("Unable to find TMC driver for %s"
+                                         % (self.stepper_name,))
+    def connect(self):
+        tmc_module = self.lookup_tmc()
+        self.mcu_tmc = tmc_module.mcu_tmc
+        stepper_enable = self.printer.lookup_object('stepper_enable')
+        self.adc_temp_reg = self.mcu_tmc.fields.lookup_register("adc_temp")
+        if self.adc_temp_reg is None:
+            self.printer.config_error("%s can't report ADC temperature"
+                                       % (self.driver_name))
+        enable_line = stepper_enable.lookup_enable(self.stepper_name)
+        enable_line.register_state_callback(self._handle_stepper_enable)
+
+    def _handle_stepper_enable(self, print_time, is_enable):
+        if is_enable:
+            cb = (lambda ev: self._do_enable(print_time))
+        else:
+            cb = (lambda ev: self._do_disable(print_time))
+        self.printer.get_reactor().register_callback(cb)
+
+    def _do_enable(self, print_time):
+        if self.sample_timer is not None:
+            self._do_disable(print_time)
+
+        reactor = self.printer.get_reactor()
+        curtime = reactor.monotonic()
+        self.sample_timer = reactor.register_timer(self._sample, curtime + 1.)
+
+    def _do_disable(self, print_time):
+        if self.sample_timer is None:
+            return
+        reactor = self.printer.get_reactor()
+        reactor.unregister_timer(self.sample_timer)
+        self.sample_timer = None
+        self.adc_temp = None
+
+    def _query_temperature(self):
+        try:
+            self.adc_temp = self.mcu_tmc.get_register(self.adc_temp_reg)
+        except self.printer.command_error as e:
+            # Ignore comms error for temperature
+            self.adc_temp = None
+            return
+
+    def _sample(self, eventtime):
+        self._query_temperature()
+        return eventtime + 1.
+
+    def get_status(self, eventtime):
+        temp = None
+        if self.adc_temp is not None:
+            temp = round((self.adc_temp - 2038) / 7.7, 2)
+        return {
+            'temperature': temp
+        }

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -122,12 +122,6 @@ class TMCErrorCheck:
                 if f in err_fields:
                     err_mask |= self.fields.all_fields[reg_name][f]
         self.drv_status_reg_info = [0, reg_name, mask, err_mask, cs_actual_mask]
-        # Setup for temperature query
-        self.adc_temp = None
-        self.adc_temp_reg = self.fields.lookup_register("adc_temp")
-        if self.adc_temp_reg is not None:
-            pheaters = self.printer.load_object(config, 'heaters')
-            pheaters.register_monitor(config)
     def _query_register(self, reg_info, try_clear=False):
         last_value, reg_name, mask, err_mask, cs_actual_mask = reg_info
         cleared_flags = 0
@@ -167,20 +161,11 @@ class TMCErrorCheck:
                 cleared_flags |= val & err_mask
                 self.mcu_tmc.set_register(reg_name, val & err_mask)
         return cleared_flags
-    def _query_temperature(self):
-        try:
-            self.adc_temp = self.mcu_tmc.get_register(self.adc_temp_reg)
-        except self.printer.command_error as e:
-            # Ignore comms error for temperature
-            self.adc_temp = None
-            return
     def _do_periodic_check(self, eventtime):
         try:
             self._query_register(self.drv_status_reg_info)
             if self.gstat_reg_info is not None:
                 self._query_register(self.gstat_reg_info)
-            if self.adc_temp_reg is not None:
-                self._query_temperature()
         except self.printer.command_error as e:
             self.printer.invoke_shutdown(str(e))
             return self.printer.get_reactor().NEVER
@@ -209,16 +194,13 @@ class TMCErrorCheck:
         return False
     def get_status(self, eventtime=None):
         if self.check_timer is None:
-            return {'drv_status': None, 'temperature': None}
-        temp = None
-        if self.adc_temp is not None:
-            temp = round((self.adc_temp - 2038) / 7.7, 2)
+            return {'drv_status': None}
         last_value, reg_name = self.drv_status_reg_info[:2]
         if last_value != self.last_drv_status:
             self.last_drv_status = last_value
             fields = self.fields.get_reg_fields(reg_name, last_value)
             self.last_drv_fields = {n: v for n, v in fields.items() if v}
-        return {'drv_status': self.last_drv_fields, 'temperature': temp}
+        return {'drv_status': self.last_drv_fields}
 
 
 ######################################################################


### PR DESCRIPTION
The problem: TMC2240 has a temperature monitoring which is currently exists, but can't be controlled or "used".
On some printers it is desired to disable some of them.
On some, to use them as a temperature source for cooling control.

Additional flags in TMC definitions look a bit ugly.

My suggestion here is to do a similar thing to the temperature sensors.
If it is required, it is possible to define a temperature monitor for the driver, or any other thing in the future.

As the next step,
If it is acceptable, I hope the stepper enabled/disabled logic can be disabled for this specific monitor, by a flag.
Which probably allows for the safe use of an array of TMC2240 data to control some driver cooling fan.

Thanks.
---
Related: https://github.com/Klipper3d/klipper/pull/6769
Related: https://github.com/Klipper3d/klipper/pull/6292
Fixes: https://github.com/fluidd-core/fluidd/issues/1190