### PR TITLE
gcode_macro: more descriptive "unable to parse as a literal" error

### DIFF
--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -178,8 +178,8 @@ class GCodeMacro:
             literal = ast.literal_eval(value)
             json.dumps(literal, separators=(',', ':'))
         except (SyntaxError, TypeError, ValueError) as e:
-            raise gcmd.error("Unable to parse '%s' as a literal: %s" %
-                             (value, e))
+            raise gcmd.error("Unable to parse '%s' as a literal: %s in '%s'" %
+                             (value, e, gcmd.get_commandline()))
         v = dict(self.variables)
         v[variable] = literal
         self.variables = v


### PR DESCRIPTION
Display faulty command

from:
```
Unable to parse 'ABS' as a literal: malformed node or string on line 1: 
```

to:
```
Unable to parse 'ABS' as a literal: malformed node or string on line 1:  in 'SET_GCODE_VARIABLE MACRO=MATERIAL_PRESET VARIABLE=material VALUE=ABS'
```