### PR TITLE
Suction controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 .config
 .config.old
 klippy/.version
+.vscode

--- a/config/example-voltera-touch-sensor.cfg
+++ b/config/example-voltera-touch-sensor.cfg
@@ -1,0 +1,25 @@
+[mcu]
+
+serial: xxxxx
+
+[mcu carrier_mcu]
+serial: xxxxx
+
+
+[touch_sensor]
+# spi_bus: spi1_gpio8_gpio11_gpio10 # MISO MOSI SCK  should be-> 11 8 10
+spi_software_miso_pin: gpio11
+spi_software_mosi_pin: gpio8
+spi_software_sclk_pin: gpio10
+cs_pin: gpio9
+adc_int_pin: gpio12
+probe_interrupt_pin: gpio2
+PI_EN_pin: gpio13
+
+
+[probe]
+z_offset: 0.
+pin: carrier_mcu:gpio21
+speed: 50 #(default 50 mm /s)
+# horizontal_move_z: 5.0
+lift_speed:  40

--- a/klippy/extras/XGZP6847D_sensor.py
+++ b/klippy/extras/XGZP6847D_sensor.py
@@ -1,0 +1,145 @@
+#################################################################
+# Klippy Suction monitoring Module @ Albatross
+# Description: This module provides klippy interface for suction
+#              i2c-based sensor (XGZP6847D) with asynchronous 
+#              read for pressure and temperature
+# Date: 2025-06-26
+# Version: 0.1
+# Owner: Mo
+#################################################################
+from . import bus
+import logging
+
+# "I2C device factory setting slave address: 0X6D."
+XGZP6847D_FACTORY_ADDRESS = 0x6D
+
+REG_ADD_P_DATA_MSB = 0x06
+REG_ADD_P_DATA_CSB = 0x07
+REG_ADD_P_DATA_LSB = 0x08
+REG_ADD_T_DATA_MSB = 0x09
+REG_ADD_T_DATA_LSB = 0x0A
+REG_ADD_CMD = 0x30
+REG_DATA_CMD = 0x0A # start combined conversion pressure and temperature
+# Sampling takes 20ms at most
+SAMPLING_CYCLE_MS = 5.
+MAX_SAMPLING_CYCLE = 6
+
+READ_READY_STATE = 0
+
+# K vlue for the datasheet
+# Pressure Range(Absolute Value-KPa）K valueSensor Pressure Range Example
+# 1000≤Pressure Range 4 0~1000kPa; 0~1500kPa; -100~1000kPa ...
+# 500<Pressure Range＜1000 8 0~700kPa; -100~700kPa...
+# 260<Pressure Range≤500 16 0~500kPa; -100~300kPa...
+# 130<Pressure Range≤260 32 0~200kPa; -100~200kPa... <<< XGZP6847D100KPG
+# 65<Pressure Range≤130 64 0~100kPa; -100~100kPa; -100~0kPa... 
+# 32<Pressure Range≤65 128 0~40kPa; -40~40kPa; -40~0kPa... 
+# 16<Pressure Range≤32 256 0~20kPa; -20~20kPa; -20~0kPa; -30~0kPa...
+# 8<Pressure Range≤16 512 0~10kPa; -10~10kPa; -10~0kPa...
+# 4<Pressure Range≤8 1024 0~5kPa; -5~5kPa; -1~1PSI...
+# 2≤Pressure Range≤4 2048 0~2.5kPa; -2.5~2.5kPa...
+# 1≤Pressure Range<2 4096 0~1kPa; -1~1kPa...
+# Pressure Range<1 8192 -0.5~0.5kPa...
+
+k_dict = {
+    'XGZP6847D100KPG': 128. # 130<Pressure Range≤260 (absolute value)
+}
+
+class PumpPressureSensor:
+    # XGZP6847D vacuum pressure sensor
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self.gcode = self.printer.lookup_object('gcode')
+
+        self.i2c = bus.MCU_I2C_from_config(config, default_speed=100000, default_addr=XGZP6847D_FACTORY_ADDRESS)
+
+        self.active_read = False
+
+        self.pressure,  self.temperature, self.read_cycle = 0, 0, 0
+        self.timer = None
+
+        self.gcode.register_command('DO_PT_MEASURE', self.cmd_do_PT_measure,
+            desc="Start a pressure and temperature measurement cycle on the XGZP6847D sensor")
+        self.gcode.register_command('TELL_PT_MEASURE', self.cmd_tell_readings,
+            desc="Give a pressure and temperature measurement cycle on the XGZP6847D sensor")
+        
+        self.printer.register_event_handler("klippy:ready", self._handle_on_ready)
+
+               
+    def get_status(self, eventtime):
+        # Read pressure and temperature from the sensor
+        return {'Sampling Status': self.active_read, 'Pressure': self.pressure, 'Temperature': self.temperature}
+    def _handle_on_ready(self):
+        """Handle the 'klippy:ready' event to initialize the sensor."""
+        # Check the sensor if conncected or not. If not this line will issue a shutdown
+        self.i2c.i2c_read([REG_ADD_CMD], 1)
+        
+    def _do_read(self, eventtime):
+        # Confirm if the sampling is done
+        cmd_data = self.i2c.i2c_read([REG_ADD_CMD], 1)['response'][0]
+        done_s = (cmd_data & 0x08) >> 3
+        if done_s == READ_READY_STATE:
+            [p_msb, p_csb, p_lsb] = self.i2c.i2c_read([REG_ADD_P_DATA_MSB], 3)['response']
+            [t_msb, t_lsb] = self.i2c.i2c_read([REG_ADD_T_DATA_MSB], 2)['response']
+            # Convert raw values to signed integers
+            raw_pressure = (p_msb << 16) | (p_csb << 8) | p_lsb
+            if raw_pressure & 0x800000:
+                raw_pressure -= 0x1000000  # Convert to signed 24-bit int
+            self.pressure = raw_pressure/ k_dict['XGZP6847D100KPG']  # Convert to Pa using the K value
+            self.temperature = (t_msb << 8) | t_lsb
+            self.temperature = self.temperature / 256.  # Convert to Celsius
+            # Force to make this the last cycle
+            self.read_cycle = MAX_SAMPLING_CYCLE
+            logging.info(f"XGZP6847D sensor read completed: Pressure={self.pressure} Pa, Temperature={self.temperature} C")
+        else:
+            # If not done, increment the read cycle
+            self.read_cycle += 1
+        if self.read_cycle >= MAX_SAMPLING_CYCLE:
+            self.active_read = False
+            self.read_cycle = 0
+            if  done_s != READ_READY_STATE:
+                logging.warning("XGZP6847D sensor read timed out or failed.")
+            return self.reactor.NEVER
+        # If not done or not timed out, reschedule the read
+        return eventtime + SAMPLING_CYCLE_MS/1000.
+
+    def _read_sensor_data(self):
+        # Start sampling
+        self.i2c.i2c_write([REG_ADD_CMD, REG_DATA_CMD])
+        waketime = self.reactor.monotonic() + SAMPLING_CYCLE_MS/1000.
+        self.active_read = True
+        self.timer = self.reactor.register_timer(self._do_read, waketime)
+
+
+    def _stop_read(self):
+        """Stop the current sensor read operation."""
+        if self.active_read:
+            self.reactor.unregister_timer(self.timer)
+            self.active_read = False
+            self.read_cycle = 0
+            self.timer = None
+            logging.info("XGZP6847D sensor read stopped.")
+        else:
+            logging.warning("No active XGZP6847D sensor read to stop.")
+    # ---------------------------------------------------------------------
+    # GCode Command Handlers
+    # ---------------------------------------------------------------------
+    def cmd_do_PT_measure(self, gcmd):
+        """Start a pressure and temperature measurement cycle on the XGZP6847D sensor."""
+        if self.active_read:
+            logging.warning("cmd:XGZP6847D sensor read already in progress.")
+            gcmd.respond_info("cmd:XGZP6847D sensor read already in progress.")
+            return
+        self._read_sensor_data()
+        gcmd.respond_info("XGZP6847D sensor measurement started.")
+    
+    def cmd_tell_readings(self, gcmd):
+        # Read pressure and temperature from the sensor
+        if self.active_read:
+            logging.warning("XGZP6847D sensor read already in progress.")
+            gcmd.respond_info("XGZP6847D sensor read already in progress.")
+            return
+        gcmd.respond_info(f"XGZP6847D sensor readings: Pressure={self.pressure} Pa, Temperature={self.temperature} C")
+def load_config(config):
+    return PumpPressureSensor(config)

