### PR TITLE
Add Heater Fan to generic-bigtreetech-skr-v1.4.cfg

### DIFF
--- a/config/generic-bigtreetech-skr-v1.4.cfg
+++ b/config/generic-bigtreetech-skr-v1.4.cfg
@@ -76,6 +76,12 @@ max_temp: 130
 [fan]
 pin: P2.3
 
+[heater_fan e0_fan]
+pin: P2.4
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
+
 [mcu]
 serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
 


### PR DESCRIPTION
The heater fan is a standard component of the BTT SKR 1.4 (Turbo), and generally needed for sane operation of the printer. I spent more hours and money than I'd really like to admit trying to get this board working before I stumbled upon the right information to get this working.