### PR TITLE
spi_flash: Add qidi-x6 to board_defs.py

### DIFF
--- a/scripts/spi_flash/board_defs.py
+++ b/scripts/spi_flash/board_defs.py
@@ -170,6 +170,14 @@ BOARD_DEFS = {
         "firmware_path": "ZNP_ROBIN_NANO.bin",
         "current_firmware_path": "ZNP_ROBIN_NANO.CUR"
     },
+    'qidi-x6': {
+        'mcu': "stm32f401xc",
+        'spi_bus': "spi2",
+        'cs_pin': "PB12",
+        'skip_verify': False,
+        'firmware_path': 'X_4.bin',
+        'current_firmware_path': 'X_4.CUR'
+    },
     'qidi-x7': {
         'mcu': "stm32f401xc",
         'spi_bus': "spi2",
@@ -228,6 +236,9 @@ BOARD_ALIASES = {
     'robin_v3': BOARD_DEFS['monster8'],
     'btt-skrat-v1.0': BOARD_DEFS['btt-skrat'],
     'chitu-v6': BOARD_DEFS['chitu-v6'],
+    'qidi-x-smart3': BOARD_DEFS['qidi-x6'],
+    'qidi-x-plus3': BOARD_DEFS['qidi-x6'],
+    'qidi-x-max3': BOARD_DEFS['qidi-x6'],
     'qidi-q1-pro': BOARD_DEFS['qidi-x7'],
     'qidi-plus4': BOARD_DEFS['qidi-x7']
 }


### PR DESCRIPTION
spi_flash: Added qidi-x6 to board_defs.py


Added board definition for stm32f401xc-based Qidi X-6 (and X-4) mainboards used in QIDI X-Smart3, X-Plus3 and X-Max3. 
This is similar to https://github.com/Klipper3d/klipper/pull/6979

The mainboards used in these printers are marked as "X-4" and "X-6" and are (in this regard) identical:
https://eu.qidi3d.com/products/x-max-3-x-plus-3-x-smart-3-motherboard
<img width="711" height="438" alt="image" src="https://github.com/user-attachments/assets/5d45d449-44bd-4515-8ceb-ccd250b8cb04" />


They dont officially provide a pinout diagram, but you can find my post with the diagram here:
https://github.com/QIDITECH/QIDI_MAX3/issues/13#issuecomment-1854691768
<img width="1079" height="951" alt="image" src="https://github.com/user-attachments/assets/71479a68-e388-48fb-82a8-04ade0b8b8d9" />


I tested it successfully on my X-Max3:
```
mks@mkspi:~/klipper$ ./scripts/flash-sdcard.sh -f ~/FreeDi/mainboard_and_toolhead_firmwares/v0.13.0-154/X_4.bin -b 500000 /dev/ttyS0 qidi-x-max3
Flashing /home/mks/FreeDi/mainboard_and_toolhead_firmwares/v0.13.0-154/X_4.bin to /dev/ttyS0
Checking FatFS CFFI Build...
Building FatFS shared library...Done
Connecting to MCU...Connected
Checking Current MCU Configuration...Done
MCU needs restart: is_config=1, is_shutdown=0
Attempting MCU Reset...Done
Waiting for device to reconnect...Done
Connecting to MCU......Connected
Initializing SD Card and Mounting file system...

SD Card Information:
Version: 2.0
SDHC/SDXC: True
Write Protected: False
Sectors: 61736960
manufacturer_id: 255
oem_id:
product_name: SDU1
product_revision: 1.16
serial_number: 14A11B35
manufacturing_date: 6/2022
capacity: 29.4 GiB
fs_type: FAT32
volume_label: b'SDCARD'
volume_serial: 676891558
Uploading Klipper Firmware to SD Card...Done
Validating Upload...Done
Firmware Upload Complete: X_4.bin, Size: 37940, Checksum (SHA1): F12489A15BBF23793CB40BA11C45747FCBB7340C
Attempting MCU Reset...Done
Waiting for device to reconnect...Done
Connecting to MCU.......Connected
Verifying Flash...Version unchanged...Checksum matched...Done
Firmware Flash Successful
Current Firmware: v0.13.0-154-g9346ad19
Attempting MCU Reset...Done
SD Card Flash Complete
mks@mkspi:~/klipper$
```

Signed-off-by: Phil Groenewold [philgroenewold@gmx.de](mailto:philgroenewold@gmx.de)