### PR TITLE
Fix for filament statistics bug  in print_stats.py for toolchangers

### DIFF
--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 
 class PrintStats:
     def __init__(self, config):
@@ -15,6 +16,11 @@ class PrintStats:
         self.gcode.register_command(
             "SET_PRINT_STATS_INFO", self.cmd_SET_PRINT_STATS_INFO,
             desc=self.cmd_SET_PRINT_STATS_INFO_help)
+        printer.register_event_handler("extruder:activate_extruder",
+                                       self._handle_activate_extruder)
+    def _handle_activate_extruder(self):
+        gc_status = self.gcode_move.get_status()
+        self.last_epos = gc_status['position'].e
     def _update_filament_usage(self, eventtime):
         gc_status = self.gcode_move.get_status(eventtime)
         cur_epos = gc_status['position'].e

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
+ 
 class PrintStats:
     def __init__(self, config):
         printer = config.get_printer()

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
- 
+
 class PrintStats:
     def __init__(self, config):
         printer = config.get_printer()

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2020  Eric Callahan <arksine.code@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
 
 class PrintStats:
     def __init__(self, config):


### PR DESCRIPTION
I found a bug that whenever the toolhead is changed the statistics for used filament and print time were incorrect. The filament usage was calculated from the difference of self.last_epos and the gc_status['position'].e. Whenever the toolhead changes self.last_epos was still related to the previous one and the difference could be negative and therefor the statistics would be off.
Here is an excerpt from the klippy.log with my temporary debug output
Before fix:
I.Do get_status: print=19 total=176 init=156 paused=0 fil.used=20.309000
I.Do get_status: print=19 total=176 init=156 paused=0 fil.used=20.309000
Activating extruder extruder
I.Do get_status: **print=0** total=176 init=176 paused=0 **fil.used=0.000000** <<< filament use copied from other toolhead
I.Do get_status: print=0 total=177 init=177 paused=0 fil.used=0.000000
I.Do get_status: print=0 total=177 init=177 paused=0 fil.used=0.000000

After:
I.Do get_status: print=502 total=796 init=293 paused=0 fil.used=830.960900 
I.Do get_status: print=502 total=796 init=293 paused=0 fil.used=830.960900 
I.Do get_status: print=502 total=796 init=293 paused=0 fil.used=830.960900 
I.Do get_status: print=503 total=797 init=293 paused=0 fil.used=830.960900 
Activating extruder extruder 
I.Do PrintStats:activate_extruder: last_epos=560
I.Do get_status: **print=503** total=797 init=293 paused=0 **fil.used=830.960900** <<< filament use continues correctly
I.Do get_status: print=503 total=797 init=293 paused=0 fil.used=830.960900

Mainsail now shows correct filament usage!

The fix is to hook into the 'extruder:activate_extruder' event and reset the last_epos value in there