### PR TITLE
Don't use `-fno-use-linker-plugin` - fix atmega328 and similar builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Klipper build system
 #
-# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -33,7 +33,8 @@ CFLAGS := -iquote $(OUT) -iquote src -iquote $(OUT)board-generic/ \
 		-std=gnu11 -O2 -MD -Wall \
 		-Wold-style-definition $(call cc-option,$(CC),-Wtype-limits,) \
     -ffunction-sections -fdata-sections -fno-delete-null-pointer-checks
-CFLAGS += -flto=auto -fwhole-program -fno-use-linker-plugin -ggdb3
+CFLAGS += -flto=auto -fwhole-program -ggdb3
+CFLAGS += $(call cc-option,$(CC),-ffat-lto-objects,-fno-use-linker-plugin)
 
 OBJS_klipper.elf = $(patsubst %.c, $(OUT)src/%.o,$(src-y))
 OBJS_klipper.elf += $(OUT)compile_time_request.o

--- a/src/pru/Makefile
+++ b/src/pru/Makefile
@@ -8,6 +8,7 @@ dirs-y += lib/pru_rpmsg
 
 CFLAGS += -Os -minrt -mmcu=am335x.pru1
 CFLAGS += -Ilib/pru_rpmsg/include -Ilib/pru_rpmsg/include/am335x
+CFLAGS += -fno-use-linker-plugin
 
 CFLAGS_klipper.elf := $(filter-out -mmcu=%, $(CFLAGS))
 CFLAGS_klipper.elf += -Wl,-r -nostdlib -Wl,-T,src/pru/pru.lds


### PR DESCRIPTION
This option seems to be confusing ld's region usage checks (builds that could fit in small chips are being reported as not fitting).  The option was disabled back in commit 4e8674d5 because it showed worse results.  However, recent versions of gcc seem to produce the same results even if this option is enabled, so change the build to avoid disabling that option on newer versions of gcc (those that have the -ffat-lto-objects option - which is needed to ensure compile_time_requests sections can be extracted with objcopy).

The PRU build is dependent on -fuse-linker-plugin, so enable that option explicitly in its build.

This fixes the build for atmega328 and similar chips.  It also allows me to add more options to chips like the stm32f042.

-Kevin