### PR TITLE
manual_stepper: Fix broken manual_stepper rail naming

### DIFF
--- a/klippy/kinematics/generic_cartesian.py
+++ b/klippy/kinematics/generic_cartesian.py
@@ -38,7 +38,7 @@ class MainCarriage:
         self.axis_name = axis
         self.dual_carriage = None
     def get_name(self):
-        return self.rail.get_name()
+        return self.rail.get_name(short=True)
     def get_axis(self):
         return self.axis
     def get_rail(self):
@@ -86,7 +86,7 @@ class DualCarriage:
                                self.primary_carriage.get_axis_name())
         self.safe_dist = config.getfloat('safe_distance', None, minval=0.)
     def get_name(self):
-        return self.rail.get_name()
+        return self.rail.get_name(short=True)
     def get_axis(self):
         return self.primary_carriage.get_axis()
     def get_rail(self):

--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -26,7 +26,7 @@ class DualCarriages:
                 DualCarriagesRail(c, primary_rails[i], axes[i], active=False)
                 for i, c in enumerate(dual_rails)]
         self.dc_rails = collections.OrderedDict(
-                [(c.rail.get_name(), c)
+                [(c.rail.get_name(short=True), c)
                  for c in self.primary_rails + self.dual_rails])
         self.saved_states = {}
         self.safe_dist = {}

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -323,7 +323,7 @@ class GenericPrinterRail:
                  default_position_endstop=None, units_in_radians=False):
         self.stepper_units_in_radians = units_in_radians
         self.printer = config.get_printer()
-        self.name = config.get_name().split()[-1]
+        self.name = config.get_name()
         self.steppers = []
         self.endstops = []
         self.endstop_map = {}
@@ -380,9 +380,11 @@ class GenericPrinterRail:
                 "Invalid homing_positive_dir / position_endstop in '%s'"
                 % (config.get_name(),))
     def get_name(self, short=False):
-        if short and self.name.startswith('stepper'):
-            # Skip an extra symbol after 'stepper'
-            return self.name[8:]
+        if short:
+            if self.name.startswith('stepper'):
+                # Skip an extra symbol after 'stepper'
+                return self.name[8:]
+            return self.name.split()[-1]
         return self.name
     def get_range(self):
         return self.position_min, self.position_max


### PR DESCRIPTION
The naming got broken during refactoring for generic_cartesian.