### PR TITLE
ar100: Convert to or1k-elf toolchain

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -8,7 +8,7 @@ set -eu
 MAIN_DIR=${PWD}
 BUILD_DIR=${PWD}/ci_build
 export PATH=${BUILD_DIR}/pru-elf/bin:${PATH}
-export PATH=${BUILD_DIR}/or1k-linux-musl-cross/bin:${PATH}
+export PATH=${BUILD_DIR}/or1k-elf/bin:${PATH}
 PYTHON=${BUILD_DIR}/python-env/bin/python
 PYTHON2=${BUILD_DIR}/python2-env/bin/python
 

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -39,20 +39,18 @@ tar xJf ${CACHE_DIR}/${PRU_ARCHIVE}
 
 
 ######################################################################
-# Install or1k-linux-musl toolchain
+# Install or1k toolchain
 ######################################################################
 
-echo -e "\n\n=============== Install or1k-linux-musl toolchain\n\n"
-TOOLCHAIN=or1k-linux-musl-cross
-TOOLCHAIN_ZIP=${TOOLCHAIN}.tgz
-GCC_VERSION=10
-TOOLCHAIN_ZIP_V=${TOOLCHAIN}-${GCC_VERSION}.tgz
-URL=https://more.musl.cc/${GCC_VERSION}/x86_64-linux-musl/
-if [ ! -f ${CACHE_DIR}/${TOOLCHAIN_ZIP_V} ]; then
-    wget "${URL}/${TOOLCHAIN_ZIP}" -O "${CACHE_DIR}/${TOOLCHAIN_ZIP_V}"
+echo -e "\n\n=============== Install or1k toolchain\n\n"
+OR1K_ARCHIVE="or1k-elf-12.0.1-20220210-20220304.tar.xz"
+OR1K_REL="or1k-12.0.1-20220210-20220304"
+OR1K_URL="https://github.com/openrisc/or1k-gcc/releases/download/${OR1K_REL}/${OR1K_ARCHIVE}"
+if [ ! -f ${CACHE_DIR}/${OR1K_ARCHIVE} ]; then
+    wget "${OR1K_URL}" -O "${CACHE_DIR}/${OR1K_ARCHIVE}"
 fi
 cd ${BUILD_DIR}
-tar xf ${CACHE_DIR}/${TOOLCHAIN_ZIP_V}
+tar xJf ${CACHE_DIR}/${OR1K_ARCHIVE}
 
 
 ######################################################################

--- a/src/ar100/Makefile
+++ b/src/ar100/Makefile
@@ -1,4 +1,4 @@
-CROSS_PREFIX=or1k-linux-musl-
+CROSS_PREFIX=or1k-elf-
 dirs-y += src/generic src/ar100 lib/ar100
 
 CFLAGS		+= -O3


### PR DESCRIPTION
The more.musl.cc site is blocking downloads from all github actions, which makes it difficult to use that site for the ar100 cross build toolchain.

This PR converts to the openrisc or1k-elf toolchain as a replacement.  With this alternative toolchain, the code builds fine, but I don't know if it will actually run or not.

The announcement of blocking github actions is at: https://musl.cc/

The openrisc or1k toolchain is at: https://github.com/openrisc/or1k-gcc/

@eliasbakken - perhaps you could look at this?

-Kevin

EDIT: Just to be clear, the main Klipper repo is not currently having an issue running the github regression tests because previous downloads of the toolchain have been actively cached.  However, any secondary repos that haven't recently built the code (and thus had their caches flushed) are experiencing build failures.