### PR TITLE
Simplify host motion flushing

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -54,6 +54,8 @@ defs_stepcompress = """
     int stepcompress_extract_old(struct stepcompress *sc
         , struct pull_history_steps *p, int max
         , uint64_t start_clock, uint64_t end_clock);
+    void stepcompress_set_stepper_kinematics(struct stepcompress *sc
+        , struct stepper_kinematics *sk);
 """
 
 defs_steppersync = """
@@ -62,13 +64,13 @@ defs_steppersync = """
     void steppersync_free(struct steppersync *ss);
     void steppersync_set_time(struct steppersync *ss
         , double time_offset, double mcu_freq);
+    int32_t steppersync_generate_steps(struct steppersync *ss
+        , double gen_steps_time, uint64_t flush_clock);
     void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
     int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
 """
 
 defs_itersolve = """
-    int32_t itersolve_generate_steps(struct stepper_kinematics *sk
-        , struct stepcompress *sc, double flush_time);
     double itersolve_check_active(struct stepper_kinematics *sk
         , double flush_time);
     int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -60,8 +60,8 @@ defs_stepcompress = """
     void steppersync_free(struct steppersync *ss);
     void steppersync_set_time(struct steppersync *ss
         , double time_offset, double mcu_freq);
-    int steppersync_flush(struct steppersync *ss, uint64_t move_clock
-        , uint64_t clear_history_clock);
+    void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
+    int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
 """
 
 defs_itersolve = """

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -17,16 +17,16 @@ COMPILE_ARGS = ("-Wall -g -O2 -shared -fPIC"
                 " -o %s %s")
 SSE_FLAGS = "-mfpmath=sse -msse2"
 SOURCE_FILES = [
-    'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'itersolve.c', 'trapq.c',
-    'pollreactor.c', 'msgblock.c', 'trdispatch.c',
+    'pyhelper.c', 'serialqueue.c', 'stepcompress.c', 'steppersync.c',
+    'itersolve.c', 'trapq.c', 'pollreactor.c', 'msgblock.c', 'trdispatch.c',
     'kin_cartesian.c', 'kin_corexy.c', 'kin_corexz.c', 'kin_delta.c',
     'kin_deltesian.c', 'kin_polar.c', 'kin_rotary_delta.c', 'kin_winch.c',
     'kin_extruder.c', 'kin_shaper.c', 'kin_idex.c', 'kin_generic.c'
 ]
 DEST_LIB = "c_helper.so"
 OTHER_FILES = [
-    'list.h', 'serialqueue.h', 'stepcompress.h', 'itersolve.h', 'pyhelper.h',
-    'trapq.h', 'pollreactor.h', 'msgblock.h'
+    'list.h', 'serialqueue.h', 'stepcompress.h', 'steppersync.h',
+    'itersolve.h', 'pyhelper.h', 'trapq.h', 'pollreactor.h', 'msgblock.h'
 ]
 
 defs_stepcompress = """
@@ -54,7 +54,9 @@ defs_stepcompress = """
     int stepcompress_extract_old(struct stepcompress *sc
         , struct pull_history_steps *p, int max
         , uint64_t start_clock, uint64_t end_clock);
+"""
 
+defs_steppersync = """
     struct steppersync *steppersync_alloc(struct serialqueue *sq
         , struct stepcompress **sc_list, int sc_num, int move_num);
     void steppersync_free(struct steppersync *ss);
@@ -228,7 +230,7 @@ defs_std = """
 
 defs_all = [
     defs_pyhelper, defs_serialqueue, defs_std, defs_stepcompress,
-    defs_itersolve, defs_trapq, defs_trdispatch,
+    defs_steppersync, defs_itersolve, defs_trapq, defs_trdispatch,
     defs_kin_cartesian, defs_kin_corexy, defs_kin_corexz, defs_kin_delta,
     defs_kin_deltesian, defs_kin_polar, defs_kin_rotary_delta, defs_kin_winch,
     defs_kin_extruder, defs_kin_shaper, defs_kin_idex,

--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -68,13 +68,12 @@ defs_steppersync = """
 
 defs_itersolve = """
     int32_t itersolve_generate_steps(struct stepper_kinematics *sk
-        , double flush_time);
+        , struct stepcompress *sc, double flush_time);
     double itersolve_check_active(struct stepper_kinematics *sk
         , double flush_time);
     int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);
-    void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq);
-    void itersolve_set_stepcompress(struct stepper_kinematics *sk
-        , struct stepcompress *sc, double step_dist);
+    void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
+        , double step_dist);
     double itersolve_calc_position_from_coord(struct stepper_kinematics *sk
         , double x, double y, double z);
     void itersolve_set_position(struct stepper_kinematics *sk

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -26,8 +26,8 @@ struct timepos {
 
 // Generate step times for a portion of a move
 static int32_t
-itersolve_gen_steps_range(struct stepper_kinematics *sk, struct move *m
-                          , double abs_start, double abs_end)
+itersolve_gen_steps_range(struct stepper_kinematics *sk, struct stepcompress *sc
+                          , struct move *m, double abs_start, double abs_end)
 {
     sk_calc_callback calc_position_cb = sk->calc_position_cb;
     double half_step = .5 * sk->step_dist;
@@ -37,7 +37,7 @@ itersolve_gen_steps_range(struct stepper_kinematics *sk, struct move *m
     if (end > m->move_t)
         end = m->move_t;
     struct timepos old_guess = {start, sk->commanded_pos}, guess = old_guess;
-    int sdir = stepcompress_get_step_dir(sk->sc);
+    int sdir = stepcompress_get_step_dir(sc);
     int is_dir_change = 0, have_bracket = 0, check_oscillate = 0;
     double target = sk->commanded_pos + (sdir ? half_step : -half_step);
     double last_time=start, low_time=start, high_time=start + SEEK_TIME_RESET;
@@ -99,13 +99,13 @@ itersolve_gen_steps_range(struct stepper_kinematics *sk, struct move *m
             if (!have_bracket || high_time - low_time > .000000001) {
                 if (!is_dir_change && rel_dist >= -half_step)
                     // Avoid rollback if stepper fully reaches step position
-                    stepcompress_commit(sk->sc);
+                    stepcompress_commit(sc);
                 // Guess is not close enough - guess again with new time
                 continue;
             }
         }
         // Found next step - submit it
-        int ret = stepcompress_append(sk->sc, sdir, m->print_time, guess.time);
+        int ret = stepcompress_append(sc, sdir, m->print_time, guess.time);
         if (ret)
             return ret;
         target = sdir ? target+half_step+half_step : target-half_step-half_step;
@@ -144,7 +144,8 @@ check_active(struct stepper_kinematics *sk, struct move *m)
 
 // Generate step times for a range of moves on the trapq
 int32_t __visible
-itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
+itersolve_generate_steps(struct stepper_kinematics *sk, struct stepcompress *sc
+                         , double flush_time)
 {
     double last_flush_time = sk->last_flush_time;
     sk->last_flush_time = flush_time;
@@ -170,15 +171,15 @@ itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
                 while (--skip_count && pm->print_time > abs_start)
                     pm = list_prev_entry(pm, node);
                 do {
-                    int32_t ret = itersolve_gen_steps_range(sk, pm, abs_start
-                                                            , flush_time);
+                    int32_t ret = itersolve_gen_steps_range(
+                        sk, sc, pm, abs_start, flush_time);
                     if (ret)
                         return ret;
                     pm = list_next_entry(pm, node);
                 } while (pm != m);
             }
             // Generate steps for this move
-            int32_t ret = itersolve_gen_steps_range(sk, m, last_flush_time
+            int32_t ret = itersolve_gen_steps_range(sk, sc, m, last_flush_time
                                                     , flush_time);
             if (ret)
                 return ret;
@@ -195,8 +196,8 @@ itersolve_generate_steps(struct stepper_kinematics *sk, double flush_time)
                 double abs_end = force_steps_time;
                 if (abs_end > flush_time)
                     abs_end = flush_time;
-                int32_t ret = itersolve_gen_steps_range(sk, m, last_flush_time
-                                                        , abs_end);
+                int32_t ret = itersolve_gen_steps_range(
+                    sk, sc, m, last_flush_time, abs_end);
                 if (ret)
                     return ret;
                 skip_count = 1;
@@ -240,16 +241,10 @@ itersolve_is_active_axis(struct stepper_kinematics *sk, char axis)
 }
 
 void __visible
-itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq)
+itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
+                    , double step_dist)
 {
     sk->tq = tq;
-}
-
-void __visible
-itersolve_set_stepcompress(struct stepper_kinematics *sk
-                           , struct stepcompress *sc, double step_dist)
-{
-    sk->sc = sc;
     sk->step_dist = step_dist;
 }
 

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -143,7 +143,7 @@ check_active(struct stepper_kinematics *sk, struct move *m)
 }
 
 // Generate step times for a range of moves on the trapq
-int32_t __visible
+int32_t
 itersolve_generate_steps(struct stepper_kinematics *sk, struct stepcompress *sc
                          , double flush_time)
 {

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -26,12 +26,11 @@ struct stepper_kinematics {
 };
 
 int32_t itersolve_generate_steps(struct stepper_kinematics *sk
-                                 , double flush_time);
+                                 , struct stepcompress *sc, double flush_time);
 double itersolve_check_active(struct stepper_kinematics *sk, double flush_time);
 int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);
