### PR TITLE
Config: Update CR6-SE 2020 config with board revision

### DIFF
--- a/config/printer-creality-cr6se-2020.cfg
+++ b/config/printer-creality-cr6se-2020.cfg
@@ -1,4 +1,5 @@
-# This file contains pin mappings for the stock 2020 Creality CR6-SE.
+# This file contains pin mappings for the stock 2020 Creality CR6-SE
+# with the early 4.5.2 board only.
 # To use this config, during "make menuconfig" select the STM32F103
 # with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
 # communication.


### PR DESCRIPTION
It has been noted that there are 3 possible boards with 2 possible configs, which we have both of, but this one does not state that it is for the 4.5.2 early kickstarter version. Which was causing some confusion.

Thanks
James

Signed-Off-By: James Hartley <james@hartleyns.com>