### PR TITLE
load_cell_probe: Miscellaneous documentation fixes

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5027,7 +5027,7 @@ sensor_type:
 #   This value is calculated by the LOAD_CELL_CALIBRATE command.
 #reference_tare_counts:
 #   The integer tare value, in raw sensor counts, taken when LOAD_CELL_CALIBRATE
-#   is run. This is the default tare value when klipper starts up.
+#   is run. This is the default tare value when Klipper starts up.
 #sensor_orientation:
 #   Change the sensor's orientation. Can be either 'normal' or 'inverted'.
 #   The default is 'normal'. Use 'inverted' if the sensor reports a
@@ -5156,10 +5156,10 @@ sensor_type:
 #   is 2.
 #buzz_filter_cutoff_frequency: 100.0
 #   The value is a frequency, in Hz, above which high frequency noise in the
-#   load cell will be igfiltered outnored. This option requires the SciPy
-#   library. Default: None
+#   load cell will be filtered out. This option requires the SciPy library.
+#   Default: None
 #buzz_filter_delay: 2
-#   The delay, or 'order', of the buzz filter. This controle the number of
+#   The delay, or 'order', of the buzz filter. This controls the number of
 #   samples required to make a trigger detection. Can be 1 or 2, the default
 #   is 2.
 #notch_filter_frequencies: 50, 60

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5134,8 +5134,8 @@ Load Cell Probe. This combines the functionality of a [probe] and a [load_cell].
 ```
 [load_cell_probe]
 sensor_type:
-#   This must be one of the supported bulk ADC sensor types and support
-#   load cell endstops on the mcu.
+#   This must be one of the bulk ADC sensor types that support probing on the
+#   MCU.
 #counts_per_gram:
 #reference_tare_counts:
 #sensor_orientation:
@@ -5147,9 +5147,9 @@ sensor_type:
 #trigger_force: 75.0
 #   The force that the probe will trigger at. 75g is the default.
 #drift_filter_cutoff_frequency: 0.8
-#   Enable optional continuous taring while homing & probing to reject drift.
-#   The value is a frequency, in Hz, below which drift will be ignored. This
-#   option requires the SciPy library. Default: None
+#   Enable optional continuous taring while probing to reject drift. The value
+#   is a frequency, in Hz, below which drift will be ignored. This option
+#   requires the SciPy library. Default: None
 #drift_filter_delay: 2
 #   The delay, or 'order', of the drift filter. This controls the number of
 #   samples required to make a trigger detection. Can be 1 or 2, the default

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -14,7 +14,7 @@ A calibrated force sensor is an important part of a load cell based probe.
 
 When you first connect a load cell its good practice to check for issues by
 running `LOAD_CELL_DIAGNOSTIC`. This tool collects 10 seconds of data from the
-load cell and resport statistics:
+load cell and reports statistics:
 
 ```
 $ LOAD_CELL_DIAGNOSTIC
