### PR TITLE
input_shaper: fix printer obj reference

### DIFF
--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -111,7 +111,7 @@ class InputShaper:
         if dual_carriage is not None:
             for shaper in self.shapers:
                 if shaper.is_enabled():
-                    raise printer.config_error(
+                    raise self.printer.config_error(
                             'Input shaper parameters cannot be configured via'
                             ' [input_shaper] section with dual_carriage(s) '
                             ' enabled. Refer to Klipper documentation on how '


### PR DESCRIPTION
Just missing `self`.