### PR TITLE
Centralize host motion flushing

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -56,6 +56,8 @@ defs_stepcompress = """
         , uint64_t start_clock, uint64_t end_clock);
     void stepcompress_set_stepper_kinematics(struct stepcompress *sc
         , struct stepper_kinematics *sk);
+    struct stepper_kinematics *stepcompress_get_stepper_kinematics(
+        struct stepcompress *sc);
 """
 
 defs_steppersync = """
@@ -76,11 +78,14 @@ defs_itersolve = """
     int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);
     void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
         , double step_dist);
+    struct trapq *itersolve_get_trapq(struct stepper_kinematics *sk);
     double itersolve_calc_position_from_coord(struct stepper_kinematics *sk
         , double x, double y, double z);
     void itersolve_set_position(struct stepper_kinematics *sk
         , double x, double y, double z);
     double itersolve_get_commanded_pos(struct stepper_kinematics *sk);
+    double itersolve_get_gen_steps_pre_active(struct stepper_kinematics *sk);
+    double itersolve_get_gen_steps_post_active(struct stepper_kinematics *sk);
 """
 
 defs_trapq = """
@@ -157,8 +162,6 @@ defs_kin_extruder = """
 """
 
 defs_kin_shaper = """
-    double input_shaper_get_step_generation_window(
-        struct stepper_kinematics *sk);
     int input_shaper_set_shaper_params(struct stepper_kinematics *sk, char axis
         , int n, double a[], double t[]);
     int input_shaper_set_sk(struct stepper_kinematics *sk

--- a/klippy/chelper/itersolve.c
+++ b/klippy/chelper/itersolve.c
@@ -248,6 +248,12 @@ itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
     sk->step_dist = step_dist;
 }
 
+struct trapq * __visible
+itersolve_get_trapq(struct stepper_kinematics *sk)
+{
+    return sk->tq;
+}
+
 double __visible
 itersolve_calc_position_from_coord(struct stepper_kinematics *sk
                                    , double x, double y, double z)
@@ -272,4 +278,16 @@ double __visible
 itersolve_get_commanded_pos(struct stepper_kinematics *sk)
 {
     return sk->commanded_pos;
+}
+
+double __visible
+itersolve_get_gen_steps_pre_active(struct stepper_kinematics *sk)
+{
+    return sk->gen_steps_pre_active;
+}
+
+double __visible
+itersolve_get_gen_steps_post_active(struct stepper_kinematics *sk)
+{
+    return sk->gen_steps_post_active;
 }

--- a/klippy/chelper/itersolve.h
+++ b/klippy/chelper/itersolve.h
@@ -31,10 +31,13 @@ double itersolve_check_active(struct stepper_kinematics *sk, double flush_time);
 int32_t itersolve_is_active_axis(struct stepper_kinematics *sk, char axis);
 void itersolve_set_trapq(struct stepper_kinematics *sk, struct trapq *tq
                          , double step_dist);
+struct trapq *itersolve_get_trapq(struct stepper_kinematics *sk);
 double itersolve_calc_position_from_coord(struct stepper_kinematics *sk
                                           , double x, double y, double z);
 void itersolve_set_position(struct stepper_kinematics *sk
                             , double x, double y, double z);
 double itersolve_get_commanded_pos(struct stepper_kinematics *sk);
+double itersolve_get_gen_steps_pre_active(struct stepper_kinematics *sk);
+double itersolve_get_gen_steps_post_active(struct stepper_kinematics *sk);
 
 #endif // itersolve.h

--- a/klippy/chelper/kin_shaper.c
+++ b/klippy/chelper/kin_shaper.c
@@ -239,14 +239,6 @@ input_shaper_set_shaper_params(struct stepper_kinematics *sk, char axis
     return status;
 }
 
-double __visible
-input_shaper_get_step_generation_window(struct stepper_kinematics *sk)
-{
-    struct input_shaper *is = container_of(sk, struct input_shaper, sk);
-    return is->sk.gen_steps_pre_active > is->sk.gen_steps_post_active
-         ? is->sk.gen_steps_pre_active : is->sk.gen_steps_post_active;
-}
-
 struct stepper_kinematics * __visible
 input_shaper_alloc(void)
 {

--- a/klippy/chelper/stepcompress.c
+++ b/klippy/chelper/stepcompress.c
@@ -674,6 +674,13 @@ stepcompress_set_stepper_kinematics(struct stepcompress *sc
     sc->sk = sk;
 }
 
+// Report current stepper_kinematics
+struct stepper_kinematics * __visible
+stepcompress_get_stepper_kinematics(struct stepcompress *sc)
+{
+    return sc->sk;
+}
+
 // Generate steps (via itersolve) and flush
 int32_t
 stepcompress_generate_steps(struct stepcompress *sc, double gen_steps_time

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -41,6 +41,8 @@ int stepcompress_extract_old(struct stepcompress *sc
 struct stepper_kinematics;
 void stepcompress_set_stepper_kinematics(struct stepcompress *sc
                                          , struct stepper_kinematics *sk);
+struct stepper_kinematics *stepcompress_get_stepper_kinematics(
+    struct stepcompress *sc);
 int32_t stepcompress_generate_steps(struct stepcompress *sc
                                     , double gen_steps_time
                                     , uint64_t flush_clock);

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -76,7 +76,7 @@ class ForceMove:
         self.trapq_append(self.trapq, print_time, accel_t, cruise_t, accel_t,
                           0., 0., 0., axis_r, 0., 0., 0., cruise_v, accel)
         print_time = print_time + accel_t + cruise_t + accel_t
-        toolhead.note_mcu_movequeue_activity(print_time)
+        self.motion_queuing.note_mcu_movequeue_activity(print_time)
         toolhead.dwell(accel_t + cruise_t + accel_t)
         toolhead.flush_step_generation()
         stepper.set_trapq(prev_trapq)

--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -146,12 +146,8 @@ class InputShaper:
             is_sk = self._get_input_shaper_stepper_kinematics(s)
             if is_sk is None:
                 continue
-            old_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
+            self.toolhead.flush_step_generation()
             ffi_lib.input_shaper_update_sk(is_sk)
-            new_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
-            if old_delay != new_delay:
-                self.toolhead.note_step_generation_scan_time(new_delay,
-                                                             old_delay)
     def _update_input_shaping(self, error=None):
         self.toolhead.flush_step_generation()
         ffi_main, ffi_lib = chelper.get_ffi()
@@ -163,16 +159,11 @@ class InputShaper:
             is_sk = self._get_input_shaper_stepper_kinematics(s)
             if is_sk is None:
                 continue
-            old_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
             for shaper in self.shapers:
                 if shaper in failed_shapers:
                     continue
                 if not shaper.set_shaper_kinematics(is_sk):
                     failed_shapers.append(shaper)
-            new_delay = ffi_lib.input_shaper_get_step_generation_window(is_sk)
-            if old_delay != new_delay:
-                self.toolhead.note_step_generation_scan_time(new_delay,
-                                                             old_delay)
         if failed_shapers:
             error = error or self.printer.command_error
             raise error("Failed to configure shaper(s) %s with given parameters"

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -72,8 +72,7 @@ class ManualStepper:
         self.sync_print_time()
         self.next_cmd_time = self._submit_move(self.next_cmd_time, movepos,
                                                speed, accel)
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.note_mcu_movequeue_activity(self.next_cmd_time)
+        self.motion_queuing.note_mcu_movequeue_activity(self.next_cmd_time)
         if sync:
             self.sync_print_time()
     def do_homing_move(self, movepos, speed, accel, triggered, check_trigger):
@@ -201,8 +200,8 @@ class ManualStepper:
         end_time = self._submit_move(start_time, newpos[0],
                                      speed, self.homing_accel)
         # Drip updates to motors
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.drip_update_time(start_time, end_time, drip_completion)
+        self.motion_queuing.drip_update_time(start_time, end_time,
+                                             drip_completion)
         # Clear trapq of any remaining parts of movement
         reactor = self.printer.get_reactor()
         self.motion_queuing.wipe_trapq(self.trapq)

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -197,11 +197,12 @@ class ManualStepper:
     def drip_move(self, newpos, speed, drip_completion):
         # Submit move to trapq
         self.sync_print_time()
-        maxtime = self._submit_move(self.next_cmd_time, newpos[0],
-                                    speed, self.homing_accel)
+        start_time = self.next_cmd_time
+        end_time = self._submit_move(start_time, newpos[0],
+                                     speed, self.homing_accel)
         # Drip updates to motors
         toolhead = self.printer.lookup_object('toolhead')
-        toolhead.drip_update_time(maxtime, drip_completion)
+        toolhead.drip_update_time(start_time, end_time, drip_completion)
         # Clear trapq of any remaining parts of movement
         reactor = self.printer.get_reactor()
         self.motion_queuing.wipe_trapq(self.trapq)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -69,14 +69,16 @@ class ExtruderStepper:
         if not pressure_advance:
             new_smooth_time = 0.
         toolhead = self.printer.lookup_object("toolhead")
-        if new_smooth_time != old_smooth_time:
-            toolhead.note_step_generation_scan_time(
-                    new_smooth_time * .5, old_delay=old_smooth_time * .5)
         ffi_main, ffi_lib = chelper.get_ffi()
         espa = ffi_lib.extruder_set_pressure_advance
-        toolhead.register_lookahead_callback(
-            lambda print_time: espa(self.sk_extruder, print_time,
-                                    pressure_advance, new_smooth_time))
+        if new_smooth_time != old_smooth_time:
+            # Need full kinematic flush to change the smooth time
+            toolhead.flush_step_generation()
+            espa(self.sk_extruder, 0., pressure_advance, new_smooth_time)
+        else:
+            toolhead.register_lookahead_callback(
+                lambda print_time: espa(self.sk_extruder, print_time,
+                                        pressure_advance, new_smooth_time))
         self.pressure_advance = pressure_advance
         self.pressure_advance_smooth_time = smooth_time
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -275,9 +275,7 @@ class ToolHead:
         sg_flush_want = min(flush_time + STEPCOMPRESS_FLUSH_TIME,
                             self.print_time - self.kin_flush_delay)
         sg_flush_time = max(sg_flush_want, flush_time)
-        trapq_free_time = sg_flush_time - self.kin_flush_delay
-        self.motion_queuing.flush_motion_queues(flush_time, sg_flush_time,
-                                                trapq_free_time)
+        self.motion_queuing.flush_motion_queues(flush_time, sg_flush_time)
         self.min_restart_time = max(self.min_restart_time, sg_flush_time)
         self.last_flush_time = flush_time
     def _advance_move_time(self, next_print_time):
@@ -596,6 +594,7 @@ class ToolHead:
             self.kin_flush_times.append(delay)
         new_delay = max(self.kin_flush_times + [SDS_CHECK_TIME])
         self.kin_flush_delay = new_delay
+        self.motion_queuing.set_step_generate_scan_time(new_delay)
     def register_lookahead_callback(self, callback):
         last_move = self.lookahead.get_last()
         if last_move is None:

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -303,7 +303,7 @@ class ToolHead:
         self.check_stall_time = 0.
     def flush_step_generation(self):
         self._flush_lookahead()
-        self.motion_queuing.advance_flush_time()
+        self.motion_queuing.flush_all_steps()
     def get_last_move_time(self):
         if self.special_queuing_state:
             self._flush_lookahead()

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -568,9 +568,8 @@ class ToolHead:
         self.motion_queuing.wipe_trapq(self.trapq)
     # Misc commands
     def stats(self, eventtime):
-        max_queue_time = max(self.print_time, self.last_flush_time)
         for m in self.all_mcus:
-            m.check_active(max_queue_time, eventtime)
+            m.check_active(self.last_step_gen_time, eventtime)
         est_print_time = self.mcu.estimated_print_time(eventtime)
         buffer_time = self.print_time - est_print_time
         is_active = buffer_time > -60. or not self.special_queuing_state

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -298,14 +298,16 @@ class ToolHead:
             self.last_step_gen_time = step_gen_time
             if flush_time >= want_flush_time:
                 break
+    def _calc_step_gen_restart(self, est_print_time):
+        kin_time = max(est_print_time + MIN_KIN_TIME, self.last_step_gen_time)
+        return kin_time + self.kin_flush_delay
     def _advance_move_time(self, next_print_time):
         self.print_time = max(self.print_time, next_print_time)
         self._advance_flush_time(self.print_time, lazy_target=True)
     def _calc_print_time(self):
         curtime = self.reactor.monotonic()
         est_print_time = self.mcu.estimated_print_time(curtime)
-        kin_time = max(est_print_time + MIN_KIN_TIME, self.last_step_gen_time)
-        kin_time += self.kin_flush_delay
+        kin_time = self._calc_step_gen_restart(est_print_time)
         min_print_time = max(est_print_time + BUFFER_TIME_START, kin_time)
         if min_print_time > self.print_time:
             self.print_time = min_print_time


### PR DESCRIPTION
This is a continuation of PR #7001.  In that PR the host motion flushing logic that was in stepper.py, manual_stepper.py, force_move.py and mcu.py was consolidated in a new motion_queuing.py module.  In this PR, the step generation flushing logic in toolhead.py is also moved into the motion_queuing.py module.

This further simplifies the toolhead.py code.  It no longer needs to track the flushing times (nor the gory details such as the "kinematic flush delays").  The toolhead.py code can now focus more on kinematics (eg, acceleration, deceleration) and lookahead logic.  I think it also helps to have the low-level flushing timer code in the motion_queuing module (where it is next to the low-level code invoked from that timer).

@nefelim4ag , @dmbutyugin - fyi.

-Kevin