### PR TITLE
Support canbus on stm32h7 PB5/PB6 wires

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -463,7 +463,7 @@ choice
         select CANSERIAL
     config STM32_MMENU_CANBUS_PB5_PB6
         bool "CAN bus (on PB5/PB6)" if LOW_LEVEL_OPTIONS
-        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS)
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || MACH_STM32H7
         select CANSERIAL
     config STM32_MMENU_CANBUS_PB12_PB13
         bool "CAN bus (on PB12/PB13)" if LOW_LEVEL_OPTIONS
@@ -503,7 +503,7 @@ choice
         depends on (MACH_STM32F4 && HAVE_STM32_CANBUS)
     config STM32_CMENU_CANBUS_PB5_PB6
         bool "CAN bus (on PB5/PB6)"
-        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || MACH_STM32G0B1
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || MACH_STM32H7 || MACH_STM32G0B1
     config STM32_CMENU_CANBUS_PB12_PB13
         bool "CAN bus (on PB12/PB13)"
         depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || HAVE_STM32_FDCANBUS

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -447,7 +447,7 @@ choice
         select CANSERIAL
     config STM32_CANBUS_PA11_PA12_REMAP
         bool "CAN bus (on PA9/PA10)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS && (MACH_STM32F042 || MACH_STM32F070x6)
+        depends on MACH_STM32F042
         select CANSERIAL
     config STM32_CANBUS_PA11_PB9
         bool "CAN bus (on PA11/PB9)"
@@ -459,15 +459,15 @@ choice
         select CANSERIAL
     config STM32_MMENU_CANBUS_PI9_PH13
         bool "CAN bus (on PI9/PH13)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS && MACH_STM32F4
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS)
         select CANSERIAL
     config STM32_MMENU_CANBUS_PB5_PB6
         bool "CAN bus (on PB5/PB6)" if LOW_LEVEL_OPTIONS
-        depends on HAVE_STM32_CANBUS && MACH_STM32F4
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS)
         select CANSERIAL
     config STM32_MMENU_CANBUS_PB12_PB13
         bool "CAN bus (on PB12/PB13)" if LOW_LEVEL_OPTIONS
-        depends on (HAVE_STM32_CANBUS && MACH_STM32F4) || HAVE_STM32_FDCANBUS
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || HAVE_STM32_FDCANBUS
         select CANSERIAL
     config STM32_MMENU_CANBUS_PD0_PD1
         bool "CAN bus (on PD0/PD1)" if LOW_LEVEL_OPTIONS
@@ -500,13 +500,13 @@ choice
         bool "CAN bus (on PB8/PB9)"
     config STM32_CMENU_CANBUS_PI9_PH13
         bool "CAN bus (on PI9/PH13)"
-        depends on HAVE_STM32_CANBUS && MACH_STM32F4
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS)
     config STM32_CMENU_CANBUS_PB5_PB6
         bool "CAN bus (on PB5/PB6)"
-        depends on (HAVE_STM32_CANBUS && MACH_STM32F4) || (HAVE_STM32_FDCANBUS && MACH_STM32G0B1)
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || MACH_STM32G0B1
     config STM32_CMENU_CANBUS_PB12_PB13
         bool "CAN bus (on PB12/PB13)"
-        depends on (HAVE_STM32_CANBUS && MACH_STM32F4) || HAVE_STM32_FDCANBUS
+        depends on (MACH_STM32F4 && HAVE_STM32_CANBUS) || HAVE_STM32_FDCANBUS
     config STM32_CMENU_CANBUS_PD0_PD1
         bool "CAN bus (on PD0/PD1)"
         depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS

--- a/src/stm32/stm32h7.c
+++ b/src/stm32/stm32h7.c
@@ -49,6 +49,10 @@ lookup_clock_line(uint32_t periph_base)
         uint32_t bit = 1 << ((periph_base - D2_APB2PERIPH_BASE) / 0x400);
         return (struct cline){.en=&RCC->APB2ENR, .rst=&RCC->APB2RSTR, .bit=bit};
     } else {
+        if (periph_base == FDCAN2_BASE)
+            // FDCAN1 and FDCAN2 share same clock enable
+            return (struct cline){.en=&RCC->APB1HENR, .rst=&RCC->APB1HRSTR,
+                                  .bit = RCC_APB1HENR_FDCANEN};
         uint32_t offset = ((periph_base - D2_APB1PERIPH_BASE) / 0x400);
         if (offset < 32) {
             uint32_t bit = 1 << offset;


### PR DESCRIPTION
Reported by JNP.

-Kevin
