### PR TITLE
Remove old host based software i2c system

### DIFF
--- a/config/generic-mightyboard.cfg
+++ b/config/generic-mightyboard.cfg
@@ -89,32 +89,32 @@ max_z_velocity: 5
 max_z_accel: 100
 
 [mcp4018 x_axis_pot]
-scl_pin: PJ5
-sda_pin: PF3
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PF3
 wiper: 0.50
 scale: 0.773
 
 [mcp4018 y_axis_pot]
-scl_pin: PJ5
-sda_pin: PF7
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PF7
 wiper: 0.50
 scale: 0.773
 
 [mcp4018 z_axis_pot]
-scl_pin: PJ5
-sda_pin: PK3
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PK3
 wiper: 0.50
 scale: 0.773
 
 [mcp4018 a_axis_pot]
-scl_pin: PJ5
-sda_pin: PA5
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PA5
 wiper: 0.50
 scale: 0.773
 
 [mcp4018 b_axis_pot]
-scl_pin: PJ5
-sda_pin: PJ6
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PJ6
 wiper: 0.50
 scale: 0.773
 

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -127,32 +127,32 @@ max_z_velocity: 5
 max_z_accel: 100
 
 [mcp4018 x_axis_pot]
-scl_pin: PJ5
-sda_pin: PF3
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PF3
 wiper: 118
 scale: 127
 
 [mcp4018 y_axis_pot]
-scl_pin: PJ5
-sda_pin: PF7
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PF7
 wiper: 118
 scale: 127
 
 [mcp4018 z_axis_pot]
-scl_pin: PJ5
-sda_pin: PK3
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PK3
 wiper: 40
 scale: 127
 
 [mcp4018 a_axis_pot]
-scl_pin: PJ5
-sda_pin: PA5
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PA5
 wiper: 118
 scale: 127
 
 [mcp4018 b_axis_pot]
-scl_pin: PJ5
-sda_pin: PJ6
+i2c_software_scl_pin: PJ5
+i2c_software_sda_pin: PJ6
 wiper: 118
 scale: 127
 

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250721: The `[pca9632]` module no longer accepts the `scl_pin` and
+`sda_pin` options.  Use `i2c_software_scl_pin` and
+`i2c_software_sda_pin` instead.
+
 20250428: The maximum `cycle_time` for pwm `[output_pin]`,
 `[pwm_cycle_time]`, `[pwm_tool]`, and similar config sections is now 3
 seconds (reduced from 5 seconds). The `maximum_mcu_duration` in

--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,8 +8,8 @@ All dates in this document are approximate.
 
 ## Changes
 
-20250721: The `[pca9632]` module no longer accepts the `scl_pin` and
-`sda_pin` options.  Use `i2c_software_scl_pin` and
+20250721: The `[pca9632]` and `[mcp4018]` modules no longer accept the
+`scl_pin` and `sda_pin` options. Use `i2c_software_scl_pin` and
 `i2c_software_sda_pin` instead.
 
 20250428: The maximum `cycle_time` for pwm `[output_pin]`,

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3477,11 +3477,6 @@ PCA9632 LED support. The PCA9632 is used on the FlashForge Dreamer.
 #i2c_speed:
 #   See the "common I2C settings" section for a description of the
 #   above parameters.
-#scl_pin:
-#sda_pin:
-#   Alternatively, if the pca9632 is not connected to a hardware I2C
-#   bus, then one may specify the "clock" (scl_pin) and "data"
-#   (sda_pin) pins. The default is to use hardware I2C.
 #color_order: RGBW
 #   Set the pixel order of the LED (using a string containing the
 #   letters R, G, B, W). The default is RGBW.

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4392,16 +4392,21 @@ prefix).
 
 ### [mcp4018]
 
