### PR TITLE
Improved MCU connection error messages

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -990,8 +990,9 @@ class MCU:
         self._is_timeout = True
         logging.info("Timeout with MCU '%s' (eventtime=%f)",
                      self._name, eventtime)
-        self._printer.invoke_shutdown("Lost communication with MCU '%s'" % (
-            self._name,))
+        error_message = "Lost communication with MCU '%s'. Check your USB/CAN connection." % (self._name,)
+        self._serial.current_error_description = error_message
+        self._printer.invoke_shutdown(error_message)
     # Misc external commands
     def is_fileoutput(self):
         return self._printer.get_start_args().get('debugoutput') is not None


### PR DESCRIPTION
Discussion at https://klipper.discourse.group/t/improved-mcu-connection-error-messages/23174?u=3dcoded

This PR aims to make it easier for users (especially new users) to diagnose MCU connection issues without looking into the `klippy.log`.

## MCU: Unable to Connect

This error has been updated to add two additional (very common) cases.

Serial port not found

<img width="758" alt="Screenshot 2025-04-27 at 7 25 25 AM" src="https://github.com/user-attachments/assets/11f7ccec-a031-4bd5-8eba-c78bd80677ae" />

Serial port in use by another MCU/program

<img width="763" alt="Screenshot 2025-04-27 at 7 26 49 AM" src="https://github.com/user-attachments/assets/c729b727-6762-484e-951f-c8b5f9eb831e" />

## Serial connection closed / Timeout on connect / Wait for identify_response

Thank you @Sineos for directing me to this common error.

Updated version:

<img width="691" alt="Screenshot 2025-04-27 at 4 30 33 PM" src="https://github.com/user-attachments/assets/58d9968b-3693-4d68-a68b-ffc38c54aa53" />

## Lost communication with MCU

Updated to recommend the user to check their USB/CAN connection.

<img width="693" alt="Screenshot 2025-04-27 at 4 28 50 PM" src="https://github.com/user-attachments/assets/1748fea6-688e-4366-83db-c08fed24aca6" />
