### PR TITLE
stm32f04x: fix the user code cannot jump to DFU

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -278,6 +278,10 @@ config STM32_DFU_ROM_ADDRESS
     default 0x1ff09800 if MACH_STM32H7
     default 0
 
+config STM32_DFU_REQUIRE_ERASE_BOOT_ADDRESS
+    bool
+    default y if MACH_STM32F042
+    default n
 
 ######################################################################
 # Bootloader

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -89,6 +89,7 @@ src-$(CONFIG_USBCANBUS) += $(usb-src-y) $(canbus-src-y)
 src-$(CONFIG_USBCANBUS) += stm32/chipid.c generic/usb_canbus.c
 src-$(CONFIG_WANT_HARD_PWM) += stm32/hard_pwm.c
 src-$(CONFIG_HAVE_GPIO_SDIO) += stm32/sdio.c
+src-$(CONFIG_STM32_DFU_REQUIRE_ERASE_BOOT_ADDRESS) += stm32/flash.c
 
 # Binary output file rules
 target-y += $(OUT)klipper.bin

--- a/src/stm32/dfu_reboot.c
+++ b/src/stm32/dfu_reboot.c
@@ -6,6 +6,7 @@
 
 #include "internal.h" // NVIC_SystemReset
 #include "board/irq.h" // irq_disable
+#include "flash.h" // flash_erase_page
 
 // Many stm32 chips have a USB capable "DFU bootloader" in their ROM.
 // In order to invoke that bootloader it is necessary to reset the
