### PR TITLE
Implement "drip moves" for manual stepper STOP_ON_ENDSTOP

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250418: The manual_stepper `STOP_ON_ENDSTOP` feature may now take
+less time to complete. Previously, the command would wait the entire
+time the move could possibly take even if the endstop triggered
+earlier. Now, the command finishes shortly after the endstop trigger.
+
 20250417: SPI devices using "software SPI" are now rate limited.
 Previously, the `spi_speed` in the config was ignored and the
 transmission speed was only limited by the processing speed of the

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -503,7 +503,7 @@ class ToolHead:
     def get_extruder(self):
         return self.extruder
     # Homing "drip move" handling
-    def drip_update_time(self, next_print_time, drip_completion):
+    def drip_update_time(self, next_print_time, drip_completion, addstepper=()):
         # Transition from "NeedPrime"/"Priming"/main state to "Drip" state
         self.special_queuing_state = "Drip"
         self.need_check_pause = self.reactor.NEVER
@@ -526,6 +526,8 @@ class ToolHead:
             npt = min(self.print_time + DRIP_SEGMENT_TIME, next_print_time)
             self.note_mcu_movequeue_activity(npt + self.kin_flush_delay,
                                              set_step_gen_time=True)
+            for stepper in addstepper:
+                stepper.generate_steps(npt)
             self._advance_move_time(npt)
         # Exit "Drip" state
         self.reactor.update_timer(self.flush_timer, self.reactor.NOW)


### PR DESCRIPTION
Currently, `MANUAL_STEPPER STOP_ON_ENDSTOP=1` type commands will move until hitting the endstop, but it will still always consume the total amount of move time.  That is, following moves can't be started until the total possible time of the homing move is completed.

Implement "drip moves" so that the code only schedules the movement in small segments.  This allows following movements to be scheduled without a significant delay.

@dmbutyugin - FYI.  This is somewhat related to the recent homing discussions.

-Kevin