-void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq);
-void itersolve_set_stepcompress(struct stepper_kinematics *sk
-                                , struct stepcompress *sc, double step_dist);
+void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
+                         , double step_dist);
 double itersolve_calc_position_from_coord(struct stepper_kinematics *sk
                                           , double x, double y, double z);
 void itersolve_set_position(struct stepper_kinematics *sk

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -1,6 +1,6 @@
 // Stepper pulse schedule compression
 //
-// Copyright (C) 2016-2021  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -277,7 +277,7 @@ stepcompress_set_invert_sdir(struct stepcompress *sc, uint32_t invert_sdir)
 }
 
 // Expire the stepcompress history older than the given clock
-static void
+void
 stepcompress_history_expire(struct stepcompress *sc, uint64_t end_clock)
 {
     while (!list_empty(&sc->history_list)) {
@@ -314,6 +314,12 @@ stepcompress_get_step_dir(struct stepcompress *sc)
     return sc->next_step_dir;
 }
 
+struct list_head *
+stepcompress_get_msg_queue(struct stepcompress *sc)
+{
+    return &sc->msg_queue;
+}
+
 // Determine the "print time" of the last_step_clock
 static void
 calc_last_step_print_time(struct stepcompress *sc)
@@ -323,7 +329,7 @@ calc_last_step_print_time(struct stepcompress *sc)
 }
 
 // Set the conversion rate of 'print_time' to mcu clock
-static void
+void
 stepcompress_set_time(struct stepcompress *sc
                       , double time_offset, double mcu_freq)
 {
@@ -532,7 +538,7 @@ stepcompress_commit(struct stepcompress *sc)
 }
 
 // Flush pending steps
