### PR TITLE
Support for additional G1 axes (6-axis support)

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2540,6 +2540,13 @@ printer kinematics.
 #   Endstop switch detection pin. If specified, then one may perform
 #   "homing moves" by adding a STOP_ON_ENDSTOP parameter to
 #   MANUAL_STEPPER movement commands.
+#position_min:
+#position_max:
+#   The minimum and maximum position the stepper can be commanded to
+#   move to. If specified then one may not command the stepper to move
+#   past the given position. Note that these limits do not prevent
+#   setting an arbitrary position with the `MANUAL_STEPPER
+#   SET_POSITION=x` command. The default is to not enforce a limit.
 ```
 
 ## Custom heaters and sensors

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -969,6 +969,7 @@ stepper move uses SYNC=0 then future G-Code movement commands may run
 in parallel with the stepper movement.
 
 `MANUAL_STEPPER STEPPER=config_name GCODE_AXIS=[A-Z]
+[LIMIT_VELOCITY=<velocity>] [LIMIT_ACCEL=<accel>]
 [INSTANTANEOUS_CORNER_VELOCITY=<velocity>]`: If the `GCODE_AXIS`
 parameter is specified then it configures the stepper motor as an
 extra axis on `G1` move commands.  For example, if one were to issue a
@@ -979,6 +980,9 @@ xyz movements.  If the motor is associated with a `GCODE_AXIS` then
 one may no longer issue movements using the above `MANUAL_STEPPER`
 command - one may unregister the stepper with a `MANUAL_STEPPER
 ... GCODE_AXIS=` command to resume manual control of the motor. The
+`LIMIT_VELOCITY` and `LIMIT_ACCEL` parameters allow one to reduce the
+speed of `G1` moves if those moves would result in a velocity or
+acceleration above the specified limits. The
 `INSTANTANEOUS_CORNER_VELOCITY` specifies the maximum instantaneous
 velocity change (in mm/s) of the motor during the junction of two
 moves (the default is 1mm/s).

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -968,17 +968,20 @@ scheduled to run after the stepper move completes, however if a manual
 stepper move uses SYNC=0 then future G-Code movement commands may run
 in parallel with the stepper movement.
 
-`MANUAL_STEPPER STEPPER=config_name GCODE_AXIS=[A-Z]`: If the
-`GCODE_AXIS` parameter is specified then it configures the stepper
-motor as an extra axis on `G1` move commands.  For example, if one
-were to issue a `MANUAL_STEPPER ... GCODE_AXIS=R` command then one
-could issue commands like `G1 X10 Y20 R30` to move the stepper motor.
-The resulting moves will occur synchronously with the associated
-toolhead xyz movements.  If the motor is associated with a
-`GCODE_AXIS` then one may no longer issue movements using the above
-`MANUAL_STEPPER` command - one may unregister the stepper with a
-`MANUAL_STEPPER ... GCODE_AXIS=` command to resume manual control of
-the motor.
+`MANUAL_STEPPER STEPPER=config_name GCODE_AXIS=[A-Z]
+[INSTANTANEOUS_CORNER_VELOCITY=<velocity>]`: If the `GCODE_AXIS`
+parameter is specified then it configures the stepper motor as an
+extra axis on `G1` move commands.  For example, if one were to issue a
+`MANUAL_STEPPER ... GCODE_AXIS=R` command then one could issue
+commands like `G1 X10 Y20 R30` to move the stepper motor.  The
+resulting moves will occur synchronously with the associated toolhead
+xyz movements.  If the motor is associated with a `GCODE_AXIS` then
+one may no longer issue movements using the above `MANUAL_STEPPER`
+command - one may unregister the stepper with a `MANUAL_STEPPER
+... GCODE_AXIS=` command to resume manual control of the motor. The
+`INSTANTANEOUS_CORNER_VELOCITY` specifies the maximum instantaneous
+velocity change (in mm/s) of the motor during the junction of two
+moves (the default is 1mm/s).
 
 ### [mcp4018]
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -968,6 +968,18 @@ scheduled to run after the stepper move completes, however if a manual
 stepper move uses SYNC=0 then future G-Code movement commands may run
 in parallel with the stepper movement.
 
+`MANUAL_STEPPER STEPPER=config_name GCODE_AXIS=[A-Z]`: If the
+`GCODE_AXIS` parameter is specified then it configures the stepper
+motor as an extra axis on `G1` move commands.  For example, if one
+were to issue a `MANUAL_STEPPER ... GCODE_AXIS=R` command then one
+could issue commands like `G1 X10 Y20 R30` to move the stepper motor.
+The resulting moves will occur synchronously with the associated
+toolhead xyz movements.  If the motor is associated with a
+`GCODE_AXIS` then one may no longer issue movements using the above
+`MANUAL_STEPPER` command - one may unregister the stepper with a
+`MANUAL_STEPPER ... GCODE_AXIS=` command to resume manual control of
+the motor.
+
 ### [mcp4018]
 
 The following command is available when a

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -186,7 +186,8 @@ class BedMesh:
             self.last_position[2] -= self.fade_target
         else:
             # return current position minus the current z-adjustment
-            x, y, z, e = self.toolhead.get_position()
+            cur_pos = self.toolhead.get_position()
+            x, y, z = cur_pos[:3]
             max_adj = self.z_mesh.calc_z(x, y)
             factor = 1.
             z_adj = max_adj - self.fade_target
@@ -202,19 +203,19 @@ class BedMesh:
                           (self.fade_dist - z_adj))
                 factor = constrain(factor, 0., 1.)
             final_z_adj = factor * z_adj + self.fade_target
-            self.last_position[:] = [x, y, z - final_z_adj, e]
+            self.last_position[:] = [x, y, z - final_z_adj] + cur_pos[3:]
         return list(self.last_position)
     def move(self, newpos, speed):
         factor = self.get_z_factor(newpos[2])
         if self.z_mesh is None or not factor:
             # No mesh calibrated, or mesh leveling phased out.
-            x, y, z, e = newpos
+            x, y, z = newpos[:3]
             if self.log_fade_complete:
                 self.log_fade_complete = False
                 logging.info(
                     "bed_mesh fade complete: Current Z: %.4f fade_target: %.4f "
                     % (z, self.fade_target))
-            self.toolhead.move([x, y, z + self.fade_target, e], speed)
+            self.toolhead.move([x, y, z + self.fade_target] + newpos[3:], speed)
         else:
             self.splitter.build_move(self.last_position, newpos, factor)
             while not self.splitter.traverse_complete:
@@ -1273,7 +1274,7 @@ class MoveSplitter:
         self.z_offset = self._calc_z_offset(prev_pos)
         self.traverse_complete = False
         self.distance_checked = 0.
-        axes_d = [self.next_pos[i] - self.prev_pos[i] for i in range(4)]
+        axes_d = [np - pp for np, pp in zip(self.next_pos, self.prev_pos)]
         self.total_move_length = math.sqrt(sum([d*d for d in axes_d[:3]]))
         self.axis_move = [not isclose(d, 0., abs_tol=1e-10) for d in axes_d]
     def _calc_z_offset(self, pos):
@@ -1286,7 +1287,7 @@ class MoveSplitter:
             raise self.gcode.error(
                 "bed_mesh: Slice distance is negative "
                 "or greater than entire move length")
-        for i in range(4):
+        for i in range(len(self.next_pos)):
             if self.axis_move[i]:
                 self.current_pos[i] = lerp(
                     t, self.prev_pos[i], self.next_pos[i])
@@ -1301,9 +1302,9 @@ class MoveSplitter:
                     next_z = self._calc_z_offset(self.current_pos)
                     if abs(next_z - self.z_offset) >= self.split_delta_z:
                         self.z_offset = next_z
-                        return self.current_pos[0], self.current_pos[1], \
-                            self.current_pos[2] + self.z_offset, \
-                            self.current_pos[3]
+                        newpos = list(self.current_pos)
+                        newpos[2] += self.z_offset
+                        return newpos
             # end of move reached
             self.current_pos[:] = self.next_pos
             self.z_offset = self._calc_z_offset(self.current_pos)

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -24,12 +24,14 @@ class BedTilt:
     def handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
     def get_position(self):
-        x, y, z, e = self.toolhead.get_position()
-        return [x, y, z - x*self.x_adjust - y*self.y_adjust - self.z_adjust, e]
+        pos = self.toolhead.get_position()
+        x, y, z = pos[:3]
+        z -= x*self.x_adjust + y*self.y_adjust + self.z_adjust
+        return [x, y, z] + pos[3:]
     def move(self, newpos, speed):
-        x, y, z, e = newpos
-        self.toolhead.move([x, y, z + x*self.x_adjust + y*self.y_adjust
-                            + self.z_adjust, e], speed)
+        x, y, z = newpos[:3]
+        z += x*self.x_adjust + y*self.y_adjust + self.z_adjust
+        self.toolhead.move([x, y, z] + newpos[3:], speed)
     def update_adjust(self, x_adjust, y_adjust, z_adjust):
         self.x_adjust = x_adjust
         self.y_adjust = y_adjust

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -142,7 +142,7 @@ class ForceMove:
         logging.info("SET_KINEMATIC_POSITION pos=%.3f,%.3f,%.3f"
                      " set_homed=%s clear_homed=%s",
                      x, y, z, set_homed_axes, clear_homed_axes)
-        toolhead.set_position([x, y, z, curpos[3]], homing_axes=set_homed_axes)
+        toolhead.set_position([x, y, z], homing_axes=set_homed_axes)
         toolhead.get_kinematics().clear_homing_state(clear_homed_axes)
 
 def load_config(config):

--- a/klippy/extras/gcode_move.py
+++ b/klippy/extras/gcode_move.py
@@ -14,6 +14,8 @@ class GCodeMove:
                                        self.reset_last_position)
         printer.register_event_handler("toolhead:manual_move",
                                        self.reset_last_position)
+        printer.register_event_handler("toolhead:update_extra_axes",
+                                       self._update_extra_axes)
         printer.register_event_handler("gcode:command_error",
                                        self.reset_last_position)
         printer.register_event_handler("extruder:activate_extruder",
@@ -103,13 +105,27 @@ class GCodeMove:
             'extrude_factor': self.extrude_factor,
             'absolute_coordinates': self.absolute_coord,
             'absolute_extrude': self.absolute_extrude,
-            'homing_origin': self.Coord(*self.homing_position),
-            'position': self.Coord(*self.last_position),
-            'gcode_position': self.Coord(*move_position),
+            'homing_origin': self.Coord(*self.homing_position[:4]),
+            'position': self.Coord(*self.last_position[:4]),
+            'gcode_position': self.Coord(*move_position[:4]),
         }
     def reset_last_position(self):
         if self.is_printer_ready:
             self.last_position = self.position_with_transform()
+    def _update_extra_axes(self):
+        toolhead = self.printer.lookup_object('toolhead')
+        axis_map = {'X':0, 'Y': 1, 'Z': 2, 'E': 3}
+        extra_axes = toolhead.get_extra_axes()
+        for index, ea in enumerate(extra_axes):
+            if ea is None:
+                continue
+            gcode_id = ea.get_axis_gcode_id()
+            if gcode_id is None or gcode_id in axis_map or gcode_id in "FN":
+                continue
+            axis_map[gcode_id] = index
+        self.axis_map = axis_map
+        self.base_position[4:] = [0.] * (len(extra_axes) - 4)
+        self.reset_last_position()
     # G-Code movement commands
     def cmd_G1(self, gcmd):
         # Move
@@ -167,7 +183,7 @@ class GCodeMove:
                     offset *= self.extrude_factor
                 self.base_position[i] = self.last_position[i] - offset
         if offsets == [None, None, None, None]:
-            self.base_position = list(self.last_position)
+            self.base_position[:4] = self.last_position[:4]
     def cmd_M114(self, gcmd):
         # Get Current Position
         p = self._get_gcode_position()
@@ -225,7 +241,7 @@ class GCodeMove:
         # Restore state
         self.absolute_coord = state['absolute_coord']
         self.absolute_extrude = state['absolute_extrude']
-        self.base_position = list(state['base_position'])
+        self.base_position[:4] = state['base_position'][:4]
         self.homing_position = list(state['homing_position'])
         self.speed = state['speed']
         self.speed_factor = state['speed_factor']
@@ -253,7 +269,7 @@ class GCodeMove:
         kinfo = zip("XYZ", kin.calc_position(dict(cinfo)))
         kin_pos = " ".join(["%s:%.6f" % (a, v) for a, v in kinfo])
         toolhead_pos = " ".join(["%s:%.6f" % (a, v) for a, v in zip(
-            "XYZE", toolhead.get_position())])
+            "XYZE", toolhead.get_position()[:4])])
         gcode_pos = " ".join(["%s:%.6f"  % (a, v)
                               for a, v in zip("XYZE", self.last_position)])
         base_pos = " ".join(["%s:%.6f"  % (a, v)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -1,8 +1,9 @@
 # Support for a manual controlled stepper
 #
-# Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 import stepper, chelper
 from . import force_move
 
@@ -28,6 +29,8 @@ class ManualStepper:
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
         self.rail.setup_itersolve('cartesian_stepper_alloc', b'x')
         self.rail.set_trapq(self.trapq)
+        # Registered with toolhead as an axtra axis
+        self.axis_gcode_id = None
         # Register commands
         stepper_name = config.get_name().split()[1]
         gcode = self.printer.lookup_object('gcode')
@@ -88,6 +91,10 @@ class ManualStepper:
                             triggered, check_trigger)
     cmd_MANUAL_STEPPER_help = "Command a manually configured stepper"
     def cmd_MANUAL_STEPPER(self, gcmd):
+        if gcmd.get('GCODE_AXIS', None) is not None:
+            return self.command_with_gcode_axis(gcmd)
+        if self.axis_gcode_id is not None:
+            raise gcmd.error("Must unregister from gcode axis first")
         enable = gcmd.get_int('ENABLE', None)
         if enable is not None:
             self.do_enable(enable)
@@ -107,6 +114,54 @@ class ManualStepper:
             self.do_move(movepos, speed, accel, sync)
         elif gcmd.get_int('SYNC', 0):
             self.sync_print_time()
+    # Register as a gcode axis
+    def command_with_gcode_axis(self, gcmd):
+        gcode_move = self.printer.lookup_object("gcode_move")
+        toolhead = self.printer.lookup_object('toolhead')
+        gcode_axis = gcmd.get('GCODE_AXIS').upper()
+        if self.axis_gcode_id is not None:
+            if gcode_axis:
+                raise gcmd.error("Must unregister axis first")
+            # Unregister
+            toolhead.remove_extra_axis(self)
+            toolhead.unregister_step_generator(self.rail.generate_steps)
+            self.axis_gcode_id = None
+            return
+        if (len(gcode_axis) != 1 or not gcode_axis.isupper()
+            or gcode_axis in "XYZEFN"):
+            if not gcode_axis:
+                # Request to unregister already unregistered axis
+                return
+            raise gcmd.error("Not a valid GCODE_AXIS")
+        for ea in toolhead.get_extra_axes():
+            if ea is not None and ea.get_axis_gcode_id() == gcode_axis:
+                raise gcmd.error("Axis '%s' already registered" % (gcode_axis,))
+        self.axis_gcode_id = gcode_axis
+        toolhead.add_extra_axis(self, self.get_position()[0])
+        toolhead.register_step_generator(self.rail.generate_steps)
+    def process_move(self, print_time, move, ea_index):
+        axis_r = move.axes_r[ea_index]
+        start_pos = move.start_pos[ea_index]
+        accel = move.accel * axis_r
+        start_v = move.start_v * axis_r
+        cruise_v = move.cruise_v * axis_r
+        self.trapq_append(self.trapq, print_time,
+                          move.accel_t, move.cruise_t, move.decel_t,
+                          start_pos, 0., 0.,
+                          1., 0., 0.,
+                          start_v, cruise_v, accel)
+    def check_move(self, move, ea_index):
+        # XXX - support out of bounds checks
+        # XXX - support max accel/velocity
+        # XXX - support non-kinematic max accel/velocity
+        pass
+    def calc_junction(self, prev_move, move, ea_index):
+        # XXX - support max instantaneous velocity change
+        return move.max_cruise_v2
+    def get_axis_gcode_id(self):
+        return self.axis_gcode_id
+    def get_trapq(self):
+        return self.trapq
     # Toolhead wrappers to support homing
     def flush_step_generation(self):
         self.sync_print_time()

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -59,12 +59,12 @@ class PrinterSkew:
         skewed_x = pos[0] - pos[1] * self.xy_factor \
             - pos[2] * (self.xz_factor - (self.xy_factor * self.yz_factor))
         skewed_y = pos[1] - pos[2] * self.yz_factor
-        return [skewed_x, skewed_y, pos[2], pos[3]]
+        return [skewed_x, skewed_y] + pos[2:]
     def calc_unskew(self, pos):
         skewed_x = pos[0] + pos[1] * self.xy_factor \
             + pos[2] * self.xz_factor
         skewed_y = pos[1] + pos[2] * self.yz_factor
-        return [skewed_x, skewed_y, pos[2], pos[3]]
+        return [skewed_x, skewed_y] + pos[2:]
     def get_position(self):
         return self.calc_unskew(self.next_transform.get_position())
     def move(self, newpos, speed):

--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -110,12 +110,12 @@ class ZThermalAdjuster:
         # Apply Z adjustment
         new_z = pos[2] + self.z_adjust_mm
         self.last_z_adjust_mm = self.z_adjust_mm
-        return [pos[0], pos[1], new_z, pos[3]]
+        return [pos[0], pos[1], new_z] + pos[3:]
 
     def calc_unadjust(self, pos):
         'Remove Z adjustment'
         unadjusted_z = pos[2] - self.z_adjust_mm
-        return [pos[0], pos[1], unadjusted_z, pos[3]]
+        return [pos[0], pos[1], unadjusted_z] + pos[3:]
 
     def get_position(self):
         position = self.calc_unadjust(self.next_transform.get_position())

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -233,7 +233,7 @@ class PrinterExtruder:
         if diff_r:
             return (self.instant_corner_v / abs(diff_r))**2
         return move.max_cruise_v2
-    def move(self, print_time, move):
+    def process_move(self, print_time, move):
         axis_r = move.axes_r[3]
         accel = move.accel * axis_r
         start_v = move.start_v * axis_r

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -197,6 +197,8 @@ class PrinterExtruder:
         return self.heater
     def get_trapq(self):
         return self.trapq
+    def get_axis_gcode_id(self):
+        return 'E'
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
     def check_move(self, move, ea_index):
@@ -298,6 +300,8 @@ class DummyExtruder:
         raise self.printer.command_error("Extruder not configured")
     def get_trapq(self):
         return None
+    def get_axis_gcode_id(self):
+        return 'E'
 
 def add_printer_objects(config):
     printer = config.get_printer()

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -199,24 +199,25 @@ class PrinterExtruder:
         return self.trapq
     def stats(self, eventtime):
         return self.heater.stats(eventtime)
-    def check_move(self, move):
-        axis_r = move.axes_r[3]
+    def check_move(self, move, ea_index):
         if not self.heater.can_extrude:
             raise self.printer.command_error(
                 "Extrude below minimum temp\n"
                 "See the 'min_extrude_temp' config option for details")
+        axis_r = move.axes_r[ea_index]
+        axis_d = move.axes_d[ea_index]
         if (not move.axes_d[0] and not move.axes_d[1]) or axis_r < 0.:
             # Extrude only move (or retraction move) - limit accel and velocity
-            if abs(move.axes_d[3]) > self.max_e_dist:
+            if abs(axis_d) > self.max_e_dist:
                 raise self.printer.command_error(
                     "Extrude only move too long (%.3fmm vs %.3fmm)\n"
                     "See the 'max_extrude_only_distance' config"
-                    " option for details" % (move.axes_d[3], self.max_e_dist))
+                    " option for details" % (axis_d, self.max_e_dist))
             inv_extrude_r = 1. / abs(axis_r)
             move.limit_speed(self.max_e_velocity * inv_extrude_r,
                              self.max_e_accel * inv_extrude_r)
         elif axis_r > self.max_extrude_ratio:
-            if move.axes_d[3] <= self.nozzle_diameter * self.max_extrude_ratio:
+            if axis_d <= self.nozzle_diameter * self.max_extrude_ratio:
                 # Permit extrusion if amount extruded is tiny
                 return
             area = axis_r * self.filament_area
@@ -226,13 +227,13 @@ class PrinterExtruder:
                 "Move exceeds maximum extrusion (%.3fmm^2 vs %.3fmm^2)\n"
                 "See the 'max_extrude_cross_section' config option for details"
                 % (area, self.max_extrude_ratio * self.filament_area))
-    def calc_junction(self, prev_move, move):
-        diff_r = move.axes_r[3] - prev_move.axes_r[3]
+    def calc_junction(self, prev_move, move, ea_index):
+        diff_r = move.axes_r[ea_index] - prev_move.axes_r[ea_index]
         if diff_r:
             return (self.instant_corner_v / abs(diff_r))**2
         return move.max_cruise_v2
-    def process_move(self, print_time, move):
-        axis_r = move.axes_r[3]
+    def process_move(self, print_time, move, ea_index):
+        axis_r = move.axes_r[ea_index]
         accel = move.accel * axis_r
         start_v = move.start_v * axis_r
         cruise_v = move.cruise_v * axis_r
@@ -242,10 +243,10 @@ class PrinterExtruder:
         # Queue movement (x is extruder movement, y is pressure advance flag)
         self.trapq_append(self.trapq, print_time,
                           move.accel_t, move.cruise_t, move.decel_t,
-                          move.start_pos[3], 0., 0.,
+                          move.start_pos[ea_index], 0., 0.,
                           1., can_pressure_advance, 0.,
                           start_v, cruise_v, accel)
-        self.last_position = move.end_pos[3]
+        self.last_position = move.end_pos[ea_index]
     def find_past_position(self, print_time):
         if self.extruder_stepper is None:
             return 0.
@@ -285,11 +286,11 @@ class PrinterExtruder:
 class DummyExtruder:
     def __init__(self, printer):
         self.printer = printer
-    def check_move(self, move):
+    def check_move(self, move, ea_index):
         raise move.move_error("Extrude when no extruder present")
     def find_past_position(self, print_time):
         return 0.
-    def calc_junction(self, prev_move, move):
+    def calc_junction(self, prev_move, move, ea_index):
         return move.max_cruise_v2
     def get_name(self):
         return ""

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -1,6 +1,6 @@
 # Code for handling printer nozzle extruders
 #
-# Copyright (C) 2016-2022  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
@@ -185,8 +185,6 @@ class PrinterExtruder:
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
                                    desc=self.cmd_ACTIVATE_EXTRUDER_help)
-    def update_move_time(self, flush_time, clear_history_time):
-        self.trapq_finalize_moves(self.trapq, flush_time, clear_history_time)
     def get_status(self, eventtime):
         sts = self.heater.get_status(eventtime)
         sts['can_extrude'] = self.heater.can_extrude
@@ -287,8 +285,6 @@ class PrinterExtruder:
 class DummyExtruder:
     def __init__(self, printer):
         self.printer = printer
-    def update_move_time(self, flush_time, clear_history_time):
-        pass
     def check_move(self, move):
         raise move.move_error("Extrude when no extruder present")
     def find_past_position(self, print_time):
@@ -300,7 +296,7 @@ class DummyExtruder:
     def get_heater(self):
         raise self.printer.command_error("Extruder not configured")
     def get_trapq(self):
-        raise self.printer.command_error("Extruder not configured")
+        return None
 
 def add_printer_objects(config):
     printer = config.get_printer()

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -459,7 +459,7 @@ class ToolHead:
         ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.trapq_set_position(self.trapq, self.print_time,
                                    newpos[0], newpos[1], newpos[2])
-        self.commanded_pos[:] = newpos
+        self.commanded_pos[:3] = newpos[:3]
         self.kin.set_position(newpos, homing_axes)
         self.printer.send_event("toolhead:set_position")
     def limit_next_junction_speed(self, speed):

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -613,6 +613,9 @@ class ToolHead:
         return self.trapq
     def register_step_generator(self, handler):
         self.step_generators.append(handler)
+    def unregister_step_generator(self, handler):
+        if handler in self.step_generators:
+            self.step_generators.remove(handler)
     def note_step_generation_scan_time(self, delay, old_delay=0.):
         self.flush_step_generation()
         if old_delay:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -350,7 +350,7 @@ class ToolHead:
                     move.axes_r[0], move.axes_r[1], move.axes_r[2],
                     move.start_v, move.cruise_v, move.accel)
             if move.axes_d[3]:
-                self.extruder.move(next_move_time, move)
+                self.extruder.process_move(next_move_time, move)
             next_move_time = (next_move_time + move.accel_t
                               + move.cruise_t + move.decel_t)
             for cb in move.timing_callbacks:

--- a/test/klippy/manual_stepper.test
+++ b/test/klippy/manual_stepper.test
@@ -22,3 +22,18 @@ M84
 # Verify stepper_buzz
 STEPPER_BUZZ STEPPER="manual_stepper basic_stepper"
 STEPPER_BUZZ STEPPER="manual_stepper homing_stepper"
+
+# Register with g-code
+MANUAL_STEPPER STEPPER=basic_stepper GCODE_AXIS=A
+G28
+G1 X20 Y20 Z10
+G1 A10 X22
+
+# Test unregistering
+MANUAL_STEPPER STEPPER=basic_stepper GCODE_AXIS=
+G1 X15
+
+# Test registering again
+G28
+MANUAL_STEPPER STEPPER=basic_stepper GCODE_AXIS=A
+G1 X20 Y20 Z10  A20


### PR DESCRIPTION
This PR adds support for extending G1 commands with additional axes.  For example, one could issue a command like `G1 X10 Y20 Z30 E40 A5 B6` to move many motors simultaneously.

This is sometimes referred to as "6-axis" support, although in this implementation the only limit on the number of axes one may register is available letters in the alphabet.

This support works by extending `[manual_stepper my_stepper]` objects to include a new `MANUAL_STEPPER STEPPER=my_stepper GCODE_AXIS=A` type command.  (See the docs in this PR for the usage.)

In order to make this change I have altered the `toolhead.get_position()`  class to support returning lists of more than 4 axes (it used to return x,y,z,e) and similarly `toolhead.move()` may require more than 4 axes.  Thus, a big part of this change is identifying and updating the many internal modules to support that.  I've attempted to find and address these issues, but lots more testing will be needed.

FYI, @dmbutyugin , @Arksine - I've modified some modules that you maintain as part of this work.

In addition to the basic support there are additional upcoming changes I plan to look at:
* Updating `G92` to support setting G-Code offsets for additional axes.
* Adding axis limit checks to manual_stepper objects.
* Possibly improving the homing speed of manual_stepper objects.
* Adding support for placing limits on instantaneous velocity changes, maximum acceleration, and maximum velocity on extra axis movements.
* Support for basic "tool center point control" - a mechanism to keep the toolhead in contact with a print if that print is rotated by an A/B/C motor that spins the bed.

My thinking is that the above changes could be submitted as additional PRs.

All of this work would be targeted at a merge after v0.13.0 is tagged.

Cheers,
-Kevin