### PR TITLE
RFC: tmc: Implement ready state current reduction

### DIFF
--- a/config/generic-duet2-duex.cfg
+++ b/config/generic-duet2-duex.cfg
@@ -98,7 +98,7 @@ cs_pin: PD14 # X_SPI_EN Required for communication
 spi_bus: usart1 # All TMC2660 drivers are connected to USART1
 run_current: 1.000
 sense_resistor: 0.051
-idle_current_percent: 20
+ready_current: 0.5
 
 [stepper_y]
 step_pin: PD7
@@ -115,7 +115,7 @@ cs_pin: PC9
 spi_bus: usart1
 run_current: 1.000
 sense_resistor: 0.051
-idle_current_percent: 20
+ready_current: 0.5
 
 [stepper_z]
 step_pin: PD8

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3825,6 +3825,9 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#ready_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the printer is in ready state - between last move and [idle_timeout].
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -3940,6 +3943,9 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#ready_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the printer is in ready state - between last move and [idle_timeout].
 #sense_resistor: 0.110
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.110 ohms.
@@ -3985,6 +3991,7 @@ uart_pin:
 #interpolate: True
 run_current:
 #hold_current:
+#ready_current:
 #sense_resistor: 0.110
 #stealthchop_threshold: 0
 #   See the "tmc2208" section for the definition of these parameters.
@@ -4069,10 +4076,10 @@ run_current:
 #sense_resistor:
 #   The resistance (in ohms) of the motor sense resistor. This
 #   parameter must be provided.
-#idle_current_percent: 100
-#   The percentage of the run_current the stepper driver will be
-#   lowered to when the idle timeout expires (you need to set up the
-#   timeout using a [idle_timeout] config section). The current will
+#ready_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the printer is in ready state - between last move and [idle_timeout].
+#   Upon move, the current will
 #   be raised again once the stepper has to move again. Make sure to
 #   set this to a high enough value such that the steppers do not lose
 #   their position. There is also small delay until the current is
@@ -4146,6 +4153,9 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#ready_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the printer is in ready state - between last move and [idle_timeout].
 #rref: 12000
 #   The resistance (in ohms) of the resistor between IREF and GND. The
 #   default is 12000.
@@ -4282,6 +4292,9 @@ run_current:
 #   when the stepper is not moving. Setting a hold_current is not
 #   recommended (see TMC_Drivers.md for details). The default is to
 #   not reduce the current.
+#ready_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the printer is in ready state - between last move and [idle_timeout].
 #sense_resistor: 0.075
 #   The resistance (in ohms) of the motor sense resistor. The default
 #   is 0.075 ohms.

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -124,16 +124,7 @@ class TMCCurrentHelper:
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        run_current = config.getfloat('run_current',
-                                      above=0., maxval=MAX_CURRENT)
-        hold_current = config.getfloat('hold_current', MAX_CURRENT,
-                                       above=0., maxval=MAX_CURRENT)
-        self.req_hold_current = hold_current
         self.sense_resistor = config.getfloat('sense_resistor', 0.110, above=0.)
-        vsense, irun, ihold = self._calc_current(run_current, hold_current)
-        self.fields.set_field("vsense", vsense)
-        self.fields.set_field("ihold", ihold)
-        self.fields.set_field("irun", irun)
     def _calc_current_bits(self, current, vsense):
         sense_resistor = self.sense_resistor + 0.020
         vref = 0.32
@@ -166,9 +157,8 @@ class TMCCurrentHelper:
         vsense = self.fields.get_field("vsense")
         run_current = self._calc_current_from_bits(irun, vsense)
         hold_current = self._calc_current_from_bits(ihold, vsense)
-        return run_current, hold_current, self.req_hold_current, MAX_CURRENT
+        return (run_current, hold_current, MAX_CURRENT)
     def set_current(self, run_current, hold_current, print_time):
