### PR TITLE
Sht3x: forbid retry of the data read within a short time window.

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -217,8 +217,8 @@ class MCU_I2C:
     def i2c_write_wait_ack(self, data, minclock=0, reqclock=0):
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
                                 minclock=minclock, reqclock=reqclock)
-    def i2c_read(self, write, read_len):
-        return self.i2c_read_cmd.send([self.oid, write, read_len])
+    def i2c_read(self, write, read_len, retry=True):
+        return self.i2c_read_cmd.send([self.oid, write, read_len], retry)
 
 def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
     # Load bus parameters

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -310,9 +310,12 @@ class SerialRetryCommand:
         self.serial.register_response(self.handle_callback, name, oid)
     def handle_callback(self, params):
         self.last_params = params
-    def get_response(self, cmds, cmd_queue, minclock=0, reqclock=0):
+    def get_response(self, cmds, cmd_queue, minclock=0, reqclock=0,
+                     retry=True):
         retries = 5
         retry_delay = .010
+        if not retry:
+            retries = 0
         while 1:
             for cmd in cmds[:-1]:
                 self.serial.raw_send(cmd, minclock, reqclock, cmd_queue)


### PR DESCRIPTION
MCU transmission to the host is virtually "error-free", so MCU does not retry the transmission, the host does.
The MCU could be successful at reading the device data, and then fail to deliver it.
That would trigger host retry, which will try to read data again from the device when the device is not ready.
That would result in NACK and shutdown.

My proposed workaround is to add the oneshot send helper, which can return None on timeout, and so the device support should handle the retries with desirable behaviour.

In case of the SHT3x it is a retry after 0.5s pause. On some other sensors, it could be another query transaction (like request temp -> read, request humidity -> read), where the secondary read is simply forbidden.

Thanks.

---
BTW, I received a report about SHT3x issues on the Discord `#klipper-development`.
I also has probably encountered that problem, but because STM32H7 did not support the nack distinguish, just assumed it is sort of the EMI because of the long I2C lines. 

---
Ref: #6974