### PR TITLE
spi_flash: fix hw bus

### DIFF
--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -1302,7 +1302,9 @@ class MCUConnection:
         else:
             if bus not in bus_enums:
                 raise SPIFlashError("Invalid SPI Bus: %s" % (bus,))
-            bus_cmds = SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, SD_SPI_SPEED)
+            bus_cmds = [
+                SPI_BUS_CMD % (SPI_OID, bus, SPI_MODE, SD_SPI_SPEED),
+            ]
         if cs_pin not in pin_enums:
             raise SPIFlashError("Invalid CS Pin: %s" % (cs_pin,))
         cfg_cmds = [ALLOC_OIDS_CMD % (1,),]


### PR DESCRIPTION
_try_send_command() expects a list of args,
But receives a string.

Fix that.

---
~~I'm waiting for Ack from the tester.~~
Acked.