-        self.req_hold_current = hold_current
         vsense, irun, ihold = self._calc_current(run_current, hold_current)
         if vsense != self.fields.get_field("vsense"):
             val = self.fields.set_field("vsense", vsense)

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -118,13 +118,8 @@ class TMC2660CurrentHelper:
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        self.current = config.getfloat('run_current', minval=0.1,
-                                       maxval=MAX_CURRENT)
         self.sense_resistor = config.getfloat('sense_resistor')
-        vsense, cs = self._calc_current(self.current)
-        self.fields.set_field("cs", cs)
-        self.fields.set_field("vsense", vsense)
-
+        self.current = .0
         # Register ready/printing handlers
         self.idle_current_percentage = config.getint(
             'idle_current_percent', default=100, minval=0, maxval=100)
@@ -177,7 +172,7 @@ class TMC2660CurrentHelper:
             self.mcu_tmc.set_register("DRVCONF", val, print_time)
 
     def get_current(self):
-        return self.current, None, None, MAX_CURRENT
+        return (self.current, None, MAX_CURRENT)
 
     def set_current(self, run_current, hold_current, print_time):
         self.current = run_current

--- a/klippy/extras/tmc5160.py
+++ b/klippy/extras/tmc5160.py
@@ -268,16 +268,7 @@ class TMC5160CurrentHelper:
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = mcu_tmc.get_fields()
-        run_current = config.getfloat('run_current',
-                                      above=0., maxval=MAX_CURRENT)
-        hold_current = config.getfloat('hold_current', MAX_CURRENT,
-                                       above=0., maxval=MAX_CURRENT)
-        self.req_hold_current = hold_current
         self.sense_resistor = config.getfloat('sense_resistor', 0.075, above=0.)
-        gscaler, irun, ihold = self._calc_current(run_current, hold_current)
-        self.fields.set_field("globalscaler", gscaler)
-        self.fields.set_field("ihold", ihold)
-        self.fields.set_field("irun", irun)
     def _calc_globalscaler(self, current):
         globalscaler = int((current * 256. * math.sqrt(2.)
                             * self.sense_resistor / VREF) + .5)
@@ -307,9 +298,8 @@ class TMC5160CurrentHelper:
     def get_current(self):
         run_current = self._calc_current_from_field("irun")
         hold_current = self._calc_current_from_field("ihold")
-        return run_current, hold_current, self.req_hold_current, MAX_CURRENT
+        return (run_current, hold_current, MAX_CURRENT)
     def set_current(self, run_current, hold_current, print_time):
-        self.req_hold_current = hold_current
         gscaler, irun, ihold = self._calc_current(run_current, hold_current)
         val = self.fields.set_field("globalscaler", gscaler)
         self.mcu_tmc.set_register("GLOBALSCALER", val, print_time)


### PR DESCRIPTION
Problem:
I periodically see that someone does enable ihold, got issues.
Then someone will ask for help about layer shifting, and then someone will suggest disabling ihold and so on.
There is even a warning that it will cause issues.
It feels like a somewhat broken part, or hardly usable in its current state.

The hold current is limited to >0, so basically it is only suitable for the idle state power reduction.
I mean, it looks so that if someone sets it to some value in the config, the intention is to reduce power while it is not used.

I've wanted to write a post, suggest hooks & etc,
but I've found a similar feature implemented on the TMC2660: `idle_current_percentage`.
So, I basically just reused it, the only difference is that I used a motor activation hook instead of a "printing" event.
I expect it to work slightly more predictably.

Old behaviour: hold current is set, driver does whatever it is supposed to do, when he thinks he can.
New behaviour: if the printer is not moving/printing, after a short time, it goes to the "ready" state.
In the ready state code enables the ihold for the steppers, then the drivers do what they are supposed to do.
Upon stepper activity, almost at the same time, the code reverts the ihold back to irun.
SET_TMC_CURRENT now, change the expected ihold value, not the real one.

So, there should be no drawbacks upon printing.

Tested: TMC2240, TMC5160, TMC2209
TMC2660 not tested, I don't have one.

Thanks.