### PR TITLE
pyhelper: drop linux/prctl header for compability with musl

### DIFF
--- a/klippy/chelper/pyhelper.c
+++ b/klippy/chelper/pyhelper.c
@@ -10,7 +10,6 @@
 #include <stdio.h> // fprintf
 #include <string.h> // strerror
 #include <time.h> // struct timespec
-#include <linux/prctl.h>  // PR_SET_NAME
 #include <sys/prctl.h>  // prctl
 #include "compiler.h" // __visible
 #include "pyhelper.h" // get_monotonic


### PR DESCRIPTION
I have no personal preference about the support of Musl. Got report on the [Discourse](https://klipper.discourse.group/t/musl-consider-removing-linux-prctl-h-from-klippy-chelper-pyhelper-c/24501):


Seems like it is safe to remove at least on recent systems, because there is an internal `linux/prctl.h` include:
```
#ifndef _SYS_PRCTL_H
#define _SYS_PRCTL_H	1

#include <features.h>
#include <linux/prctl.h>  /*  The magic values come from here  */
```
Seems like it does so for quite some time:
https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sys/prctl.h;hb=refs/heads/release/2.10/master#l22

Thanks.

---
Ref: https://wiki.musl-libc.org/faq#Q:-Why-am-I-getting-