### PR TITLE
idle_timeout: Add status field for current idle timeout

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -292,7 +292,7 @@ is always available):
   been in the "Printing" state (as tracked by the idle_timeout
   module).
 - `idle_timeout`: The current 'timeout' (in seconds)
-   to wait for the gcode to be triggered. 
+   to wait for the gcode to be triggered.
    (as set by [SET_IDLE_TIMEOUT](G-Codes.md#set_idle_timeout))
 
 ## led

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -291,6 +291,9 @@ is always available):
 - `printing_time`: The amount of time (in seconds) the printer has
   been in the "Printing" state (as tracked by the idle_timeout
   module).
+- `idle_timeout`: The current 'timeout' (in seconds)
+   to wait for the gcode to be triggered. 
+   (as set by [SET_IDLE_TIMEOUT](G-Codes.md#set_idle_timeout))
 
 ## led
 

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -35,7 +35,9 @@ class IdleTimeout:
         printing_time = 0.
         if self.state == "Printing":
             printing_time = eventtime - self.last_print_start_systime
-        return { "state": self.state, "printing_time": printing_time }
+        return {"state": self.state,
+                "printing_time": printing_time,
+                "idle_timeout": self.idle_timeout}
     def handle_ready(self):
         self.toolhead = self.printer.lookup_object('toolhead')
         self.timeout_timer = self.reactor.register_timer(self.timeout_handler)


### PR DESCRIPTION
Add a status field exposing the current idle timeout value.

Use case:
Allows adjustment of things like LED brightness based on time until idle timeout. While the initial timeout can be read from the configfile, the `SET_IDLE_TIMEOUT` command may change it at runtime, which if not intercepted, makes it impossible to know the current time till timeout.

Signed-off-by: Eric Billmeyer <eric.billmeyer@freenet.de>
