### PR TITLE
LIS2DW: make it work when spi bus polarity is switching

### DIFF
--- a/klippy/extras/lis2dw.py
+++ b/klippy/extras/lis2dw.py
@@ -145,6 +145,9 @@ class LIS2DW:
                     "This is generally indicative of connection problems\n"
                     "(e.g. faulty wiring) or a faulty lis2dw chip."
                     % (dev_id, LIS2DW_DEV_ID))
+            if self.bus_type == SPI_SERIAL_TYPE:
+                # Disable I2C
+                self.set_reg(REG_LIS2DW_CTRL_REG2_ADDR, 0x06)
             # Setup chip in requested query rate
             # ODR/2, +-16g, low-pass filter, Low-noise abled
             self.set_reg(REG_LIS2DW_CTRL_REG6_ADDR, 0x34)

--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -10,6 +10,7 @@
 #include "internal.h" // pclock, gpio_peripheral
 #include "hardware/structs/spi.h" // spi_hw_t
 #include "hardware/regs/resets.h" // RESETS_RESET_SPI*_BITS
+#include "board/misc.h" // timer_is_before
 
 
 DECL_ENUMERATION("spi_bus", "spi0_gpio0_gpio3_gpio2", 0);
@@ -115,10 +116,16 @@ spi_prepare(struct spi_config config)
     spi_hw_t *spi = config.spi;
     if (spi->cr0 == config.cr0 && spi->cpsr == config.cpsr)
         return;
+    uint32_t diff = spi->cr0 ^ config.cr0;
     spi->cr1 = 0;
     spi->cr0 = config.cr0;
     spi->cpsr = config.cpsr;
     spi->cr1 = SPI_SSPCR1_SSE_BITS;
+    // Give time for state to update before caller changes CS pin
+    uint32_t end = timer_read_time() + timer_from_us(1);
+    if (diff & SPI_SSPCR0_SPO_BITS)
+        while (timer_is_before(timer_read_time(), end))
+            ;
 }
 
 void

--- a/src/spi_software.c
+++ b/src/spi_software.c
@@ -40,17 +40,20 @@ DECL_COMMAND(command_spi_set_sw_bus,
              "spi_set_sw_bus oid=%c miso_pin=%u mosi_pin=%u sclk_pin=%u"
              " mode=%u pulse_ticks=%u");
 
-void
-spi_software_prepare(struct spi_software *ss)
-{
-    gpio_out_write(ss->sclk, ss->mode & 0x02);
-}
-
 static void
 spi_delay(uint32_t end)
 {
     while (timer_is_before(timer_read_time(), end));
 }
+
+void
+spi_software_prepare(struct spi_software *ss)
+{
+    gpio_out_write(ss->sclk, ss->mode & 0x02);
+    uint32_t end = timer_read_time() + ss->sck_ticks;
+    spi_delay(end);
+}
+
 
 void
 spi_software_transfer(struct spi_software *ss, uint8_t receive_data


### PR DESCRIPTION
For some unknown reason, LIS2DW refuses to work if the time between the SCK polarity change and CS goes down is too short.
This problem is at least specific to RP2040 + LIS2DW boards, like: Fly SHT36v3, BTT LIS2DW.
The problem worsens if there are other devices on the bus with different SCK polarity, ex. MAX31865.

Possible workarounds and outcomes:
- Double reading of chip_id. It hides the issue if the second read arrives fast enough.
- Disable the I2C mode support if it is connected by SPI. Does not help.
- MAX31865 actually has support for mode 3. So, simply switching it on, makes everything work.

It seems that introducing a delay between the SCK polarity change and the CS toggle fixes the issue.
Because this problem happens if the time is too short, it is only implemented for RP2040 and STM32H7, because they are known to be fast enough and probably could trigger it.

Ref: [Discourse topic](https://klipper.discourse.group/t/lis2dw-on-mellow-sht36-v3-invalid-lis2dw-id/23490)

RP2040 SPI SW: tested MAX31865 + LIS2DW
RP2040 SPI HW: tested MAX31865 + LIS2DW
STM32H7 SPI HW: tested MAX31865 + TMC

Thanks.