### PR TITLE
Name the python threads

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -182,7 +182,7 @@ defs_serialqueue = """
     };
 
     struct serialqueue *serialqueue_alloc(int serial_fd, char serial_fd_type
-        , int client_id);
+        , int client_id, char name[16]);
     void serialqueue_exit(struct serialqueue *sq);
     void serialqueue_free(struct serialqueue *sq);
     struct command_queue *serialqueue_alloc_commandqueue(void);

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -219,6 +219,7 @@ defs_trdispatch = """
 defs_pyhelper = """
     void set_python_logging_callback(void (*func)(const char *));
     double get_monotonic(void);
+    int set_thread_name(char name[16]);
 """
 
 defs_std = """

--- a/klippy/chelper/pyhelper.c
+++ b/klippy/chelper/pyhelper.c
@@ -10,6 +10,8 @@
 #include <stdio.h> // fprintf
 #include <string.h> // strerror
 #include <time.h> // struct timespec
+#include <linux/prctl.h>  // PR_SET_NAME
+#include <sys/prctl.h>  // prctl
 #include "compiler.h" // __visible
 #include "pyhelper.h" // get_monotonic
 
@@ -91,4 +93,11 @@ dump_string(char *outbuf, int outbuf_size, char *inbuf, int inbuf_size)
     }
     *o = '\0';
     return outbuf;
+}
+
+// Set custom thread names
+int __visible
+set_thread_name(char name[16])
+{
+    return prctl(PR_SET_NAME, name);
 }

--- a/klippy/chelper/pyhelper.h
+++ b/klippy/chelper/pyhelper.h
@@ -7,5 +7,6 @@ void set_python_logging_callback(void (*func)(const char *));
 void errorf(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 void report_errno(char *where, int rc);
 char *dump_string(char *outbuf, int outbuf_size, char *inbuf, int inbuf_size);
+int set_thread_name(char name[16]);
 
 #endif // pyhelper.h

--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -47,6 +47,7 @@ struct serialqueue {
     pthread_mutex_t lock; // protects variables below
     pthread_cond_t cond;
     int receive_waiting;
+    char name[16];
     // Baud / clock tracking
     int receive_window;
     double bittime_adjust, idle_time;
@@ -612,6 +613,7 @@ static void *
 background_thread(void *data)
 {
     struct serialqueue *sq = data;
+    set_thread_name(sq->name);
     pollreactor_run(sq->pr);
 
     pthread_mutex_lock(&sq->lock);
@@ -623,13 +625,15 @@ background_thread(void *data)
 
 // Create a new 'struct serialqueue' object
 struct serialqueue * __visible
-serialqueue_alloc(int serial_fd, char serial_fd_type, int client_id)
+serialqueue_alloc(int serial_fd, char serial_fd_type, int client_id
+                  , char name[16])
 {
     struct serialqueue *sq = malloc(sizeof(*sq));
     memset(sq, 0, sizeof(*sq));
     sq->serial_fd = serial_fd;
     sq->serial_fd_type = serial_fd_type;
     sq->client_id = client_id;
+    strncpy(sq->name, name, sizeof(sq->name));
 
     int ret = pipe(sq->pipe_fds);
     if (ret)

--- a/klippy/chelper/serialqueue.h
+++ b/klippy/chelper/serialqueue.h
@@ -27,7 +27,7 @@ struct pull_queue_message {
 
 struct serialqueue;
 struct serialqueue *serialqueue_alloc(int serial_fd, char serial_fd_type
-                                      , int client_id);
+                                      , int client_id, char name[16]);
 void serialqueue_exit(struct serialqueue *sq);
 void serialqueue_free(struct serialqueue *sq);
 struct command_queue *serialqueue_alloc_commandqueue(void);

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -564,8 +564,8 @@ class MCU:
         if self._name.startswith('mcu '):
             self._name = self._name[4:]
         # Serial port
-        wp = "mcu '%s': " % (self._name)
-        self._serial = serialhdl.SerialReader(self._reactor, warn_prefix=wp)
+        name = self._name
+        self._serial = serialhdl.SerialReader(self._reactor, mcu_name = name)
         self._baud = 0
         self._canbus_iface = None
         canbus_uuid = config.get('canbus_uuid', None)

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -18,6 +18,8 @@ class SerialReader:
         self.mcu_name = mcu_name
         if self.mcu_name:
             self.warn_prefix = "mcu '%s': " % (self.mcu_name)
+        sq_name = ("serialq %s" % (self.mcu_name))[:15]
+        self.sq_name = sq_name.encode("utf-8")
         # Serial port
         self.serial_dev = None
         self.msgparser = msgproto.MessageParser(warn_prefix=self.warn_prefix)
@@ -85,7 +87,8 @@ class SerialReader:
         self.serial_dev = serial_dev
         self.serialqueue = self.ffi_main.gc(
             self.ffi_lib.serialqueue_alloc(serial_dev.fileno(),
-                                           serial_fd_type, client_id),
+                                           serial_fd_type, client_id,
+                                           self.sq_name),
             self.ffi_lib.serialqueue_free)
         self.background_thread = threading.Thread(target=self._bg_thread)
         self.background_thread.start()
@@ -205,7 +208,8 @@ class SerialReader:
         self.serial_dev = debugoutput
         self.msgparser.process_identify(dictionary, decompress=False)
         self.serialqueue = self.ffi_main.gc(
-            self.ffi_lib.serialqueue_alloc(self.serial_dev.fileno(), b'f', 0),
+            self.ffi_lib.serialqueue_alloc(self.serial_dev.fileno(), b'f', 0,
+                                           self.sq_name),
             self.ffi_lib.serialqueue_free)
     def set_clock_est(self, freq, conv_time, conv_clock, last_clock):
         self.ffi_lib.serialqueue_set_clock_est(


### PR DESCRIPTION
Sometimes I wish to see the threads' names inside `htop` or in the perf dumps.
So, these are bells and whistles.
Htop screenshot with demonstration:
<img width="1559" height="470" alt="image" src="https://github.com/user-attachments/assets/92e66ea3-4009-4508-92a2-fdd1aaf18ddc" />

I can easily see that there are serialhdls' per MCU threads, serialqueues, and a logging thread, and also some threads with unknown origin for me right now (unnamed).

Thanks.

---
Unnamed threads are:
`blas_thread_server` `(/home/user/klippy-env/lib/python3.13/site-packages/numpy.libs/libscipy_openblas64_-48fd33d4.so)`