### PR TITLE
In the MenuManager `key_event` method, add support for event notifications

### DIFF
--- a/klippy/extras/display/menu.py
+++ b/klippy/extras/display/menu.py
@@ -1026,6 +1026,8 @@ class MenuManager:
             self.begin(eventtime)
 
     def key_event(self, key, eventtime):
+        self.printer.send_event(f'menu:{key}', key, eventtime) # granular
+        self.printer.send_event('menu:action', key, eventtime) # any item
         if key == 'click':
             self._click_callback(eventtime, key)
         elif key == 'long_click':


### PR DESCRIPTION
In the MenuManager `key_event` method, add support for event notifications for key events using the `send_event()` method. This will allow other host modules to register for event notifications with `register_event_handler()`.

This could be useful for developers to know when the rotary encoder is activated so that they might do something such as activate LED lights.

The change publishes two notifications for each key event:

  - `menu:{key}` notification can be subscribed to if the developer is only interested in a single key event type, such as clicking the encoder. One could subscribe to every event type with subsequent uses of `register_event_handler()`, one for each key event type.

  - `menu:action` notification can be subscribed to in order to receive a notification for every key event type, avoiding the need to use multiple `register_event_handler()` uses. The actual key pressed will be present in the next positional parameter. One may still prefer to receive a single notification with the first version in order to avoid excessive use of the callbacks if only one event is interesting.

Signed-off-by: Jim Derry <balthisar@gmail.com>