--- a/klippy/extras/dev_setup.py
+++ b/klippy/extras/dev_setup.py
@@ -1,0 +1,34 @@
+#################################################################
+# Klipper debug/development setup 
+#################################################################
+
+import logging
+from . import bus
+
+# -------------------------------------------------------------------------
+# Dev Setup Class
+# -------------------------------------------------------------------------
+class dev_setup:
+
+    def __init__(self, config):
+
+        # Printer and pin setup
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        self.fakeHome = config.getboolean('fake_home', False, False)
+  
+    # ---------------------------------------------------------------------
+    # Event Handlers
+    # ---------------------------------------------------------------------
+    def _handle_on_ready(self):
+        if self.fakeHome:
+            logging.info("Fake home enabled, running FAKE_HOME script.")
+            self.gcode.run_script("SET_KINEMATIC_POSITION X=0 Y=0 Z=199")
+
+  
+
+# -------------------------------------------------------------------------
+# Module Load Function
+# -------------------------------------------------------------------------
+def load_config(config):
+    return dev_setup(config)

--- a/klippy/extras/dev_setup.py
+++ b/klippy/extras/dev_setup.py
@@ -15,7 +15,7 @@ class dev_setup:
         # Printer and pin setup
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
-        self.fakeHome = config.getboolean('fake_home', False, False)
+        self.fakeHome = config.getboolean('fake_home', False)
   
     # ---------------------------------------------------------------------
     # Event Handlers

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -77,7 +77,7 @@ class ProbeCommandHelper:
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, gcmd):
-        self.printer.send_event("probe:PROBE")
+        self.printer.send_event("probe:PROBE", gcmd)
         pos = run_single_probe(self.probe, gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
         self.last_z_result = pos[2]
@@ -175,8 +175,11 @@ class ProbeCommandHelper:
 
 # Helper to lookup the minimum Z position for the printer
 def lookup_minimum_z(config):
-    zconfig = manual_probe.lookup_z_endstop_config(config)
-    if zconfig is not None:
+    if config.has_section('stepper_z'):
+        zconfig = config.getsection('stepper_z')
+        return zconfig.getfloat('position_min', 0., note_valid=False)
+    elif config.has_section('carriage z'):
+        zconfig = config.getsection('carriage z')
         return zconfig.getfloat('position_min', 0., note_valid=False)
     pconfig = config.getsection('printer')
     return pconfig.getfloat('minimum_z_position', 0., note_valid=False)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -77,6 +77,7 @@ class ProbeCommandHelper:
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_help = "Probe Z-height at current XY position"
     def cmd_PROBE(self, gcmd):
+        self.printer.send_event("probe:PROBE")
         pos = run_single_probe(self.probe, gcmd)
         gcmd.respond_info("Result is z=%.6f" % (pos[2],))
         self.last_z_result = pos[2]
@@ -174,11 +175,8 @@ class ProbeCommandHelper:
 
 # Helper to lookup the minimum Z position for the printer
 def lookup_minimum_z(config):
-    if config.has_section('stepper_z'):
-        zconfig = config.getsection('stepper_z')
-        return zconfig.getfloat('position_min', 0., note_valid=False)
-    elif config.has_section('carriage z'):
-        zconfig = config.getsection('carriage z')
+    zconfig = manual_probe.lookup_z_endstop_config(config)
+    if zconfig is not None:
         return zconfig.getfloat('position_min', 0., note_valid=False)
     pconfig = config.getsection('printer')
     return pconfig.getfloat('minimum_z_position', 0., note_valid=False)

--- a/klippy/extras/suction_controller.py
+++ b/klippy/extras/suction_controller.py
@@ -1,0 +1,107 @@
+#################################################################
+# Klippy Suction control Module @ Albatross
+# Description: This module provides klippy interface for suction
+#               pump control with i2c-based pressure sensor (XGZP6847D)
+# Date: 2025-06-26
+# Version: 0.1
+# Owner: Mo
+#################################################################
+from . import  output_pin
+from XGZP6847D_sensor import PumpPressureSensor
+
+class Pump:
+    def __init__(self, config, default_shutdown_pressure=0.):
+        self.printer = config.get_printer()
+        self.last_fan_value = self.last_req_value = 0.
+        # Read config
+        self.max_power = config.getfloat('max_power', 1., above=0., maxval=1.)
+        self.kick_start_time = config.getfloat('kick_start_time', 0.1,
+                                               minval=0.)
+        self.off_below = config.getfloat('off_below', default=0.,
+                                         minval=0., maxval=1.)
+        cycle_time = config.getfloat('cycle_time', 0.010, above=0.)
+        hardware_pwm = config.getboolean('hardware_pwm', False)
+        shutdown_pressure = config.getfloat(
+            'shutdown_pressure', default_shutdown_pressure, minval=0., maxval=1.)
+        # Setup pwm object
+        ppins = self.printer.lookup_object('pins')
+        self.mcu_fan = ppins.setup_pin('pwm', config.get('pin'))
+        self.mcu_fan.setup_max_duration(0.)
+        self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
+        shutdown_power = max(0., min(self.max_power, shutdown_pressure))
+        self.mcu_fan.setup_start_value(0., shutdown_power)
+
+        self.enable_pin = None
+        enable_pin = config.get('enable_pin', None)
+        if enable_pin is not None:
+            self.enable_pin = ppins.setup_pin('digital_out', enable_pin)
+            self.enable_pin.setup_max_duration(0.)
+
+        # Create gcode request queue
+        self.gcrq = output_pin.GCodeRequestQueue(config, self.mcu_fan.get_mcu(),
+                                                 self._apply_pressure)
+
+        # Setup Pressure sensor
+        self.PressureSensor = PumpPressureSensor(config)
+
+        # Register callbacks
+        self.printer.register_event_handler("gcode:request_restart",
+                                            self._handle_request_restart)
+
+    def get_mcu(self):
+        return self.mcu_fan.get_mcu()
+    def _apply_pressure(self, print_time, value):
+        if value < self.off_below:
+            value = 0.
+        value = max(0., min(self.max_power, value * self.max_power))
+        if value == self.last_fan_value:
+            return "discard", 0.
+        if self.enable_pin:
+            if value > 0 and self.last_fan_value == 0:
+                self.enable_pin.set_digital(print_time, 1)
+            elif value == 0 and self.last_fan_value > 0:
+                self.enable_pin.set_digital(print_time, 0)
+        if (value and self.kick_start_time
+            and (not self.last_fan_value or value - self.last_fan_value > .5)):
+            # Run fan at full pressure for specified kick_start_time
+            self.last_req_value = value
+            self.last_fan_value = self.max_power
+            self.mcu_fan.set_pwm(print_time, self.max_power)
+            return "delay", self.kick_start_time
+        self.last_fan_value = self.last_req_value = value
+        self.mcu_fan.set_pwm(print_time, value)
+    def set_pressure(self, value, print_time=None):
+        self.gcrq.send_async_request(value, print_time)
+    def set_pressure_from_command(self, value):
+        self.gcrq.queue_gcode_request(value)
+    def _handle_request_restart(self, print_time):
+        self.set_pressure(0., print_time)
+
+    def get_status(self, eventtime):
+        PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
+        return {
+            'Pump Power': self.last_req_value,
+            'Actual Pressure': PumpPressureSensor_status['pressure'],
+        }
+
+
+
+class PrinterPump:
+    def __init__(self, config):
+        self.pump = Pump(config)
+        # Register commands
+        gcode = config.get_printer().lookup_object('gcode')
+        gcode.register_command("M106", self.cmd_M106)
+        gcode.register_command("M107", self.cmd_M107)
+    def get_status(self, eventtime):
+        return self.pump.get_status(eventtime)
+    def cmd_M106(self, gcmd):
+        # Set fan pressure
+        value = gcmd.get_float('P', 255., minval=0.) / 255.
+        self.pump.set_pressure_from_command(value)
+    def cmd_M107(self, gcmd):
+        # Turn fan off
+        self.pump.set_pressure_from_command(0.)
+
+def load_config(config):
+    return PrinterPump(config)

--- a/klippy/extras/suction_controller.py
+++ b/klippy/extras/suction_controller.py
@@ -7,7 +7,7 @@
 # Owner: Mo
 #################################################################
 from . import  output_pin
-from XGZP6847D_sensor import PumpPressureSensor
+# from .XGZP6847D_sensor import XGZP6847D_sensor
 
 class Pump:
     def __init__(self, config, default_shutdown_pressure=0.):
@@ -42,7 +42,7 @@ class Pump:
                                                  self._apply_pressure)
 
         # Setup Pressure sensor
