### PR TITLE
Ensure minimum time between step pin and dir pin change

### DIFF
--- a/src/stepper.c
+++ b/src/stepper.c
@@ -109,6 +109,10 @@ stepper_load_next(struct stepper *s)
                 shutdown("Stepper too far in past");
             s->time.waketime = min_next_time;
         }
+        if (was_active && need_dir_change && s->flags & SF_SINGLE_SCHED)
+            // Must ensure minimum time between step change and dir change
+            while (timer_is_before(timer_read_time(), min_next_time))
+                ;
     }
 
     // Set new direction (if needed)


### PR DESCRIPTION
Commit 8faed8d9 made it possible to utilize `stepper_event_full()` while utilizing tmc "step on both edges" optimation.  That commit would ensure a minimum step pulse duration, but it did not ensure a minimum duration between step pin and dir pin changes.  Commits 0d27195f and 554ae78d optimized the gpio handling on stm32h7 chips, which could potentially cause a very small amount of time between step pin and dir pin changes.

The PR here adds a minimum duration check between altering the step pin and altering the dir pin.  This should only impact stm32h7 as it is the only platform that would use this code path (if one is using a typical `step_pulse_duration`).

There was recent discussion on this at https://klipper.discourse.group/t/issues-with-stepper-drift-on-latest-klipper/23304/27 .  It is unclear if the issue identified here is the cause of the issue reported there.  However, regardless of the outcome of that discussion, it will be necessary to ensure a minimum duration between step and dir pin changes.

@nefelim4ag - FYI.

-Kevin