### PR TITLE
skew_correction: clear skew profile name when clearing the skew

### DIFF
--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -98,6 +98,7 @@ class PrinterSkew:
     def cmd_SET_SKEW(self, gcmd):
         if gcmd.get_int("CLEAR", 0):
             self._update_skew(0., 0., 0.)
+            self.current_profile_name = ""
             return
         planes = ["XY", "XZ", "YZ"]
         for plane in planes:


### PR DESCRIPTION
Builds on the work done in #6821 to now clear the profile name when clearing the skew. 

> [!NOTE]
> Perhaps we should also clear it if we successfully update the skew using `SET_SKEW`? Thoughts?