### PR TITLE
webhooks: support optional msgspec json serialization

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -10,3 +10,4 @@ Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1
 setuptools==75.6.0 ; python_version >= '3.12' # Needed by python-can
+msgspec==0.19.0 ; python_version >= '3.9'


### PR DESCRIPTION
Use [msgspec](https://github.com/jcrist/msgspec) to decode/encode json for API requests.  When `msgspec` is not available the standard library is used.  This should substantially speed up encoding large amounts of data.