### PR TITLE
DOCS: BED_MESH_CALIBRATE makes a mesh that is immediately available.

### DIFF
--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -497,7 +497,7 @@ _Default Adaptive Margin: 0_
 
 Initiates the probing procedure for Bed Mesh Calibration.
 
-The mesh will be immediately ready to use when the command completes and saved 
+The mesh will be immediately ready to use when the command completes and saved
 into a profile specified by the `PROFILE` parameter,
 or `default` if unspecified. The `METHOD` parameter takes one of the following
 values:
@@ -560,10 +560,10 @@ on startup if it was present.  This behavior has been removed in favor of
 allowing the user to determine when a profile is loaded.  If a user wishes to
 load the `default` profile it is recommended to add
 `BED_MESH_PROFILE LOAD=default` to either their `START_PRINT` macro or their
-slicer's "Start G-Code" configuration, whichever is applicable. 
+slicer's "Start G-Code" configuration, whichever is applicable.
 
-Note that this is not required if a new mesh is generated with 
-`BED_MESH_CALIBRATE` in the `START_PRINT` macro or the slicer's "Start G-Code" 
+Note that this is not required if a new mesh is generated with
+`BED_MESH_CALIBRATE` in the `START_PRINT` macro or the slicer's "Start G-Code"
 and may produce unexpected results, especially with adaptive meshing.
 
 Alternatively the old behavior of loading a profile at startup can be

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -497,7 +497,8 @@ _Default Adaptive Margin: 0_
 
 Initiates the probing procedure for Bed Mesh Calibration.
 
-The mesh will be saved into a profile specified by the `PROFILE` parameter,
+The mesh will be immediately ready to use when the command completes and saved 
+into a profile specified by the `PROFILE` parameter,
 or `default` if unspecified. The `METHOD` parameter takes one of the following
 values:
 
@@ -559,7 +560,9 @@ on startup if it was present.  This behavior has been removed in favor of
 allowing the user to determine when a profile is loaded.  If a user wishes to
 load the `default` profile it is recommended to add
 `BED_MESH_PROFILE LOAD=default` to either their `START_PRINT` macro or their
-slicer's "Start G-Code" configuration, whichever is applicable.
+slicer's "Start G-Code" configuration, whichever is applicable. 
+
+Note that this is not required if a new mesh is generated with `BED_MESH_CALIBRATE` in the `START_PRINT` macro or the slicer's "Start G-Code" and may produce unexpected results, especially with adaptive meshing.
 
 Alternatively the old behavior of loading a profile at startup can be
 restored with a `[delayed_gcode]`:

--- a/docs/Bed_Mesh.md
+++ b/docs/Bed_Mesh.md
@@ -562,7 +562,9 @@ load the `default` profile it is recommended to add
 `BED_MESH_PROFILE LOAD=default` to either their `START_PRINT` macro or their
 slicer's "Start G-Code" configuration, whichever is applicable. 
 
-Note that this is not required if a new mesh is generated with `BED_MESH_CALIBRATE` in the `START_PRINT` macro or the slicer's "Start G-Code" and may produce unexpected results, especially with adaptive meshing.
+Note that this is not required if a new mesh is generated with 
+`BED_MESH_CALIBRATE` in the `START_PRINT` macro or the slicer's "Start G-Code" 
+and may produce unexpected results, especially with adaptive meshing.
 
 Alternatively the old behavior of loading a profile at startup can be
 restored with a `[delayed_gcode]`:

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -176,7 +176,8 @@ specified by the parameters in the config. After probing, a mesh is generated
 and z-movement is adjusted according to the mesh.
 The mesh is immediately active after successful completion of `BED_MESH_CALIBRATE`.
 The mesh will be saved into a profile specified by the `PROFILE` parameter,
-or `default` if unspecified.
+or `default` if unspecified. If ADAPTIVE=1 is specified then the profile
+name will begin with `adaptive-` and should not be saved for reuse.
 See the PROBE command for details on the optional probe parameters. If
 METHOD=manual is specified then the manual probing tool is activated - see the
 MANUAL_PROBE command above for details on the additional commands available

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -174,6 +174,7 @@ The following commands are available when the
 [ADAPTIVE_MARGIN=<value>]`: This command probes the bed using generated points
 specified by the parameters in the config. After probing, a mesh is generated
 and z-movement is adjusted according to the mesh.
+The mesh is immediately active after successful completion of `BED_MESH_CALIBRATE`.
 The mesh will be saved into a profile specified by the `PROFILE` parameter,
 or `default` if unspecified.
 See the PROBE command for details on the optional probe parameters. If


### PR DESCRIPTION
The docs aren't particularly clear that if you generate a mesh you can just use it without additional commands, for example in `START_PRINT` or equivalent slicer gcode. This is causing confusion and issues with support on r/klippers and likely in other places.

There's a lot of "helpful" advice suggesting that `BED_MESH_CALIBRATE` doesn't work without a `BED_MESH_PROFILE LOAD=default` after it. There are instructions to add `BED_MESH_PROFILE LOAD=default` to start gcode but it's not really clear that this is if and only if the intent is to use a previously prepared and saved mesh. It's increasingly fashionable to use `BED_MESH_CALIBRATE` in start gcode, which does not need a profile loading afterwards and if `BED_MESH_CALIBRATE adaptive=1` is used, the mesh name will not be "default". 

At best this introduces a redundant command, at worst this introduces a failure point for some people that is dismissed as "has always worked for me" by users with a slightly different setup.

Signed-off-by: Rowland Straylight <rowlandstraylight@gmail.com>