### PR TITLE
Gh pages cleanups

### DIFF
--- a/docs/_klipper3d/build-translations.sh
+++ b/docs/_klipper3d/build-translations.sh
@@ -82,3 +82,6 @@ while IFS="," read dirname langsite langdesc langsearch; do
   ln -sf "${PWD}/site/${langsite}/" "${WORK_DIR}lang/${langsite}/site"
   mkdocs build -f "${new_mkdocs_file}"
 done < <(egrep -v '^ *(#|$)' ${TRANS_FILE})
+
+# Avoid push of pycache
+find "${PWD}/site/" -type f -name "*.pyc" -delete

--- a/docs/_klipper3d/build-translations.sh
+++ b/docs/_klipper3d/build-translations.sh
@@ -85,3 +85,10 @@ done < <(egrep -v '^ *(#|$)' ${TRANS_FILE})
 
 # Avoid push of pycache
 find "${PWD}/site/" -type f -name "*.pyc" -delete
+
+LAST_MODIFIED=$(git log -1 origin/master --format="%cs")
+CDATE=$(date +%Y-%m-%d)
+# Stabilize sitemap.xml dates
+for f in $(find "${PWD}/site/" -name "sitemap.xml"); do
+  sed -i "s/${CDATE}/${LAST_MODIFIED}/g" ${f}
+done

--- a/docs/_klipper3d/mkdocs.yml
+++ b/docs/_klipper3d/mkdocs.yml
@@ -4,6 +4,7 @@
 # layout.  See that script and the README file for more details.
 
 # Site and directory configuration
+site_url: https://www.klipper3d.org
 site_name: Klipper documentation
 repo_url: https://github.com/Klipper3d/klipper
 repo_name: Klipper3d/klipper


### PR DESCRIPTION
Every day, CI rebuilds gh-pages with no actual changes in it.
So, I tried to make it slightly conservative.
1. Do not push or store pycache in gh-pages
2. Fix site map URLs
```
    <url>
         <loc>https://www.klipper3d.org/index.html</loc>
         <lastmod>2025-05-29</lastmod>
         <changefreq>daily</changefreq>
    </url>
```
3. Avoid unnecessary date updates. `lastmod` is stable now.

I'm not sure it would make the stable sitemap.xml.gz, because afaik, gzip has a file timestamp in the format.
Possibly it could be either worked around by recompressing with `gzip -n` (didn't test that) or by simply removing of sitemap.xml.gz in the output directory.

Thanks.