### PR TITLE
feat(elf2uf2): Added RP2350 MCU support

### DIFF
--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -49,7 +49,7 @@ $(OUT)lib/elf2uf2/elf2uf2: lib/elf2uf2/main.cpp
 
 $(OUT)klipper.uf2: $(OUT)klipper.elf $(OUT)lib/elf2uf2/elf2uf2
 	@echo "  Creating uf2 file $@"
-	$(Q)$(OUT)lib/elf2uf2/elf2uf2 $< $@
+	$(Q)$(OUT)lib/elf2uf2/elf2uf2 --mcu $(MCU) $< $@
 
 rptarget-y := $(OUT)klipper.uf2
 stage2-$(CONFIG_RP2040_HAVE_STAGE2) := $(OUT)stage2.o


### PR DESCRIPTION
The test found that the current rp2350 firmware compiled by klipper cannot drag and drop the uf2 file to the removable disk for flash.
It seems that the rp2350 bootloader checks the firmware's family_id, and will not flash if it does not match.
This modification will pass the mcu model to elf2uf2 to set the family_id of RP2040 or RP2350.
In the future, you can abandon the existing elf2uf2 program (because it is also officially abandoned) and use the official RPI picotool instead.

Signed-off-by: Xiaokui Zhao <xiaok@zxkxzk.cn>