### PR TITLE
klippy: python 3.13

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -4,10 +4,11 @@
 #   pip install -r klippy-requirements.txt
 
 # The 'cffi' package is used by the "chelper" code
-cffi==1.14.6
+cffi==1.14.6 ; python_version < '3.12'
+cffi==1.17.1 ; python_version >= '3.12'
 # greenlet is used by the reactor.py code
 greenlet==2.0.2 ; python_version < '3.12'
-greenlet==3.0.3 ; python_version >= '3.12'
+greenlet==3.1.1 ; python_version >= '3.12'
 # Jinja2 is used by gcode_macro.py
 Jinja2==2.11.3
 markupsafe==1.1.1       # Needed by Jinja2


### PR DESCRIPTION
Those are minimal that can be installed/built on Python 3.13.
cffi 1.17.1
greenlet 3.1.1 # Depends on newer CFFI

This should help people with 3.13, from there: #6525

~~Greenlet 3.1.1 could possibly be reused on 3.12 with newer CFFI~~ - smoke test seems fine

Generally, I expect it would be helpful to have feedback that:
- ~~CAN still works on 3.13~~ - python-can seems to be only used in the `canbus_query.py`
- Klipper works as before with 3.12