### PR TITLE
Fix `SHAPER_CALIBRATE` internal error due to typo

### DIFF
--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -167,10 +167,10 @@ class ResonanceTestExecutor:
                 # The move first goes to a complete stop, then changes direction
                 d_decel = -last_v2 * half_inv_accel
                 decel_X, decel_Y = axis.get_point(d_decel)
-                toolhead.move([X + decel_X, Y + decel_Y] + tpos[2:], abs_last_v)
-                toolhead.move([nX, nY] + tpos[2:], abs_v)
+                toolhead.move([X + decel_X, Y + decel_Y] + thpos[2:], abs_last_v)
+                toolhead.move([nX, nY] + thpos[2:], abs_v)
             else:
-                toolhead.move([nX, nY] + tpos[2:], max(abs_v, abs_last_v))
+                toolhead.move([nX, nY] + thpos[2:], max(abs_v, abs_last_v))
             if math.floor(freq) > math.floor(last_freq):
                 gcmd.respond_info("Testing frequency %.0f Hz" % (freq,))
                 reactor.pause(reactor.monotonic() + 0.01)
@@ -184,7 +184,7 @@ class ResonanceTestExecutor:
             decel_X, decel_Y = axis.get_point(d_decel)
             toolhead.cmd_M204(self.gcode.create_gcode_command(
                 "M204", "M204", {"S": old_max_accel}))
-            toolhead.move([X + decel_X, Y + decel_Y] + tpos[2:], abs(last_v))
+            toolhead.move([X + decel_X, Y + decel_Y] + thpos[2:], abs(last_v))
         # Restore the original acceleration values
         self.gcode.run_script_from_command(
             "SET_VELOCITY_LIMIT ACCEL=%.3f MINIMUM_CRUISE_RATIO=%.3f"

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -127,7 +127,7 @@ class ResonanceTestExecutor:
     def run_test(self, test_seq, axis, gcmd):
         reactor = self.printer.get_reactor()
         toolhead = self.printer.lookup_object('toolhead')
-        tpos = toolhead.get_position()
+        thpos = toolhead.get_position()
         X, Y = thpos[:2]
         # Override maximum acceleration and acceleration to
         # deceleration based on the maximum test frequency

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -167,7 +167,8 @@ class ResonanceTestExecutor:
                 # The move first goes to a complete stop, then changes direction
                 d_decel = -last_v2 * half_inv_accel
                 decel_X, decel_Y = axis.get_point(d_decel)
-                toolhead.move([X + decel_X, Y + decel_Y] + thpos[2:], abs_last_v)
+                toolhead.move(
+                    [X + decel_X, Y + decel_Y] + thpos[2:], abs_last_v)
                 toolhead.move([nX, nY] + thpos[2:], abs_v)
             else:
                 toolhead.move([nX, nY] + thpos[2:], max(abs_v, abs_last_v))


### PR DESCRIPTION
This PR solves an issue introduced with 307c03e4804800ecf5833efe3aa097d91a7fa0e7 causing the `SHAPRE_CALIBRATE` command to fail with below error:

```
Testing axis x
ADXL345 starting 'adxl345' measurements
Internal error on command:"SHAPER_CALIBRATE"
Traceback (most recent call last):
  File "/home/biqu/klipper/klippy/gcode.py", line 212, in _process_commands
    handler(gcmd)
  File "/home/biqu/klipper/klippy/gcode.py", line 140, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biqu/klipper/klippy/extras/resonance_tester.py", line 373, in cmd_SHAPER_CALIBRATE
    calibration_data = self._run_test(gcmd, calibrate_axes, helper,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biqu/klipper/klippy/extras/resonance_tester.py", line 265, in _run_test
    self.executor.run_test(test_seq, axis, gcmd)
  File "/home/biqu/klipper/klippy/extras/resonance_tester.py", line 131, in run_test
    X, Y = thpos[:2]
           ^^^^^
NameError: name 'thpos' is not defined
Transition to shutdown state: Internal error on command:"SHAPER_CALIBRATE"
```

I renamed everything `thpos` to be consistent with [klippy/extras/homing.py](https://github.com/Klipper3d/klipper/blob/1af219fad6c2abda1eadbd4c48ad541110100f4c/klippy/extras/homing.py#L73)