### PR TITLE
Use prebuilt pru gcc binaries during github build checks

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -7,7 +7,7 @@ set -eu
 # Paths to tools installed by ci-install.sh
 MAIN_DIR=${PWD}
 BUILD_DIR=${PWD}/ci_build
-export PATH=${BUILD_DIR}/pru-gcc/bin:${PATH}
+export PATH=${BUILD_DIR}/pru-elf/bin:${PATH}
 export PATH=${BUILD_DIR}/or1k-linux-musl-cross/bin:${PATH}
 PYTHON=${BUILD_DIR}/python-env/bin/python
 PYTHON2=${BUILD_DIR}/python2-env/bin/python

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -19,34 +19,24 @@ echo -e "\n\n=============== Install system dependencies\n\n"
 PKGS="virtualenv python2-dev libffi-dev build-essential"
 PKGS="${PKGS} gcc-avr avr-libc"
 PKGS="${PKGS} libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi"
-PKGS="${PKGS} pv libmpfr-dev libgmp-dev libmpc-dev texinfo bison flex"
 sudo apt-get update
 sudo apt-get install ${PKGS}
 
 
 ######################################################################
-# Install (or build) pru gcc
+# Install pru gcc
 ######################################################################
 
 echo -e "\n\n=============== Install embedded pru gcc\n\n"
-PRU_FILE=${CACHE_DIR}/gnupru.tar.gz
-PRU_DIR=${BUILD_DIR}/pru-gcc
+PRU_ARCHIVE="pru-elf-2024.05.amd64.tar.xz"
+PRU_URL="https://github.com/dinuxbg/gnupru/releases/download/2024.05/${PRU_ARCHIVE}"
 
-if [ ! -f ${PRU_FILE} ]; then
-    cd ${BUILD_DIR}
-    git config --global user.email "you@example.com"
-    git config --global user.name "Your Name"
-    git clone https://github.com/dinuxbg/gnupru -b 2024.05 --depth 1
-    cd gnupru
-    export PREFIX=${PRU_DIR}
-    ./download-and-prepare.sh 2>&1 | pv -nli 30 > ${BUILD_DIR}/gnupru-build.log
-    ./build.sh 2>&1 | pv -nli 30 >> ${BUILD_DIR}/gnupru-build.log
-    cd ${BUILD_DIR}
-    tar cfz ${PRU_FILE} pru-gcc/
-else
-    cd ${BUILD_DIR}
-    tar xfz ${PRU_FILE}
+if [ ! -f ${CACHE_DIR}/${PRU_ARCHIVE} ]; then
+    wget "${PRU_URL}" -O "${CACHE_DIR}/${PRU_ARCHIVE}"
 fi
+cd ${BUILD_DIR}
+tar xJf ${CACHE_DIR}/${PRU_ARCHIVE}
+
 
 ######################################################################
 # Install or1k-linux-musl toolchain
@@ -59,10 +49,12 @@ GCC_VERSION=10
 TOOLCHAIN_ZIP_V=${TOOLCHAIN}-${GCC_VERSION}.tgz
 URL=https://more.musl.cc/${GCC_VERSION}/x86_64-linux-musl/
 if [ ! -f ${CACHE_DIR}/${TOOLCHAIN_ZIP_V} ]; then
-    curl ${URL}/${TOOLCHAIN_ZIP} -o ${CACHE_DIR}/${TOOLCHAIN_ZIP_V}
+    wget "${URL}/${TOOLCHAIN_ZIP}" -O "${CACHE_DIR}/${TOOLCHAIN_ZIP_V}"
 fi
 cd ${BUILD_DIR}
 tar xf ${CACHE_DIR}/${TOOLCHAIN_ZIP_V}
+
+
 ######################################################################
 # Create python3 virtualenv environment
 ######################################################################


### PR DESCRIPTION
The PRU compile is time intensive and error prone - avoid it by using the prebuilt binaries.

-Kevin