-static int
+int
 stepcompress_flush(struct stepcompress *sc, uint64_t move_clock)
 {
     if (sc->next_step_clock && move_clock >= sc->next_step_clock) {
@@ -655,163 +661,4 @@ stepcompress_extract_old(struct stepcompress *sc, struct pull_history_steps *p
         res++;
     }
     return res;
-}
-
-
-/****************************************************************
- * Step compress synchronization
- ****************************************************************/
-
-// The steppersync object is used to synchronize the output of mcu
-// step commands.  The mcu can only queue a limited number of step
-// commands - this code tracks when items on the mcu step queue become
-// free so that new commands can be transmitted.  It also ensures the
-// mcu step queue is ordered between steppers so that no stepper
-// starves the other steppers of space in the mcu step queue.
-
-struct steppersync {
-    // Serial port
-    struct serialqueue *sq;
-    struct command_queue *cq;
-    // Storage for associated stepcompress objects
-    struct stepcompress **sc_list;
-    int sc_num;
-    // Storage for list of pending move clocks
-    uint64_t *move_clocks;
-    int num_move_clocks;
-};
-
-// Allocate a new 'steppersync' object
-struct steppersync * __visible
-steppersync_alloc(struct serialqueue *sq, struct stepcompress **sc_list
-                  , int sc_num, int move_num)
-{
-    struct steppersync *ss = malloc(sizeof(*ss));
-    memset(ss, 0, sizeof(*ss));
-    ss->sq = sq;
-    ss->cq = serialqueue_alloc_commandqueue();
-
-    ss->sc_list = malloc(sizeof(*sc_list)*sc_num);
-    memcpy(ss->sc_list, sc_list, sizeof(*sc_list)*sc_num);
-    ss->sc_num = sc_num;
-
-    ss->move_clocks = malloc(sizeof(*ss->move_clocks)*move_num);
-    memset(ss->move_clocks, 0, sizeof(*ss->move_clocks)*move_num);
-    ss->num_move_clocks = move_num;
-
-    return ss;
-}
-
-// Free memory associated with a 'steppersync' object
-void __visible
-steppersync_free(struct steppersync *ss)
-{
-    if (!ss)
-        return;
-    free(ss->sc_list);
-    free(ss->move_clocks);
-    serialqueue_free_commandqueue(ss->cq);
-    free(ss);
-}
-
-// Set the conversion rate of 'print_time' to mcu clock
-void __visible
-steppersync_set_time(struct steppersync *ss, double time_offset
-                     , double mcu_freq)
-{
-    int i;
-    for (i=0; i<ss->sc_num; i++) {
-        struct stepcompress *sc = ss->sc_list[i];
-        stepcompress_set_time(sc, time_offset, mcu_freq);
-    }
-}
-
-// Expire the stepcompress history before the given clock time
-void __visible
-steppersync_history_expire(struct steppersync *ss, uint64_t end_clock)
-{
-    int i;
-    for (i = 0; i < ss->sc_num; i++) {
-        struct stepcompress *sc = ss->sc_list[i];
-        stepcompress_history_expire(sc, end_clock);
-    }
-}
-
-// Implement a binary heap algorithm to track when the next available
-// 'struct move' in the mcu will be available
-static void
-heap_replace(struct steppersync *ss, uint64_t req_clock)
-{
-    uint64_t *mc = ss->move_clocks;
-    int nmc = ss->num_move_clocks, pos = 0;
-    for (;;) {
-        int child1_pos = 2*pos+1, child2_pos = 2*pos+2;
-        uint64_t child2_clock = child2_pos < nmc ? mc[child2_pos] : UINT64_MAX;
-        uint64_t child1_clock = child1_pos < nmc ? mc[child1_pos] : UINT64_MAX;
-        if (req_clock <= child1_clock && req_clock <= child2_clock) {
-            mc[pos] = req_clock;
-            break;
-        }
-        if (child1_clock < child2_clock) {
-            mc[pos] = child1_clock;
-            pos = child1_pos;
-        } else {
-            mc[pos] = child2_clock;
-            pos = child2_pos;
-        }
-    }
-}
-
-// Find and transmit any scheduled steps prior to the given 'move_clock'
-int __visible
-steppersync_flush(struct steppersync *ss, uint64_t move_clock)
-{
-    // Flush each stepcompress to the specified move_clock
-    int i;
-    for (i=0; i<ss->sc_num; i++) {
-        int ret = stepcompress_flush(ss->sc_list[i], move_clock);
-        if (ret)
-            return ret;
-    }
-
-    // Order commands by the reqclock of each pending command
-    struct list_head msgs;
-    list_init(&msgs);
-    for (;;) {
-        // Find message with lowest reqclock
-        uint64_t req_clock = MAX_CLOCK;
-        struct queue_message *qm = NULL;
-        for (i=0; i<ss->sc_num; i++) {
-            struct stepcompress *sc = ss->sc_list[i];
-            if (!list_empty(&sc->msg_queue)) {
-                struct queue_message *m = list_first_entry(
-                    &sc->msg_queue, struct queue_message, node);
-                if (m->req_clock < req_clock) {
-                    qm = m;
-                    req_clock = m->req_clock;
-                }
-            }
-        }
-        if (!qm || (qm->min_clock && req_clock > move_clock))
-            break;
-
-        uint64_t next_avail = ss->move_clocks[0];
-        if (qm->min_clock)
-            // The qm->min_clock field is overloaded to indicate that
-            // the command uses the 'move queue' and to store the time
-            // that move queue item becomes available.
-            heap_replace(ss, qm->min_clock);
-        // Reset the min_clock to its normal meaning (minimum transmit time)
-        qm->min_clock = next_avail;
-
-        // Batch this command
-        list_del(&qm->node);
-        list_add_tail(&qm->node, &msgs);
-    }
-
-    // Transmit commands
-    if (!list_empty(&msgs))
-        serialqueue_send_batch(ss->sq, ss->cq, &msgs);
-
-    return 0;
 }

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -42,7 +42,7 @@ struct steppersync *steppersync_alloc(
 void steppersync_free(struct steppersync *ss);
 void steppersync_set_time(struct steppersync *ss, double time_offset
                           , double mcu_freq);
-int steppersync_flush(struct steppersync *ss, uint64_t move_clock
-                      , uint64_t clear_history_clock);
+void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
+int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
 
 #endif // stepcompress.h

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -27,7 +27,6 @@ void stepcompress_set_time(struct stepcompress *sc
 int stepcompress_append(struct stepcompress *sc, int sdir
                         , double print_time, double step_time);
 int stepcompress_commit(struct stepcompress *sc);
-int stepcompress_flush(struct stepcompress *sc, uint64_t move_clock);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
 int stepcompress_set_last_position(struct stepcompress *sc, uint64_t clock
                                    , int64_t last_position);
@@ -39,5 +38,11 @@ int stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
 int stepcompress_extract_old(struct stepcompress *sc
                              , struct pull_history_steps *p, int max
                              , uint64_t start_clock, uint64_t end_clock);
+struct stepper_kinematics;
+void stepcompress_set_stepper_kinematics(struct stepcompress *sc
+                                         , struct stepper_kinematics *sk);
+int32_t stepcompress_generate_steps(struct stepcompress *sc
+                                    , double gen_steps_time
+                                    , uint64_t flush_clock);
 
 #endif // stepcompress.h

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -17,12 +17,17 @@ void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
                        , int32_t set_next_step_dir_msgtag);
 void stepcompress_set_invert_sdir(struct stepcompress *sc
                                   , uint32_t invert_sdir);
+void stepcompress_history_expire(struct stepcompress *sc, uint64_t end_clock);
 void stepcompress_free(struct stepcompress *sc);
 uint32_t stepcompress_get_oid(struct stepcompress *sc);
 int stepcompress_get_step_dir(struct stepcompress *sc);
+struct list_head *stepcompress_get_msg_queue(struct stepcompress *sc);
+void stepcompress_set_time(struct stepcompress *sc
+                           , double time_offset, double mcu_freq);
 int stepcompress_append(struct stepcompress *sc, int sdir
                         , double print_time, double step_time);
 int stepcompress_commit(struct stepcompress *sc);
+int stepcompress_flush(struct stepcompress *sc, uint64_t move_clock);
 int stepcompress_reset(struct stepcompress *sc, uint64_t last_step_clock);
 int stepcompress_set_last_position(struct stepcompress *sc, uint64_t clock
                                    , int64_t last_position);
@@ -34,15 +39,5 @@ int stepcompress_queue_mq_msg(struct stepcompress *sc, uint64_t req_clock
 int stepcompress_extract_old(struct stepcompress *sc
                              , struct pull_history_steps *p, int max
                              , uint64_t start_clock, uint64_t end_clock);
-
-struct serialqueue;
-struct steppersync *steppersync_alloc(
-    struct serialqueue *sq, struct stepcompress **sc_list, int sc_num
-    , int move_num);
-void steppersync_free(struct steppersync *ss);
-void steppersync_set_time(struct steppersync *ss, double time_offset
-                          , double mcu_freq);
-void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
-int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
 
 #endif // stepcompress.h

--- a/klippy/chelper/steppersync.c
+++ b/klippy/chelper/steppersync.c
@@ -1,0 +1,168 @@
+// Stepper step transmit synchronization
+//
+// Copyright (C) 2016-2025  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+// The steppersync object is used to synchronize the output of mcu
+// step commands.  The mcu can only queue a limited number of step
+// commands - this code tracks when items on the mcu step queue become
+// free so that new commands can be transmitted.  It also ensures the
+// mcu step queue is ordered between steppers so that no stepper
+// starves the other steppers of space in the mcu step queue.
+
+#include <stddef.h> // offsetof
+#include <stdlib.h> // malloc
+#include <string.h> // memset
+#include "compiler.h" // __visible
+#include "serialqueue.h" // struct queue_message
+#include "stepcompress.h" // stepcompress_flush
+#include "steppersync.h" // steppersync_alloc
+
+struct steppersync {
+    // Serial port
+    struct serialqueue *sq;
+    struct command_queue *cq;
+    // Storage for associated stepcompress objects
+    struct stepcompress **sc_list;
+    int sc_num;
+    // Storage for list of pending move clocks
+    uint64_t *move_clocks;
+    int num_move_clocks;
+};
+
+// Allocate a new 'steppersync' object
+struct steppersync * __visible
+steppersync_alloc(struct serialqueue *sq, struct stepcompress **sc_list
+                  , int sc_num, int move_num)
+{
+    struct steppersync *ss = malloc(sizeof(*ss));
+    memset(ss, 0, sizeof(*ss));
+    ss->sq = sq;
+    ss->cq = serialqueue_alloc_commandqueue();
+
+    ss->sc_list = malloc(sizeof(*sc_list)*sc_num);
+    memcpy(ss->sc_list, sc_list, sizeof(*sc_list)*sc_num);
+    ss->sc_num = sc_num;
+
+    ss->move_clocks = malloc(sizeof(*ss->move_clocks)*move_num);
+    memset(ss->move_clocks, 0, sizeof(*ss->move_clocks)*move_num);
+    ss->num_move_clocks = move_num;
+
+    return ss;
+}
+
+// Free memory associated with a 'steppersync' object
+void __visible
+steppersync_free(struct steppersync *ss)
+{
+    if (!ss)
+        return;
+    free(ss->sc_list);
+    free(ss->move_clocks);
+    serialqueue_free_commandqueue(ss->cq);
+    free(ss);
+}
+
+// Set the conversion rate of 'print_time' to mcu clock
+void __visible
+steppersync_set_time(struct steppersync *ss, double time_offset
+                     , double mcu_freq)
+{
+    int i;
+    for (i=0; i<ss->sc_num; i++) {
+        struct stepcompress *sc = ss->sc_list[i];
+        stepcompress_set_time(sc, time_offset, mcu_freq);
+    }
+}
+
+// Expire the stepcompress history before the given clock time
+void __visible
+steppersync_history_expire(struct steppersync *ss, uint64_t end_clock)
+{
+    int i;
+    for (i = 0; i < ss->sc_num; i++) {
+        struct stepcompress *sc = ss->sc_list[i];
+        stepcompress_history_expire(sc, end_clock);
+    }
+}
+
+// Implement a binary heap algorithm to track when the next available
+// 'struct move' in the mcu will be available
+static void
+heap_replace(struct steppersync *ss, uint64_t req_clock)
+{
+    uint64_t *mc = ss->move_clocks;
+    int nmc = ss->num_move_clocks, pos = 0;
+    for (;;) {
+        int child1_pos = 2*pos+1, child2_pos = 2*pos+2;
+        uint64_t child2_clock = child2_pos < nmc ? mc[child2_pos] : UINT64_MAX;
+        uint64_t child1_clock = child1_pos < nmc ? mc[child1_pos] : UINT64_MAX;
+        if (req_clock <= child1_clock && req_clock <= child2_clock) {
+            mc[pos] = req_clock;
+            break;
+        }
+        if (child1_clock < child2_clock) {
+            mc[pos] = child1_clock;
+            pos = child1_pos;
+        } else {
+            mc[pos] = child2_clock;
+            pos = child2_pos;
+        }
+    }
+}
+
+// Find and transmit any scheduled steps prior to the given 'move_clock'
+int __visible
+steppersync_flush(struct steppersync *ss, uint64_t move_clock)
+{
+    // Flush each stepcompress to the specified move_clock
+    int i;
+    for (i=0; i<ss->sc_num; i++) {
+        int ret = stepcompress_flush(ss->sc_list[i], move_clock);
+        if (ret)
+            return ret;
+    }
+
+    // Order commands by the reqclock of each pending command
+    struct list_head msgs;
+    list_init(&msgs);
+    for (;;) {
+        // Find message with lowest reqclock
+        uint64_t req_clock = MAX_CLOCK;
+        struct queue_message *qm = NULL;
+        for (i=0; i<ss->sc_num; i++) {
+            struct stepcompress *sc = ss->sc_list[i];
+            struct list_head *sc_mq = stepcompress_get_msg_queue(sc);
+            if (!list_empty(sc_mq)) {
+                struct queue_message *m = list_first_entry(
+                    sc_mq, struct queue_message, node);
+                if (m->req_clock < req_clock) {
+                    qm = m;
+                    req_clock = m->req_clock;
+                }
+            }
+        }
+        if (!qm || (qm->min_clock && req_clock > move_clock))
+            break;
+
+        uint64_t next_avail = ss->move_clocks[0];
+        if (qm->min_clock)
+            // The qm->min_clock field is overloaded to indicate that
+            // the command uses the 'move queue' and to store the time
+            // that move queue item becomes available.
+            heap_replace(ss, qm->min_clock);
+        // Reset the min_clock to its normal meaning (minimum transmit time)
+        qm->min_clock = next_avail;
+
+        // Batch this command
+        list_del(&qm->node);
+        list_add_tail(&qm->node, &msgs);
+    }
+
+    // Transmit commands
+    if (!list_empty(&msgs))
+        serialqueue_send_batch(ss->sq, ss->cq, &msgs);
+
+    return 0;
+}

--- a/klippy/chelper/steppersync.h
+++ b/klippy/chelper/steppersync.h
@@ -1,0 +1,16 @@
+#ifndef STEPPERSYNC_H
+#define STEPPERSYNC_H
+
+#include <stdint.h> // uint64_t
+
+struct serialqueue;
+struct steppersync *steppersync_alloc(
+    struct serialqueue *sq, struct stepcompress **sc_list, int sc_num
+    , int move_num);
+void steppersync_free(struct steppersync *ss);
+void steppersync_set_time(struct steppersync *ss, double time_offset
+                          , double mcu_freq);
+void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
+int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+
+#endif // steppersync.h

--- a/klippy/chelper/steppersync.h
+++ b/klippy/chelper/steppersync.h
@@ -10,6 +10,8 @@ struct steppersync *steppersync_alloc(
 void steppersync_free(struct steppersync *ss);
 void steppersync_set_time(struct steppersync *ss, double time_offset
                           , double mcu_freq);
+int32_t steppersync_generate_steps(struct steppersync *ss, double gen_steps_time
+                                   , uint64_t flush_clock);
 void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
 int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
 

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -85,14 +85,13 @@ class ForceMove:
         self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
                           0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time = print_time + accel_t + cruise_t + accel_t
-        stepper.generate_steps(print_time)
-        self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
-                                  print_time + 99999.9)
-        stepper.set_trapq(prev_trapq)
-        stepper.set_stepper_kinematics(prev_sk)
         toolhead.note_mcu_movequeue_activity(print_time)
         toolhead.dwell(accel_t + cruise_t + accel_t)
         toolhead.flush_step_generation()
+        stepper.set_trapq(prev_trapq)
+        stepper.set_stepper_kinematics(prev_sk)
+        self.trapq_finalize_moves(self.trapq, print_time + 99999.9,
+                                  print_time + 99999.9)
     def _lookup_stepper(self, gcmd):
         name = gcmd.get('STEPPER')
         if name not in self.steppers:

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -76,7 +76,6 @@ class ManualStepper:
         self.sync_print_time()
         self.next_cmd_time = self._submit_move(self.next_cmd_time, movepos,
                                                speed, accel)
-        self.rail.generate_steps(self.next_cmd_time)
         self.trapq_finalize_moves(self.trapq, self.next_cmd_time + 99999.9,
                                   self.next_cmd_time + 99999.9)
         toolhead = self.printer.lookup_object('toolhead')
@@ -138,7 +137,6 @@ class ManualStepper:
                 raise gcmd.error("Must unregister axis first")
             # Unregister
             toolhead.remove_extra_axis(self)
-            toolhead.unregister_step_generator(self.rail.generate_steps)
             self.axis_gcode_id = None
             return
         if (len(gcode_axis) != 1 or not gcode_axis.isupper()
@@ -155,7 +153,6 @@ class ManualStepper:
         self.gaxis_limit_velocity = limit_velocity
         self.gaxis_limit_accel = limit_accel
         toolhead.add_extra_axis(self, self.get_position()[0])
-        toolhead.register_step_generator(self.rail.generate_steps)
     def process_move(self, print_time, move, ea_index):
         axis_r = move.axes_r[ea_index]
         start_pos = move.start_pos[ea_index]
@@ -208,7 +205,7 @@ class ManualStepper:
                                     speed, self.homing_accel)
         # Drip updates to motors
         toolhead = self.printer.lookup_object('toolhead')
-        toolhead.drip_update_time(maxtime, drip_completion, self.steppers)
+        toolhead.drip_update_time(maxtime, drip_completion)
         # Clear trapq of any remaining parts of movement
         reactor = self.printer.get_reactor()
         self.trapq_finalize_moves(self.trapq, reactor.NEVER, 0)

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -13,6 +13,7 @@ class PrinterMotionQueuing:
         self.trapqs = []
         self.stepcompress = []
         self.steppersyncs = []
+        self.flush_callbacks = []
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
     def allocate_trapq(self):
@@ -40,7 +41,11 @@ class PrinterMotionQueuing:
         return ss
     def register_stepper(self, config, stepper):
         self.steppers.append(stepper)
+    def register_flush_callback(self, callback):
+        self.flush_callbacks.append(callback)
     def flush_motion_queues(self, must_flush_time, max_step_gen_time):
+        for cb in self.flush_callbacks:
+            cb(must_flush_time)
         for stepper in self.steppers:
             stepper.generate_steps(max_step_gen_time)
     def clean_motion_queues(self, trapq_free_time, clear_history_time):

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -50,10 +50,15 @@ class PrinterMotionQueuing:
         self.steppers.append(stepper)
     def register_flush_callback(self, callback):
         self.flush_callbacks.append(callback)
+    def unregister_flush_callback(self, callback):
+        if callback in self.flush_callbacks:
+            fcbs = list(self.flush_callbacks)
+            fcbs.remove(callback)
+            self.flush_callbacks = fcbs
     def flush_motion_queues(self, must_flush_time, max_step_gen_time):
         # Invoke flush callbacks (if any)
         for cb in self.flush_callbacks:
-            cb(must_flush_time)
+            cb(must_flush_time, max_step_gen_time)
         # Generate itersolve steps
         for stepper in self.steppers:
             stepper.generate_steps(max_step_gen_time)

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -11,6 +11,7 @@ class PrinterMotionQueuing:
         self.printer = config.get_printer()
         self.steppers = []
         self.trapqs = []
+        self.steppersyncs = []
         ffi_main, ffi_lib = chelper.get_ffi()
         self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
     def allocate_trapq(self):
@@ -18,6 +19,14 @@ class PrinterMotionQueuing:
         trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
         self.trapqs.append(trapq)
         return trapq
+    def allocate_steppersync(self, mcu, serialqueue, stepqueues, move_count):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        ss = ffi_main.gc(
+            ffi_lib.steppersync_alloc(serialqueue, stepqueues, len(stepqueues),
+                                      move_count),
+            ffi_lib.steppersync_free)
+        self.steppersyncs.append((mcu, ss))
+        return ss
     def register_stepper(self, config, stepper):
         self.steppers.append(stepper)
     def flush_motion_queues(self, must_flush_time, max_step_gen_time):

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -1,0 +1,19 @@
+# Helper code for low-level motion queuing and flushing
+#
+# Copyright (C) 2025  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+class PrinterMotionQueuing:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.steppers = []
+    def register_stepper(self, config, stepper):
+        self.steppers.append(stepper)
+    def flush_motion_queues(self, must_flush_time, max_step_gen_time):
+        for stepper in self.steppers:
+            stepper.generate_steps(max_step_gen_time)
+
+def load_config(config):
+    return PrinterMotionQueuing(config)

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -4,16 +4,36 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
+import chelper
 
 class PrinterMotionQueuing:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.steppers = []
+        self.trapqs = []
+        ffi_main, ffi_lib = chelper.get_ffi()
+        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
+    def allocate_trapq(self):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
+        self.trapqs.append(trapq)
+        return trapq
     def register_stepper(self, config, stepper):
         self.steppers.append(stepper)
     def flush_motion_queues(self, must_flush_time, max_step_gen_time):
         for stepper in self.steppers:
             stepper.generate_steps(max_step_gen_time)
+    def clean_motion_queues(self, trapq_free_time, clear_history_time):
+        for trapq in self.trapqs:
+            self.trapq_finalize_moves(trapq, trapq_free_time,
+                                      clear_history_time)
+    def wipe_trapq(self, trapq):
+        # Expire any remaining movement in the trapq (force to history list)
+        NEVER = 9999999999999999.
+        self.trapq_finalize_moves(trapq, NEVER, 0.)
+    def lookup_trapq_append(self):
+        ffi_main, ffi_lib = chelper.get_ffi()
+        return ffi_lib.trapq_append
 
 def load_config(config):
     return PrinterMotionQueuing(config)

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -53,10 +53,12 @@ class PrinterMotionQueuing:
             fcbs = list(self.flush_callbacks)
             fcbs.remove(callback)
             self.flush_callbacks = fcbs
-    def flush_motion_queues(self, must_flush_time, max_step_gen_time):
+    def flush_motion_queues(self, must_flush_time, max_step_gen_time,
+                            trapq_free_time):
         # Invoke flush callbacks (if any)
         for cb in self.flush_callbacks:
             cb(must_flush_time, max_step_gen_time)
+        # Generate stepper movement and transmit
         for mcu, ss in self.steppersyncs:
             clock = max(0, mcu.print_time_to_clock(must_flush_time))
             # Generate steps
@@ -69,7 +71,7 @@ class PrinterMotionQueuing:
             if ret:
                 raise mcu.error("Internal error in MCU '%s' stepcompress"
                                 % (mcu.get_name(),))
-    def clean_motion_queues(self, trapq_free_time):
+        # Determine maximum history to keep
         clear_history_time = self.clear_history_time
         if self.is_debugoutput:
             clear_history_time = trapq_free_time - MOVE_HISTORY_EXPIRE

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -50,10 +50,11 @@ class GCodeRequestQueue:
             del rqueue[:pos+1]
             self.next_min_flush_time = next_time + max(min_wait, min_sched_time)
             # Ensure following queue items are flushed
-            self.toolhead.note_mcu_movequeue_activity(self.next_min_flush_time)
+            self.toolhead.note_mcu_movequeue_activity(self.next_min_flush_time,
+                                                      is_step_gen=False)
     def _queue_request(self, print_time, value):
         self.rqueue.append((print_time, value))
-        self.toolhead.note_mcu_movequeue_activity(print_time)
+        self.toolhead.note_mcu_movequeue_activity(print_time, is_step_gen=False)
     def queue_gcode_request(self, value):
         self.toolhead.register_lookahead_callback(
             (lambda pt: self._queue_request(pt, value)))

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -25,12 +25,12 @@ class GCodeRequestQueue:
         printer.register_event_handler("klippy:connect", self._handle_connect)
     def _handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
-    def _flush_notification(self, print_time):
+    def _flush_notification(self, must_flush_time, max_step_gen_time):
         min_sched_time = self.mcu.min_schedule_time()
         rqueue = self.rqueue
         while rqueue:
             next_time = max(rqueue[0][0], self.next_min_flush_time)
-            if next_time > print_time:
+            if next_time > must_flush_time:
                 return
             # Skip requests that have been overridden with a following request
             pos = 0

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -20,11 +20,12 @@ class GCodeRequestQueue:
         self.rqueue = []
         self.next_min_flush_time = 0.
         self.toolhead = None
-        mcu.register_flush_callback(self._flush_notification)
+        motion_queuing = printer.load_object(config, 'motion_queuing')
+        motion_queuing.register_flush_callback(self._flush_notification)
         printer.register_event_handler("klippy:connect", self._handle_connect)
     def _handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
-    def _flush_notification(self, print_time, clock):
+    def _flush_notification(self, print_time):
         min_sched_time = self.mcu.min_schedule_time()
         rqueue = self.rqueue
         while rqueue:

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -115,7 +115,8 @@ class MCU_queued_pwm:
             # Continue flushing to resend time
             wakeclock += self._duration_ticks
         wake_print_time = self._mcu.clock_to_print_time(wakeclock)
-        self._toolhead.note_mcu_movequeue_activity(wake_print_time)
+        self._toolhead.note_mcu_movequeue_activity(wake_print_time,
+                                                   is_step_gen=False)
     def set_pwm(self, print_time, value):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._invert:

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -124,8 +124,8 @@ class MCU_queued_pwm:
             value = 1. - value
         v = int(max(0., min(1., value)) * self._pwm_max + 0.5)
         self._send_update(clock, v)
-    def _flush_notification(self, print_time):
-        clock = self._mcu.print_time_to_clock(print_time)
+    def _flush_notification(self, must_flush_time, max_step_gen_time):
+        clock = self._mcu.print_time_to_clock(must_flush_time)
         if self._last_value != self._default_value:
             while clock >= self._last_clock + self._duration_ticks:
                 self._send_update(self._last_clock + self._duration_ticks,

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -9,18 +9,18 @@ class error(Exception):
     pass
 
 class MCU_queued_pwm:
-    def __init__(self, pin_params):
-        self._mcu = pin_params['chip']
+    def __init__(self, config, pin_params):
+        self._mcu = mcu = pin_params['chip']
         self._hardware_pwm = False
         self._cycle_time = 0.100
         self._max_duration = 2.
-        self._oid = self._mcu.create_oid()
+        self._oid = oid = mcu.create_oid()
+        printer = mcu.get_printer()
+        motion_queuing = printer.load_object(config, 'motion_queuing')
+        self._stepqueue = motion_queuing.allocate_stepcompress(mcu, oid)
         ffi_main, ffi_lib = chelper.get_ffi()
-        self._stepqueue = ffi_main.gc(ffi_lib.stepcompress_alloc(self._oid),
-                                      ffi_lib.stepcompress_free)
-        self._mcu.register_stepqueue(self._stepqueue)
         self._stepcompress_queue_mq_msg = ffi_lib.stepcompress_queue_mq_msg
-        self._mcu.register_config_callback(self._build_config)
+        mcu.register_config_callback(self._build_config)
         self._pin = pin_params['pin']
         self._invert = pin_params['invert']
         self._start_value = self._shutdown_value = float(self._invert)
@@ -29,7 +29,6 @@ class MCU_queued_pwm:
         self._pwm_max = 0.
         self._set_cmd_tag = None
         self._toolhead = None
-        printer = self._mcu.get_printer()
         printer.register_event_handler("klippy:connect", self._handle_connect)
     def _handle_connect(self):
         self._toolhead = self._mcu.get_printer().lookup_object("toolhead")
@@ -135,7 +134,7 @@ class PrinterOutputPin:
         ppins = self.printer.lookup_object('pins')
         # Determine pin type
         pin_params = ppins.lookup_pin(config.get('pin'), can_invert=True)
-        self.mcu_pin = MCU_queued_pwm(pin_params)
+        self.mcu_pin = MCU_queued_pwm(config, pin_params)
         max_duration = self.mcu_pin.get_mcu().max_nominal_duration()
         cycle_time = config.getfloat('cycle_time', 0.100, above=0.,
                                      maxval=max_duration)

--- a/klippy/extras/statistics.py
+++ b/klippy/extras/statistics.py
@@ -65,8 +65,8 @@ class PrinterStats:
     def generate_stats(self, eventtime):
         stats = [cb(eventtime) for cb in self.stats_cb]
         if max([s[0] for s in stats]):
-            logging.info("Stats %.1f: %s", eventtime,
-                         ' '.join([s[1] for s in stats]))
+            stats_str = ' '.join([s[1] for s in stats if s[1]])
+            logging.info("Stats %.1f: %s", eventtime, stats_str)
         return eventtime + 1.
 
 def load_config(config):

--- a/klippy/kinematics/cartesian.py
+++ b/klippy/kinematics/cartesian.py
@@ -36,7 +36,6 @@ class CartKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat('max_z_velocity', max_velocity,

--- a/klippy/kinematics/corexy.py
+++ b/klippy/kinematics/corexy.py
@@ -20,7 +20,6 @@ class CoreXYKinematics:
         self.rails[2].setup_itersolve('cartesian_stepper_alloc', b'z')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/corexz.py
+++ b/klippy/kinematics/corexz.py
@@ -20,7 +20,6 @@ class CoreXZKinematics:
         self.rails[2].setup_itersolve('corexz_stepper_alloc', b'-')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/delta.py
+++ b/klippy/kinematics/delta.py
@@ -52,7 +52,6 @@ class DeltaKinematics:
             r.setup_itersolve('delta_stepper_alloc', a, t[0], t[1])
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         self.need_home = True
         self.limit_xy2 = -1.

--- a/klippy/kinematics/deltesian.py
+++ b/klippy/kinematics/deltesian.py
@@ -40,7 +40,6 @@ class DeltesianKinematics:
         self.rails[2].setup_itersolve('cartesian_stepper_alloc', b'y')
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         self.limits = [(1.0, -1.0)] * 3
         # X axis limits
         min_angle = config.getfloat('min_angle', MIN_ANGLE,

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -163,10 +163,9 @@ class PrinterExtruder:
         self.instant_corner_v = config.getfloat(
             'instantaneous_corner_velocity', 1., minval=0.)
         # Setup extruder trapq (trapezoidal motion queue)
-        ffi_main, ffi_lib = chelper.get_ffi()
-        self.trapq = ffi_main.gc(ffi_lib.trapq_alloc(), ffi_lib.trapq_free)
-        self.trapq_append = ffi_lib.trapq_append
-        self.trapq_finalize_moves = ffi_lib.trapq_finalize_moves
+        self.motion_queuing = self.printer.load_object(config, 'motion_queuing')
+        self.trapq = self.motion_queuing.allocate_trapq()
+        self.trapq_append = self.motion_queuing.lookup_trapq_append()
         # Setup extruder stepper
         self.extruder_stepper = None
         if (config.get('step_pin', None) is not None

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -39,8 +39,6 @@ class ExtruderStepper:
                                    self.name, self.cmd_SYNC_EXTRUDER_MOTION,
                                    desc=self.cmd_SYNC_EXTRUDER_MOTION_help)
     def _handle_connect(self):
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.register_step_generator(self.stepper.generate_steps)
         self._set_pressure_advance(self.config_pa, self.config_smooth_time)
     def get_status(self, eventtime):
         return {'pressure_advance': self.pressure_advance,

--- a/klippy/kinematics/generic_cartesian.py
+++ b/klippy/kinematics/generic_cartesian.py
@@ -108,7 +108,6 @@ class GenericCartesianKinematics:
         self._load_kinematics(config)
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         self.dc_module = None
         if self.dc_carriages:
             pcs = [dc.get_dual_carriage() for dc in self.dc_carriages]

--- a/klippy/kinematics/hybrid_corexy.py
+++ b/klippy/kinematics/hybrid_corexy.py
@@ -39,7 +39,6 @@ class HybridCoreXYKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/hybrid_corexz.py
+++ b/klippy/kinematics/hybrid_corexz.py
@@ -39,7 +39,6 @@ class HybridCoreXZKinematics:
                         'safe_distance', None, minval=0.))
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/polar.py
+++ b/klippy/kinematics/polar.py
@@ -21,7 +21,6 @@ class PolarKinematics:
                                           for s in r.get_steppers() ]
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         max_velocity, max_accel = toolhead.get_max_velocity()
         self.max_z_velocity = config.getfloat(

--- a/klippy/kinematics/rotary_delta.py
+++ b/klippy/kinematics/rotary_delta.py
@@ -52,7 +52,6 @@ class RotaryDeltaKinematics:
                               math.radians(a), ua, la)
         for s in self.get_steppers():
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         self.need_home = True
         self.limit_xy2 = -1.

--- a/klippy/kinematics/winch.py
+++ b/klippy/kinematics/winch.py
@@ -21,7 +21,6 @@ class WinchKinematics:
             self.anchors.append(a)
             s.setup_itersolve('winch_stepper_alloc', *a)
             s.set_trapq(toolhead.get_trapq())
-            toolhead.register_step_generator(s.generate_steps)
         # Setup boundary checks
         acoords = list(zip(*self.anchors))
         self.axes_min = toolhead.Coord(*[min(a) for a in acoords], e=0.)

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -970,19 +970,6 @@ class MCU:
     # Move queue tracking
     def request_move_queue_slot(self):
         self._reserved_move_slots += 1
-    def flush_moves(self, print_time, clear_history_time):
-        if self._steppersync is None:
-            return
-        clock = self.print_time_to_clock(print_time)
-        if clock < 0:
-            return
-        clear_history_clock = \
-            max(0, self.print_time_to_clock(clear_history_time))
-        ret = self._ffi_lib.steppersync_flush(self._steppersync, clock,
-                                              clear_history_clock)
-        if ret:
-            raise error("Internal error in MCU '%s' stepcompress"
-                        % (self._name,))
     def check_active(self, print_time, eventtime):
         if self._steppersync is None:
             return

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -606,7 +606,6 @@ class MCU:
                                                   minval=0.)
         self._reserved_move_slots = 0
         self._steppersync = None
-        self._flush_callbacks = []
         # Stats
         self._get_status_info = {}
         self._stats_sumsq_base = 0.
@@ -971,16 +970,12 @@ class MCU:
     # Move queue tracking
     def request_move_queue_slot(self):
         self._reserved_move_slots += 1
-    def register_flush_callback(self, callback):
-        self._flush_callbacks.append(callback)
     def flush_moves(self, print_time, clear_history_time):
         if self._steppersync is None:
             return
         clock = self.print_time_to_clock(print_time)
         if clock < 0:
             return
-        for cb in self._flush_callbacks:
-            cb(print_time, clock)
         clear_history_clock = \
             max(0, self.print_time_to_clock(clear_history_time))
         ret = self._ffi_lib.steppersync_flush(self._steppersync, clock,

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -605,7 +605,6 @@ class MCU:
         self._max_stepper_error = config.getfloat('max_stepper_error', 0.000025,
                                                   minval=0.)
         self._reserved_move_slots = 0
-        self._stepqueues = []
         self._steppersync = None
         self._flush_callbacks = []
         # Stats
@@ -773,8 +772,7 @@ class MCU:
         ss_move_count = move_count - self._reserved_move_slots
         motion_queuing = self._printer.lookup_object('motion_queuing')
         self._steppersync = motion_queuing.allocate_steppersync(
-            self, self._serial.get_serialqueue(),
-            self._stepqueues, ss_move_count)
+            self, self._serial.get_serialqueue(), ss_move_count)
         self._ffi_lib.steppersync_set_time(self._steppersync,
                                            0., self._mcu_freq)
         # Log config information
@@ -971,8 +969,6 @@ class MCU:
     def _firmware_restart_bridge(self):
         self._firmware_restart(True)
     # Move queue tracking
-    def register_stepqueue(self, stepqueue):
-        self._stepqueues.append(stepqueue)
     def request_move_queue_slot(self):
         self._reserved_move_slots += 1
     def register_flush_callback(self, callback):

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -273,7 +273,8 @@ def PrinterStepper(config, units_in_radians=False):
                               rotation_dist, steps_per_rotation,
                               step_pulse_duration, units_in_radians)
     # Register with helper modules
-    for mname in ['stepper_enable', 'force_move', 'motion_report']:
+    mods = ['stepper_enable', 'force_move', 'motion_report', 'motion_queuing']
+    for mname in mods:
         m = printer.load_object(config, mname)
         m.register_stepper(config, mcu_stepper)
     return mcu_stepper
@@ -442,9 +443,6 @@ class GenericPrinterRail:
     def setup_itersolve(self, alloc_func, *params):
         for stepper in self.steppers:
             stepper.setup_itersolve(alloc_func, *params)
-    def generate_steps(self, flush_time):
-        for stepper in self.steppers:
-            stepper.generate_steps(flush_time)
     def set_trapq(self, trapq):
         for stepper in self.steppers:
             stepper.set_trapq(trapq)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -275,11 +275,10 @@ class ToolHead:
         sg_flush_want = min(flush_time + STEPCOMPRESS_FLUSH_TIME,
                             self.print_time - self.kin_flush_delay)
         sg_flush_time = max(sg_flush_want, flush_time)
-        self.motion_queuing.flush_motion_queues(flush_time, sg_flush_time)
+        trapq_free_time = sg_flush_time - self.kin_flush_delay
+        self.motion_queuing.flush_motion_queues(flush_time, sg_flush_time,
+                                                trapq_free_time)
         self.min_restart_time = max(self.min_restart_time, sg_flush_time)
-        # Free trapq entries that are no longer needed
-        free_time = sg_flush_time - self.kin_flush_delay
-        self.motion_queuing.clean_motion_queues(free_time)
         self.last_flush_time = flush_time
     def _advance_move_time(self, next_print_time):
         pt_delay = self.kin_flush_delay + STEPCOMPRESS_FLUSH_TIME

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -285,8 +285,7 @@ class ToolHead:
         free_time = sg_flush_time - self.kin_flush_delay
         self.motion_queuing.clean_motion_queues(free_time, clear_history_time)
         # Flush stepcompress and mcu steppersync
-        for m in self.all_mcus:
-            m.flush_moves(flush_time, clear_history_time)
+        self.motion_queuing.flush_steppersync(flush_time, clear_history_time)
         self.last_flush_time = flush_time
     def _advance_move_time(self, next_print_time):
         pt_delay = self.kin_flush_delay + STEPCOMPRESS_FLUSH_TIME

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -279,11 +279,6 @@ class ToolHead:
         gcode.register_command('M204', self.cmd_M204)
         self.printer.register_event_handler("klippy:shutdown",
                                             self._handle_shutdown)
-        # Load some default modules
-        modules = ["gcode_move", "homing", "idle_timeout", "statistics",
-                   "manual_probe", "tuning_tower", "garbage_collection"]
-        for module_name in modules:
-            self.printer.load_object(config, module_name)
     # Print time and flush tracking
     def _advance_flush_time(self, flush_time):
         flush_time = max(flush_time, self.last_flush_time)
@@ -712,5 +707,11 @@ class ToolHead:
         self._calc_junction_deviation()
 
 def add_printer_objects(config):
-    config.get_printer().add_object('toolhead', ToolHead(config))
+    printer = config.get_printer()
+    printer.add_object('toolhead', ToolHead(config))
     kinematics.extruder.add_printer_objects(config)
+    # Load some default modules
+    modules = ["gcode_move", "homing", "idle_timeout", "statistics",
+               "manual_probe", "tuning_tower", "garbage_collection"]
+    for module_name in modules:
+        printer.load_object(config, module_name)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -284,8 +284,6 @@ class ToolHead:
             clear_history_time = flush_time - MOVE_HISTORY_EXPIRE
         free_time = sg_flush_time - self.kin_flush_delay
         self.motion_queuing.clean_motion_queues(free_time, clear_history_time)
-        # Flush stepcompress and mcu steppersync
-        self.motion_queuing.flush_steppersync(flush_time, clear_history_time)
         self.last_flush_time = flush_time
     def _advance_move_time(self, next_print_time):
         pt_delay = self.kin_flush_delay + STEPCOMPRESS_FLUSH_TIME

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -342,8 +342,7 @@ class ToolHead:
             for cb in move.timing_callbacks:
                 cb(next_move_time)
         # Generate steps for moves
-        self.note_mcu_movequeue_activity(next_move_time + self.kin_flush_delay,
-                                         set_step_gen_time=True)
+        self.note_mcu_movequeue_activity(next_move_time + self.kin_flush_delay)
         self._advance_move_time(next_move_time)
     def _flush_lookahead(self):
         # Transit from "NeedPrime"/"Priming"/"Drip"/main state to "NeedPrime"
@@ -539,8 +538,7 @@ class ToolHead:
                 drip_completion.wait(curtime + wait_time)
                 continue
             npt = min(self.print_time + DRIP_SEGMENT_TIME, next_print_time)
-            self.note_mcu_movequeue_activity(npt + self.kin_flush_delay,
-                                             set_step_gen_time=True)
+            self.note_mcu_movequeue_activity(npt + self.kin_flush_delay)
             for stepper in addstepper:
                 stepper.generate_steps(npt)
             self._advance_move_time(npt)
@@ -638,9 +636,9 @@ class ToolHead:
             callback(self.get_last_move_time())
             return
         last_move.timing_callbacks.append(callback)
-    def note_mcu_movequeue_activity(self, mq_time, set_step_gen_time=False):
+    def note_mcu_movequeue_activity(self, mq_time, is_step_gen=True):
         self.need_flush_time = max(self.need_flush_time, mq_time)
-        if set_step_gen_time:
+        if is_step_gen:
             self.step_gen_time = max(self.step_gen_time, mq_time)
         if self.do_kick_flush_timer:
             self.do_kick_flush_timer = False


### PR DESCRIPTION
Generating a movement in the host python code requires an elaborate sequence.  The desired move must be added to a "trapq" (`trapq_append()`), the steps have to be generated via the iterative solver (`stepper.generate_steps()`), the toolhead must be notified of the time the move completes (`toolhead.note_mcu_movequeue_activity()`), old entries need to be removed from the trapq (`trapq_finalize`), and the toolhead code needs to signal the "steppersync" code to process the results (`steppersync_flush()`).  This process is tedious and error prone.  If the process is not done fully it typically results in hard to debug errors.

This PR attempts to simplify the above process.  A new `motion_queuing.py` module is added and it is tasked with globally flushing all "itersolve" instances, "trapq" instances, and "steppersync" instances.  The goal is to centralize the process and reduce the number of steps needed in other areas of the code.  This simplifies the code in toolhead.py, mcu.py, stepper.py, force_move.py, and manual_stepper.py .  At the end of this PR, callers should only need to generate the move (`trapq_append()`) and notify the toolhead of the movement end time (`toolhead.note_mcu_movequeue_activity()`).

This work is a result of a discussion at #6992 .  There is a desire to utilize multiple threads in the "iterative solver" and "step compression" code.  I think it may be worthwhile to first simplify how flushing is implemented prior to adding more complexity.

@nefelim4ag - this PR will conflict with your work, but hopefully not too badly.

@dmbutyugin - FYI.

-Kevin