### PR TITLE
rp2040: Fix spi overflow issue

### DIFF
--- a/src/rp2040/spi.c
+++ b/src/rp2040/spi.c
@@ -128,22 +128,27 @@ spi_prepare(struct spi_config config)
             ;
 }
 
+#define MAX_FIFO 8 // Max rx fifo size (don't tx past this size)
+
 void
 spi_transfer(struct spi_config config, uint8_t receive_data,
              uint8_t len, uint8_t *data)
 {
-    uint8_t* wptr = data;
-    uint8_t* end = data + len;
+    uint8_t *wptr = data, *end = data + len;
     spi_hw_t *spi = config.spi;
     while (data < end) {
         uint32_t sr = spi->sr & (SPI_SSPSR_TNF_BITS | SPI_SSPSR_RNE_BITS);
-        if ((sr == SPI_SSPSR_TNF_BITS) && wptr < end)
+        if (sr == SPI_SSPSR_TNF_BITS && wptr < end && wptr < data + MAX_FIFO)
             spi->dr = *wptr++;
         if (!(sr & SPI_SSPSR_RNE_BITS))
             continue;
         uint8_t rdata = spi->dr;
-        if(receive_data)
+        if (receive_data)
             *data = rdata;
         data++;
     }
+    // Wait for any remaining SCLK updates before returning
+    while ((spi->sr & (SPI_SSPSR_TFE_BITS|SPI_SSPSR_BSY_BITS))
+           != SPI_SSPSR_TFE_BITS)
+        ;
 }


### PR DESCRIPTION
Completely filling the spi transmit fifo could lead to a situation where the rx fifo overflows.  Reduce the fifo usage to avoid this.

Also, be sure to wait for the transmission to fully complete before exiting spi_transfer().

Discussed at https://github.com/Klipper3d/klipper/pull/6945#issuecomment-2923350748

@nefelim4ag - fyi.

-Kevin
