### PR TITLE
tmc5160: add short conf settings

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4359,6 +4359,10 @@ run_current:
 #driver_PWM_OFS: 30
 #driver_PWM_REG: 4
 #driver_PWM_LIM: 12
+#driver_S2VS_LEVEL: 6
+#driver_S2G_LEVEL: 6
+#driver_SHORTFILTER: 1
+#driver_SHORTDELAY: 0
 #driver_SGT: 0
 #driver_SEMIN: 0
 #driver_SEUP: 0

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -131,6 +131,12 @@ Fields["DRV_STATUS"] = {
 Fields["FACTORY_CONF"] = {
     "factory_conf":             0x1F << 0
 }
+Fields["SHORT_CONF"] = {
+    "s2vs_level":               0x0F << 0,
+    "s2g_level":                0x0F << 8,
+    "shortfilter":              0x03 << 16,
+    "shortdelay":               0x01 << 18
+}
 Fields["GCONF"] = {
     "recalibrate":              0x01 << 0,
     "faststandstill":           0x01 << 1,
@@ -382,6 +388,11 @@ class TMC5160:
         set_config_field(config, "freewheel", 0)
         set_config_field(config, "pwm_reg", 4)
         set_config_field(config, "pwm_lim", 12)
+        #   SHORT_CONF
+        set_config_field(config, "s2vs_level", 6)
+        set_config_field(config, "s2g_level", 6)
+        set_config_field(config, "shortfilter", 1)
+        set_config_field(config, "shortdelay", 0)
         #   TPOWERDOWN
         set_config_field(config, "tpowerdown", 10)
 


### PR DESCRIPTION
With stealth in specific conditions,
TMC5160 could detect Short to Supply.
Those settings allow to adapt short detection
to the actual V supply/motor.

![image](https://github.com/user-attachments/assets/defdc82c-4057-4ef4-9bca-5723a61263d4)

I got sporadic S2VSA/S2VSB errors  while trying to do test prints in StealthChop with code from here: https://klipper.discourse.group/t/implement-stepper-shaper/21260
New `driver_s2vs_level: 6 -> 8` seems to fix that.

I'm not sure how often it does happen in normal (SpreadCycle) conditions (I think never for me).
So, because it is specific for the TMC5160, I think it could wait until if/when StealthChop lag compensation is merged #7258.

Thanks.