### PR TITLE
gcode_macro: Added ephemeral store support

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -78,6 +78,7 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
+        self.store = {}
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:
@@ -107,10 +108,41 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
             'action_call_remote_method': self._action_call_remote_method,
+            'store': GCodeMacroEphemeralStore(self.store),
         }
 
 def load_config(config):
     return PrinterGCodeMacro(config)
+
+
+######################################################################
+# GCode macro store
+######################################################################
+
+class GCodeMacroEphemeralStore:
+    def __init__(self, existing_store):
+        self._store = existing_store
+    def set(self, key, value):
+        self._store[key] = value
+        return ""
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+    def exists(self, key):
+        return key in self._store
+    def delete(self, key):
+        if key in self._store:
+            del self._store[key]
+        return ""
+    def clear(self):
+        self._store.clear()
+        return ""
+    def list(self):
+        return list(self._store.keys())
+    def dump(self):
+        return json.dumps(self._store)
+    def load(self, data):
+        self._store = dict(data)
+        return ""
 
 
 ######################################################################

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -78,6 +78,7 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
+        self.cache_store = {}
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:
@@ -107,7 +108,7 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
             'action_call_remote_method': self._action_call_remote_method,
-            'cache': GCodeMacroEphemeralCache(),
+            'cache': GCodeMacroEphemeralCache(self.cache_store),
         }
 
 def load_config(config):
@@ -119,8 +120,8 @@ def load_config(config):
 ######################################################################
 
 class GCodeMacroEphemeralCache:
-    def __init__(self):
-        self._store = {}
+    def __init__(self, existing_cache):
+        self._store = existing_cache
     def set(self, key, value):
         self._store[key] = value
         return ""

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -107,10 +107,41 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
             'action_call_remote_method': self._action_call_remote_method,
+            'cache': GCodeMacroEphemeralCache(),
         }
 
 def load_config(config):
     return PrinterGCodeMacro(config)
+
+
+######################################################################
+# GCode macro cache
+######################################################################
+
+class GCodeMacroEphemeralCache:
+    def __init__(self):
+        self._store = {}
+    def set(self, key, value):
+        self._store[key] = value
+        return ""
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+    def exists(self, key):
+        return key in self._store
+    def delete(self, key):
+        if key in self._store:
+            del self._store[key]
+        return ""
+    def clear(self):
+        self._store.clear()
+        return ""
+    def list(self):
+        return list(self._store.keys())
+    def dump(self):
+        return json.dumps(self._store)
+    def load(self, data):
+        self._store = dict(data)
+        return ""
 
 
 ######################################################################

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -78,7 +78,7 @@ class PrinterGCodeMacro:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.env = jinja2.Environment('{%', '%}', '{', '}')
-        self.cache_store = {}
+        self.store = {}
     def load_template(self, config, option, default=None):
         name = "%s:%s" % (config.get_name(), option)
         if default is None:
@@ -108,7 +108,7 @@ class PrinterGCodeMacro:
             'action_respond_info': self._action_respond_info,
             'action_raise_error': self._action_raise_error,
             'action_call_remote_method': self._action_call_remote_method,
-            'cache': GCodeMacroEphemeralCache(self.cache_store),
+            'store': GCodeMacroEphemeralStore(self.store),
         }
 
 def load_config(config):
@@ -116,12 +116,12 @@ def load_config(config):
 
 
 ######################################################################
-# GCode macro cache
+# GCode macro store
 ######################################################################
 
-class GCodeMacroEphemeralCache:
-    def __init__(self, existing_cache):
-        self._store = existing_cache
+class GCodeMacroEphemeralStore:
+    def __init__(self, existing_store):
+        self._store = existing_store
     def set(self, key, value):
         self._store[key] = value
         return ""


### PR DESCRIPTION
This adds support for an ephemeral store within the context of macros.

**NOTICE:** I am not a python dev but I do have experience in other languages. I also leaned on AI to help bridge the gap. So this code should be reviewed appropriately!

## Why

The current macro system doesn't have any support for in-memory objects, re-using jinja functions (aka jinja macros), or a simple system for accessing live variable data. (for example, `printer` is only initially populated when the macro starts, and never updated, but child macros can see newer data when they start)

All of this is OK if we are only talking about a single macro, but once you have macros calling other macros or macros that take a long time to complete, these functions start becoming useful for passing live data and reusable logic around.

This store adds some basic support for these concepts, but for the sake of simplicity-when-using only provides an initially empty object at Klipper restart.

## Features
- Store and retrieve simple or complex data types:
  - ✔️ Numbers
  - ✔️ Strings
  - ✔️ Lists/Arrays
  - ✔️ Dictionaries/Objects
- Methods for checking, managing, loading, and clearing store data
- Automatically cleared on reboot.
- Safe for concurrent macro use.

## Sample Usage
Typical Usage:
```j2
{% set _ = store.set("Z_HOME_HEIGHT", 15.2) %}
{% set z_height = store.get("Z_HOME_HEIGHT", 0.0) %}
{% if store.exists("Z_HOME_HEIGHT") %}
	# Safe to use
{% endif %}
{% set _ = store.delete("Z_HOME_HEIGHT") %}
{% set keys = store.list() %}
{% set _ = store.clear() %}
```

Create a reusable function in macro "A" and use it in macro "B":
```j2
; Macro A
{% macro addFive(value) -%}
	{% set value = value + 5 -%}
	{value}
{%- endmacro -%}
{% set _ = store.set("addFive", addFive) %}

; Macro B (Notice I don't have to redefine addFive, I just fetch it and use it)
{% set addFive = store.get("addFive") %}
{ addFive(20) } ; Shows "25"
```