### PR TITLE
Software SPI/I2C: declare struct members as const

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -43,6 +43,7 @@ class MCU_SPI:
                  cs_active_high=False):
         self.mcu = mcu
         self.bus = bus
+        self.speed = speed
         # Config SPI object (set all CS pins high before spi_set_bus commands)
         self.oid = mcu.create_oid()
         if pin is None:
@@ -51,11 +52,17 @@ class MCU_SPI:
             mcu.add_config_cmd("config_spi oid=%d pin=%s cs_active_high=%d"
                                % (self.oid, pin, cs_active_high))
         # Generate SPI bus config message
+        self.config_fmt_ticks = None
         if sw_pins is not None:
             self.config_fmt = (
                 "spi_set_software_bus oid=%d"
                 " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d rate=%d"
                 % (self.oid, sw_pins[0], sw_pins[1], sw_pins[2], mode, speed))
+            self.config_fmt_ticks = (
+                "spi_set_sw_bus oid=%d"
+                " miso_pin=%s mosi_pin=%s sclk_pin=%s mode=%d pulse_ticks=%%d"
+                % (self.oid, sw_pins[0], sw_pins[1],
+                    sw_pins[2], mode))
         else:
             self.config_fmt = (
                 "spi_set_bus oid=%d spi_bus=%%s mode=%d rate=%d"
@@ -78,6 +85,12 @@ class MCU_SPI:
         if '%' in self.config_fmt:
             bus = resolve_bus_name(self.mcu, "spi_bus", self.bus)
             self.config_fmt = self.config_fmt % (bus,)
+        if self.config_fmt_ticks:
+            if self.mcu.try_lookup_command("spi_set_sw_bus oid=%c miso_pin=%u "
+                                           "mosi_pin=%u sclk_pin=%u "
+                                           "mode=%u pulse_ticks=%u"):
+                pulse_ticks = self.mcu.seconds_to_clock(1./self.speed)
+                self.config_fmt = self.config_fmt_ticks % (pulse_ticks,)
         self.mcu.add_config_cmd(self.config_fmt)
         self.spi_send_cmd = self.mcu.lookup_command(
             "spi_send oid=%c data=%*s", cq=self.cmd_queue)

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -27,7 +27,7 @@ alloc_init(void)
 DECL_INIT(alloc_init);
 
 // Allocate an area of memory
-void *
+static void *
 alloc_chunk(size_t size)
 {
     if (alloc_end + size > dynmem_end())

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -38,6 +38,18 @@ alloc_chunk(size_t size)
     return data;
 }
 
+// Allocate an area of memory with default value
+void *
+alloc_chunk_init(size_t size, const void *ptr)
+{
+    if (alloc_end + size > dynmem_end())
+        shutdown("alloc_chunk failed");
+    void *data = alloc_end;
+    alloc_end += ALIGN(size, __alignof__(void *));
+    memcpy(data, ptr, size);
+    return data;
+}
+
 // Allocate an array of chunks
 static void *
 alloc_chunks(size_t size, size_t count, uint16_t *avail)

--- a/src/basecmd.h
+++ b/src/basecmd.h
@@ -12,6 +12,7 @@ struct move_queue_head {
 };
 
 void *alloc_chunk(size_t size);
+void *alloc_chunk_init(size_t size, const void *ptr);
 void move_free(void *m);
 void *move_alloc(void);
 int move_queue_empty(struct move_queue_head *mh);

--- a/src/basecmd.h
+++ b/src/basecmd.h
@@ -11,7 +11,6 @@ struct move_queue_head {
     struct move_node *first, *last;
 };
 
-void *alloc_chunk(size_t size);
 void *alloc_chunk_init(size_t size, const void *ptr);
 void move_free(void *m);
 void *move_alloc(void);

--- a/src/i2c_software.c
+++ b/src/i2c_software.c
@@ -25,13 +25,15 @@ void
 command_i2c_set_software_bus(uint32_t *args)
 {
     struct i2cdev_s *i2c = i2cdev_oid_lookup(args[0]);
-    struct i2c_software *is = alloc_chunk(sizeof(*is));
-    is->ticks = CONFIG_CLOCK_FREQ / (100000 * 2); // 100KHz
-    is->addr = (args[4] & 0x7f) << 1; // address format shifted
-    is->scl_in = gpio_in_setup(args[1], 1);
-    is->scl_out = gpio_out_setup(args[1], 1);
-    is->sda_in = gpio_in_setup(args[2], 1);
-    is->sda_out = gpio_out_setup(args[2], 1);
+    struct i2c_software init = {
+        .ticks = CONFIG_CLOCK_FREQ / (100000 * 2), // 100KHz
+        .addr = (args[4] & 0x7f) << 1,             // address format shifted
+        .scl_in = gpio_in_setup(args[1], 1),
+        .scl_out = gpio_out_setup(args[1], 1),
+        .sda_in = gpio_in_setup(args[2], 1),
+        .sda_out = gpio_out_setup(args[2], 1),
+    };
+    struct i2c_software *is = alloc_chunk_init(sizeof(*is), &init);
     i2cdev_set_software_bus(i2c, is);
 }
 DECL_COMMAND(command_i2c_set_software_bus,

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -4,7 +4,9 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "autoconf.h"   // CONFIG_*
 #include "board/gpio.h" // gpio_out_setup
+#include "board/misc.h" // timer_read_time
 #include "basecmd.h" // oid_alloc
 #include "command.h" // DECL_COMMAND
 #include "sched.h" // sched_shutdown
@@ -13,6 +15,7 @@
 struct spi_software {
     struct gpio_in miso;
     struct gpio_out mosi, sclk;
+    uint32_t sck_ticks;
     uint8_t mode;
 };
 
@@ -20,6 +23,8 @@ void
 command_spi_set_software_bus(uint32_t *args)
 {
     uint8_t mode = args[4];
+    uint32_t rate = args[5];
+    uint8_t div = 0;
     if (mode > 3)
         shutdown("Invalid spi config");
 
@@ -29,6 +34,9 @@ command_spi_set_software_bus(uint32_t *args)
     ss->mosi = gpio_out_setup(args[2], 0);
     ss->sclk = gpio_out_setup(args[3], 0);
     ss->mode = mode;
+    while (((CONFIG_CLOCK_FREQ/2) >> div) > rate)
+        div++;
+    ss->sck_ticks = 1 << div;
     spidev_set_software_bus(spi, ss);
 }
 DECL_COMMAND(command_spi_set_software_bus,
@@ -41,30 +49,49 @@ spi_software_prepare(struct spi_software *ss)
     gpio_out_write(ss->sclk, ss->mode & 0x02);
 }
 
+static void
+spi_delay(uint32_t end)
+{
+    while (timer_is_before(timer_read_time(), end));
+}
+
 void
 spi_software_transfer(struct spi_software *ss, uint8_t receive_data
                       , uint8_t len, uint8_t *data)
 {
+    uint32_t t1 = ss->sck_ticks >> 1;
+    uint32_t t2 = ss->sck_ticks - t1;
+    uint32_t end = timer_read_time() + t1;
     while (len--) {
         uint8_t outbuf = *data;
         uint8_t inbuf = 0;
-        for (uint_fast8_t i = 0; i < 8; i++) {
-            if (ss->mode & 0x01) {
+        if (ss->mode & 0x01) {
+            for (uint_fast8_t i = 0; i < 8; i++) {
+                spi_delay(end);
                 // MODE 1 & 3
                 gpio_out_toggle(ss->sclk);
                 gpio_out_write(ss->mosi, outbuf & 0x80);
+                end = timer_read_time() + t2;
                 outbuf <<= 1;
-                gpio_out_toggle(ss->sclk);
                 inbuf <<= 1;
+                spi_delay(end);
+                gpio_out_toggle(ss->sclk);
                 inbuf |= gpio_in_read(ss->miso);
-            } else {
+                end = timer_read_time() + t1;
+            }
+        } else {
+            for (uint_fast8_t i = 0; i < 8; i++) {
+                spi_delay(end);
                 // MODE 0 & 2
                 gpio_out_write(ss->mosi, outbuf & 0x80);
-                outbuf <<= 1;
                 gpio_out_toggle(ss->sclk);
+                end = timer_read_time() + t2;
+                outbuf <<= 1;
                 inbuf <<= 1;
+                spi_delay(end);
                 inbuf |= gpio_in_read(ss->miso);
                 gpio_out_toggle(ss->sclk);
+                end = timer_read_time() + t1;
             }
         }
 

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -27,14 +27,14 @@ command_spi_set_software_bus(uint32_t *args)
     uint32_t pulse_ticks = args[5];
     if (mode > 3)
         shutdown("Invalid spi config");
-
     struct spidev_s *spi = spidev_oid_lookup(args[0]);
-    struct spi_software *ss = alloc_chunk(sizeof(*ss));
-    ss->miso = gpio_in_setup(args[1], 1);
-    ss->mosi = gpio_out_setup(args[2], 0);
-    ss->sclk = gpio_out_setup(args[3], 0);
-    ss->mode = mode;
-    ss->sck_ticks = pulse_ticks;
+    struct spi_software init = {
+        .miso = gpio_in_setup(args[1], 1),
+        .mosi = gpio_out_setup(args[2], 0),
+        .sclk = gpio_out_setup(args[3], 0),
+        .mode = mode,
+        .sck_ticks = pulse_ticks};
+    struct spi_software *ss = alloc_chunk_init(sizeof(*ss), &init);
     spidev_set_software_bus(spi, ss);
 }
 DECL_COMMAND(command_spi_set_software_bus,

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -23,8 +23,8 @@ void
 command_spi_set_software_bus(uint32_t *args)
 {
     uint8_t mode = args[4];
-    uint32_t rate = args[5];
-    uint8_t div = 0;
+    // 550Mhz/100Khz = 5500 ticks
+    uint32_t pulse_ticks = args[5];
     if (mode > 3)
         shutdown("Invalid spi config");
 
@@ -34,14 +34,12 @@ command_spi_set_software_bus(uint32_t *args)
     ss->mosi = gpio_out_setup(args[2], 0);
     ss->sclk = gpio_out_setup(args[3], 0);
     ss->mode = mode;
-    while (((CONFIG_CLOCK_FREQ/2) >> div) > rate)
-        div++;
-    ss->sck_ticks = 1 << div;
+    ss->sck_ticks = pulse_ticks;
     spidev_set_software_bus(spi, ss);
 }
 DECL_COMMAND(command_spi_set_software_bus,
-             "spi_set_software_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
-             " mode=%u rate=%u");
+             "spi_set_sw_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
+             " mode=%u pulse_ticks=%u");
 
 void
 spi_software_prepare(struct spi_software *ss)


### PR DESCRIPTION
This depends on: #6856 and #6885
This simply suggests compiler that those members will not change during runtime.

Those patches do not measurably change performance, but decrease code size:
patch | size
-- | --
Fix i2c delay | 36708
Const SPI | 36548
Const I2C | 36532

Thanks.