@@ -131,7 +131,7 @@ a macro:
 
 * [load_cell_probe Config Reference](Config_Reference.md#load_cell_probe)
 * [load_cell_probe G-Code Commands](G-Codes.md#load_cell_probe)
-* [load_cell_probe Statuc Reference](Status_Reference.md#load_cell_probe)
+* [load_cell_probe Status Reference](Status_Reference.md#load_cell_probe)
 
 ## Load Cell Probe Safety
 
@@ -185,11 +185,11 @@ in force applied to the toolhead at the end of a probing cycle. Because
 external forces can vary greatly between probing locations,
 `load_cell_probe` performs a tare before beginning each probe. If you repeat
 the `PROBE` command, load_cell_probe will tare the endstop at the current force.
-Multiple cycles of this will result in ever-increasing force on the toolhead.
+Multiple cycles of this will result in ever increasing force on the toolhead.
 `force_safety_limit` stops this cycle from running out of control.
 
-Another way this run-away can happen is damage to a strain gauge. If the metal
-part is permanently bent it wil change the `reference_tare_counts` of the
+Another way this run away can happen is damage to a strain gauge. If the metal
+part is permanently bent it will change the `reference_tare_counts` of the
 device. This puts the starting tare value much closer to the limit making it
 more likely to be violated. You want to be notified if this is happening
 because your hardware has been permanently damaged.
@@ -200,7 +200,7 @@ at ambient temperature vs operating temperature. In this case you may need
 to increase the `force_safety_limit` to allow for thermal changes.
 
 #### Load Cell Endstop Watchdog Task
-When homing the load_cell_endstop starts a task on the MCU to trac
+When homing the load_cell_endstop starts a task on the MCU to track
 measurements arriving from the sensor. If the sensor fails to send
 measurements for 2 sample periods the watchdog will shut down the printer
 with an error `!! LoadCell Endstop timed out waiting on ADC data`.
@@ -241,7 +241,7 @@ commands. Use `LOAD_CELL_TEST_TAP` for testing functionality before probing.
 ### Homing Macros
 
 Load cell probe is not an endstop and doesn't support `endstop:
-prove:z_virtual_endstop`. For the time being you'll need to configure your z
+probe:z_virtual_endstop`. For the time being you'll need to configure your z
 axis with an MCU pin as its endstop. You won't actually be using the pin but
 for the time being you have to configure something.
 
@@ -301,12 +301,11 @@ way to detect poor quality taps due to filament ooze. The existing code may
 decide that a tap is valid when it is of poor quality. Classifying these poor
 quality taps is an area of active research.
 
-Klipper also lacks support for re-locating a probe point if the
-location has become fouled by filament ooze. Modules like `quad_gantry_level`
-will repeatedly probe the same coordinates even if a probe previously failed
-there.
+Klipper also lacks support for relocating a probe point if the location has
+become fouled by filament ooze. Modules like `quad_gantry_level` will
+repeatedly probe the same coordinates even if a probe previously failed there.
 
-Give the above it is strongly suggested not to probe at printing temperatures.
+Given the above it is strongly suggested not to probe at printing temperatures.
 
 ### Hot Nozzle Protection
 
@@ -373,7 +372,7 @@ max_z_adjustment: 0.1
 ## Continuous Tare Filters for Toolhead Load Cells
 
 Klipper implements a configurable IIR filter on the MCU to provide continuous
-tareing of the load cell while probing. Continuous taring means the 0 value
+taring of the load cell while probing. Continuous taring means the 0 value
 moves with drift caused by external factors like bowden tubes and thermal
 changes. This is aimed at toolhead sensors and moving beds that experience lots
 of external forces that change while probing.
@@ -383,7 +382,7 @@ of external forces that change while probing.
 The filtering code uses the excellent [SciPy](https://scipy.org/) library to
 compute the filter coefficients based on the values your enter into the config.
 
-Pre-compiled SciPi builds are available for Python 3 on 32 bit Raspberry Pi
+Pre-compiled SciPy builds are available for Python 3 on 32 bit Raspberry Pi
 systems. 32 bit + Python 3 is strongly recommended because it will streamline
 your installation experience. It does work with Python 2 but installation can
 take 30+ minutes and require installing additional tools.
@@ -426,9 +425,9 @@ Ideally a sensor would meet these criteria:
 
 * At least 24 bits wide
 * Use SPI communications
-* Has a pin can be used to indicate sample ready without SPI communications.
-  This is often called the "data ready" or "DRDY" pin. Checking a pin is much
-  faster than running an SPI query.
+* Has a pin that can be used to indicate sample ready without SPI
+  communications. This is often called the "data ready" or "DRDY" pin. Checking
+  a pin is much faster than running an SPI query.
 * Has a programmable gain amplifier gain setting of 128. This should eliminate
   the need for a separate amplifier.
 * Indicates via SPI if the sensor has been reset. Detecting resets avoids
@@ -475,7 +474,7 @@ should have proper grounding back to the DC supply.
 This sensor is popular because of its low cost and availability in the
 supply chain. However, this is a sensor with some drawbacks:
 
-* The HX71x sensors use bit-bang communication which has a high overhead on the
+* The HX71x sensors use bitbang communication which has a high overhead on the
   MCU. Using a sensor that communicates via SPI would save resources on the tool
   board's CPU.
 * The HX71x lacks a way to communicate reset events to the MCU. Klipper detects
@@ -486,4 +485,4 @@ supply chain. However, this is a sensor with some drawbacks:
   limited to less than 2mm/s.
 * The sample rate on the HX71x cannot be set from klipper's config. If you have
   the 10SPS version of the sensor (which is widely distributed) it needs to
-  be physically re-wired to run at 80SPS.
+  be physically rewired to run at 80SPS.


### PR DESCRIPTION
I've split this up into two commits, one to fix simple spelling mistakes and typos, and another to make more invasive edits. These fixes are mostly related to documentation not being updated as #6871 changed to to exclude endstop support.

 * Remove references to "endstop" where appropriate
 * Replace "load_cell_endstop" with "load_cell_probe"
 * Remove references to "homing" where appropriate
 * SciPy installs from wheels on 64bit aarch64 Linux
 * Update error messages in docs for newer versions
 * Update G-Code command names for newer versions