### PR TITLE
[stm32f1] More robust workaround for I2C errata

### DIFF
--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -60,6 +60,10 @@ void i2c_shutdown_on_err(int ret)
         shutdown("I2C START READ NACK");
     case I2C_BUS_TIMEOUT:
         shutdown("I2C Timeout");
+    case I2C_BUS_BUSY:
+        shutdown("I2C BUS BUSY");
+    case I2C_BUS_ERR:
+        shutdown("I2C BUS ERR");
     }
 }
 

--- a/src/i2ccmds.h
+++ b/src/i2ccmds.h
@@ -11,6 +11,8 @@ enum {
     I2C_BUS_TIMEOUT,
     I2C_BUS_START_NACK,
     I2C_BUS_START_READ_NACK,
+    I2C_BUS_BUSY,
+    I2C_BUS_ERR,
 };
 
 struct i2cdev_s {

--- a/src/stm32/i2c.c
+++ b/src/stm32/i2c.c
@@ -13,6 +13,12 @@
 #include "board/irq.h" //irq_disable
 #include "i2ccmds.h"   // I2C_BUS_SUCCESS
 
+// The timeout for read/write transactions
+#define I2C_TIMEOUT_US 5000
+// What portion of the timeout to reserve at the start of a transaction
+// in case we need to kick-start I2C in some way.
+#define I2C_TIMEOUT_START_ERRATA_US 1000
+
 struct i2c_info {
     I2C_TypeDef *i2c;
     uint8_t scl_pin, sda_pin;
@@ -51,18 +57,73 @@ static const struct i2c_info i2c_bus[] = {
 #endif
 };
 
-// Work around stm32 errata causing busy bit to be stuck
 static void
-i2c_busy_errata(uint8_t scl_pin, uint8_t sda_pin)
+i2c_us_delay(uint32_t us)
 {
-    if (! CONFIG_MACH_STM32F1)
+    uint32_t timeout = timer_read_time() + timer_from_us(us);
+    while (timer_is_before(timer_read_time(), timeout))
+      ;
+}
+
+static void
+i2c_init(I2C_TypeDef *i2c)
+{
+    uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
+    i2c->CR2 = pclk / 1000000;
+    i2c->CCR = pclk / 100000 / 2;
+    i2c->TRISE = (pclk / 1000000) + 1;
+    i2c->CR1 = I2C_CR1_PE;
+}
+
+// Work around stm32 errata causing busy bit to be stuck
+// "2.9.7 I2C analog filter may provide wrong value, locking BUSY
+// flag and preventing master mode entry"
+static void
+i2c_stm32f1_busy_errata(I2C_TypeDef *i2c)
+{
+    if (!CONFIG_MACH_STM32F1)
         return;
-    gpio_peripheral(scl_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
-    gpio_peripheral(sda_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
-    gpio_peripheral(sda_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, -1);
-    gpio_peripheral(scl_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, -1);
-    gpio_peripheral(scl_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
-    gpio_peripheral(sda_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
+
+    const struct i2c_info *ii =
+      container_of((I2C_TypeDef * const *)i2c, struct i2c_info, i2c);
+
+    i2c->SR1;
+    i2c->SR2;
+    i2c->DR;
+    i2c->CR1 = 0;
+    i2c->CR2 = 0;
+    i2c->DR = 0;
+
+    struct gpio_out scl_gpio = {
+      .regs = digital_regs[GPIO2PORT(ii->scl_pin)],
+      .bit = GPIO2BIT(ii->scl_pin)
+    };
+
+    struct gpio_out sda_gpio = {
+      .regs = digital_regs[GPIO2PORT(ii->sda_pin)],
+      .bit = GPIO2BIT(ii->sda_pin)
+    };
+
+    // Note: the errata indicates a bunch of SCL/SDA pin level checks
+    // in between the various state changes that this code omits.
+    gpio_peripheral(ii->scl_pin, GPIO_OUTPUT, 1);
+    gpio_peripheral(ii->sda_pin, GPIO_OUTPUT, 1);
+    gpio_out_write(scl_gpio, 1);
+    gpio_out_write(sda_gpio, 1);
+    i2c_us_delay(20);
+    gpio_peripheral(ii->sda_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, -1);
+    gpio_out_write(sda_gpio, 0);
+    gpio_peripheral(ii->scl_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, -1);
+    gpio_out_write(scl_gpio, 0);
+    gpio_peripheral(ii->scl_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
+    gpio_out_write(scl_gpio, 1);
+    gpio_peripheral(ii->sda_pin, GPIO_OUTPUT | GPIO_OPEN_DRAIN, 1);
+    gpio_out_write(sda_gpio, 1);
+
+    i2c->CR1 = I2C_CR1_SWRST;
+    i2c_us_delay(5);
+    i2c->CR1 = 0;
+    i2c_init(i2c);
 }
 
 struct i2c_config
@@ -77,47 +138,79 @@ i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
     if (!is_enabled_pclock((uint32_t)i2c)) {
         // Enable i2c clock and gpio
         enable_pclock((uint32_t)i2c);
-        i2c_busy_errata(ii->scl_pin, ii->sda_pin);
+        i2c_stm32f1_busy_errata(i2c);
         gpio_peripheral(ii->scl_pin, GPIO_FUNCTION(4) | GPIO_OPEN_DRAIN, 1);
         gpio_peripheral(ii->sda_pin, GPIO_FUNCTION(4) | GPIO_OPEN_DRAIN, 1);
         i2c->CR1 = I2C_CR1_SWRST;
         i2c->CR1 = 0;
 
         // Set 100Khz frequency and enable
-        uint32_t pclk = get_pclock_frequency((uint32_t)i2c);
-        i2c->CR2 = pclk / 1000000;
-        i2c->CCR = pclk / 100000 / 2;
-        i2c->TRISE = (pclk / 1000000) + 1;
-        i2c->CR1 = I2C_CR1_PE;
+        i2c_init(i2c);
     }
 
     return (struct i2c_config){ .i2c=i2c, .addr=addr<<1 };
 }
 
-static uint32_t
+static int
 i2c_wait(I2C_TypeDef *i2c, uint32_t set, uint32_t clear, uint32_t timeout)
 {
     for (;;) {
-        uint32_t sr1 = i2c->SR1;
+        uint32_t sr1 = i2c->SR1, sr2 = i2c->SR2;
+
         if ((sr1 & set) == set && (sr1 & clear) == 0)
-            return sr1;
+            return I2C_BUS_SUCCESS;
+
         if (sr1 & I2C_SR1_AF)
-            shutdown("I2C NACK error encountered");
-        if (!timer_is_before(timer_read_time(), timeout))
-            shutdown("i2c timeout");
+            return I2C_BUS_NACK;
+
+        if (timer_is_before(timer_read_time(), timeout))
+            continue;
+
+        if (sr2 & I2C_SR2_BUSY)
+            return I2C_BUS_BUSY;
+
+        if (sr1 & I2C_SR1_BERR)
+            return I2C_BUS_ERR;
+
+        return I2C_BUS_TIMEOUT;
     }
 }
 
-static void
+static int
 i2c_start(I2C_TypeDef *i2c, uint8_t addr, uint8_t xfer_len,
           uint32_t timeout)
 {
+    int ret = 0;
+    int retries = 1;
+    uint32_t start_timeout = timeout - I2C_TIMEOUT_START_ERRATA_US;
+
+restart:
     i2c->CR1 = I2C_CR1_START | I2C_CR1_PE;
-    i2c_wait(i2c, I2C_SR1_SB, 0, timeout);
+    ret = i2c_wait(i2c, I2C_SR1_SB, 0, start_timeout);
+
+    // On this chip, there's a condition where the I2C
+    // lines can get wedged. Try to resolve this at the start
+    // of a transaction.
+    if (CONFIG_MACH_STM32F1 && ret == I2C_BUS_BUSY) {
+        if (retries--) {
+            i2c_stm32f1_busy_errata(i2c);
+            // reset the original deadline
+            start_timeout = timeout;
+            goto restart;
+        }
+    }
+
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
+
     i2c->DR = addr;
     if (addr & 0x01)
         i2c->CR1 |= I2C_CR1_ACK;
-    i2c_wait(i2c, I2C_SR1_ADDR, 0, timeout);
+
+    ret = i2c_wait(i2c, I2C_SR1_ADDR, 0, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
+
     irqstatus_t flag = irq_save();
     uint32_t sr2 = i2c->SR2;
     if (addr & 0x01 && xfer_len == 1)
@@ -125,19 +218,23 @@ i2c_start(I2C_TypeDef *i2c, uint8_t addr, uint8_t xfer_len,
     irq_restore(flag);
     if (!(sr2 & I2C_SR2_MSL))
         shutdown("Failed to send i2c addr");
+    return ret;
 }
 
 static void
-i2c_send_byte(I2C_TypeDef *i2c, uint8_t b, uint32_t timeout)
+i2c_send_byte(I2C_TypeDef *i2c, uint8_t b, uint32_t timeout, int *error)
 {
     i2c->DR = b;
-    i2c_wait(i2c, I2C_SR1_TXE, 0, timeout);
+    *error = i2c_wait(i2c, I2C_SR1_TXE, 0, timeout);
 }
 
 static uint8_t
-i2c_read_byte(I2C_TypeDef *i2c, uint32_t timeout, uint8_t remaining)
+i2c_read_byte(I2C_TypeDef *i2c, uint32_t timeout, uint8_t remaining, int *error)
 {
-    i2c_wait(i2c, I2C_SR1_RXNE, 0, timeout);
+    *error = i2c_wait(i2c, I2C_SR1_RXNE, 0, timeout);
+    if (*error != I2C_BUS_SUCCESS)
+        return 0;
+
     irqstatus_t flag = irq_save();
     uint8_t b = i2c->DR;
     if (remaining == 1)
@@ -156,38 +253,55 @@ i2c_stop(I2C_TypeDef *i2c, uint32_t timeout)
 int
 i2c_write(struct i2c_config config, uint8_t write_len, uint8_t *write)
 {
+    int ret = 0;
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(I2C_TIMEOUT_US);
 
-    i2c_start(i2c, config.addr, write_len, timeout);
-    while (write_len--)
-        i2c_send_byte(i2c, *write++, timeout);
+    ret = i2c_start(i2c, config.addr, write_len, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
+    while (write_len--) {
+        i2c_send_byte(i2c, *write++, timeout, &ret);
+        if (ret != I2C_BUS_SUCCESS)
+            break;
+    }
     i2c_stop(i2c, timeout);
-
-    return I2C_BUS_SUCCESS;
+    return ret;
 }
 
 int
 i2c_read(struct i2c_config config, uint8_t reg_len, uint8_t *reg
          , uint8_t read_len, uint8_t *read)
 {
+    int ret = 0;
     I2C_TypeDef *i2c = config.i2c;
-    uint32_t timeout = timer_read_time() + timer_from_us(5000);
+    uint32_t timeout = timer_read_time() + timer_from_us(I2C_TIMEOUT_US);
     uint8_t addr = config.addr | 0x01;
 
     if (reg_len) {
         // write the register
-        i2c_start(i2c, config.addr, reg_len, timeout);
-        while(reg_len--)
-            i2c_send_byte(i2c, *reg++, timeout);
+        ret = i2c_start(i2c, config.addr, reg_len, timeout);
+        if (ret != I2C_BUS_SUCCESS)
+            return ret;
+        while (reg_len--) {
+            i2c_send_byte(i2c, *reg++, timeout, &ret);
+            if (ret != I2C_BUS_SUCCESS)
+                break;
+        }
+        if (ret != I2C_BUS_SUCCESS)
+            return ret;
     }
     // start/re-start and read data
-    i2c_start(i2c, addr, read_len, timeout);
-    while(read_len--) {
-        *read = i2c_read_byte(i2c, timeout, read_len);
-        read++;
+    ret = i2c_start(i2c, addr, read_len, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
+    while (read_len--) {
+        *read++ = i2c_read_byte(i2c, timeout, read_len, &ret);
+        if (ret != I2C_BUS_SUCCESS)
+            break;
     }
-    i2c_wait(i2c, 0, I2C_SR1_RXNE, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
 
-    return I2C_BUS_SUCCESS;
+    return i2c_wait(i2c, 0, I2C_SR1_RXNE, timeout);
 }


### PR DESCRIPTION
The stm32f1 has an issue that can cause the i2c Lines to be "stuck". This patch implements a more thorough version of the workaround from the errata. Klipper currently only applies the errata during `i2c_setup`, but the condition can happen at any point. This adds detection of the condition (via bus busy) and tries to apply the errata process again in i2c_wait.

The original patch comes from Sovol, though I can't link to it because it lives in the .git directory that they ship on the eMMC with the Sovol Zero :p I've refactored and cleaned up much of the patch, not sure how to give attribution though. Without this patch, the i2c devices on the Sovol Zero (and presumably SV08 Max, I think it's the same one) toolhead are not usable.

Though reading through this again... this will double-apply an i2c_wait timeout in i2c_start in case of bus busy on _all_ stm32s, not just those that need to have the errata applied. I'll fix that. I'm not deeply familiar with the stm32 though, so there may be details that I've missed.