### PR TITLE
sos_filter.c: fix overflows_int32

### DIFF
--- a/src/sos_filter.c
+++ b/src/sos_filter.c
@@ -29,7 +29,7 @@ struct sos_filter {
     struct sos_filter_section filter[0];
 };
 
-inline uint8_t
+static inline uint8_t
 overflows_int32(int64_t value) {
     return value > (int64_t)INT32_MAX || value < (int64_t)INT32_MIN;
 }


### PR DESCRIPTION
Modify the inline function overflows_int32 to static inline
Inline functions cannot be debugged in -O0 mode
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49653