### PR TITLE
dual_carriage: Fixed input shaper stepper kinematics initialization

### DIFF
--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -101,6 +101,10 @@ class InputShaper:
                                desc=self.cmd_SET_INPUT_SHAPER_help)
     def get_shapers(self):
         return self.shapers
+    def init_for_steppers(self, steppers):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        for s in steppers:
+            self._get_input_shaper_stepper_kinematics(s)
     def connect(self):
         self.toolhead = self.printer.lookup_object("toolhead")
         # Configure initial values


### PR DESCRIPTION
The IDEX refactoring for `generic_cartesian`  broke initialization order of input shaper and dual carriage stepper_kinematics, resulting in an incorrect input shaper stepper_kinematics initialization for `dual_carriage`. This PR fixes that, ensuring the correct initialization order (first, dual_carriage_stepper, then input_shaper, then selecting the carriages and changing their scaling multipliers).