### PR TITLE
ads1220: Expose registers for FIR filter, power switching, etc. as configuration variables

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4896,6 +4896,38 @@ data_ready_pin:
 #vref:
 #   The selected voltage reference. Valid values are: 'internal', 'REF0', 'REF1'
 #   and 'analog_supply'. Default is 'internal'.
+#fir_filter:
+#   Noise filtering for 50/60Hz power line rejection.
+#   Valid values are: 'none', '50Hz', '60Hz', and 'both'.
+#   Default is 'none'.
+#power_switch:
+#   The low-side power switch is responsible for providing power to the
+#   load cell bridge between conversion intervals.
+#   If True, the switch remains closed during conversions, therefore power will
+#   continue to be provided to the bridge.
+#   The default is False.
+#idac_current:
+#   Configures the excitation current source value of the IDAC bridges.
+#   When using a vref of either 'analog_supply' or 'internal', the IDAC current
+#   value is used to determine how much current will flow across the bridge
+#   IDAC pairs (idac1_routing/idac2_routing). The current is set for both IDACs.
+#   The value is specified in microamps (μA).
+#   Valid values are: 'none', '10', '50', '100', '250', '500', '1000', and '1500'.
+#   The default is 'none'.
+#idac1_routing:
+#   Configures IDAC1 to be routed to the specified pin.
+#   Valid values are: 'none', 'AIN0_REFP1', 'AIN1', 'AIN2', 'AIN3_REFN1', 'REFP0',
+#   and 'REFN0'.
+#   The default is 'none'.
+#idac2_routing:
+#   Configures IDAC2 to be routed to the specified pin.
+#   Valid values are the same as for IDAC1.
+#   The default is 'none'.
+#data_ready_mode:
+#   The behavior of the data ready pins.
+#   If True, the data ready signal is present on both DOUT and DRDY pins.
+#   When False, the data ready signal is only supplied to the DRDY pin.
+#   The default is False.
 ```
 
 ## Board specific hardware support


### PR DESCRIPTION
This provides the registers of the ADS1220 as configurable parameters for the end user.

Different implementations of the ADC will have varying use cases, therefore it is worthwhile to have these available.

Especially useful is the IDAC, when no external voltage reference is present on the `input_mux` line. For example, when the user is using the built-in source, or the analog supply line, they can use the IDAC to set a predetermined amount of current to be used for reading across a bridge.

The ADS1220 also contains a built-in FIR filter for 50/60Hz noise rejection, which can prove very useful if the ADC is situated close to a switching mode power supply. For load cell probing, this is also done in a software filter, as other chips may lack this capability. Specifically for the ADS1220 however, it should speed up the processing time of load cell probe analysis by using the hardware filter.

Signed-off-by: Ella Fox <ella@fox.gal>