@@ -51,6 +52,9 @@ dfu_reboot_check(void)
     if (*(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
         return;
     *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
+#if CONFIG_STM32_DFU_REQUIRE_ERASE_BOOT_ADDRESS
+    flash_erase_page(CONFIG_FLASH_BOOT_ADDRESS);
+#endif
     uint32_t *sysbase = (uint32_t*)CONFIG_STM32_DFU_ROM_ADDRESS;
     asm volatile("mov sp, %0\n bx %1"
                  : : "r"(sysbase[0]), "r"(sysbase[1]));

--- a/src/stm32/dfu_reboot.c
+++ b/src/stm32/dfu_reboot.c
@@ -53,7 +53,12 @@ dfu_reboot_check(void)
         return;
     *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
 #if CONFIG_STM32_DFU_REQUIRE_ERASE_BOOT_ADDRESS
-    flash_erase_page(CONFIG_FLASH_BOOT_ADDRESS);
+    #if !CONFIG_ARMCM_RAM_VECTORTABLE
+        flash_erase_page(CONFIG_FLASH_BOOT_ADDRESS);
+    #else
+        #warning "We cann't jump directly from klipper to system bootloader\
+ if there is a bootloader in the MCU"
+    #endif
 #endif
     uint32_t *sysbase = (uint32_t*)CONFIG_STM32_DFU_ROM_ADDRESS;
     asm volatile("mov sp, %0\n bx %1"

--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -1,0 +1,101 @@
+// Flash (IAP) functionality for STM32
+//
+// Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // memset
+#include "autoconf.h" // CONFIG_MACH_STM32F103
+#include "board/io.h" // writew
+#include "flash.h" // flash_write_block
+#include "internal.h" // FLASH
+
+// Some chips have slightly different register names
+#if CONFIG_MACH_STM32G0
+#define FLASH_SR_BSY (FLASH_SR_BSY1 | FLASH_SR_BSY2)
+#elif CONFIG_MACH_STM32H7
+#define CR CR1
+#define SR SR1
+#define KEYR KEYR1
+#endif
+
+// Wait for flash hardware to report ready
+static void
+wait_flash(void)
+{
+    while (FLASH->SR & FLASH_SR_BSY)
+        ;
+}
+
+#ifndef FLASH_KEY1 // Some stm32 headers don't define this
+#define FLASH_KEY1 (0x45670123UL)
+#define FLASH_KEY2 (0xCDEF89ABUL)
+#endif
+
+// Issue low-level flash hardware unlock sequence
+static void
+unlock_flash(void)
+{
+    if (FLASH->CR & FLASH_CR_LOCK) {
+        // Unlock Flash Erase
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+    wait_flash();
+}
+
+// Place low-level flash hardware into a locked state
+static void
+lock_flash(void)
+{
+    FLASH->CR = FLASH_CR_LOCK;
+}
+
+// Issue a low-level flash hardware erase request for a flash page
+static void
+erase_page(uint32_t page_address)
+{
+#if CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
+    uint32_t sidx;
+    if (page_address < 0x08010000)
+        sidx = (page_address - 0x08000000) / (16 * 1024);
+    else if (page_address < 0x08020000)
+        sidx = 4;
+    else
+        sidx = 5 + (page_address - 0x08020000) / (128 * 1024);
+    sidx = sidx > 0x0f ? 0x0f : sidx;
+    FLASH->CR = (FLASH_CR_PSIZE_1 | FLASH_CR_STRT | FLASH_CR_SER
+                 | (sidx << FLASH_CR_SNB_Pos));
+#elif CONFIG_MACH_STM32F0 || CONFIG_MACH_STM32F1
+    FLASH->CR = FLASH_CR_PER;
+    FLASH->AR = page_address;
+    FLASH->CR = FLASH_CR_PER | FLASH_CR_STRT;
+#elif CONFIG_MACH_STM32G0 || CONFIG_MACH_STM32G4
+    uint32_t pidx = (page_address - 0x08000000) / (2 * 1024);
+    if (pidx >= 64) {
+        uint16_t *flash_size = (void*)FLASHSIZE_BASE;
+        if (*flash_size <= 256)
+            pidx = pidx + 256 - 64;
+        else
+            pidx = pidx < 128 ? pidx : pidx + 256 - 128;
+    }
+    pidx = pidx > 0x3ff ? 0x3ff : pidx;
+    FLASH->CR = FLASH_CR_PER | FLASH_CR_STRT | (pidx << FLASH_CR_PNB_Pos);
+#elif CONFIG_MACH_STM32H7
+    uint32_t snb = (page_address - 0x08000000) / (128 * 1024);
+    snb = snb > 7 ? 7 : snb;
+    FLASH->CR = FLASH_CR_SER | FLASH_CR_START | (snb << FLASH_CR_SNB_Pos);
+    while (FLASH->SR & FLASH_SR_QW)
+        ;
+    SCB_InvalidateDCache_by_Addr((void*)page_address, 128*1024);
+#endif
+    wait_flash();
+}
+
+void
+flash_erase_page(uint32_t page_address)
+{
+    unlock_flash();
+    erase_page(page_address);
+    lock_flash();
+}

--- a/src/stm32/flash.h
+++ b/src/stm32/flash.h
@@ -1,0 +1,8 @@
+#ifndef __STM32_FLASH_H
+#define __STM32_FLASH_H
+
+#include <stdint.h>
+
+void flash_erase_page(uint32_t page_address);
+
+#endif


### PR DESCRIPTION
According to [AN2606.pdf](https://www.st.com/resource/en/application_note/an2606-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf) page 81:
```
Note: Due to empty check mechanism present on these products, it is not possible to jump from
user code to system bootloader. Such jump results in a jump back to user flash memory
space. If the first four bytes of User flash (at 0x0800 0000) are empty at the moment of jump
(i.e. erase first sector before jump or execute code from SRAM while flash is empty), then
system bootloader is executed when jumped to.
```
So on `STM32F04xxx` devices, it is not possible to directly jump from user code to system bootloader, unless we erase the flash 0x08000000 before jumping.

This PR implements erasing flash before jumping to system bootloader on  `STM32F04xxx` devices, And I have tested that it meets expectations. According to AN2606, It should also be applied to `STM32F070x6` and `STM32L01xxx/02xxx` devices, but since I do not have the conditions for actual testing, and erasing flash is a very cautious thing, so I only enabled it on `STM32F04xxx` devices here.

The API for erasing flash was copied from [katapult](https://github.com/Arksine/katapult/blob/master/src/stm32/flash.c)