### PR TITLE
RFC: gcode_arcs add max error support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1723,6 +1723,9 @@ Support for gcode arc (G2/G3) commands.
 #   finer arc, but also more work for your machine. Arcs smaller than
 #   the configured value will become straight lines. The default is
 #   1mm.
+#sagitta: 0.01
+#   Max path deviation between the actual arg segment and
+#   the approximated line. The default is 0.01mm
 ```
 
 ### [respond]

--- a/klippy/extras/gcode_arcs.py
+++ b/klippy/extras/gcode_arcs.py
@@ -29,6 +29,7 @@ class ArcSupport:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.mm_per_arc_segment = config.getfloat('resolution', 1., above=0.0)
+        self.sagitta = config.getfloat('sagitta', 0.01, above=0.0)
 
         self.gcode_move = self.printer.load_object(config, 'gcode_move')
         self.gcode = self.printer.lookup_object('gcode')
@@ -137,7 +138,13 @@ class ArcSupport:
             mm_of_travel = math.hypot(flat_mm, linear_travel)
         else:
             mm_of_travel = math.fabs(flat_mm)
-        segments = max(1., math.floor(mm_of_travel / self.mm_per_arc_segment))
+        mm_per_segment = self.mm_per_arc_segment
+        if radius > self.sagitta:
+            r = radius
+            s = self.sagitta
+            l = 2 * math.sqrt(2 * r * s - s**2)
+            mm_per_segment = min(l, self.mm_per_arc_segment)
+        segments = max(1., math.floor(mm_of_travel / mm_per_segment))
 
         # Generate coordinates
         theta_per_segment = angular_travel / segments


### PR DESCRIPTION
# Preamble
I stubled upon the white paper: "[Circular arc approximation using polygons](https://www.sciencedirect.com/science/article/pii/S037704271730153X)"
So, I got curious about the actual error introduced by the gcode_arcs.
I ended up with what you will see below.

# Precision vs number of polygons
I think that the N mm approach is confusing because it does not specify the actual error introduced during the line splitting.
When the original post processor (arc welder) specifies the max error.
For example, the OrcaSlicer seems to use resolution:
https://github.com/SoftFever/OrcaSlicer/blob/c8b3899c5e492d1751ad1aca054e6e7df638f1dd/src/libslic3r/LayerRegion.cpp#L1035
Which in most profiles seems to be set to a small number like ~0.0125mm.
https://github.com/SoftFever/OrcaSlicer/blob/c8b3899c5e492d1751ad1aca054e6e7df638f1dd/resources/profiles/Prusa/process/0.32mm%20Speed%20%40Prusa%20XL%200.6.json#L64

Some arbitrary low values like 0.1 could work and produce smooth shapes, but it seems suboptimal for large arcs.
https://github.com/SoftFever/OrcaSlicer/blob/c8b3899c5e492d1751ad1aca054e6e7df638f1dd/README.md?plain=1#L133

One of the options was, actually redo the job from the paper, recalculate the actual travel path, and compare the lengths.
But I would expect that would be too complicated, with the more additional work and questions.
(It would be hard to notice <1% extrusion error in my opinion).

I ended up with the idea that error could be defined as the "sag" ([saggita](https://en.wikipedia.org/wiki/Sagitta_(geometry))) between the chord and arc. Technically max commanded path deviation.
<img width="230" height="193" alt="image" src="https://github.com/user-attachments/assets/e4ff033d-e878-4786-a246-943eecdcfad0" />

So, the suggestion is to allow limiting the "sag". Chords are inscribed in the circle.
With an arbitrary fixed length, we do get different sag between the actual arc and the chord.
Sag is directly proportional to chord length and inversely proportional to arc radius.
I'm not sure it is a good idea to replace one parameter with another, because it would produce a different result.

I made a graph with an expected error of 0.01 mm.
_Probably, there is also some extrusion error, because the sum of the chords' length inscribed in the arc could be shorter than the arc itself._
The default 1mm chord length gives 0.01mm or less error starting from ~12.5mm radius.
<img width="1231" height="731" alt="image" src="https://github.com/user-attachments/assets/cd81fc08-f17e-4760-981a-0ac477c9e6a9" />
<details closed>
  <summary>Graph code</summary>
  
```
#!/usr/bin/python3

import numpy as np
import matplotlib.pyplot as plt

def plot_chord_length_and_segment_count(sagitta: float):
    R = np.linspace(sagitta + 0.000001, 50, 10000)

    # Chord length formula from sagitta
    chord_lengths = 2 * np.sqrt(2 * R * sagitta - sagitta**2)
    circumferences = 2 * np.pi * R
    segment_counts = circumferences / chord_lengths

    fig, ax1 = plt.subplots(figsize=(10, 6))

    ax1.set_xlabel("Radius (mm)")
    ax1.set_ylabel("Chord Length (mm)", color='tab:blue')
    ax1.plot(R, chord_lengths, color='tab:blue', label=f'Chord Length (sagitta = {sagitta:.3f} mm)')
    ax1.tick_params(axis='y', labelcolor='tab:blue')
    ax1.legend(loc='upper left')

    ax2 = ax1.twinx()
    ax2.set_ylabel("Segments per Full Circle", color='tab:red')
    ax2.plot(R, segment_counts, color='tab:red', linestyle='dotted', label='Segment Count')
    ax2.tick_params(axis='y', labelcolor='tab:red')

    plt.title(f"Chord Length and Segment Count vs Radius (Target Sagitta = {sagitta:.3f} mm)")
    fig.tight_layout()
    plt.grid(True)
    plt.show()

# Run with sagitta = 0.01 mm
plot_chord_length_and_segment_count(0.01)
```

</details>

Basically, those changes handle the cases when the radius is less than 12.5 mm.

---
After such dig into the topic, it seems like aside from Gcode file size, there is little value in arcs, until slicers could produce them naturally, I think.

So, this is RFC, a suggestion to improve precision for small arcs.
Maybe someone would find it useful.

Thanks.