### PR TITLE
rp2040: spi - enable fifo

### DIFF
--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -125,11 +125,15 @@ void
 spi_transfer(struct spi_config config, uint8_t receive_data,
              uint8_t len, uint8_t *data)
 {
+    uint8_t* wptr = data;
+    uint8_t* end = data + len;
     spi_hw_t *spi = config.spi;
-    while (len--) {
-        spi->dr = *data;
-        while (!(spi->sr & SPI_SSPSR_RNE_BITS))
-            ;
+    while (data < end) {
+        uint32_t sr = spi->sr & (SPI_SSPSR_TNF_BITS | SPI_SSPSR_RNE_BITS);
+        if ((sr == SPI_SSPSR_TNF_BITS) && wptr < end)
+            spi->dr = *wptr++;
+        if (!(sr & SPI_SSPSR_RNE_BITS))
+            continue;
         uint8_t rdata = spi->dr;
         if(receive_data)
             *data = rdata;


### PR DESCRIPTION
RP2040 seems to have a similar to H7 #6937, [ARM unit underneath](https://developer.arm.com/documentation/ddi0194/h/introduction/about-the-arm-primecell-ssp--pl022-/features-of-the-primecell-ssp)
The code is "identical".

Now we have probably fixed the LIS2DW on RP2040, and I can at least somehow test those changes on a real board.
They seem to work, but provide zero performance benefit in my limited testing.
_Probably because there is no other load on the board, aside from MAX31865/LIS2DW._

I would suggest to merge it after #6944, maybe with some time gap.

Ref: #6936

Thanks.