### PR TITLE
stm32: enable 64KiB bootloader for n32g45x, clarify Makefile output

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -302,7 +302,7 @@ choice
     config STM32_FLASH_START_C000
         bool "48KiB bootloader" if MACH_STM32F4x5 || MACH_STM32F401
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F4
+        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F4 || MACH_N32G45x
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader" if MACH_STM32F103

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -94,7 +94,7 @@ src-$(CONFIG_HAVE_GPIO_SDIO) += stm32/sdio.c
 target-y += $(OUT)klipper.bin
 
 $(OUT)klipper.bin: $(OUT)klipper.elf
-	@echo "  Creating hex file $@"
+	@echo "  Creating bin file $@"
 	$(Q)$(OBJCOPY) -O binary $< $@
 
 # Flash rules


### PR DESCRIPTION
Add new machine definitions for N32G452xB and N32G455xB/xC/xE in Kconfig, selecting appropriate base configs (MACH_STM32F1, MACH_N32G45x, and specific N32G45x series variants). Extend bootloader flash-start options to include MACH_N32G45x.

In Makefile, adjust build outputs to produce both .bin and .hex firmware.