### PR TITLE
Verify 'config' object isn't accessed after initial load

### DIFF
--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -286,6 +286,11 @@ The following may also be useful:
   during the `load_config()` or "connect event" phases. Use either
   `raise config.error("my error")` or `raise printer.config_error("my
   error")` to report the error.
+* Do not store a reference to the `config` object in a class member
+  variable (nor in any similar location that may persist past initial
+  module loading). The `config` object is a reference to a "config
+  loading phase" class and it is not valid to invoke its methods after
+  the "config loading phase" has completed.
 * Use the "pins" module to configure a pin on a micro-controller. This
   is typically done with something similar to
   `printer.lookup_object("pins").setup_pin("pwm",

--- a/klippy/extras/ads1x1x.py
+++ b/klippy/extras/ads1x1x.py
@@ -321,7 +321,6 @@ class ADS1X1X_pin:
     def __init__(self, chip, config):
         self.mcu = chip.mcu
         self.chip = chip
-        self.config = config
 
         self.invalid_count = 0
 

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -9,7 +9,6 @@ from . import probe
 
 class ScrewsTiltAdjust:
     def __init__(self, config):
-        self.config = config
         self.printer = config.get_printer()
         self.screws = []
         self.results = {}
@@ -33,7 +32,7 @@ class ScrewsTiltAdjust:
                                        default='CW-M3')
         # Initialize ProbePointsHelper
         points = [coord for coord, name in self.screws]
-        self.probe_helper = probe.ProbePointsHelper(self.config,
+        self.probe_helper = probe.ProbePointsHelper(config,
                                                     self.probe_finalize,
                                                     default_points=points)
         self.probe_helper.minimum_points(3)

--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -16,7 +16,6 @@ class ZThermalAdjuster:
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
         self.lock = threading.Lock()
-        self.config = config
 
         # Get config parameters, convert to SI units where necessary
         self.temp_coeff = config.getfloat('temp_coeff', minval=-1, maxval=1,


### PR DESCRIPTION
Update Code_Overview.md to note that the config object should not be stored after the "config loading phase".

Add a run-time check to verify the 'config' object isn't inadvertently accessed.

Remove a few inadvertent cases where a 'config' object was stored in module member variables.

-Kevin