### PR TITLE
Support MCUs faster than 400Mhz

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250425: The maximum `cycle_time` for pwm `[output_pin]`,
+`[pwm_cycle_time]`, `[pwm_tool]`, and similar config sections is now 3
+seconds (reduced from 5 seconds). The `maximum_mcu_duration` in
+`[pwm_tool]` is now also 3 seconds.
+
 20250418: The manual_stepper `STOP_ON_ENDSTOP` feature may now take
 less time to complete. Previously, the command would wait the entire
 time the move could possibly take even if the endstop triggered

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -1,6 +1,6 @@
 # Tracking of PWM controlled heaters and their temperature control
 #
-# Copyright (C) 2016-2020  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import os, logging, threading
@@ -11,7 +11,7 @@ import os, logging, threading
 ######################################################################
 
 KELVIN_TO_CELSIUS = -273.15
-MAX_HEAT_TIME = 5.0
+MAX_HEAT_TIME = 3.0
 AMBIENT_TEMP = 25.
 PID_PARAM_BASE = 255.
 MAX_MAINTHREAD_TIME = 5.0

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -1,11 +1,9 @@
 # Queued PWM gpio output
 #
-# Copyright (C) 2017-2023  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2017-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import chelper
-
-MAX_SCHEDULE_TIME = 5.0
 
 class error(Exception):
     pass
@@ -137,16 +135,16 @@ class PrinterOutputPin:
         # Determine pin type
         pin_params = ppins.lookup_pin(config.get('pin'), can_invert=True)
         self.mcu_pin = MCU_queued_pwm(pin_params)
+        max_duration = self.mcu_pin.get_mcu().max_nominal_duration()
         cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
-                                     maxval=MAX_SCHEDULE_TIME)
+                                     maxval=max_duration)
         hardware_pwm = config.getboolean('hardware_pwm', False)
         self.mcu_pin.setup_cycle_time(cycle_time, hardware_pwm)
         self.scale = config.getfloat('scale', 1., above=0.)
         self.last_print_time = 0.
         # Support mcu checking for maximum duration
         max_mcu_duration = config.getfloat('maximum_mcu_duration', 0.,
-                                           minval=0.500,
-                                           maxval=MAX_SCHEDULE_TIME)
+                                           minval=0.500, maxval=max_duration)
         self.mcu_pin.setup_max_duration(max_mcu_duration)
         # Determine start and shutdown values
         self.last_value = config.getfloat(

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -548,7 +548,7 @@ class MCU_adc:
 # Minimum time host needs to get scheduled events queued into mcu
 MIN_SCHEDULE_TIME = 0.100
 # Maximum time all MCUs can internally schedule into the future
-MAX_NOMINAL_DURATION = 5.0
+MAX_NOMINAL_DURATION = 3.0
 
 class MCU:
     error = error

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -1,6 +1,6 @@
 # Interface to Klipper micro-controller code
 #
-# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, zlib, logging, math
@@ -545,6 +545,11 @@ class MCU_adc:
 # Main MCU class
 ######################################################################
 
+# Minimum time host needs to get scheduled events queued into mcu
+MIN_SCHEDULE_TIME = 0.100
+# Maximum time all MCUs can internally schedule into the future
+MAX_NOMINAL_DURATION = 5.0
+
 class MCU:
     error = error
     def __init__(self, config, clocksync):
@@ -868,6 +873,10 @@ class MCU:
         return int(time * self._mcu_freq)
     def get_max_stepper_error(self):
         return self._max_stepper_error
+    def min_schedule_time(self):
+        return MIN_SCHEDULE_TIME
+    def max_nominal_duration(self):
+        return MAX_NOMINAL_DURATION
     # Wrapper functions
     def get_printer(self):
         return self._printer

--- a/src/basecmd.c
+++ b/src/basecmd.c
@@ -299,6 +299,13 @@ command_get_uptime(uint32_t *args)
 }
 DECL_COMMAND_FLAGS(command_get_uptime, HF_IN_SHUTDOWN, "get_uptime");
 
+// Similar to timer_is_before(), but handles full 32bit duration
+static int
+timer_has_elapsed(uint32_t start, uint32_t cur, uint32_t duration)
+{
+    return (uint32_t)(cur - start) >= duration;
+}
+
 #define SUMSQ_BASE 256
 DECL_CONSTANT("STATS_SUMSQ_BASE", SUMSQ_BASE);
 
@@ -322,7 +329,7 @@ stats_update(uint32_t start, uint32_t cur)
         nextsumsq = 0xffffffff;
     sumsq = nextsumsq;
 
-    if (timer_is_before(cur, stats_send_time + timer_from_us(5000000)))
+    if (!timer_has_elapsed(stats_send_time, cur, timer_from_us(5000000)))
         return;
     sendf("stats count=%u sum=%u sumsq=%u", count, sum, sumsq);
     if (cur < stats_send_time)


### PR DESCRIPTION
This is an alternative to PR #6806 .  It has the same goals - allow the internal timers of MCUs to support greater than 400Mhz.  With this change, it should be possible to support up to ~700Mhz.

@nefelim4ag - fyi.  This is a slightly different approach.  I added a `timer_has_elapsed()` wrapper function to basecmd.c .  I've added new `mcu.min_schedule_time()` and `mcu.max_nominal_duration()` helpers.  I'm keeping `MAX_HEAT_TIME` a constant (this is a safety check, so we don't want it changing from one mcu to another).  It isn't necessary to change controller_fan.

It's possible I missed something, so let me know if that is the case.

-Kevin