### PR TITLE
tmc: allow spi pipeline register reads

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -450,8 +450,9 @@ class TMCCommandHelper:
                 if reg_name not in self.read_registers:
                     gcmd.respond_info(self.fields.pretty_format(reg_name, val))
             gcmd.respond_info("========== Queried registers ==========")
-            for reg_name in self.read_registers:
-                val = self.mcu_tmc.get_register(reg_name)
+            reg_kv = self.mcu_tmc.get_registers(*self.read_registers)
+            for reg_name in reg_kv:
+                val = reg_kv[reg_name]
                 if self.read_translate is not None:
                     reg_name, val = self.read_translate(reg_name, val)
                 gcmd.respond_info(self.fields.pretty_format(reg_name, val))

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -198,6 +198,11 @@ class MCU_TMC2660_SPI:
         self.fields = fields
     def get_fields(self):
         return self.fields
+    def get_registers(self, *reg_names):
+        ret = {}
+        for reg_name in reg_names:
+            ret[reg_name] = self.get_register(reg_name)
+        return ret
     def get_register(self, reg_name):
         new_rdsel = ReadRegisters.index(reg_name)
         reg = self.name_to_reg["DRVCONF"]

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -232,6 +232,11 @@ class MCU_TMC_uart:
                 return val
         raise self.printer.command_error(
             "Unable to read tmc uart '%s' register %s" % (self.name, reg_name))
+    def get_registers(self, *reg_names):
+        ret = {}
+        for reg_name in reg_names:
+            ret[reg_name] = self.get_register(reg_name)
+        return ret
     def get_register(self, reg_name):
         with self.mutex:
             return self._do_get_register(reg_name)


### PR DESCRIPTION
Because of the TMC-specific SPI implementation, TMC returns the result of the previous command in the next one.
So, right now, to do RW, we always do the 2 reads or read + write.

There are cases, like register dump, where we do read several registers.
It could be optimized by utilizing that specific, so we read the previous one and ask for the next one.

_I initially got to that idea because, technically, sensorless homing, stall guard monitoring, TMCErrorCheck could utilize multiple register reads. But I hope it could be useful on its own.

Not like we have a lack of SPI speed, but those technically decrease the amount of data transfer for reads by x0.5 + 1.
So, for example full dump on the TMC2240, where there are 24 read registers.
It went from `24 * 40 * 2 = 1920 bytes`, to the  `(24 + 1) * 40 = 1000 bytes`.

Thanks.