### PR TITLE
virtual_sdcard: emit events on file load

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -196,6 +196,7 @@ class VirtualSD:
         self.file_position = 0
         self.file_size = fsize
         self.print_stats.set_current_file(filename)
+        self.printer.send_event("virtual_sdcard:load_file")
     def cmd_M24(self, gcmd):
         # Start/resume SD print
         self.do_resume()


### PR DESCRIPTION
## Summary

This PR adds new event hook in the virtual SD-card code:

  - **virtual_sdcard:load_file**  
    Emitted when a new file is successfully opened for printing.

## Motivation

Currently there is no clean way for a plugin to know exactly when Klipper has switched to
a new file (i.e. when a job actually begins). 

## Implementation

No existing behavior is changed; these are purely additive hooks.

## Testing

- Verified on my test bench that when I load a file via `PRINT_FILE` the  
  `load_file` event fires immediately.  
- No regressions observed in normal SD printing.
