### PR TITLE
stm32: Add i2c2_PA7_PA6 and i2c3_PA7_PA6 for stm32g0

### DIFF
--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -44,11 +44,15 @@ struct i2c_info {
   DECL_CONSTANT_STR("BUS_PINS_i2c2_PB10_PB11", "PB10,PB11");
   DECL_ENUMERATION("i2c_bus", "i2c2_PB13_PB14", 4);
   DECL_CONSTANT_STR("BUS_PINS_i2c2_PB13_PB14", "PB13,PB14");
+  DECL_ENUMERATION("i2c_bus", "i2c2_PA7_PA6", 5);
+  DECL_CONSTANT_STR("BUS_PINS_i2c2_PA7_PA6", "PA7,PA6");
   #ifdef I2C3
-    DECL_ENUMERATION("i2c_bus", "i2c3_PB3_PB4", 5);
+    DECL_ENUMERATION("i2c_bus", "i2c3_PB3_PB4", 6);
     DECL_CONSTANT_STR("BUS_PINS_i2c3_PB3_PB4", "PB3,PB4");
-    DECL_ENUMERATION("i2c_bus", "i2c3_PC0_PC1", 6);
+    DECL_ENUMERATION("i2c_bus", "i2c3_PC0_PC1", 7);
     DECL_CONSTANT_STR("BUS_PINS_i2c3_PC0_PC1", "PC0,PC1");
+    DECL_ENUMERATION("i2c_bus", "i2c3_PA7_PA6", 8);
+    DECL_CONSTANT_STR("BUS_PINS_i2c3_PA7_PA6", "PA7,PA6");
   #endif
 #elif CONFIG_MACH_STM32L4
   DECL_ENUMERATION("i2c_bus", "i2c1_PB6_PB7", 0);
@@ -105,9 +109,11 @@ static const struct i2c_info i2c_bus[] = {
     { I2C1, GPIO('A', 9), GPIO('A', 10), GPIO_FUNCTION(6) },
     { I2C2, GPIO('B', 10), GPIO('B', 11), GPIO_FUNCTION(6) },
     { I2C2, GPIO('B', 13), GPIO('B', 14), GPIO_FUNCTION(6) },
+    { I2C2, GPIO('A', 7), GPIO('A', 6), GPIO_FUNCTION(8) },
   #ifdef I2C3
     { I2C3, GPIO('B', 3), GPIO('B', 4), GPIO_FUNCTION(6) },
     { I2C3, GPIO('C', 0), GPIO('C', 1), GPIO_FUNCTION(6) },
+    { I2C3, GPIO('A', 7), GPIO('A', 6), GPIO_FUNCTION(9) },
   #endif
 #elif CONFIG_MACH_STM32L4
     { I2C1, GPIO('B', 6), GPIO('B', 7), GPIO_FUNCTION(4) },


### PR DESCRIPTION
Signed-off-by: Alan.Ma from BigTreeTech tech@biqu3d.com