### PR TITLE
generic_cartesian: Fixed safe_z_home and manual_probe for new kinematics

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -172,13 +172,17 @@ class ProbeCommandHelper:
         configfile = self.printer.lookup_object('configfile')
         configfile.set(self.name, 'z_offset', "%.3f" % (new_calibrate,))
 
+def lookup_z_endstop_config(config):
+    if config.has_section('stepper_z'):
+        return config.getsection('stepper_z')
+    elif config.has_section('carriage z'):
+        return config.getsection('carriage z')
+    return None
+
 # Helper to lookup the minimum Z position for the printer
 def lookup_minimum_z(config):
-    if config.has_section('stepper_z'):
-        zconfig = config.getsection('stepper_z')
-        return zconfig.getfloat('position_min', 0., note_valid=False)
-    elif config.has_section('carriage z'):
-        zconfig = config.getsection('carriage z')
+    zconfig = lookup_z_endstop_config(config)
+    if zconfig is not None:
         return zconfig.getfloat('position_min', 0., note_valid=False)
     pconfig = config.getsection('printer')
     return pconfig.getfloat('minimum_z_position', 0., note_valid=False)

--- a/klippy/extras/safe_z_home.py
+++ b/klippy/extras/safe_z_home.py
@@ -4,6 +4,8 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
+from . import probe
+
 class SafeZHoming:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -11,7 +13,9 @@ class SafeZHoming:
         self.home_x_pos, self.home_y_pos = x_pos, y_pos
         self.z_hop = config.getfloat("z_hop", default=0.0)
         self.z_hop_speed = config.getfloat('z_hop_speed', 15., above=0.)
-        zconfig = config.getsection('stepper_z')
+        zconfig = probe.lookup_z_endstop_config(config)
+        if zconfig is None:
+            raise gcmd.error('Missing Z endstop config for safe_z_homing')
         self.max_z = zconfig.getfloat('position_max', note_valid=False)
         self.speed = config.getfloat('speed', 50.0, above=0.)
         self.move_to_previous = config.getboolean('move_to_previous', False)


### PR DESCRIPTION
Fixed references to `stepper_z` in these two modules, as `generic_cartesian` uses `carriage z` for endstop position configuration.