### PR TITLE
Increase time before clearing the temperature of an inactive heater

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -15,6 +15,7 @@ MAX_HEAT_TIME = 3.0
 AMBIENT_TEMP = 25.
 PID_PARAM_BASE = 255.
 MAX_MAINTHREAD_TIME = 5.0
+QUELL_STALE_TIME = 7.0
 
 class Heater:
     def __init__(self, config, sensor):
@@ -110,9 +111,10 @@ class Heater:
         with self.lock:
             self.target_temp = degrees
     def get_temp(self, eventtime):
-        print_time = self.mcu_pwm.get_mcu().estimated_print_time(eventtime) - 5.
+        est_print_time = self.mcu_pwm.get_mcu().estimated_print_time(eventtime)
+        quell_time = est_print_time - QUELL_STALE_TIME
         with self.lock:
-            if self.last_temp_time < print_time:
+            if self.last_temp_time < quell_time:
                 return 0., self.target_temp
             return self.smoothed_temp, self.target_temp
     def check_busy(self, eventtime):


### PR DESCRIPTION
The get_temp() code will stop reporting the last temperature of the heater if there hasn't been any recent temperature updates.  However, on a full mcu communication loss this can cause the verify_heater code to report a heating error prior to the mcu code reporting the communication failure.  Increase the heater timeout from 5 to 7 seconds to make it more likely the mcu failure is reported first.

@Sineos - fyi.

-Kevin