-Statically configured MCP4018 digipot connected via two gpio "bit
-banging" pins (one may define any number of sections with an "mcp4018"
-prefix).
+Statically configured MCP4018 digipot connected via i2c (one may
+define any number of sections with an "mcp4018" prefix).
 
 ```
 [mcp4018 my_digipot]
-scl_pin:
-#   The SCL "clock" pin. This parameter must be provided.
-sda_pin:
-#   The SDA "data" pin. This parameter must be provided.
+#i2c_address: 47
+#   The i2c address that the chip is using on the i2c bus. The default
+#   is 47.
+#i2c_mcu:
+#i2c_bus:
+#i2c_software_scl_pin:
+#i2c_software_sda_pin:
+#i2c_speed:
+#   See the "common I2C settings" section for a description of the
+#   above parameters.
 wiper:
 #   The value to statically set the given MCP4018 "wiper" to. This is
 #   typically set to a number between 0.0 and 1.0 with 1.0 being the

--- a/klippy/extras/mcp4018.py
+++ b/klippy/extras/mcp4018.py
@@ -1,75 +1,14 @@
-# MCP4018 digipot support (via bit-banging)
+# MCP4018 digipot support
 #
-# Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2019-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-
-class SoftwareI2C:
-    def __init__(self, config, addr):
-        self.addr = addr << 1
-        self.update_pin_cmd = None
-        # Lookup pins
-        ppins = config.get_printer().lookup_object('pins')
-        scl_pin = config.get('scl_pin')
-        scl_params = ppins.lookup_pin(scl_pin, share_type='sw_scl')
-        self.mcu = scl_params['chip']
-        self.scl_pin = scl_params['pin']
-        self.scl_main = scl_params.get('class')
-        if self.scl_main is None:
-            self.scl_main = scl_params['class'] = self
-            self.scl_oid = self.mcu.create_oid()
-            self.cmd_queue = self.mcu.alloc_command_queue()
-            self.mcu.register_config_callback(self.build_config)
-        else:
-            self.scl_oid = self.scl_main.scl_oid
-            self.cmd_queue = self.scl_main.cmd_queue
-        sda_params = ppins.lookup_pin(config.get('sda_pin'))
-        self.sda_oid = self.mcu.create_oid()
-        if sda_params['chip'] != self.mcu:
-            raise ppins.error("%s: scl_pin and sda_pin must be on same mcu" % (
-                config.get_name(),))
-        self.mcu.add_config_cmd("config_digital_out oid=%d pin=%s"
-                                " value=%d default_value=%d max_duration=%d" % (
-                                    self.sda_oid, sda_params['pin'], 1, 1, 0))
-    def get_mcu(self):
-        return self.mcu
-    def build_config(self):
-        self.mcu.add_config_cmd("config_digital_out oid=%d pin=%s value=%d"
-                                " default_value=%d max_duration=%d" % (
-                                    self.scl_oid, self.scl_pin, 1, 1, 0))
-        self.update_pin_cmd = self.mcu.lookup_command(
-            "update_digital_out oid=%c value=%c", cq=self.cmd_queue)
-    def i2c_write(self, msg, minclock=0, reqclock=0):
-        msg = [self.addr] + msg
-        send = self.scl_main.update_pin_cmd.send
-        # Send ack
-        send([self.sda_oid, 0], minclock=minclock, reqclock=reqclock)
-        send([self.scl_oid, 0], minclock=minclock, reqclock=reqclock)
-        # Send bytes
-        sda_last = 0
-        for data in msg:
-            # Transmit 8 data bits
-            for i in range(8):
-                sda_next = not not (data & (0x80 >> i))
-                if sda_last != sda_next:
-                    sda_last = sda_next
-                    send([self.sda_oid, sda_last],
-                         minclock=minclock, reqclock=reqclock)
-                send([self.scl_oid, 1], minclock=minclock, reqclock=reqclock)
-                send([self.scl_oid, 0], minclock=minclock, reqclock=reqclock)
-            # Transmit clock for ack
-            send([self.scl_oid, 1], minclock=minclock, reqclock=reqclock)
-            send([self.scl_oid, 0], minclock=minclock, reqclock=reqclock)
-        # Send stop
-        if sda_last:
-            send([self.sda_oid, 0], minclock=minclock, reqclock=reqclock)
-        send([self.scl_oid, 1], minclock=minclock, reqclock=reqclock)
-        send([self.sda_oid, 1], minclock=minclock, reqclock=reqclock)
+from . import bus
 
 class mcp4018:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.i2c = SoftwareI2C(config, 0x2f)
+        self.i2c = bus.MCU_I2C_from_config(config, default_addr=0x2f)
         self.scale = config.getfloat('scale', 1., above=0.)
         self.start_value = config.getfloat('wiper',
                                            minval=0., maxval=self.scale)

--- a/klippy/extras/pca9632.py
+++ b/klippy/extras/pca9632.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022  Ricardo Alcantara <ricardo@vulcanolabs.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import bus, led, mcp4018
+from . import bus, led
 
 BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
 
@@ -25,10 +25,7 @@ PCA9632_LED3 = 0x06
 class PCA9632:
     def __init__(self, config):
         self.printer = printer = config.get_printer()
-        if config.get("scl_pin", None) is not None:
-            self.i2c = mcp4018.SoftwareI2C(config, 98)
-        else:
-            self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
+        self.i2c = bus.MCU_I2C_from_config(config, default_addr=98)
         color_order = config.get("color_order", "RGBW")
         if sorted(color_order) != sorted("RGBW"):
             raise config.error("Invalid color_order '%s'" % (color_order,))

--- a/src/avr/gpio.c
+++ b/src/avr/gpio.c
@@ -70,8 +70,10 @@ void
 gpio_out_reset(struct gpio_out g, uint8_t val)
 {
     irqstatus_t flag = irq_save();
-    g.regs->out = val ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
-    g.regs->mode |= g.bit;
+    uint8_t newmode = g.regs->mode | g.bit;
+    uint8_t newout = val ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
+    g.regs->out = newout;
+    g.regs->mode = newmode;
     irq_restore(flag);
 }
 
@@ -114,8 +116,10 @@ void
 gpio_in_reset(struct gpio_in g, int8_t pull_up)
 {
     irqstatus_t flag = irq_save();
-    g.regs->out = pull_up > 0 ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
-    g.regs->mode &= ~g.bit;
+    uint8_t newout = pull_up>0 ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
+    uint8_t newmode = g.regs->mode & ~g.bit;
+    g.regs->mode = newmode;
+    g.regs->out = newout;
     irq_restore(flag);
 }
 

--- a/src/i2c_software.c
+++ b/src/i2c_software.c
@@ -28,10 +28,10 @@ command_i2c_set_sw_bus(uint32_t *args)
     struct i2c_software *is = alloc_chunk(sizeof(*is));
     is->ticks = args[3];
     is->addr = (args[4] & 0x7f) << 1; // address format shifted
-    is->scl_in = gpio_in_setup(args[1], 1);
     is->scl_out = gpio_out_setup(args[1], 1);
-    is->sda_in = gpio_in_setup(args[2], 1);
+    is->scl_in = gpio_in_setup(args[1], 1);
     is->sda_out = gpio_out_setup(args[2], 1);
+    is->sda_in = gpio_in_setup(args[2], 1);
     i2cdev_set_software_bus(i2c, is);
 }
 DECL_COMMAND(command_i2c_set_sw_bus,

--- a/src/i2c_software.c
+++ b/src/i2c_software.c
@@ -38,13 +38,6 @@ DECL_COMMAND(command_i2c_set_sw_bus,
              "i2c_set_sw_bus oid=%c scl_pin=%u sda_pin=%u"
              " pulse_ticks=%u address=%u");
 
-// The AVR micro-controllers require specialized timing
-#if CONFIG_MACH_AVR
-
-#define i2c_delay(ticks) (void)(ticks)
-
-#else
-
 static void
 i2c_delay(uint32_t ticks)
 {
@@ -52,8 +45,6 @@ i2c_delay(uint32_t ticks)
     while (timer_is_before(timer_read_time(), end))
         ;
 }
-
-#endif
 
 static void
 i2c_software_send_ack(struct i2c_software *is, const uint8_t ack)

--- a/test/klippy/led.cfg
+++ b/test/klippy/led.cfg
@@ -25,8 +25,8 @@ initial_GREEN: 0.2
 initial_BLUE: 0.3
 
 [pca9632 p6led]
-scl_pin: PB1
-sda_pin: PB2
+i2c_software_scl_pin: PB1
+i2c_software_sda_pin: PB2
 initial_RED: 0.4
 initial_GREEN: 0.5
 initial_BLUE: 0.6


### PR DESCRIPTION
The mcp4018 and pca9632 code had an ability to program the devices using a primitive host based software i2c system.  However, after that code was added, a more extensive micro-controller based software i2c system was implemented.  The new mcu software i2c system does a much better job implementing the i2c protocol and has better error handling.  This PR removes the old code - users can use the mcu software i2c system as an alternative.  This does require changes to the user config, but the changes are minimal (rename `sda_pin` to `i2c_software_sda_pin` and rename `scl_pin` to `i2c_software_scl_pin`).

I do not have the hardware to test these changes.  However, the software changes are straight forward.

@loop777 , @jake-b - FYI.

-Kevin