### PR TITLE
load_cell_probe: Fix memory leak on some probe failures

### DIFF
--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -482,7 +482,11 @@ class LoadCellProbingMove:
         # start collector after tare samples are consumed
         collector = self._start_collector()
         # do homing move
-        return phoming.probing_move(self, pos, speed), collector
+        try:
+            return phoming.probing_move(self, pos, speed), collector
+        except:
+            collector.stop_collecting()
+            raise
 
     # Wait for the MCU to trigger with no movement
     def probing_test(self, gcmd, timeout):


### PR DESCRIPTION
In the case where the homing module's `probing_move` raises an exception, the collector's `_finish_collecting` is never called. Normally the caller of `LoadCellProbingMove`'s `probing_move` uses the collector object by calling `collect_until`, which calls `_finish_collecting` when it is done, but if an exception is raised before that can be done the collector object keeps receiving samples and never does anything with them.

This ensures that the collector is stopped if an exception is raised, so that samples do not accumulate indefinitely.