### PR TITLE
tmc2240: Add OTW_OV_VTH to ReadRegisters

### DIFF
--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -262,6 +262,9 @@ FieldFormatters.update({
     "adc_temp":         (lambda v: "0x%04x(%.1fC)" % (v, ((v - 2038) / 7.7))),
     "adc_vsupply":      (lambda v: "0x%04x(%.3fV)" % (v, v * 0.009732)),
     "adc_ain":          (lambda v: "0x%04x(%.3fmV)" % (v, v * 0.3052)),
+    "overvoltage_vth":  (lambda v: "0x%04x(%.3fV)" % (v, v * 0.009732)),
+    "overtempprewarning_vth": (lambda v:
+                               "0x%04x(%.1fC)" % (v, ((v - 2038) / 7.7))),
 })
 
 


### PR DESCRIPTION
This register is readable and contains the overvoltage and overtemp threshold settings. It was missing for the ReadRegisters list, so it did not show up in DUMP_TMC.

Before

    DUMP_TMC stepper=stepper_x register=OTW_OV_VTH
    Unknown register name 'OTW_OV_VTH'

After

    DUMP_TMC stepper=stepper_x register=OTW_OV_VTH
    OTW_OV_VTH: 0b920f25 overvoltage_vth=0x0f25(37.731V) overtempprewarning_vth=0x0b92(120.0C)