### PR TITLE
dual_carriage: Fixed broken safe_distance parameter

### DIFF
--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -32,7 +32,8 @@ class CartKinematics:
             self.dc_module = idex_modes.DualCarriages(
                     self.printer, [self.rails[self.dual_carriage_axis]],
                     [self.rails[3]], axes=[self.dual_carriage_axis],
-                    safe_dist=config.getfloat('safe_distance', None, minval=0.))
+                    safe_dist=dc_config.getfloat(
+                        'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -35,7 +35,8 @@ class HybridCoreXYKinematics:
             self.rails[3].setup_itersolve('corexy_stepper_alloc', b'+')
             self.dc_module = idex_modes.DualCarriages(
                     self.printer, [self.rails[0]], [self.rails[3]], axes=[0],
-                    safe_dist=config.getfloat('safe_distance', None, minval=0.))
+                    safe_dist=dc_config.getfloat(
+                        'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -35,7 +35,8 @@ class HybridCoreXZKinematics:
             self.rails[3].setup_itersolve('corexz_stepper_alloc', b'+')
             self.dc_module = idex_modes.DualCarriages(
                     self.printer, [self.rails[0]], [self.rails[3]], axes=[0],
-                    safe_dist=config.getfloat('safe_distance', None, minval=0.))
+                    safe_dist=dc_config.getfloat(
+                        'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
             toolhead.register_step_generator(s.generate_steps)

--- a/test/klippy/dual_carriage.cfg
+++ b/test/klippy/dual_carriage.cfg
@@ -12,6 +12,7 @@ homing_speed: 50
 
 [dual_carriage]
 axis: x
+safe_distance: 50
 step_pin: PH1
 dir_pin: PH0
 enable_pin: !PA1


### PR DESCRIPTION
Unfortunately, the merge of PR #6815 broke `safe_distance` parameter for regular kinematics supporting IDEX due to a typo. This PR fixes that unintentional regression.