### PR TITLE
RFC: TMC add a sub command to activate the passive brake

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -456,6 +456,60 @@ class TMCCommandHelper:
                     reg_name, val = self.read_translate(reg_name, val)
                 gcmd.respond_info(self.fields.pretty_format(reg_name, val))
 
+######################################################################
+# TMC passive braking
+######################################################################
+
+class TMCPassiveBrake:
+    def __init__(self, config, mcu_tmc):
+        self.printer = config.get_printer()
+        self.mcu_tmc = mcu_tmc
+        self.fields = mcu_tmc.get_fields()
+        name_parts = config.get_name().split()
+        self.stepper_name = ' '.join(name_parts[1:])
+        self.state = {}
+        gcode = self.printer.lookup_object("gcode")
+        gcode.register_mux_command("TMC_PASSIVE_BRAKE", "STEPPER",
+                                   self.stepper_name,
+                                   self.cmd_TMC_PASSIVE_BRAKE,
+                                   desc=self.cmd_TMC_PASSIVE_BRAKE_help)
+    cmd_TMC_PASSIVE_BRAKE_help = "Enable the passive braking"
+    def cmd_TMC_PASSIVE_BRAKE(self, gcmd):
+        force_move = self.printer.lookup_object("force_move")
+        stepper = force_move.lookup_stepper(self.stepper_name)
+        stepper.add_active_callback(self.restore)
+        state = {}
+        reg = self.fields.lookup_register("en_pwm_mode", None)
+        if reg is not None:
+            en_pwm = self.fields.get_field("en_pwm_mode")
+            if en_pwm == 0:
+                state["en_pwm_mode"] = 0
+                val = self.fields.set_field("en_pwm_mode", 1)
+                self.mcu_tmc.set_register("GCONF", val)
+        if reg is None:
+            en_spread = not self.fields.get_field("en_spreadcycle")
+            if en_spread == 1:
+                val = self.fields.set_field("en_spreadcycle", 0)
+                state["en_spreadcycle"] = 1
+                self.mcu_tmc.set_register("GCONF", val)
+        pwmthrs = self.fields.get_field("tpwmthrs")
+        if pwmthrs == 0xfffff:
+            state["tpwmthrs"] = 0xfffff
+            val = self.fields.set_field("tpwmthrs", 0xffff0)
+            self.mcu_tmc.set_register("TPWMTHRS", val)
+        ihold = self.fields.get_field("ihold")
+        if ihold:
+            state["ihold"] = ihold
+            val = self.fields.set_field("ihold", 0)
+            self.mcu_tmc.set_register("IHOLD_IRUN", val)
+        self.state = state
+    def restore(self, flush_time):
+        state = self.state
+        self.state = {}
+        for field in state:
+            reg = self.fields.lookup_register(field)
+            v = self.fields.set_field(field, state[field])
+            self.mcu_tmc.set_register(reg, v)
 
 ######################################################################
 # TMC virtual pins

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -288,6 +288,8 @@ class TMC2130:
                                    TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        # Passibe braking command
+        tmc.TMCPassiveBrake(config, self.mcu_tmc)
         # Register commands
         current_helper = TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2208.py
+++ b/klippy/extras/tmc2208.py
@@ -193,6 +193,8 @@ class TMC2208:
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)
         cmdhelper.setup_register_dump(ReadRegisters, self.read_translate)
+        # Passibe braking command
+        tmc.TMCPassiveBrake(config, self.mcu_tmc)
         self.get_phase_offset = cmdhelper.get_phase_offset
         self.get_status = cmdhelper.get_status
         # Setup basic register values

--- a/klippy/extras/tmc2209.py
+++ b/klippy/extras/tmc2209.py
@@ -65,6 +65,8 @@ class TMC2209:
         self.fields.set_field("senddelay", 2) # Avoid tx errors on shared uart
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        # Passibe braking command
+        tmc.TMCPassiveBrake(config, self.mcu_tmc)
         # Register commands
         current_helper = tmc2130.TMCCurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -355,6 +355,8 @@ class TMC2240:
                                                TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        # Passibe braking command
+        tmc.TMCPassiveBrake(config, self.mcu_tmc)
         # Register commands
         current_helper = TMC2240CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -330,6 +330,8 @@ class TMC5160:
                                            TMC_FREQUENCY)
         # Allow virtual pins to be created
         tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+        # Passibe braking command
+        tmc.TMCPassiveBrake(config, self.mcu_tmc)
         # Register commands
         current_helper = TMC5160CurrentHelper(config, self.mcu_tmc)
         cmdhelper = tmc.TMCCommandHelper(config, self.mcu_tmc, current_helper)


### PR DESCRIPTION
Based on the Discord conversation.
Allows putting any TMC stepper in passive braking mode.
Which would auto-revert on any stepper activity.
`TMC_PASSIVE_BRAKE STEPPER=stepper_a`

Not sure if there is a need for locking or set_register(,,print_time) scheduling.
Like, if there is any chance of a race condition when there is a step and another brake command running simultaneously on top?

Thanks.