### PR TITLE
Added file size check on c_helper.so

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -250,11 +250,20 @@ def get_mtimes(filelist):
         out.append(t)
     return out
 
+# return the file size, or 0 if not present
+def get_size(file):
+    try:
+        size = os.path.getsize(file)
+    except os.error:
+        return 0
+    return size
+
 # Check if the code needs to be compiled
 def check_build_code(sources, target):
     src_times = get_mtimes(sources)
     obj_times = get_mtimes([target])
-    return not obj_times or max(src_times) > min(obj_times)
+    target_size = get_size(target)
+    return not target_size or not obj_times or max(src_times) > min(obj_times)
 
 # Check if the current gcc version supports a particular command-line option
 def check_gcc_option(option):


### PR DESCRIPTION
I'm not 100% sure why, but I continue to occasionally see users (mostly new builds) encounter errors where they have a zero size c_helper.so file, which causes klipper to fail.
To correct this, I've added an extra error check, so that a zero size c_helper.so will result in recompilation.