### PR TITLE
homing_override: Add rename_existing option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -1502,6 +1502,10 @@ gcode:
 #   disables homing checks for that axis. This may be useful if the
 #   head must move prior to invoking the normal G28 mechanism for an
 #   axis. The default is to not force a position for an axis.
+#rename_existing:
+#   If specified, this option will rename the original G28 command to
+#   the value specified here, allowing the unmodified homing sequence
+#   to be used outside of this block.
 ```
 
 ### [endstop_phase]


### PR DESCRIPTION
Within a `[homing_override]` block, add a `rename_existing` option that functions like the option for `gcode_macro`s. This will allow the user to rename the existing G28 command to something else (say, G90028), so that the original homing sequence can be used elsewhere.

My specific use-case of this feature is to allow me to _not_ remove a magentic bed levelling probe (e.g. Klicky probe) after homing, when I know I will immediately follow it with another operation that requires the probe (e.g. BED_MESH_CALIBRATE). However, I'm sure there are many other use-cases where generally, the override should be used, but sometimes, it's helpful to have the original homing sequence. 

Theoretically, this could be done another way: someone could use a `gcode_macro` block to override G28 and essentially re-implement what `homing_override` provides. Alternatives, someone could use jinga templating to get the true, original G28 command within a macro. It seems clear to me that these alternatives are hacky workarounds at best, and shouldn't be necessary to attain this behavior. 

I have tested these changes for functionality -- the renamed command works as expected, and the command cannot be renamed to an existing command name. These changes aren't particularly complicated, and the code should, hopefully, be easy to understand. 

