### PR TITLE
Run stm32h723 at 520Mhz

### DIFF
--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -250,22 +250,22 @@ results were obtained by running an STM32F407 binary on an STM32F446
 
 ### STM32H7 step rate benchmark
 
-The following configuration sequence is used on STM32H7:
+The following configuration sequence is used on STM32H723:
 ```
 allocate_oids count=3
-config_stepper oid=0 step_pin=PA13 dir_pin=PB5 invert_step=-1 step_pulse_ticks=40
-config_stepper oid=1 step_pin=PB2 dir_pin=PB6 invert_step=-1 step_pulse_ticks=40
-config_stepper oid=2 step_pin=PB3 dir_pin=PB7 invert_step=-1 step_pulse_ticks=40
+config_stepper oid=0 step_pin=PA13 dir_pin=PB5 invert_step=-1 step_pulse_ticks=52
+config_stepper oid=1 step_pin=PB2 dir_pin=PB6 invert_step=-1 step_pulse_ticks=52
+config_stepper oid=2 step_pin=PB3 dir_pin=PB7 invert_step=-1 step_pulse_ticks=52
 finalize_config crc=0
 ```
 
-The test was last run on commit `0d27195f` with gcc version
+The test was last run on commit `554ae78d` with gcc version
 `arm-none-eabi-gcc (Fedora 14.1.0-1.fc40) 14.1.0`.
 
 | stm32h723            | ticks |
 | -------------------- | ----- |
-| 1 stepper            | 60    |
-| 3 stepper            | 183   |
+| 1 stepper            | 70    |
+| 3 stepper            | 181   |
 
 ### STM32G0B1 step rate benchmark
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -195,7 +195,7 @@ represent total number of steps per second on the micro-controller.
 | RP2040                          | 4000K             | 2571K             |
 | RP2350                          | 4167K             | 2663K             |
 | SAME70                          | 6667K             | 4737K             |
-| STM32H723                       | 6667K             | 6557K             |
+| STM32H723                       | 7429K             | 8619K             |
 
 If unsure of the micro-controller on a particular board, find the
 appropriate [config file](../config/), and look for the

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -208,7 +208,8 @@ config CLOCK_FREQ
     default 64000000 if MACH_STM32G0
     default 150000000 if MACH_STM32G431
     default 170000000 if MACH_STM32G474
-    default 400000000 if MACH_STM32H7 # 400Mhz is max Klipper currently supports
+    default 520000000 if MACH_STM32H723
+    default 400000000 if MACH_STM32H743 || MACH_STM32H750
     default 80000000 if MACH_STM32L412
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
     default 128000000 if MACH_N32G45x

--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -149,17 +149,17 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
         gpio_peripheral(ii->sda_pin, ii->function | GPIO_OPEN_DRAIN, 1);
 
         // Set 100Khz frequency and enable
