### PR TITLE
By modifying pll_base to match different HSE values

### DIFF
--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -98,7 +98,7 @@ clock_setup(void)
     PWR->CR3 = (PWR->CR3 | PWR_CR3_LDOEN) & ~(PWR_CR3_BYPASS | PWR_CR3_SCUEN);
     while (!(PWR->CSR1 & PWR_CSR1_ACTVOSRDY))
         ;
-    // (HSE 8mhz) /DIVM1(1) (pll_base 8Mhz) *DIVN1(100) (pll_freq 800Mhz)
+    // (HSE 8mhz) /DIVM1(2) (pll_base 8Mhz) *DIVN1(200) (pll_freq 800Mhz)
     // /DIVP1(2) (SYSCLK 400Mhz)
     // (HSE 12mhz) /DIVM1(3) (pll_base 4Mhz) *DIVN1(200) (pll_freq 800Mhz)
     // /DIVP1(2) (SYSCLK 400Mhz)
@@ -113,8 +113,6 @@ clock_setup(void)
     uint32_t pll_base;
 #if CONFIG_STM32_CLOCK_REF_25M
     pll_base = 5000000;
-#elif CONFIG_STM32_CLOCK_REF_8M
-    pll_base = 8000000;
 #else
     pll_base = 4000000;
 #endif

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -98,9 +98,26 @@ clock_setup(void)
     PWR->CR3 = (PWR->CR3 | PWR_CR3_LDOEN) & ~(PWR_CR3_BYPASS | PWR_CR3_SCUEN);
     while (!(PWR->CSR1 & PWR_CSR1_ACTVOSRDY))
         ;
-    // (HSE 25mhz) /DIVM1(5) (pll_base 5Mhz) *DIVN1(192) (pll_freq 960Mhz)
-    // /DIVP1(2) (SYSCLK 480Mhz)
-    uint32_t pll_base = 5000000;
+    // (HSE 8mhz) /DIVM1(1) (pll_base 8Mhz) *DIVN1(100) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    // (HSE 12mhz) /DIVM1(3) (pll_base 4Mhz) *DIVN1(200) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    // (HSE 16mhz) /DIVM1(4) (pll_base 4Mhz) *DIVN1(200) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    // (HSE 20mhz) /DIVM1(5) (pll_base 4Mhz) *DIVN1(200) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    // (HSE 24mhz) /DIVM1(6) (pll_base 4Mhz) *DIVN1(200) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    // (HSE 25mhz) /DIVM1(5) (pll_base 5Mhz) *DIVN1(160) (pll_freq 800Mhz)
+    // /DIVP1(2) (SYSCLK 400Mhz)
+    uint32_t pll_base;
+#if CONFIG_STM32_CLOCK_REF_25M
+    pll_base = 5000000;
+#elif CONFIG_STM32_CLOCK_REF_8M
+    pll_base = 8000000;
+#else
+    pll_base = 4000000;
+#endif
     // Only even dividers (DIVP1) are allowed
     uint32_t pll_freq = CONFIG_CLOCK_FREQ * 2;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {


### PR DESCRIPTION
By modifying pll_base to match different HSE values, the SYSCLK can be kept constant at 400MHz. 

HSE 8mhz->pll_base = 8Mhz
HSE 12mhz,16mhz,20mzh,24mhz->pll_base = 4Mh
HSE 25mhz->pll_base = 5Mhz

Signed-off-by: 笑饮砒霜 <qpzm1258@163.com>