### PR TITLE
update QUERY_PROBE with optional NO_OUTPUT=1

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1068,8 +1068,9 @@ optional parameters are provided they override their equivalent
 setting in the [probe config section](Config_Reference.md#probe).
 
 #### QUERY_PROBE
-`QUERY_PROBE`: Report the current status of the probe ("triggered" or
-"open").
+`QUERY_PROBE [NO_OUTPUT=1]`: Report the current status of the probe 
+("triggered" or "open"). If NO_OUTPUT=1 is specified then QUERY_PROBE 
+will only update the probe state, but not report the status to console.
 
 #### PROBE_ACCURACY
 `PROBE_ACCURACY [PROBE_SPEED=<mm/s>] [SAMPLES=<count>]

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -74,7 +74,8 @@ class ProbeCommandHelper:
         print_time = toolhead.get_last_move_time()
         res = self.query_endstop(print_time)
         self.last_state = res
-        gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
+        if gcmd.get_int('NO_OUTPUT', 0):
+            gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, gcmd):
         pos = run_single_probe(self.probe, gcmd)


### PR DESCRIPTION
Module: Adding optional NO_OUTPUT=1 to QUERY_PROBE for use in macros

This PR aims to reduce spam in console when macros use QUERY_PROBE command.
For example when a klicky probe is used, it is constantly checked if the 
probe is attached or not which results in a lot of unnecessary prints to 
console. 
Even worse when the probe state is checked withing a for loop to measure 
the height of the probe dock for example. This can result in hundreds of prints 
to console that all have zero benefit for the user and are only required to 
get the state updated for the macro.

Signed-off-by: Robin Ehnert [robin.ehnert@web.de](mailto:robin.ehnert@web.de)