### PR TITLE
idex_modes: Fixed dual_carriage axis range calculation after homing

### DIFF
--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -124,7 +124,7 @@ class DualCarriages:
             self.toggle_active_dc_rail(dc)
             kin.home_axis(homing_state, axis, dc.rail)
         # Restore the original rails ordering
-        self.toggle_active_dc_rail(dcs[0])
+        self.activate_dc_mode(dcs[0], PRIMARY)
     def get_status(self, eventtime=None):
         status = {'carriages' : {dc.get_name() : dc.mode
                                  for dc in self.dc_rails.values()}}


### PR DESCRIPTION
`activate_dc_mode` correctly calculates the axis motion range, while `toggle_active_dc_rail` sets the full range of motion, ignoring `safe_distance` option.