### PR TITLE
FATFS fix missing long filenames support needed by flash-sdcard.sh 

### DIFF
--- a/lib/fatfs/ffconf.h
+++ b/lib/fatfs/ffconf.h
@@ -97,7 +97,7 @@
 */
 
 
-#define FF_USE_LFN		0
+#define FF_USE_LFN		1
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -50,6 +50,9 @@ BOARD_DEFS = {
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
+    # twotrees sapphire 5 v1.1 using mks robin 1.2 board
+    # renaming the firmware to "Robin_nano43.bin" supposed to allow updates without lcd connected, but it never worked for me.
+    # i left original screen plugged in and taped nside, while using 5" screen connected to RPI_3b+
     'mks-robin-v12': {
         'mcu': "stm32f103xe",
         'spi_bus': "swspi",
@@ -57,8 +60,8 @@ BOARD_DEFS = {
         'cs_pin': "PC11",
         'skip_verify': True
         "conversion_script": "scripts/update_mks_robin.py",
-        "firmware_path": "ROBIN_NANO43.BIN",
-        "current_firmware_path": "ROBIN_NANO43.BIN"
+        "firmware_path": "ROBIN_NANO35.BIN", 
+        "current_firmware_path": "ROBIN_NANO35.BIN"
     },
     'btt-octopus-f407-v1': {
         'mcu': "stm32f407xx",

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -58,7 +58,7 @@ BOARD_DEFS = {
         'spi_bus': "swspi",
         'spi_pins': "PC8,PD2,PC12",
         'cs_pin': "PC11",
-        'skip_verify': True
+        'skip_verify': True,
         "conversion_script": "scripts/update_mks_robin.py",
         "firmware_path": "ROBIN_NANO35.BIN", 
         "current_firmware_path": "ROBIN_NANO35.BIN"

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -50,6 +50,16 @@ BOARD_DEFS = {
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
+    'mks-robin-v12': {
+        'mcu': "stm32f103xe",
+        'spi_bus': "swspi",
+        'spi_pins': "PC8,PD2,PC12",
+        'cs_pin': "PC11",
+        'skip_verify': True
+        "conversion_script": "scripts/update_mks_robin.py",
+        "firmware_path": "ROBIN_NANO43.BIN",
+        "current_firmware_path": "ROBIN_NANO43.BIN"
+    },
     'btt-octopus-f407-v1': {
         'mcu': "stm32f407xx",
         'spi_bus': "swspi",

--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -50,9 +50,7 @@ BOARD_DEFS = {
         "firmware_path": "Robin_e3.bin",
         "current_firmware_path": "Robin_e3.cur"
     },
-    # twotrees sapphire 5 v1.1 using mks robin 1.2 board
-    # renaming the firmware to "Robin_nano43.bin" supposed to allow updates without lcd connected, but it never worked for me.
-    # i left original screen plugged in and taped nside, while using 5" screen connected to RPI_3b+
+    # twotrees sapphire 5 v1.1 using mks robin nano 1.2 board
     'mks-robin-v12': {
         'mcu': "stm32f103xe",
         'spi_bus': "swspi",
@@ -60,7 +58,7 @@ BOARD_DEFS = {
         'cs_pin': "PC11",
         'skip_verify': True,
         "conversion_script": "scripts/update_mks_robin.py",
-        "firmware_path": "ROBIN_NANO35.BIN", 
+        "firmware_path": "ROBIN_NANO35.BIN",
         "current_firmware_path": "ROBIN_NANO35.BIN"
     },
     'btt-octopus-f407-v1': {

--- a/scripts/spi_flash/fatfs_api.h
+++ b/scripts/spi_flash/fatfs_api.h
@@ -26,7 +26,8 @@ struct ff_file_info {
     uint16_t modified_date;
     uint16_t modified_time;
     uint8_t  attrs;
-    char     name[255];
+    char     name_sfn[13]; // unused, just for compatibility with fatfs lib
+    char     name[256];
 };
 
 struct ff_disk_info {

--- a/scripts/spi_flash/fatfs_api.h
+++ b/scripts/spi_flash/fatfs_api.h
@@ -26,7 +26,7 @@ struct ff_file_info {
     uint16_t modified_date;
     uint16_t modified_time;
     uint8_t  attrs;
-    char     name[13];
+    char     name[255];
 };
 
 struct ff_disk_info {

--- a/scripts/spi_flash/fatfs_lib.py
+++ b/scripts/spi_flash/fatfs_lib.py
@@ -32,7 +32,8 @@ FATFS_CDEFS = """
         uint16_t modified_date;
         uint16_t modified_time;
         uint8_t  attrs;
-        char     name[13];
+        char     name_sfn[13];
+        char     name[256];
     };
 
     struct ff_disk_info {

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -1386,7 +1386,6 @@ class MCUConnection:
                 with self.fatfs.open_file(fw_path, "wb") as sd_f:
                     while True:
                         buf = local_f.read(4096)
-                        output(".")
                         if not buf:
                             break
                         input_sha.update(buf)
@@ -1398,10 +1397,9 @@ class MCUConnection:
         output("Validating Upload...")
         try:
             finfo = self.fatfs.get_file_info(fw_path)
-            with self.fatfs.open_file(fw_path, 'rb') as sd_f:
+            with self.fatfs.open_file(fw_path, 'r') as sd_f:
                 while True:
                     buf = sd_f.read(4096)
-                    output(".")
                     if not buf:
                         break
                     sd_sha.update(buf)

--- a/scripts/spi_flash/spi_flash.py
+++ b/scripts/spi_flash/spi_flash.py
@@ -380,7 +380,7 @@ class FatFS:
             (fdate >> 5) & 0xF, fdate & 0x1F, ((fdate >> 9) & 0x7F) + 1980,
             (ftime >> 11) & 0x1F, (ftime >> 5) & 0x3F, ftime & 0x1F)
         return {
-            'name': self.ffi_main.string(finfo.name, 13),
+            'name': self.ffi_main.string(finfo.name, 256),
             'size': finfo.size,
             'modified': dstr,
             'is_dir': bool(finfo.attrs & 0x10),
@@ -1386,6 +1386,7 @@ class MCUConnection:
                 with self.fatfs.open_file(fw_path, "wb") as sd_f:
                     while True:
                         buf = local_f.read(4096)
+                        output(".")
                         if not buf:
                             break
                         input_sha.update(buf)
@@ -1397,9 +1398,10 @@ class MCUConnection:
         output("Validating Upload...")
         try:
             finfo = self.fatfs.get_file_info(fw_path)
-            with self.fatfs.open_file(fw_path, 'r') as sd_f:
+            with self.fatfs.open_file(fw_path, 'rb') as sd_f:
                 while True:
                     buf = sd_f.read(4096)
+                    output(".")
                     if not buf:
                         break
                     sd_sha.update(buf)


### PR DESCRIPTION
fatfs: enable long filename support needed for flash-sdcard.sh  firmware updates on some boards.

Flashing boards that use SDIO bootloaders using flash-sdcard.sh script will fail with long firmware filename.
For example mks robin nano 1.1 and 1.2 boards are using SDIO and require firmware in "robin_nano35.bin" file.
Update will fail with "file not found" error due to only 8.3 filenames being supported.

As seen below this impacts other boards too:
https://klipper.discourse.group/t/need-help-adding-a-board-def-for-flash-sdcard/14243
https://klipper.discourse.group/t/sdcard-update-mks-robin-nano-printerboard-via-ssh/7002

Changes were tested on RPI-3B+ host and MKR robin v2 (board printed with MKS robin nano v1.2) running old v11 klipper installed on rasbian lite base OS and doing update to current version.
I do not own other boards to test with, but running script with creality-4.2.2 as target succeeds with patched and unpatched code. The creality-4.2.2 board uses the same sd card pinout and 8.3 firmware filename.
Testing with board using hardware SPI for SD card connection would be needed to fully rule out regression.

Documentation does not mention filename length limitation, therefore I'm assuming this is an oversight and documention is alredy matching this PR behaviour.
https://www.klipper3d.org/SDCard_Updates.html in "caveats" section already mentions board I tested with, now the mentioned board is also in boad_defs.py. Board definition addition should be in seperate PR but since its already mentioned in related documentantion it could be allowed?

Signed-off-by: Leszek Zajac <zajc3w@gmail.com>