-        self.PressureSensor = PumpPressureSensor(config)
+        # self.PressureSensor = XGZP6847D_sensor(config)
 
         # Register callbacks
         self.printer.register_event_handler("gcode:request_restart",
@@ -50,6 +50,7 @@ class Pump:
 
     def get_mcu(self):
         return self.mcu_fan.get_mcu()
+    
     def _apply_pressure(self, print_time, value):
         if value < self.off_below:
             value = 0.
@@ -78,15 +79,17 @@ class Pump:
         self.set_pressure(0., print_time)
 
     def get_status(self, eventtime):
-        PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
+        # PumpPressureSensor_status = self.PumpPressureSensor.get_status(eventtime)
         return {
             'Pump Power': self.last_req_value,
-            'Actual Pressure': PumpPressureSensor_status['pressure'],
+            # 'Actual Pressure': PumpPressureSensor_status['Pressure'],
+            # 'Temperature': PumpPressureSensor_status['Temperature'],
+            # 'Sampling Status': PumpPressureSensor_status['Sampling Status']
         }
 
 
 
-class PrinterPump:
+class suction_controller:
     def __init__(self, config):
         self.pump = Pump(config)
         # Register commands
@@ -104,4 +107,4 @@ class PrinterPump:
         self.pump.set_pressure_from_command(0.)
 
 def load_config(config):
-    return PrinterPump(config)
+    return suction_controller(config)

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -81,8 +81,14 @@ class Touch_sensor_MCP3462R:
         if not self.configured:
             raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
         self._pending_gcmd = gcmd  # Store for later response
+        logging.info("Probing event detected, starting touch sensor session.")
+        # Report the internal values
+        logging.info("Touch sensor OID: %s", self.oid)
+        logging.info("Touch sensor SPI OID: %s", self.spi_oid)
+        logging.info("Touch sensor configured: %s", self.configured)
+        
         self.start_ts_session_cmd.send([
-            self.oid, 100000, 1000000, 500
+            self.oid, 100000, 10000, 500
         ])
 
     def _handle_ts_session_response(self, params):

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -5,39 +5,51 @@
 # Version: 0.1
 # Owner: Mo
 #################################################################
+
 import logging
 from . import bus
 
-FULL_RST = bytes([0b01111000])
-ADCDATA_READ = bytes([0b01000011])
-CONFIG0_WRITE = bytes([0b01000110])
-CONFIG0_DATA = bytes([0b01100011])
-CONFIG1_DATA = bytes([0b00001100]) # This is the default
-CONFIG2_FORCE_DATA = bytes([0b10110011]) # Gain is x32 (x16 analog, x2 digital) 
-CONFIG3_DATA = bytes([0b11000000])
-IRQ_DATA = bytes([0b00000110])
-MUX_FORCE_DATA = bytes([0b00110010]) # This is for ch2&3. The default is Ch0&1, which is not what we want.
-        
+# -------------------------------------------------------------------------
+# MCP3462R SPI Command Constants
+# -------------------------------------------------------------------------
+FULL_RST         = bytes([0b01111000])
+ADCDATA_READ     = bytes([0b01000011])
+CONFIG0_WRITE    = bytes([0b01000110])
+CONFIG0_DATA     = bytes([0b01100011])
+CONFIG1_DATA     = bytes([0b00001100])  # Default
+CONFIG2_FORCE_DATA = bytes([0b10110011])  # Gain is x32 (x16 analog, x2 digital)
+CONFIG3_DATA     = bytes([0b11000000])
+IRQ_DATA         = bytes([0b00000110])
+MUX_FORCE_DATA   = bytes([0b00110010])  # For ch2&3. Default is Ch0&1.
 
+# -------------------------------------------------------------------------
+# Touch Sensor Class
+# -------------------------------------------------------------------------
 class Touch_sensor_MCP3462R:
-    def __init__(self, config):
-        self.spi = bus.MCU_SPI_from_config(
-            config, 0, pin_option="cs_pin")
-        self.spi_oid = self.spi.get_oid()  # Get the OID for the SPI bus
-        self.mcu = self.spi.get_mcu()  
-        self.oid = self.mcu.create_oid() # Get an OID for that sensor
+    """Klipper interface for MCP3462R SPI-based touch sensor."""
 
+    def __init__(self, config):
+        # SPI and MCU setup
+        self.spi = bus.MCU_SPI_from_config(config, 0, pin_option="cs_pin")
+        self.spi_oid = self.spi.get_oid()
+        self.mcu = self.spi.get_mcu()
+        self.oid = self.mcu.create_oid()
+
+        # Printer and pin setup
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
         ppins = self.printer.lookup_object('pins')
         self.probe_interrupt_pin = ppins.lookup_pin(config.get('probe_interrupt_pin'))
-        self.adc_int_pin = ppins.lookup_pin(config.get('adc_int_pin')) 
+        self.adc_int_pin = ppins.lookup_pin(config.get('adc_int_pin'))
 
-
-        self.mcu.add_config_cmd("cfg_ts_adc oid=%d spi_oid=%d adc_int_pin=%s trigger_out_pin=%s" % (self.oid, self.spi_oid, self.adc_int_pin['pin'], self.probe_interrupt_pin['pin']))
-
+        # Register MCU configuration
+        self.mcu.add_config_cmd(
+            "cfg_ts_adc oid=%d spi_oid=%d adc_int_pin=%s trigger_out_pin=%s" %
+            (self.oid, self.spi_oid, self.adc_int_pin['pin'], self.probe_interrupt_pin['pin'])
+        )
         self.mcu.register_config_callback(self._build_config)
 
+        # Register GCode commands
         self.gcode.register_command('INIT_SPI_TS', self.cmd_INIT_TS,
             desc="Initialize the touch sensor")
         self.gcode.register_command('RESET_TS', self.cmd_RESET_TS,
@@ -45,13 +57,15 @@ class Touch_sensor_MCP3462R:
         self.gcode.register_command('GET_TS_VAL', self.cmd_GET_TS_VALUE,
             desc="Klippy read for touch sensor value")
 
-
         self.configured = False
 
+        # Register event handlers
         self.printer.register_event_handler("klippy:ready", self._handle_on_ready)
-        # Hooking a handler to probing event, so once it is triggered, we tell the mcu/adc that we are looking for your input now.
         self.printer.register_event_handler("probe:PROBE", self._handle_probing_event)
-        
+
+    # ---------------------------------------------------------------------
+    # MCU/Session Configuration
+    # ---------------------------------------------------------------------
     def _build_config(self):
         self.start_ts_session_cmd = self.mcu.lookup_command(
             "start_ts_session oid=%c timeout_cycles=%u rest_ticks=%u sensitivity=%u"
@@ -59,34 +73,34 @@ class Touch_sensor_MCP3462R:
         self.mcu.register_response(self._handle_ts_session_response, "Ts_session_result", self.oid)
 
     def _do_initialization_commands(self):
-
+        """Send initialization commands to the touch sensor."""
         self.spi.spi_send(
             CONFIG0_WRITE + CONFIG0_DATA + CONFIG1_DATA +
             CONFIG2_FORCE_DATA + CONFIG3_DATA + IRQ_DATA
-            )
+        )
         logging.info("Touch sensor configuration commands sent successfully.")
-
-        # For future validation
         return True
 
+    # ---------------------------------------------------------------------
+    # Event Handlers
+    # ---------------------------------------------------------------------
     def _handle_on_ready(self):
-        # Startup configuration for the touch sensor (Initialization)
+        """Handle printer ready event and initialize sensor if needed."""
         if not self.configured:
             self.configured = self._do_initialization_commands()
-        #TEMPORARY: For testing purposes, I will run a fake home command
+        # TEMPORARY: For testing purposes, run a fake home command
         self.gcode.run_script("FAKE_HOME")
         # self.gcode.run_script("PROBE")
 
     def _handle_probing_event(self, gcmd):
+        """Handle probing event and start touch sensor session."""
         if not self.configured:
             raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
         self._pending_gcmd = gcmd  # Store for later response
         logging.info("Probing event detected, starting touch sensor session.")
-        # Report the internal values
         logging.info("Touch sensor OID: %s", self.oid)
         logging.info("Touch sensor SPI OID: %s", self.spi_oid)
         logging.info("Touch sensor configured: %s", self.configured)
-        
         self.start_ts_session_cmd.send([
             self.oid, 100000, 10000, 500
         ])
@@ -109,10 +123,13 @@ class Touch_sensor_MCP3462R:
                 logging.info("Touched with value: %d", data)
             elif status == 0:
                 logging.warning("Touch sensor session timed out without sensing.")
+
+    # ---------------------------------------------------------------------
+    # GCode Command Handlers
+    # ---------------------------------------------------------------------
     def cmd_INIT_TS(self, gcmd):
         """Initialize the touch sensor-SPI."""
         if not self.configured:
-            # Perform any necessary initialization commands here
             self.configured = self._do_initialization_commands()
             gcmd.respond_info("Touch sensor-SPI initialized successfully.")
         else:
@@ -122,7 +139,6 @@ class Touch_sensor_MCP3462R:
         """Reset the touch sensor."""
         self.spi.spi_send(FULL_RST)
         self.configured = False
-        # do whatever commands are needed to reset the touch sensor
         gcmd.respond_info("Touch sensor reset. Please reinitialize SPI once attachment is connected.")
 
     def cmd_GET_TS_VALUE(self, gcmd):
@@ -132,14 +148,17 @@ class Touch_sensor_MCP3462R:
 
         self.spi.spi_send(ADCDATA_READ)
         resp = self.spi.spi_transfer([0xff, 0xff])
-        data = resp['response']  # <- FIXED: extract the actual bytes
+        data = resp['response']
 
         if not isinstance(data, (bytes, bytearray)) or len(data) != 2:
             raise gcmd.error("Invalid SPI response: expected 2 bytes, got %s" % repr(data))
 
         value = (data[0] << 8) | data[1]
         hex_v = data.hex()
-        gcmd.respond_info("Touch sensor value: %d, hex: %s" % (value , hex_v))
+        gcmd.respond_info("Touch sensor value: %d, hex: %s" % (value, hex_v))
 
+# -------------------------------------------------------------------------
+# Module Load Function
+# -------------------------------------------------------------------------
 def load_config(config):
     return Touch_sensor_MCP3462R(config)

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -1,7 +1,7 @@
 #################################################################
 # Klippy Touch Sensor Module @ Albatross
 # Description: This module provides klippy interface for spi-based touch sensor (MCP3462R)
-# Date: 2025-06-20
+# Date: 2025-05-20
 # Version: 0.1
 # Owner: Mo
 #################################################################
@@ -23,19 +23,25 @@ class Touch_sensor_MCP3462R:
     def __init__(self, config):
         self.spi = bus.MCU_SPI_from_config(
             config, 0, pin_option="cs_pin")
+        self.spi_oid = self.spi.get_oid()  # Get the OID for the SPI bus
+        self.mcu = self.spi.get_mcu()  
+        self.oid = self.mcu.create_oid() # Get an OID for that sensor
 
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
 
         ppins = self.printer.lookup_object('pins')
-        self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin'))
+        self.probe_interrupt_pin = ppins.setup_pin('digital_out',config.get('probe_interrupt_pin'))
+        self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin')) # Future edit: register config cmd for the sensor with the oid
 
         self.gcode.register_command('INIT_SPI_TS', self.cmd_INIT_TS,
-            desc="Initialize the touch sensor-SPI")
+            desc="Initialize the touch sensor")
         self.gcode.register_command('RESET_TS', self.cmd_RESET_TS,
             desc="Reset the touch sensor")
         self.gcode.register_command('GET_TS_VAL', self.cmd_GET_TS_VALUE,
             desc="Klippy read for touch sensor value")
+
+        self.mcu.register_response(self._handle_ts_session_response, "ts_session_result", self.oid)
 
         self.configured = False
 
@@ -54,15 +60,41 @@ class Touch_sensor_MCP3462R:
     def _handle_on_ready(self):
         # Startup configuration for the touch sensor (Initialization)
         self.configured = self._do_config_commands()
-        self.gcode.run_script("FAKE_HOME")
 
+        #TEMPORARY: For testing purposes, I will run a fake home command
+        self.gcode.run_script("FAKE_HOME")
 
     def _handle_probing_event(self, gcmd):
         if not self.configured:
             raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
 
-        # send a cmd to the mcu to start reading the touch sensor adc
+        # TODO: send a cmd to the mcu to start reading the touch sensor adc with a prspecified timout.
         # It should watch out and do some logic to give an interrupt signal to the Z-probe pin
+        # # Get the command object (usually done once, e.g. in __init__ or _build_config)
+        # self._set_cmd = self._mcu.lookup_command(
+        #     "queue_digital_out oid=%c clock=%u on_ticks=%u"
+        # )
+
+        # # Later, send the command with the appropriate data
+        # self._set_cmd.send([oid, clock, on_ticks])
+
+    def _handle_ts_session_response(self, params):
+        """Handle the response from the touch sensor session."""
+        # if response['oid'] != self.oid:
+        #     logging.warning("Received response for unknown OID: %s", response['oid'])
+        #     return
+
+        # # Process the response data
+        # if 'response' in response:
+        #     data = response['response']
+        #     if isinstance(data, (bytes, bytearray)) and len(data) == 2:
+        #         value = (data[0] << 8) | data[1]
+        #         hex_v = data.hex()
+        #         logging.info("Touch sensor value: %d, hex: %s", value, hex_v)
+        #     else:
+        #         logging.error("Invalid SPI response: expected 2 bytes, got %s", repr(data))
+        # else:
+        #     logging.error("No response data received.")
 
     def cmd_INIT_TS(self, gcmd):
         """Initialize the touch sensor-SPI."""

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -36,7 +36,6 @@ class Touch_sensor_MCP3462R:
 
         self.mcu.add_config_cmd("cfg_ts_adc oid=%d spi_oid=%d adc_int_pin=%s trigger_out_pin=%s" % (self.oid, self.spi_oid, self.adc_int_pin['pin'], self.probe_interrupt_pin['pin']))
 
-
         self.mcu.register_config_callback(self._build_config)
 
         self.gcode.register_command('INIT_SPI_TS', self.cmd_INIT_TS,
@@ -50,7 +49,7 @@ class Touch_sensor_MCP3462R:
         self.configured = False
 
         self.printer.register_event_handler("klippy:ready", self._handle_on_ready)
-        # Hook a handler to probing event, so once it is triggered, we tell the mcu/adc that we are looking for your input now.
+        # Hooking a handler to probing event, so once it is triggered, we tell the mcu/adc that we are looking for your input now.
         self.printer.register_event_handler("probe:PROBE", self._handle_probing_event)
         
     def _build_config(self):
@@ -65,6 +64,8 @@ class Touch_sensor_MCP3462R:
             CONFIG0_WRITE + CONFIG0_DATA + CONFIG1_DATA +
             CONFIG2_FORCE_DATA + CONFIG3_DATA + IRQ_DATA
             )
+        logging.info("Touch sensor configuration commands sent successfully.")
+
         # For future validation
         return True
 
@@ -74,14 +75,14 @@ class Touch_sensor_MCP3462R:
             self.configured = self._do_initialization_commands()
         #TEMPORARY: For testing purposes, I will run a fake home command
         self.gcode.run_script("FAKE_HOME")
-        self.gcode.run_script("PROBE")
+        # self.gcode.run_script("PROBE")
 
     def _handle_probing_event(self, gcmd):
         if not self.configured:
             raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
         self._pending_gcmd = gcmd  # Store for later response
         self.start_ts_session_cmd.send([
-            self.oid, 10, 10000, 500
+            self.oid, 100000, 1000000, 500
         ])
 
     def _handle_ts_session_response(self, params):

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -31,8 +31,8 @@ class Touch_sensor_MCP3462R:
         self.gcode = self.printer.lookup_object('gcode')
 
         ppins = self.printer.lookup_object('pins')
-        self.probe_interrupt_pin = ppins.setup_pin('digital_out',config.get('probe_interrupt_pin'))
-        self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin')) # Future edit: register config cmd for the sensor with the oid
+        self.probe_interrupt_pin = ppins.lookup_pin(config.get('probe_interrupt_pin'))
+        self.adc_int_pin = ppins.lookup_pin(config.get('adc_int_pin')) 
 
         self.gcode.register_command('INIT_SPI_TS', self.cmd_INIT_TS,
             desc="Initialize the touch sensor")
@@ -41,7 +41,13 @@ class Touch_sensor_MCP3462R:
         self.gcode.register_command('GET_TS_VAL', self.cmd_GET_TS_VALUE,
             desc="Klippy read for touch sensor value")
 
-        self.mcu.register_response(self._handle_ts_session_response, "ts_session_result", self.oid)
+        self.cfg_hw_cmd = self.mcu.lookup_command(
+            "cfg_ts_adc oid=%c spi_oid=%c adc_int_pin=%u trigger_out_pin=%u"
+        )
+        self.start_ts_session_cmd = self.mcu.lookup_command(
+            "start_ts_session oid=%c timeout_cycles=%u rest_ticks=%u sensitivity=%u"
+        )
+
 
         self.configured = False
 
@@ -49,17 +55,21 @@ class Touch_sensor_MCP3462R:
         # Hook a handler to probing event, so once it is triggered, we tell the mcu/adc that we are looking for your input now.
         self.printer.register_event_handler("probe:PROBE", self._handle_probing_event)
         
-    def _do_config_commands(self):
+    def _do_initialization_commands(self):
         self.spi.spi_send(
             CONFIG0_WRITE + CONFIG0_DATA + CONFIG1_DATA +
             CONFIG2_FORCE_DATA + CONFIG3_DATA + IRQ_DATA
             )
+        # Config the HW connections, send a command
+        self.cfg_hw_cmd.send([
+            self.oid, self.spi_oid, self.adc_int_pin['pin'], self.probe_interrupt_pin['pin']
+        ])
         # For future validation
         return True
 
     def _handle_on_ready(self):
         # Startup configuration for the touch sensor (Initialization)
-        self.configured = self._do_config_commands()
+        self.configured = self._do_initialization_commands()
 
         #TEMPORARY: For testing purposes, I will run a fake home command
         self.gcode.run_script("FAKE_HOME")
@@ -67,40 +77,31 @@ class Touch_sensor_MCP3462R:
     def _handle_probing_event(self, gcmd):
         if not self.configured:
             raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
-
-        # TODO: send a cmd to the mcu to start reading the touch sensor adc with a prspecified timout.
-        # It should watch out and do some logic to give an interrupt signal to the Z-probe pin
-        # # Get the command object (usually done once, e.g. in __init__ or _build_config)
-        # self._set_cmd = self._mcu.lookup_command(
-        #     "queue_digital_out oid=%c clock=%u on_ticks=%u"
-        # )
-
+        self.mcu.register_response(self._handle_ts_session_response, "Ts_session_result", self.oid)
+        self.start_ts_session_cmd.send([
+            self.oid, 1000, 100, 10
+        ])
         # # Later, send the command with the appropriate data
         # self._set_cmd.send([oid, clock, on_ticks])
 
     def _handle_ts_session_response(self, params):
         """Handle the response from the touch sensor session."""
-        # if response['oid'] != self.oid:
-        #     logging.warning("Received response for unknown OID: %s", response['oid'])
-        #     return
+        if params['oid'] != self.oid:
+            logging.warning("Received response for unknown OID: %s", params['oid'])
+            return
+        status = params['status']
+        data = params['lstValue']
 
-        # # Process the response data
-        # if 'response' in response:
-        #     data = response['response']
-        #     if isinstance(data, (bytes, bytearray)) and len(data) == 2:
-        #         value = (data[0] << 8) | data[1]
-        #         hex_v = data.hex()
-        #         logging.info("Touch sensor value: %d, hex: %s", value, hex_v)
-        #     else:
-        #         logging.error("Invalid SPI response: expected 2 bytes, got %s", repr(data))
-        # else:
-        #     logging.error("No response data received.")
+        if status == 'done':
+            logging.info("Touched with value: %d, hex: %s", data, data.hex())
+        elif status == 'timeout':
+            logging.warning("Touch sensor session timed out without sensing.")
 
     def cmd_INIT_TS(self, gcmd):
         """Initialize the touch sensor-SPI."""
         if not self.configured:
             # Perform any necessary initialization commands here
-            self.configured = self._do_config_commands()
+            self.configured = self._do_initialization_commands()
             gcmd.respond_info("Touch sensor-SPI initialized successfully.")
         else:
             gcmd.respond_info("Touch sensor-SPI already initialized. Reset first, if you attached a new head.")

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -1,5 +1,5 @@
 #################################################################
-# Klippy Touch Sensor Module @ Alpatros
+# Klippy Touch Sensor Module @ Albatross
 # Description: This module provides klippy interface for spi-based touch sensor (MCP3462R)
 # Date: 2025-06-20
 # Version: 0.1
@@ -8,94 +8,84 @@
 import logging
 from . import bus
 
+FULL_RST = bytes([0b01111000])
+ADCDATA_READ = bytes([0b01000011])
+CONFIG0_WRITE = bytes([0b01000110])
+CONFIG0_DATA = bytes([0b01100011])
+CONFIG1_DATA = bytes([0b00001100]) # This is the default
+CONFIG2_FORCE_DATA = bytes([0b10110011]) # Gain is x32 (x16 analog, x2 digital) 
+CONFIG3_DATA = bytes([0b11000000])
+IRQ_DATA = bytes([0b00000110])
+MUX_FORCE_DATA = bytes([0b00110010]) # This is for ch2&3. The default is Ch0&1, which is not what we want.
+        
+
 class Touch_sensor_MCP3462R:
     def __init__(self, config):
         self.spi = bus.MCU_SPI_from_config(
             config, 0, pin_option="cs_pin")
 
         self.printer = config.get_printer()
-
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command('RESET_TS', self.cmd_reset_touch_sensor,
+
+        ppins = self.printer.lookup_object('pins')
+        self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin'))
+
+        self.gcode.register_command('INIT_SPI_TS', self.cmd_INIT_TS,
+            desc="Initialize the touch sensor-SPI")
+        self.gcode.register_command('RESET_TS', self.cmd_RESET_TS,
             desc="Reset the touch sensor")
-        self.gcode.register_command('INIT_SPI_TS', self.cmd_init_spi_touch_sensor,
-            desc="Initialize the touch sensor SPI")
-        self.gcode.register_command('GET_TS_VAL', self.cmd_get_touch_sensor_reading,
+        self.gcode.register_command('GET_TS_VAL', self.cmd_GET_TS_VALUE,
             desc="Klippy read for touch sensor value")
 
-        # ppins = self.printer.lookup_object('pins')
-        # self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin'))
+        self.configured = False
 
-        self.FULL_RST = bytes([0b01111000])
-        self.ADCDATA_READ = bytes([0b01000011])
-        self.CONFIG0_WRITE = bytes([0b01000110])
-        self.CONFIG0_DATA = bytes([0b01100011])
-        self.CONFIG1_DATA = bytes([0b00001100]) # This is the default
-        self.CONFIG2_FORCE_DATA = bytes([0b10110011]) # Gain is x32 (x16 analog, x2 digital) 
-        self.CONFIG3_DATA = bytes([0b11000000])
-        self.IRQ_DATA = bytes([0b00000110])
-        self.MUX_FORCE_DATA = bytes([0b00110010]) # This is for ch2&3. The defualt is Ch0&1, which is not what we want.
-        self.configured = self._do_config_commands()
-
-        # need to hook a handler to probing envent, so once it is triggered, we tell the mcu/adc that we are looking for you inpu now.
+        self.printer.register_event_handler("klippy:ready", self._handle_on_ready)
+        # Hook a handler to probing event, so once it is triggered, we tell the mcu/adc that we are looking for your input now.
         self.printer.register_event_handler("probe:PROBE", self._handle_probing_event)
-        # self.gcode.register_command('TOGGLE_CS', self.cmd_toggle_cs_pin,
-        #     desc="Toggle CS pin manually for debugging")
-        self.printer.register_event_handler("klippy:ready", self._on_ready)
-
-    def cmd_toggle_cs_pin(self, gcmd):
-        for i in range(10000):
-            resp = self.spi.spi_transfer([0xff])
-            data = resp['response']  # <- FIXED: extract the actual bytes
-
-            if not isinstance(data, (bytes, bytearray)) or len(data) != 1:
-                raise gcmd.error("Invalid SPI response: expected 1 byte, got %s" % repr(data))
-
-            value = data[0]
-            hex_v = data.hex()
-            gcmd.respond_info("Touch sensor value: %d, hex: %s" % (value , hex_v))
-    def _on_ready(self):
-        self.gcode.run_script("GET_TS_VAL")
         
     def _do_config_commands(self):
         self.spi.spi_send(
-            self.CONFIG0_WRITE + self.CONFIG0_DATA + self.CONFIG1_DATA +
-            self.CONFIG2_FORCE_DATA + self.CONFIG3_DATA + self.IRQ_DATA
+            CONFIG0_WRITE + CONFIG0_DATA + CONFIG1_DATA +
+            CONFIG2_FORCE_DATA + CONFIG3_DATA + IRQ_DATA
             )
+        # For future validation
         return True
 
-    def cmd_init_spi_touch_sensor(self, gcmd):
-        """Initialize the touch sensor SPI."""
+    def _handle_on_ready(self):
+        # Startup configuration for the touch sensor (Initialization)
+        self.configured = self._do_config_commands()
+        self.gcode.run_script("FAKE_HOME")
+
+
+    def _handle_probing_event(self, gcmd):
         if not self.configured:
-            self.printer.get_printer().logger.info("Initializing touch sensor SPI")
+            raise gcmd.error("Touch sensor is not configured. Please initialize it first.")
+
+        # send a cmd to the mcu to start reading the touch sensor adc
+        # It should watch out and do some logic to give an interrupt signal to the Z-probe pin
+
+    def cmd_INIT_TS(self, gcmd):
+        """Initialize the touch sensor-SPI."""
+        if not self.configured:
             # Perform any necessary initialization commands here
             self.configured = self._do_config_commands()
-            if not self.configured:
-                raise gcmd.error("Failed to configure touch sensor SPI.")
-            gcmd.respond_info("Touch sensor SPI initialized successfully.")
+            gcmd.respond_info("Touch sensor-SPI initialized successfully.")
         else:
-            gcmd.respond_info("Touch sensor SPI already initialized. Reset first if you attached a new head.")
-        
-    def cmd_reset_touch_sensor(self, gcmd):
+            gcmd.respond_info("Touch sensor-SPI already initialized. Reset first, if you attached a new head.")
+
+    def cmd_RESET_TS(self, gcmd):
         """Reset the touch sensor."""
-        self.spi.spi_send(self.FULL_RST)
+        self.spi.spi_send(FULL_RST)
         self.configured = False
         # do whatever commands are needed to reset the touch sensor
-        self.printer.get_printer().logger.info("Touch sensor reset. Please reinitialize SPI.")
-        gcmd.respond_info("Touch sensor reset. Please reinitialize SPI once attachement is connected.")
+        gcmd.respond_info("Touch sensor reset. Please reinitialize SPI once attachment is connected.")
 
-    def _handle_probing_event(self, event):
-        if not self.configured:
-            self.printer.get_printer().logger.error("Touch sensor not configured. Please initialize it first.")
-            return
-        # send a cmd to the mcu to start reading the touch sensor adc
-        # It should watch out and do some logic to give an interrupt singnal to the Z-probe pin
-    def cmd_get_touch_sensor_reading(self, gcmd):
+    def cmd_GET_TS_VALUE(self, gcmd):
         """Get the touch sensor data."""
         if not self.configured:
             raise gcmd.error("Touch sensor not configured. Please initialize it first.")
 
-        self.spi.spi_send(self.ADCDATA_READ)
+        self.spi.spi_send(ADCDATA_READ)
         resp = self.spi.spi_transfer([0xff, 0xff])
         data = resp['response']  # <- FIXED: extract the actual bytes
 

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -1,0 +1,110 @@
+#################################################################
+# Klippy Touch Sensor Module @ Alpatros
+# Description: This module provides klippy interface for spi-based touch sensor (MCP3462R)
+# Date: 2025-06-20
+# Version: 0.1
+# Owner: Mo
+#################################################################
+import logging
+from . import bus
+
+class Touch_sensor_MCP3462R:
+    def __init__(self, config):
+        self.spi = bus.MCU_SPI_from_config(
+            config, 0, pin_option="cs_pin")
+
+        self.printer = config.get_printer()
+
+        self.gcode = self.printer.lookup_object('gcode')
+        self.gcode.register_command('RESET_TS', self.cmd_reset_touch_sensor,
+            desc="Reset the touch sensor")
+        self.gcode.register_command('INIT_SPI_TS', self.cmd_init_spi_touch_sensor,
+            desc="Initialize the touch sensor SPI")
+        self.gcode.register_command('GET_TS_VAL', self.cmd_get_touch_sensor_reading,
+            desc="Klippy read for touch sensor value")
+
+        # ppins = self.printer.lookup_object('pins')
+        # self.adc_int_pin = ppins.setup_pin('endstop',config.get('adc_int_pin'))
+
+        self.FULL_RST = bytes([0b01111000])
+        self.ADCDATA_READ = bytes([0b01000011])
+        self.CONFIG0_WRITE = bytes([0b01000110])
+        self.CONFIG0_DATA = bytes([0b01100011])
+        self.CONFIG1_DATA = bytes([0b00001100]) # This is the default
+        self.CONFIG2_FORCE_DATA = bytes([0b10110011]) # Gain is x32 (x16 analog, x2 digital) 
+        self.CONFIG3_DATA = bytes([0b11000000])
+        self.IRQ_DATA = bytes([0b00000110])
+        self.MUX_FORCE_DATA = bytes([0b00110010]) # This is for ch2&3. The defualt is Ch0&1, which is not what we want.
+        self.configured = self._do_config_commands()
+
+        # need to hook a handler to probing envent, so once it is triggered, we tell the mcu/adc that we are looking for you inpu now.
+        self.printer.register_event_handler("probe:PROBE", self._handle_probing_event)
+        # self.gcode.register_command('TOGGLE_CS', self.cmd_toggle_cs_pin,
+        #     desc="Toggle CS pin manually for debugging")
+        self.printer.register_event_handler("klippy:ready", self._on_ready)
+
+    def cmd_toggle_cs_pin(self, gcmd):
+        for i in range(10000):
+            resp = self.spi.spi_transfer([0xff])
+            data = resp['response']  # <- FIXED: extract the actual bytes
+
+            if not isinstance(data, (bytes, bytearray)) or len(data) != 1:
+                raise gcmd.error("Invalid SPI response: expected 1 byte, got %s" % repr(data))
+
+            value = data[0]
+            hex_v = data.hex()
+            gcmd.respond_info("Touch sensor value: %d, hex: %s" % (value , hex_v))
+    def _on_ready(self):
+        self.gcode.run_script("GET_TS_VAL")
+        
+    def _do_config_commands(self):
+        self.spi.spi_send(
+            self.CONFIG0_WRITE + self.CONFIG0_DATA + self.CONFIG1_DATA +
+            self.CONFIG2_FORCE_DATA + self.CONFIG3_DATA + self.IRQ_DATA
+            )
+        return True
+
+    def cmd_init_spi_touch_sensor(self, gcmd):
+        """Initialize the touch sensor SPI."""
+        if not self.configured:
+            self.printer.get_printer().logger.info("Initializing touch sensor SPI")
+            # Perform any necessary initialization commands here
+            self.configured = self._do_config_commands()
+            if not self.configured:
+                raise gcmd.error("Failed to configure touch sensor SPI.")
+            gcmd.respond_info("Touch sensor SPI initialized successfully.")
+        else:
+            gcmd.respond_info("Touch sensor SPI already initialized. Reset first if you attached a new head.")
+        
+    def cmd_reset_touch_sensor(self, gcmd):
+        """Reset the touch sensor."""
+        self.spi.spi_send(self.FULL_RST)
+        self.configured = False
+        # do whatever commands are needed to reset the touch sensor
+        self.printer.get_printer().logger.info("Touch sensor reset. Please reinitialize SPI.")
+        gcmd.respond_info("Touch sensor reset. Please reinitialize SPI once attachement is connected.")
+
+    def _handle_probing_event(self, event):
+        if not self.configured:
+            self.printer.get_printer().logger.error("Touch sensor not configured. Please initialize it first.")
+            return
+        # send a cmd to the mcu to start reading the touch sensor adc
+        # It should watch out and do some logic to give an interrupt singnal to the Z-probe pin
+    def cmd_get_touch_sensor_reading(self, gcmd):
+        """Get the touch sensor data."""
+        if not self.configured:
+            raise gcmd.error("Touch sensor not configured. Please initialize it first.")
+
+        self.spi.spi_send(self.ADCDATA_READ)
+        resp = self.spi.spi_transfer([0xff, 0xff])
+        data = resp['response']  # <- FIXED: extract the actual bytes
+
+        if not isinstance(data, (bytes, bytearray)) or len(data) != 2:
+            raise gcmd.error("Invalid SPI response: expected 2 bytes, got %s" % repr(data))
+
+        value = (data[0] << 8) | data[1]
+        hex_v = data.hex()
+        gcmd.respond_info("Touch sensor value: %d, hex: %s" % (value , hex_v))
+
+def load_config(config):
+    return Touch_sensor_MCP3462R(config)

--- a/klippy/extras/touch_sensor.py
+++ b/klippy/extras/touch_sensor.py
@@ -91,10 +91,7 @@ class Touch_sensor_MCP3462R:
         """Handle printer ready event and initialize sensor if needed."""
         if not self.configured:
             self.configured = self._do_initialization_commands()
-        # TEMPORARY: For testing purposes, run a fake home command
-        self.gcode.run_script("FAKE_HOME")
-        # self.gcode.run_script("PROBE")
-
+    
     def _handle_probing_event(self, gcmd):
         """Handle probing event and start touch sensor session."""
         if not self.configured:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Main code build rules
 
-src-y += sched.c command.c basecmd.c debugcmds.c
-src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c \
+src-y += sched.c command.c basecmd.c debugcmds.c touch_sensor_mcp3462r.c
+src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c 
     trsync.c
 src-$(CONFIG_WANT_ADC) += adccmds.c
 src-$(CONFIG_WANT_SPI) += spicmds.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Main code build rules
 
 src-y += sched.c command.c basecmd.c debugcmds.c touch_sensor_mcp3462r.c
-src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c 
+src-$(CONFIG_HAVE_GPIO) += initial_pins.c gpiocmds.c stepper.c endstop.c \
     trsync.c
 src-$(CONFIG_WANT_ADC) += adccmds.c
 src-$(CONFIG_WANT_SPI) += spicmds.c

--- a/src/touch_sensor_mcp3462r.c
+++ b/src/touch_sensor_mcp3462r.c
@@ -141,7 +141,7 @@ void command_start_touch_sensing_session(uint32_t *args) {
 
     output("Starting touch sensing session with OID=%c, timeout_cycles=%u, rest_ticks=%u, sensitivity=%u",
            mcp_adc_ptr->oid, mcp_adc_ptr->timeout_cycles, mcp_adc_ptr->rest_ticks, mcp_adc_ptr->sensitivity);
-
+    // TODO: Make the errors less aggressive
     if (!mcp_adc_ptr->timeout_cycles || !mcp_adc_ptr->rest_ticks) {
         shutdown("Timeout cycles and rest ticks must be greater than 0");
     }

--- a/src/touch_sensor_mcp3462r.c
+++ b/src/touch_sensor_mcp3462r.c
@@ -1,0 +1,114 @@
+/*
+#################################################################
+Klipper Touch Sensor Module @ Albatross
+Description: This module provides low level kllipper interface for spi-based touch sensor (MCP3462R-ADC)
+Date: 2025-06-05
+Version: 0.1
+Owner: Mo
+#################################################################
+*/
+#include "board/gpio.h" // irq_disable
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
+#include "command.h" // DECL_COMMAND
+#include "sched.h" // DECL_TASK
+#include "spicmds.h" // spidev_transfer
+
+
+#define READ_CMD 0b01000011 // Read command for MCP3462R
+
+struct mcp3462r_adc {
+    uint8_t oid; // Object ID for this ADC instance
+    struct spidev_s *spi;
+    struct gpio_in adc_ready_pin;
+    struct gpio_out trigger_out_pin;
+    uint32_t rest_ticks, timeout_cycles;
+    struct timer timer;
+    uint8_t active_session_flag, configured_flag;
+    uint8_t msg[2];
+};
+
+static struct mcp3462r_adc *mcp_adc_ptr = NULL;
+
+void
+command_cfg_ts_adc(uint32_t *args)
+{
+    mcp_adc_ptr = oid_alloc(args[0], command_cfg_ts_adc, sizeof(*mcp_adc_ptr));
+    mcp_adc_ptr->oid = args[0];
+    mcp_adc_ptr->spi = spidev_oid_lookup(args[1]);
+    mcp_adc_ptr->adc_ready_pin = gpio_in_setup(args[2], 0);
+    mcp_adc_ptr->trigger_out_pin = gpio_out_setup(args[3], 0);
+    mcp_adc_ptr->timer.func = mcp3462r_event;
+    mcp_adc_ptr->active_session_flag = 0;
+    mcp_adc_ptr->configured_flag = 1;
+    mcp_adc_ptr->msg = {0x00, 0x00};
+}
+
+DECL_COMMAND(command_cfg_ts_adc, "cfg_ts_adc oid=%c spi_oid=%c adc_int_pin=%u trigger_out_pin=%u");
+
+
+int8_t
+mcp3462r_is_data_ready(struct mcp3462r_adc *mcp3462r)
+{
+    return gpio_in_read(mcp3462r->adc_ready_pin) == 0;
+}
+
+
+static uint_fast8_t
+mcp3462r_event(struct timer *t)
+{
+    // struct mcp3462r_adc *mcp_adc_ptr = container_of(t, struct mcp3462r_adc, timer);
+    if (mcp3462r_is_data_ready(mcp_adc_ptr)) 
+    {
+        // Read ADC data
+        mcp_adc_ptr->msg = {0x00, 0x00}; // Clear previous data
+        spidev_transfer(mcp_adc_ptr->spi, 1, 2, msg);
+        // Process the raw values here
+    }
+    else
+    {
+        mcp_adc_ptr->timer.waketime += mcp_adc_ptr->rest_ticks;
+        if (--mcp_adc_ptr->timeout_cycles == 0) {
+            // Timeout reached, stop the task
+            mcp_adc_ptr->active_session_flag = 0;
+            // sched_del_timer(&mcp_adc_ptr->timer);
+            return SF_DONE;
+        }
+
+    }
+    
+    return SF_RESCHEDULE;
+}
+
+/*
+// This function is the event that is initiated by the user to walk 
+// the a timered tasl for reading the value and  doing the low level logic
+*/
+void
+command_start_touch_sensing_session(uint32_t *args)
+{
+    if (mcp_adc_ptr == NULL || !mcp_adc_ptr->configured_flag) 
+        shutdown("Touch sensor ADC HW is not configured");
+    if (mcp_adc_ptr->oid != args[0]) 
+        shutdown("Touch sensor ADC OID does not match the configured OID");
+    
+    mcp_adc_ptr->timeout_cycles = args[1];
+    mcp_adc_ptr->rest_ticks = args[2];
+    if (!mcp_adc_ptr->timeout_cycles || !mcp_adc_ptr->rest_ticks) 
+        shutdown("Timeout cycles and rest ticks must be greater than 0");
+    
+    // Send a reading command to the MCP3462R ADC
+    mcp_adc_ptr->msg[0] = READ_CMD;
+    spidev_transfer(mcp_adc_ptr->spi, 0, 1, mcp_adc_ptr->msg[0]);
+
+    // Start the periodic event to listen for data ready
+    sched_del_timer(&mcp_adc_ptr->timer);
+    irq_disable();
+    mcp_adc_ptr->timer.waketime = timer_read_time() + mcp_adc_ptr->rest_ticks;
+    sched_add_timer(&mcp_adc_ptr->timer);
+    irq_enable();
+}
+
+DECL_COMMAND(command_start_touch_sensing_session,
+             "start_ts_session oid=%c timeout_cycles=%u rest_ticks=%u");
+

--- a/src/touch_sensor_mcp3462r.c
+++ b/src/touch_sensor_mcp3462r.c
@@ -1,91 +1,97 @@
 /*
 #################################################################
 Klipper Touch Sensor Module @ Albatross
-Description: This module provides low level kllipper interface for spi-based touch sensor (MCP3462R-ADC)
+Description: This module provides low level klipper interface for spi-based touch sensor (MCP3462R-ADC)
 Date: 2025-06-05
 Version: 0.1
 Owner: Mo
 #################################################################
 */
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "board/gpio.h" // irq_disable
-#include "board/irq.h" // irq_disable
-
-#include "basecmd.h" // oid_alloc
-#include "board/misc.h" // timer_read_time
-#include "command.h" // DECL_COMMAND
-#include "sched.h" // DECL_TASK
-#include "spicmds.h" // spidev_transfer
+#include "board/gpio.h"
+#include "board/irq.h"
+#include "basecmd.h"
+#include "board/misc.h"
+#include "command.h"
+#include "sched.h"
+#include "spicmds.h"
 #include "touch_sensor_mcp3462r.h"
 
 #define ADC_ACTIVE_STATE 1
 
-
-
+// Global pointer to the ADC instance
 static struct mcp3462r_adc *mcp_adc_ptr = NULL;
 
-int8_t
-mcp3462r_is_data_ready(struct mcp3462r_adc *mcp3462r)
-{
+// -----------------------------------------------------------------------------
+// Utility Functions
+// -----------------------------------------------------------------------------
+
+// Check if ADC data is ready
+int8_t mcp3462r_is_data_ready(struct mcp3462r_adc *mcp3462r) {
     return gpio_in_read(mcp3462r->adc_ready_pin) == ADC_ACTIVE_STATE;
 }
 
+// -----------------------------------------------------------------------------
+// Timer Event Handlers
+// -----------------------------------------------------------------------------
 
-static uint_fast8_t
-mcp3462r_terminator_event(struct timer *t)
-{
-    // Reset the touch sensor ADC state
+// Terminator event: called at the end of a session to reset state
+static uint_fast8_t mcp3462r_terminator_event(struct timer *t) {
     gpio_out_write(mcp_adc_ptr->trigger_out_pin, 0);
     sched_del_timer(&mcp_adc_ptr->timer);
+    mcp_adc_ptr->active_session_flag = 0; // Ensure session flag is cleared
     output("Touch sensor ADC terminator event triggered at cycle= %u", mcp_adc_ptr->timeout_cycles);
-    // Report the end of the session flag
-    output("Touch sensor ADC session terminated at cycle= %u, session flag is= %u", mcp_adc_ptr->timeout_cycles, mcp_adc_ptr->active_session_flag);
+    output("Touch sensor ADC session terminated at cycle= %u, session flag is= %u",
+           mcp_adc_ptr->timeout_cycles, mcp_adc_ptr->active_session_flag);
     return SF_DONE;
-    
 }
-static uint_fast8_t
-mcp3462r_event(struct timer *t)
-{
-    uint16_t doneP =0, data =0;
-    // struct mcp3462r_adc *mcp_adc_ptr = container_of(t, struct mcp3462r_adc, timer);
-    output("Touch sensor ADC event triggered at cycle= %u",  mcp_adc_ptr->timeout_cycles);
-    if (mcp3462r_is_data_ready(mcp_adc_ptr)) 
-    {
+
+// Main event: handles ADC data polling and session logic
+static uint_fast8_t mcp3462r_event(struct timer *t) {
+    uint16_t doneP = 0, data = 0;
+
+    output("Touch sensor ADC event triggered at cycle= %u", mcp_adc_ptr->timeout_cycles);
+
+    if (mcp3462r_is_data_ready(mcp_adc_ptr)) {
         // Read ADC data
         mcp_adc_ptr->msg[0] = 0x00;
         mcp_adc_ptr->msg[1] = 0x00;
         spidev_transfer(mcp_adc_ptr->spi, 1, 2, mcp_adc_ptr->msg);
-        // Process the raw values here
-        output("Got new raw ADC data: %u %u at cycle= %u", mcp_adc_ptr->msg[0], mcp_adc_ptr->msg[1], mcp_adc_ptr->timeout_cycles); 
+
+        // Process the raw values
+        output("Got new raw ADC data: %u %u at cycle= %u",
+               mcp_adc_ptr->msg[0], mcp_adc_ptr->msg[1], mcp_adc_ptr->timeout_cycles);
+
         data = (mcp_adc_ptr->msg[0] << 8) | mcp_adc_ptr->msg[1];
-        if (data > mcp_adc_ptr->sensitivity) 
-        {
-            // Trigger the touch event
+
+        if (data > mcp_adc_ptr->sensitivity) {
+            // Touch detected
             gpio_out_write(mcp_adc_ptr->trigger_out_pin, 1);
-            // Terminate the session and send the result
-            mcp_adc_ptr->timeout_cycles =1;
+            mcp_adc_ptr->timeout_cycles = 1; // End session soon
             doneP = 1;
         } else {
-            // No touch detected, reset the output pin
+            // No touch detected, reset output pin and send another read command
             gpio_out_write(mcp_adc_ptr->trigger_out_pin, 0);
-            // send another read command to the ADC
             mcp_adc_ptr->msg[0] = READ_CMD;
             spidev_transfer(mcp_adc_ptr->spi, 0, 1, &mcp_adc_ptr->msg[0]);
         }
-
     }
 
     mcp_adc_ptr->timer.waketime += mcp_adc_ptr->rest_ticks;
+
     if (--mcp_adc_ptr->timeout_cycles == 0) {
         // Timeout reached, stop the task
         mcp_adc_ptr->active_session_flag = 0;
-        sendf("Ts_session_result oid=%c status=%u lstValue=%u", mcp_adc_ptr->oid, doneP,data);
-        output("Ts_session_result status=%u lstValue=%u", doneP,data);
+        sendf("Ts_session_result oid=%c status=%u lstValue=%u",
+              mcp_adc_ptr->oid, doneP, data);
+        output("Ts_session_result status=%u lstValue=%u", doneP, data);
+
         if (doneP) {
-            // Point to the terminator event to reset the probe event state
+            // Schedule terminator event to reset probe state
             mcp_adc_ptr->timer.func = mcp3462r_terminator_event;
             return SF_RESCHEDULE;
         }
@@ -95,9 +101,12 @@ mcp3462r_event(struct timer *t)
     return SF_RESCHEDULE;
 }
 
-void
-command_cfg_ts_adc(uint32_t *args)
-{
+// -----------------------------------------------------------------------------
+// Command Handlers
+// -----------------------------------------------------------------------------
+
+// Configure the ADC hardware and state
+void command_cfg_ts_adc(uint32_t *args) {
     mcp_adc_ptr = oid_alloc(args[0], command_cfg_ts_adc, sizeof(*mcp_adc_ptr));
     mcp_adc_ptr->oid = args[0];
     mcp_adc_ptr->spi = spidev_oid_lookup(args[1]);
@@ -109,43 +118,49 @@ command_cfg_ts_adc(uint32_t *args)
     mcp_adc_ptr->msg[0] = 0x00;
     mcp_adc_ptr->msg[1] = 0x00;
     gpio_out_write(mcp_adc_ptr->trigger_out_pin, 0);
+
     output("Touch sensor ADC configured with OID=%c, SPI OID=%c, ADC ready pin=%u, Trigger out pin=%u",
-         mcp_adc_ptr->oid, args[1], args[2], args[3]);
+           mcp_adc_ptr->oid, args[1], args[2], args[3]);
 }
 
-DECL_COMMAND(command_cfg_ts_adc, "cfg_ts_adc oid=%c spi_oid=%c adc_int_pin=%u trigger_out_pin=%u");
+DECL_COMMAND(command_cfg_ts_adc,
+             "cfg_ts_adc oid=%c spi_oid=%c adc_int_pin=%u trigger_out_pin=%u");
 
-/*
-// This function is the cmd that is initiated by the user to wake up
-// a timered event for reading the value and  doing the low level logic
-*/
-void
-command_start_touch_sensing_session(uint32_t *args)
-{
-    output("got a new touch sensing request");
-    if (mcp_adc_ptr == NULL || !mcp_adc_ptr->configured_flag) 
+// Start a new touch sensing session
+void command_start_touch_sensing_session(uint32_t *args) {
+    if (mcp_adc_ptr == NULL || !mcp_adc_ptr->configured_flag) {
         shutdown("Touch sensor ADC HW is not configured");
-    if (mcp_adc_ptr->oid != args[0]) 
+    }
+    if (mcp_adc_ptr->oid != args[0]) {
         shutdown("Touch sensor ADC OID does not match the configured OID");
-    
+    }
+
     mcp_adc_ptr->timeout_cycles = args[1];
     mcp_adc_ptr->rest_ticks = args[2];
     mcp_adc_ptr->sensitivity = args[3];
-    output("Starting touch sensing session with OID=%c, timeout_cycles=%u, rest_ticks=%u, sensitivity=%u\n",
-         mcp_adc_ptr->oid, mcp_adc_ptr->timeout_cycles, mcp_adc_ptr->rest_ticks, mcp_adc_ptr->sensitivity);
-    if (!mcp_adc_ptr->timeout_cycles || !mcp_adc_ptr->rest_ticks) 
+
+    output("Starting touch sensing session with OID=%c, timeout_cycles=%u, rest_ticks=%u, sensitivity=%u",
+           mcp_adc_ptr->oid, mcp_adc_ptr->timeout_cycles, mcp_adc_ptr->rest_ticks, mcp_adc_ptr->sensitivity);
+
+    if (!mcp_adc_ptr->timeout_cycles || !mcp_adc_ptr->rest_ticks) {
         shutdown("Timeout cycles and rest ticks must be greater than 0");
-    if (mcp_adc_ptr->sensitivity == 0) 
+    }
+    if (mcp_adc_ptr->sensitivity == 0) {
         shutdown("Sensitivity must be greater than 0");
-    if (mcp_adc_ptr->active_session_flag) 
+    }
+    if (mcp_adc_ptr->active_session_flag) {
         shutdown("Touch sensing session is already active");
+    }
+
     // Send a reading command to the MCP3462R ADC
     mcp_adc_ptr->msg[0] = READ_CMD;
     spidev_transfer(mcp_adc_ptr->spi, 0, 1, &mcp_adc_ptr->msg[0]);
     mcp_adc_ptr->active_session_flag = 1;
+
     // Start the periodic event to listen for data ready
     sched_del_timer(&mcp_adc_ptr->timer);
     mcp_adc_ptr->timer.func = mcp3462r_event;
+
     irq_disable();
     mcp_adc_ptr->timer.waketime = timer_read_time() + mcp_adc_ptr->rest_ticks;
     sched_add_timer(&mcp_adc_ptr->timer);
@@ -154,4 +169,3 @@ command_start_touch_sensing_session(uint32_t *args)
 
 DECL_COMMAND(command_start_touch_sensing_session,
              "start_ts_session oid=%c timeout_cycles=%u rest_ticks=%u sensitivity=%u");
-

--- a/src/touch_sensor_mcp3462r.h
+++ b/src/touch_sensor_mcp3462r.h
@@ -5,9 +5,10 @@ struct mcp3462r_adc {
     struct spidev_s *spi;
     struct gpio_in adc_ready_pin;
     struct gpio_out trigger_out_pin;
+    struct gpio_out PI_EN_pin;
     uint32_t rest_ticks, timeout_cycles;
     struct timer timer;
     uint8_t active_session_flag, configured_flag;
-    uint8_t msg[2];
+    uint8_t msg[3];
     uint16_t sensitivity; 
 };

--- a/src/touch_sensor_mcp3462r.h
+++ b/src/touch_sensor_mcp3462r.h
@@ -1,0 +1,13 @@
+#define READ_CMD 0b01000011 // Read command for MCP3462R
+
+struct mcp3462r_adc {
+    uint8_t oid; // Object ID for this ADC instance
+    struct spidev_s *spi;
+    struct gpio_in adc_ready_pin;
+    struct gpio_out trigger_out_pin;
+    uint32_t rest_ticks, timeout_cycles;
+    struct timer timer;
+    uint8_t active_session_flag, configured_flag;
+    uint8_t msg[2];
+    uint16_t sensitivity; 
+};


### PR DESCRIPTION
#  Add Klipper Integration Module for XGZP6847D Pressure Sensor

This PR introduces a new Klippy module for interfacing with the **XGZP6847D** vacuum pressure sensor via I2C. It enables pressure and temperature measurements using asynchronous read cycles and provides a GCode interface for printer-side access.

##  Module 1: pressure sensor module
- `XGZP6847D.py` — high-level Klippy integration for the XGZP6847D sensor
##  Module 2: suction controller
- `suction_controller.py` —  A custom controller for suction fans (currently mirrors standard fan behavior but is designed for future fusion with pressure feedback logic)
##  Configuration Example
```ini
[XGZP6847D_sensor]
i2c_bus: i2c0e
i2c_mcu: mu_mcu

[suction_controller]
pin: mu_mcu:gpio25
```
##  Features
- Automatically reads sensor status periodically for live monitoring  (get_status())
- Initializes and verifies sensor presence on Klipper startup  
- Starts combined pressure/temperature read via I2C with `DO_PT_MEASURE`  
- Reports last measured values via `TELL_PT_MEASURE`  


##  Supported GCodes
### XGZP6847D
- `DO_PT_MEASURE` — starts an async read cycle  
- `TELL_PT_MEASURE` — returns latest pressure and temperature values  
- `get_status(eventtime)` — internal Klipper query interface to check sampling state and last values  
### Suction Controller
- Custom fan-like device driver  
- Compatible with standard `M107 & M106` GCodes  
- Lays groundwork for future integration with pressure sensor feedback  

##  Notes
- The sensor is polled asynchronously using Klipper’s reactor system  
- Pressure is converted using the appropriate factory `K` value (128 for 100kPa full-scale range)  
- Timeouts and failure cases are logged with appropriate warnings  



