### PR TITLE
I2C write: use connect hook for early writes

### DIFF
--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -52,6 +52,10 @@ class SX1509(object):
             curtime = reactor.monotonic()
             printtime = self._mcu.estimated_print_time(curtime)
             self.send_register(_reg, printtime)
+        for reg in self.reg_i_on_dict:
+            curtime = reactor.monotonic()
+            printtime = self._mcu.estimated_print_time(curtime)
+            self.send_register(reg, printtime)
     def setup_pin(self, pin_type, pin_params):
         if pin_type == 'digital_out' and pin_params['pin'][0:4] == "PIN_":
             return SX1509_digital_out(self, pin_params)
@@ -158,15 +162,6 @@ class SX1509_pwm(object):
             raise pins.error("SX1509_pwm must have hardware_pwm enabled")
         if self._max_duration:
             raise pins.error("SX1509 pins are not suitable for heaters")
-        # Send initial value
-        self._sx1509.set_register(self._i_on_reg,
-                                  ~int(255 * self._start_value) & 0xFF)
-        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self._sx1509.get_oid(),
-            self._i_on_reg,
-            self._sx1509.reg_i_on_dict[self._i_on_reg]
-            ),
-                                 is_init=True)
     def get_mcu(self):
         return self._mcu
     def setup_max_duration(self, max_duration):
@@ -180,6 +175,8 @@ class SX1509_pwm(object):
             shutdown_value = 1. - shutdown_value
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
+        self._sx1509.set_register(self._i_on_reg,
+                                  ~int(255 * self._start_value) & 0xFF)
     def set_pwm(self, print_time, value):
         self._sx1509.set_register(self._i_on_reg, ~int(255 * value)
                                   if not self._invert

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -29,7 +29,6 @@ class SX1509(object):
         self._ppins = self._printer.lookup_object("pins")
         self._ppins.register_chip("sx1509_" + self._name, self)
         self._mcu = self._i2c.get_mcu()
-        self._mcu.register_config_callback(self._build_config)
         self._oid = self._i2c.get_oid()
         self._last_clock = 0
         # Set up registers default values
@@ -37,22 +36,22 @@ class SX1509(object):
                          REG_PULLUP : 0, REG_PULLDOWN : 0,
                          REG_INPUT_DISABLE : 0, REG_ANALOG_DRIVER_ENABLE : 0}
         self.reg_i_on_dict = {reg : 0 for reg in REG_I_ON}
-    def _build_config(self):
+        config.get_printer().register_event_handler("klippy:connect",
+                                                    self.handle_connect)
+    def handle_connect(self):
         # Reset the chip, Default RegClock/RegMisc 0x0
-        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self._oid, REG_RESET, 0x12))
-        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self._oid, REG_RESET, 0x34))
+        self._i2c.i2c_write([REG_RESET, 0x12])
+        self._i2c.i2c_write([REG_RESET, 0x34])
         # Enable Oscillator
-        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self._oid, REG_CLOCK, (1 << 6)))
+        self._i2c.i2c_write([REG_CLOCK, (1 << 6)])
         # Setup Clock Divider
-        self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%02x" % (
-            self._oid, REG_MISC, (1 << 4)))
+        self._i2c.i2c_write([REG_MISC, (1 << 4)])
         # Transfer all regs with their initial cached state
-        for _reg, _data in self.reg_dict.items():
-            self._mcu.add_config_cmd("i2c_write oid=%d data=%02x%04x" % (
-                self._oid, _reg, _data), is_init=True)
+        reactor = self._mcu.get_printer().get_reactor()
+        for _reg in self.reg_dict:
+            curtime = reactor.monotonic()
+            printtime = self._mcu.estimated_print_time(curtime)
+            self.send_register(_reg, printtime)
     def setup_pin(self, pin_type, pin_params):
         if pin_type == 'digital_out' and pin_params['pin'][0:4] == "PIN_":
             return SX1509_digital_out(self, pin_params)


### PR DESCRIPTION
I probably want to finish the I2C error handling #6689. 
So, I have to get rid of direct or indirect usages of i2c_write inside modules.

Probably I've found everything, and hopefully it is still correct.
Unfortunately, I do not have that hardware to test something out.

So, this is just refactoring, no functional changes.

Thanks.