### PR TITLE
heaters: Set next_pwm_time to 0.66 * MAX_HEAT_TIME

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -75,7 +75,8 @@ class Heater:
             # No significant change in value - can suppress update
             return
         pwm_time = read_time + self.pwm_delay
-        self.next_pwm_time = pwm_time + 0.75 * MAX_HEAT_TIME
+        self.next_pwm_time = (pwm_time + MAX_HEAT_TIME
+                              - (3. * self.pwm_delay + 0.001))
         self.last_pwm_value = value
         self.mcu_pwm.set_pwm(pwm_time, value)
         #logging.debug("%s: pwm=%.3f@%.3f (from %.3f@%.3f [%.3f])",


### PR DESCRIPTION
Commit 0f94f6c8 decreased the MAX_HEAT_TIME from 5 seconds to 3 seconds.  However, that also decreased the amount of tolerance for lost temperature updates from 1.25 seconds to 0.75 seconds.  With the default temperature update every 300ms, only 2 consecutive missing temperature updates could lead to a fault.

Tweak the internal "next_pwm_time" setting so that it is more tolerant of two consecutive lost temperature updates.

-Kevin