-        uint32_t nom_i2c_clock = 8000000;  // 8mhz internal clock = 125ns ticks
-        uint32_t scll = 40; // 40 * 125ns = 5us
-        uint32_t sclh = 32; // 32 * 125ns = 4us
-        uint32_t sdadel = 4; // 4 * 125ns = 500ns
-        uint32_t scldel = 10; // 10 * 125ns = 1250ns
+        uint32_t nom_i2c_clock = 12000000; // 12mhz internal clock (83.3ns tick)
+        uint32_t scll = 60; // 60 * 83.3ns = 5us
+        uint32_t sclh = 48; // 48 * 83.3ns = 4us
+        uint32_t sdadel = 6; // 6 * 83.3ns = 500ns
+        uint32_t scldel = 15; // 15 * 83.3ns = 1250ns
         // Clamp the rate to 400Khz
         if (rate >= 400000) {
-            scll = 10; // 10 * 125ns = 1250ns
-            sclh = 4; // 4 * 125 = 500ns
-            sdadel = 3; // 3 * 125 = 375ns
-            scldel = 4; // 4 * 125 = 500ns
+            scll = 15; // 15 * 83.3ns = 1250ns
+            sclh = 6; // 6 * 83.3 = 500ns
+            sdadel = 4; // 4 * 83.3 = 333ns
+            scldel = 6; // 6 * 83.3 = 500ns
         }
 
         uint32_t pclk = get_pclock_frequency((uint32_t)i2c);

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -161,7 +161,8 @@ static const uint8_t adc_pins[] = {
 #define ADC_ATICKS 0b110
 #define ADC_ATICKS_H723_ADC3 0b111
 // 400Mhz stm32h7: clock=25Mhz, Tsamp=387.5, Tconv=394, total=15.76us
-// 400Mhz stm32h723 adc3: clock=50Mhz, Tsamp=640.5, Tconv=653, total=13.06us
+// 520Mhz stm32h723: clock=32.5Mhz, Tsamp=387.5, Tconv=394, total=12.12us
+// 520Mhz stm32h723 adc3: clock=65Mhz, Tsamp=640.5, Tconv=653, total=10.05us
 // 80Mhz stm32l4: clock=20Mhz, Tsamp=247.5, Tconv=260, total=13.0us
 // 150Mhz stm32g4: clock=37.5Mhz, Tsamp=247.5, Tconv=260, total=6.933us
 

--- a/src/stm32/stm32h7_adc.c
+++ b/src/stm32/stm32h7_adc.c
@@ -160,10 +160,10 @@ static const uint8_t adc_pins[] = {
 #define ADC_CKMODE 0b11
 #define ADC_ATICKS 0b110
 #define ADC_ATICKS_H723_ADC3 0b111
-// stm32h7: clock=25Mhz, Tsamp=387.5, Tconv=394, total=15.76us
-// stm32h723 adc3: clock=50Mhz, Tsamp=640.5, Tconv=653, total=13.06us
-// stm32l4: clock=20Mhz, Tsamp=247.5, Tconv=260, total=13.0us
-// stm32g4: clock=37.5Mhz, Tsamp=247.5, Tconv=260, total=6.933us
+// 400Mhz stm32h7: clock=25Mhz, Tsamp=387.5, Tconv=394, total=15.76us
+// 400Mhz stm32h723 adc3: clock=50Mhz, Tsamp=640.5, Tconv=653, total=13.06us
+// 80Mhz stm32l4: clock=20Mhz, Tsamp=247.5, Tconv=260, total=13.0us
+// 150Mhz stm32g4: clock=37.5Mhz, Tsamp=247.5, Tconv=260, total=6.933us
 
 // Handle register name differences between chips
 #if CONFIG_MACH_STM32H723
@@ -231,8 +231,9 @@ gpio_adc_setup(uint32_t pin)
         } else {
             // Use linear calibration on stm32h7
             cr |= ADC_CR_ADCALLIN;
-            // Set boost mode on stm32h7 (adc clock is at 25Mhz)
-            cr |= 0b10 << ADC_CR_BOOST_Pos;
+            // Set boost mode on stm32h7
+            uint32_t boost = CONFIG_CLOCK_FREQ > 400000000 ? 0b11 : 0b10;
+            cr |= boost << ADC_CR_BOOST_Pos;
             // Set 12bit samples on the stm32h7
             adc->CFGR = ADC_CFGR_JQDIS | (0b110 << ADC_CFGR_RES_Pos);
         }


### PR DESCRIPTION
This increases the speed of stm32h723 chips from 400Mhz to 520Mhz.

I have only lightly tested this change.  I have run the step benchmarks, but I haven't tested the ADC nor I2C in a real-world setup.  I don't have a test setup readily available for more intensive tests.

In theory, the stm32h743/stm32h750 could also be changed to 480Mhz, however I have not done that here.

@nefelim4ag, @adelyser , @D4SK - FYI

-Kevin