### PR TITLE
I2C klippy's side error handling

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import mcu
+import logging
 
 def resolve_bus_name(mcu, param, bus):
     # Find enumerations for the given bus
@@ -155,12 +156,14 @@ def MCU_SPI_from_config(config, mode, pin_option="cs_pin",
 
 # Helper code for working with devices connected to an MCU via an I2C bus
 class MCU_I2C:
-    def __init__(self, mcu, bus, addr, speed, sw_pins=None):
+    def __init__(self, mcu, bus, addr, speed, sw_pins=None,
+                 async_write_only=False):
         self.mcu = mcu
         self.bus = bus
         self.i2c_address = addr
         self.oid = self.mcu.create_oid()
         self.speed = speed
+        self.async_write_only = async_write_only
         self.config_fmt_ticks = None
         mcu.add_config_cmd("config_i2c oid=%d" % (self.oid,))
         # Generate I2C bus config message
@@ -180,7 +183,7 @@ class MCU_I2C:
         self.cmd_queue = self.mcu.alloc_command_queue()
         self.mcu.register_config_callback(self.build_config)
         self.i2c_write_cmd = self.i2c_read_cmd = None
-        self.i2c_transfer_cmd = None
+        self.i2c_transfer_cmd = self.i2c_write_only_cmd = None
         printer = self.mcu.get_printer()
         printer.register_event_handler("klippy:connect", self._handle_connect)
         # backward support i2c_write inside the init section
@@ -198,6 +201,13 @@ class MCU_I2C:
         return self.i2c_address
     def get_command_queue(self):
         return self.cmd_queue
+    def _async_write_status(self, params):
+        status = params["i2c_bus_status"]
+        if status == "SUCCESS":
+            return
+        err_msg = "MCU '%s' I2C request to addr %i reports error %s" % (
+            self.mcu.get_name(), self.i2c_address, status)
+        logging.error(err_msg)
     def build_config(self):
         if '%' in self.config_fmt:
             bus = resolve_bus_name(self.mcu, "i2c_bus", self.bus)
@@ -209,9 +219,10 @@ class MCU_I2C:
                 pulse_ticks = self.mcu.seconds_to_clock(1./self.speed/2)
                 self.config_fmt = self.config_fmt_ticks % (pulse_ticks,)
         self.mcu.add_config_cmd(self.config_fmt)
-        self.i2c_write_cmd = self.mcu.lookup_command(
-            "i2c_write oid=%c data=%*s", cq=self.cmd_queue)
         if self.mcu.try_lookup_command("i2c_read oid=%c reg=%*s read_len=%u"):
+            self.i2c_write_cmd = self.mcu.lookup_command(
+                "i2c_write oid=%c data=%*s", cq=self.cmd_queue)
+            self.i2c_write_only_cmd = self.i2c_write_cmd
             self.i2c_read_cmd = self.mcu.lookup_query_command(
                 "i2c_read oid=%c reg=%*s read_len=%u",
                 "i2c_read_response oid=%c response=%*s", oid=self.oid,
@@ -221,17 +232,31 @@ class MCU_I2C:
                 "i2c_transfer oid=%c write=%*s read_len=%u",
                 "i2c_response oid=%c i2c_bus_status=%c response=%*s",
                 oid=self.oid, cq=self.cmd_queue)
+            self.i2c_write_only_cmd = self.mcu.lookup_command(
+                "i2c_transfer oid=%c write=%*s read_len=%u",
+                cq=self.cmd_queue)
             if self.mcu.is_fileoutput():
                 self.i2c_transfer_cmd = self.mcu.lookup_command(
                     "i2c_transfer oid=%c write=%*s read_len=%u",
                     cq=self.cmd_queue)
+            if self.async_write_only:
+                self.mcu.register_response(self._async_write_status,
+                                           "i2c_response", self.oid)
         self._configured = True
     def i2c_write_noack(self, data, minclock=0, reqclock=0):
+        if self.async_write_only:
+            self.i2c_write_only_cmd.send([self.oid, data, 0],
+                                         minclock=minclock, reqclock=reqclock)
+            return
         self.i2c_write_cmd.send([self.oid, data],
                                 minclock=minclock, reqclock=reqclock)
     def i2c_write(self, data, minclock=0, reqclock=0, retry=True):
         if not self._configured:
             self._to_write.append(data)
+            return
+        if self.async_write_only:
+            self.i2c_write_only_cmd.send([self.oid, data, 0],
+                                         minclock=minclock, reqclock=reqclock)
             return
         if self.i2c_transfer_cmd is not None:
             self.i2c_transfer(data, minclock=minclock, reqclock=reqclock,
@@ -240,12 +265,16 @@ class MCU_I2C:
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
                                          minclock=minclock, reqclock=reqclock)
     def i2c_read(self, write, read_len, retry=True):
+        if self.async_write_only:
+            raise mcu.error("I2C dev is write only")
         if self.i2c_transfer_cmd is not None:
             return self.i2c_transfer(write, read_len, retry=retry)
         return self.i2c_read_cmd.send([self.oid, write, read_len],
                                       retry=retry)
     def i2c_transfer(self, write, read_len=0, minclock=0, reqclock=0,
                      retry=True):
+        if self.async_write_only:
+            raise mcu.error("I2C dev is write only")
         cmd = self.i2c_transfer_cmd
         if self.mcu.is_fileoutput():
             cmd.send([self.oid, write, read_len],
@@ -260,7 +289,8 @@ class MCU_I2C:
             self.mcu.get_name(), self.i2c_address, status)
         self.mcu.get_printer().invoke_shutdown(err_msg)
 
-def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
+def MCU_I2C_from_config(config, default_addr=None, default_speed=100000,
+                        async_write_only=False):
     # Load bus parameters
     printer = config.get_printer()
     i2c_mcu = mcu.get_printer_mcu(printer, config.get('i2c_mcu', 'mcu'))
@@ -286,7 +316,7 @@ def MCU_I2C_from_config(config, default_addr=None, default_speed=100000):
         bus = config.get('i2c_bus', None)
         sw_pins = None
     # Create MCU_I2C object
-    return MCU_I2C(i2c_mcu, bus, addr, speed, sw_pins)
+    return MCU_I2C(i2c_mcu, bus, addr, speed, sw_pins, async_write_only)
 
 
 ######################################################################

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -130,7 +130,8 @@ class SPI4wire:
 class I2C:
     def __init__(self, config, default_addr):
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=default_addr,
-                                           default_speed=400000)
+                                           default_speed=400000,
+                                           async_write_only=True)
     def send(self, cmds, is_data=False):
         if is_data:
             hdr = 0x40

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -25,7 +25,8 @@ class SX1509(object):
     def __init__(self, config):
         self._printer = config.get_printer()
         self._name = config.get_name().split()[1]
