### PR TITLE
fan: use shutdown_speed during restart

### DIFF
--- a/klippy/extras/fan.py
+++ b/klippy/extras/fan.py
@@ -17,7 +17,7 @@ class Fan:
                                          minval=0., maxval=1.)
         cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
         hardware_pwm = config.getboolean('hardware_pwm', False)
-        shutdown_speed = config.getfloat(
+        self.shutdown_speed = shutdown_speed = config.getfloat(
             'shutdown_speed', default_shutdown_speed, minval=0., maxval=1.)
         # Setup pwm object
         ppins = self.printer.lookup_object('pins')
@@ -71,7 +71,7 @@ class Fan:
     def set_speed_from_command(self, value):
         self.gcrq.queue_gcode_request(value)
     def _handle_request_restart(self, print_time):
-        self.set_speed(0., print_time)
+        self.set_speed(self.shutdown_speed, print_time)
 
     def get_status(self, eventtime):
         tachometer_status = self.tachometer.get_status(eventtime)


### PR DESCRIPTION
Prior to this change, issuing a RESTART command would turn off all fans, including heater fans, for the duration of the restart. This left them off for at least a couple seconds, and if for any reason the restart failed, they could be left permanently off. This could result in damage to toolhead components not intended to be exposed to high temperatures, including plastic cooling ducts and hotend mounts, lights, toolboards, etc. This is especially the case for hotends with high thermal mass and small heatsinks,

By honoring shutdown_speed for all fans during restart, rather than special-casing heater fans, we make it possible to also keep controller fans or macro-controlled generic fans powered across restart if configured to be on at shutdown.