### PR TITLE
PoC: klippy thread per stepper

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -21,7 +21,8 @@ SOURCE_FILES = [
     'pollreactor.c', 'msgblock.c', 'trdispatch.c',
     'kin_cartesian.c', 'kin_corexy.c', 'kin_corexz.c', 'kin_delta.c',
     'kin_deltesian.c', 'kin_polar.c', 'kin_rotary_delta.c', 'kin_winch.c',
-    'kin_extruder.c', 'kin_shaper.c', 'kin_idex.c', 'kin_generic.c'
+    'kin_extruder.c', 'kin_shaper.c', 'kin_idex.c', 'kin_generic.c',
+    'offload_worker.c'
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
@@ -65,8 +66,6 @@ defs_stepcompress = """
 """
 
 defs_itersolve = """
-    int32_t itersolve_generate_steps(struct stepper_kinematics *sk
-        , double flush_time);
     double itersolve_check_active(struct stepper_kinematics *sk
         , double flush_time);
     int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);
@@ -226,13 +225,22 @@ defs_std = """
     void free(void*);
 """
 
+defs_offload_worker = """
+    struct offload_worker *offload_worker_alloc(char name[16]);
+    void async_itersolve_generate_steps(struct offload_worker *worker,
+                                        struct stepper_kinematics *sk,
+                                        double flush_time);
+    int result_offload_worker(struct offload_worker *worker);
+    void offload_worker_free(struct offload_worker *worker);
+"""
+
 defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std, defs_stepcompress,
     defs_itersolve, defs_trapq, defs_trdispatch,
     defs_kin_cartesian, defs_kin_corexy, defs_kin_corexz, defs_kin_delta,
     defs_kin_deltesian, defs_kin_polar, defs_kin_rotary_delta, defs_kin_winch,
     defs_kin_extruder, defs_kin_shaper, defs_kin_idex,
-    defs_kin_generic_cartesian,
+    defs_kin_generic_cartesian, defs_offload_worker,
 ]
 
 # Update filenames to an absolute path

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -229,7 +229,8 @@ defs_offload_worker = """
     struct offload_worker *offload_worker_alloc(char name[16]);
     void async_itersolve_generate_steps(struct offload_worker *worker,
                                         struct stepper_kinematics *sk,
-                                        double flush_time);
+                                        double flush_time,
+                                        uint64_t move_clock);
     int result_offload_worker(struct offload_worker *worker);
     void offload_worker_free(struct offload_worker *worker);
 """

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -143,7 +143,7 @@ check_active(struct stepper_kinematics *sk, struct move *m)
 }
 
 // Generate step times for a range of moves on the trapq
-int32_t __visible
+int32_t
 itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
 {
     double last_flush_time = sk->last_flush_time;

--- a/klippy/chelper/offload_worker.c
+++ b/klippy/chelper/offload_worker.c
@@ -1,0 +1,130 @@
+#include <pthread.h> // pthread_create
+#include <stdint.h> // uint64_t
+#include <stdlib.h> // malloc
+#include <string.h> // memset
+#include "stepcompress.h" // struct stepcompress *sc
+#include "itersolve.h" // struct stepper_kinematics *sk
+#include "compiler.h" // __visible
+#include "pyhelper.h" // set_thread_name
+
+// function types
+enum {
+    ITERSOLVE_GEN_STEPS,
+};
+
+struct offload_worker {
+    pthread_mutex_t work_mutex;
+    pthread_cond_t work_cond;
+    pthread_mutex_t done_mutex;
+    pthread_cond_t done_cond;
+    pthread_t thread;
+    char name[16];
+
+    uint8_t ftype;
+    union {
+        struct stepper_kinematics *sk;
+    };
+    union {
+        double flush_time;
+    };
+    int ret;
+
+    uint8_t has_work;
+    uint8_t shutdown;
+    uint8_t work_done;
+};
+
+static void*
+worker_thread(void* arg) {
+    struct offload_worker *worker = (struct offload_worker *)arg;
+    set_thread_name(worker->name);
+    while (1) {
+        pthread_mutex_lock(&worker->work_mutex);
+        while (!worker->has_work && !worker->shutdown) {
+            pthread_cond_wait(&worker->work_cond, &worker->work_mutex);
+        }
+
+        if (worker->shutdown) {
+            pthread_mutex_unlock(&worker->work_mutex);
+            break;
+        }
+
+        int ret = -1;
+        switch (worker->ftype) {
+            case ITERSOLVE_GEN_STEPS:
+                ret = itersolve_generate_steps(worker->sk, worker->flush_time);
+                break;
+        }
+
+        worker->has_work = 0;
+        pthread_mutex_unlock(&worker->work_mutex);
+        worker->ret = ret;
+        // Signal completion
+        pthread_mutex_lock(&worker->done_mutex);
+        worker->work_done = 1;
+        pthread_cond_signal(&worker->done_cond);
+        pthread_mutex_unlock(&worker->done_mutex);
+    }
+
+    return NULL;
+}
+
+struct offload_worker * __visible
+offload_worker_alloc(char name[16]) {
+    struct offload_worker *worker;
+    worker = malloc(sizeof(struct offload_worker));
+    memset(worker, 0, sizeof(*worker));
+    strncpy(worker->name, name, sizeof(worker->name));
+    worker->name[sizeof(worker->name)-1] = '\0';
+
+    pthread_mutex_init(&worker->work_mutex, NULL);
+    pthread_cond_init(&worker->work_cond, NULL);
+    pthread_mutex_init(&worker->done_mutex, NULL);
+    pthread_cond_init(&worker->done_cond, NULL);
+
+    pthread_create(&worker->thread, NULL, worker_thread, worker);
+    return worker;
+}
+
+void __visible
+async_itersolve_generate_steps(struct offload_worker *worker,
+                               struct stepper_kinematics *sk,
+                               double flush_time) {
+    pthread_mutex_lock(&worker->work_mutex);
+    worker->sk = sk;
+    worker->flush_time = flush_time;
+    worker->ftype = ITERSOLVE_GEN_STEPS;
+    worker->has_work = 1;
+    worker->work_done = 0;
+    pthread_cond_signal(&worker->work_cond);
+    pthread_mutex_unlock(&worker->work_mutex);
+}
+
+int __visible
+result_offload_worker(struct offload_worker *worker) {
+    int ret;
+    pthread_mutex_lock(&worker->done_mutex);
+    while (!worker->work_done)
+        pthread_cond_wait(&worker->done_cond, &worker->done_mutex);
+    worker->work_done = 0;
+    ret = worker->ret;
+    pthread_mutex_unlock(&worker->done_mutex);
+    return ret;
+}
+
+void __visible
+offload_worker_free(struct offload_worker *worker) {
+    pthread_mutex_lock(&worker->work_mutex);
+    worker->shutdown = 1;
+    pthread_cond_signal(&worker->work_cond);
+    pthread_mutex_unlock(&worker->work_mutex);
+
+    pthread_join(worker->thread, NULL);
+
+    pthread_mutex_destroy(&worker->work_mutex);
+    pthread_cond_destroy(&worker->work_cond);
+    pthread_mutex_destroy(&worker->done_mutex);
+    pthread_cond_destroy(&worker->done_cond);
+
+    free(worker);
+}

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -539,7 +539,7 @@ stepcompress_commit(struct stepcompress *sc)
 }
 
 // Flush pending steps
-static int
+int
 stepcompress_flush(struct stepcompress *sc, uint64_t move_clock)
 {
     if (sc->next_step_clock && move_clock >= sc->next_step_clock) {

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -34,6 +34,7 @@ int stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
 int stepcompress_extract_old(struct stepcompress *sc
                              , struct pull_history_steps *p, int max
                              , uint64_t start_clock, uint64_t end_clock);
+int stepcompress_flush(struct stepcompress *sc, uint64_t move_clock);
 
 struct serialqueue;
 struct steppersync *steppersync_alloc(

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -155,7 +155,8 @@ class ManualStepper:
         self.gaxis_limit_velocity = limit_velocity
         self.gaxis_limit_accel = limit_accel
         toolhead.add_extra_axis(self, self.get_position()[0])
-        toolhead.register_step_generator(self.rail.generate_steps)
+        toolhead.register_step_generator(self.rail.generate_steps,
+                                         self.rail.run_active_callbacks)
     def process_move(self, print_time, move, ea_index):
         axis_r = move.axes_r[ea_index]
         start_pos = move.start_pos[ea_index]

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -36,7 +36,8 @@ class CartKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -20,7 +20,8 @@ class CoreXYKinematics:
         self.rails[2].setup_itersolve('cartesian_stepper_alloc', b'z')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -20,7 +20,8 @@ class CoreXZKinematics:
         self.rails[2].setup_itersolve('corexz_stepper_alloc', b'-')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -52,7 +52,8 @@ class DeltaKinematics:
             r.setup_itersolve('delta_stepper_alloc', a, t[0], t[1])
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         self.need_home = True
         self.limit_xy2 = -1.

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -40,7 +40,8 @@ class DeltesianKinematics:
         self.rails[2].setup_itersolve('cartesian_stepper_alloc', b'y')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         self.limits = [(1.0, -1.0)] * 3
         # X axis limits
         min_angle = config.getfloat('min_angle', MIN_ANGLE,

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -40,7 +40,8 @@ class ExtruderStepper:
                                    desc=self.cmd_SYNC_EXTRUDER_MOTION_help)
     def _handle_connect(self):
         toolhead = self.printer.lookup_object('toolhead')
-        toolhead.register_step_generator(self.stepper.generate_steps)
+        toolhead.register_step_generator(self.stepper.generate_steps,
+                                         self.stepper.run_active_callbacks)
         self._set_pressure_advance(self.config_pa, self.config_smooth_time)
     def get_status(self, eventtime):
         return {'pressure_advance': self.pressure_advance,

--- a/klippy/kinematics/generic_cartesian.py
+++ b/klippy/kinematics/generic_cartesian.py
@@ -108,7 +108,8 @@ class GenericCartesianKinematics:
         self._load_kinematics(config)
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         self.dc_module = None
         if self.dc_carriages:
             pcs = [dc.get_dual_carriage() for dc in self.dc_carriages]

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -39,7 +39,8 @@ class HybridCoreXYKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -39,7 +39,8 @@ class HybridCoreXZKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -21,7 +21,8 @@ class PolarKinematics:
                                           for s in r.get_steppers() ]
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -52,7 +52,8 @@ class RotaryDeltaKinematics:
                               math.radians(a), ua, la)
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         self.need_home = True
         self.limit_xy2 = -1.

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -21,7 +21,8 @@ class WinchKinematics:
             self.anchors.append(a)
             s.setup_itersolve('winch_stepper_alloc', *a)
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
+            toolhead.register_step_generator(s.generate_steps,
+                                             s.run_active_callbacks)
         # Setup boundary checks
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -304,7 +304,7 @@ class ToolHead:
             hook(sg_flush_time)
         cbs = []
         for sg, _ in self.step_generators:
-            res = sg(sg_flush_time, async_run=True)
+            res = sg(sg_flush_time, async_run=True, sc_flush_time=flush_time)
             cbs.extend(res)
         for cb in cbs:
             cb()


### PR DESCRIPTION
Preamble:
I basically show that it is possible, and it seems to work.
I do not advocate that this change has great value right now.
It is possible that on some slow, but multicore SBCs, it makes everything slightly faster.

Problem:
Itersolve and stepcompress can be expensive.
I spent some time around them to check if I could make them cheaper on average (I'm unable).

If we add additional calculations around, a stepper shaper, a more expensive input shaper, or whatever, itersolve tends to be slower.

Because of the current architecture, while flush happens:
Klippy calculates step timings for each stepper one by one (sequentially),
and then flushes the stepper queues for each stepper one by one (sequentially).

---
I was curious if it is possible to offload calculations to other threads (make them happen simultaneously) and make the total flush time smaller.
Actually, it seems that the current CFFI code has been written in such a good way, that I was able to almost effortlessly do that.
Probably, there was already an attempt to do that or this is a lucky coincidence :D.

I did simple perf comparisons, with fixed CPU frequencies, to make results more or less reproducible.
```
time python3 klippy/klippy.py rp2040_printer.cfg -a /tmp/klippy_uds -i ./geometry_test_simple_0.2mm_PLA_2m28s.gcode -d out/klipper.dict -o test.serial -v |& grep -v Unknown | grep -v WIDTH
```
(Some notebook, CPU:  AMD Ryzen AI 7 350).
1. Base: 4.95s
2. Callbacks: 4.98s
3. Itersolve threads: 3.5s
4. +Stepcompress threads: 3.68s
5. C pthreds: 3.45s
6. -Stepcompress threads: 3.40s (no commit)

Microsteps 32/64 -> 256 
1. Base 13.83s
2. C pthreads: 7.15s
3. -Stepcompress threads: 7.02s (no commit)

So, itersolve threads seem to be useful.
Stepcompress threads seem to only give the overhead.

Thanks.