-        self._i2c = bus.MCU_I2C_from_config(config, default_speed=400000)
+        self._i2c = bus.MCU_I2C_from_config(config, default_speed=400000,
+                                            async_write_only=True)
         self._ppins = self._printer.lookup_object("pins")
         self._ppins.register_chip("sx1509_" + self._name, self)
         self._mcu = self._i2c.get_mcu()

--- a/src/i2ccmds.c
+++ b/src/i2ccmds.c
@@ -78,16 +78,6 @@ int i2c_dev_write(struct i2cdev_s *i2c, uint8_t write_len, uint8_t *data)
         return i2c_write(i2c->i2c_hw, write_len, data);
 }
 
-void command_i2c_write(uint32_t *args)
-{
-    uint8_t oid = args[0];
-    struct i2cdev_s *i2c = oid_lookup(oid, command_config_i2c);
-    uint8_t data_len = args[1];
-    uint8_t *data = command_decode_ptr(args[2]);
-    i2c_dev_write(i2c, data_len, data);
-}
-DECL_COMMAND(command_i2c_write, "i2c_write oid=%c data=%*s");
-
 int i2c_dev_read(struct i2cdev_s *i2c, uint8_t reg_len, uint8_t *reg
                   , uint8_t read_len, uint8_t *read)
 {


### PR DESCRIPTION
Migration of the I2C read error to the host side. So, if the host requests the data, and the MCU is unable to read it, the host raises an exception and shuts down.

There is an optional retry for the reads, as they are currently retriable by semantics.
Because there is a retry with pause underneath, I'm not sure if it is really necessary to implement the same retry pause loop in the bus.py.

Something similar could be done to i2c_write.  I'm a little unhappy that it would make i2c_write chains less effective; on the other hand, I'm not aware of the code, where they would be practically reasonable.

Generally, I would assume, I2C write is retriable, in the sense that it writes the final register state.
I'm a little unsure if we can still implement i2c_write chaining and if it is really required by any device/usage.
I do think it is possible to register an Async callback, which would raise the error inside the bus.py.
But it seems a little tricky, and there is a chance that the MCU would lose the error feedback in the communication.
But if we do always respond with the error/success feedback, I do not see a non-blocking way to do so in any meaningful manner, which would allow retrying the last write.

Anyway, I'm open to suggestions.

I think that it is okay for now to just raise an exception and stop the machine from the host side, instead of the MCU.
It is a bonus if we do implement auto-retry here for all other modules.

Thanks.

---
Depends on: #7012, #7020
Child of: #6689