### PR TITLE
SET_LED_TEMPLATE size change fix

### DIFF
--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -129,7 +129,7 @@ class PrinterTemplateEvaluator:
         # Render all templates
         flush_callbacks = {}
         render_cache = {}
-        template_info = self.active_templates.items()
+        template_info = list(self.active_templates.items())
         for callback, (uid, template, lparams, flush_callback) in template_info:
             text = render_cache.get(uid)
             if text is None:


### PR DESCRIPTION
SET_LED_TEMPLATE causes crash due to dictionary size change during iteration (if you just hit it at the right time)

fix: take take copy.

error can be reproduced with:
```
        {% for idx in range(10) %}
          SET_LED_TEMPLATE LED={led_name} TEMPLATE={template} INDEX={idx}
          G4 P50
        {% endfor %}
```