### PR TITLE
spi_flash: Add ZNP Robin Nano v2.2 to board defs

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -151,6 +151,13 @@ BOARD_DEFS = {
         "conversion_script": "scripts/update_chitu.py",
         "firmware_path": "update.cbd",
         'skip_verify': True
+    },
+    'znp-robin-nano-dw-v2.2': {
+        'mcu': "stm32f401xc",
+        'spi_bus': "spi2",
+        "cs_pin": "PB12",
+        "firmware_path": "ZNP_ROBIN_NANO.bin",
+        "current_firmware_path": "ZNP_ROBIN_NANO.CUR"
     }
 }
 


### PR DESCRIPTION
Adds SD card flashing support for the ZNP Robin Nano DW v2.2 board into `board_defs.py`, used in the Neptune 3 Pro/Plus/Max.

This PR requires that #6981 is finished and merged, as the firmware name required by the board is too long, and will currently fail with a "file not found" error due to only 8.3 filenames being supported. For now, this PR is in a draft state until that PR is merged, then this one will be opened.