### PR TITLE
Update Octopi install script to use python3

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -8,7 +8,7 @@ PYTHONDIR="${HOME}/klippy-env"
 install_packages()
 {
     # Packages for python cffi
-    PKGLIST="virtualenv python-dev libffi-dev build-essential"
+    PKGLIST="virtualenv python3-dev libffi-dev build-essential"
     # kconfig requirements
     PKGLIST="${PKGLIST} libncurses-dev"
     # hub-ctrl
@@ -34,7 +34,7 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv -p python2 ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
 
     # Install/update dependencies
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt


### PR DESCRIPTION
Verified on RaspberryPi4 with a clean Octopi install that just updating the python dependency to 3 and changing the virtual env is enough to install and run the klipper service. The chain dependencies automatically updated to support the newer versions.

Ignoring greenlet: markers 'python_version >= "3.12"' don't match your environment
Ignoring cffi: markers 'python_version >= "3.12"' don't match your environment
Ignoring setuptools: markers 'python_version >= "3.12"' don't match your environment