### PR TITLE
resonance_tester: replace missing M204 call

### DIFF
--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -148,8 +148,7 @@ class ResonanceTestExecutor:
         last_v = last_t = last_accel = last_freq = 0.
         for next_t, accel, freq in test_seq:
             t_seg = next_t - last_t
-            toolhead.cmd_M204(self.gcode.create_gcode_command(
-                "M204", "M204", {"S": abs(accel)}))
+            toolhead.set_max_velocities(None, abs(accel), None, None)
             v = last_v + accel * t_seg
             abs_v = abs(v)
             if abs_v < 0.000001:
@@ -182,8 +181,7 @@ class ResonanceTestExecutor:
         if last_v:
             d_decel = -.5 * last_v2 / old_max_accel
             decel_X, decel_Y = axis.get_point(d_decel)
-            toolhead.cmd_M204(self.gcode.create_gcode_command(
-                "M204", "M204", {"S": old_max_accel}))
+            toolhead.set_max_velocities(None, old_max_accel, None, None)
             toolhead.move([X + decel_X, Y + decel_Y] + tpos[2:], abs(last_v))
         # Restore the original acceleration values
         self.gcode.run_script_from_command(


### PR DESCRIPTION
After the: f8da8099d5e5cdec
The cmd_M204 was migrated to a helper class. I'm not sure how to get it or why there is a G-code command translation.
So, this is just a fast fix that I can come up with.

```
TEST_RESONANCES AXIS=x
```

```
Disabled [input_shaper] for resonance testing
Internal error on command:"TEST_RESONANCES"
Traceback (most recent call last):
  File "/home/user/klipper/klippy/gcode.py", line 212, in _process_commands
    handler(gcmd)
    ~~~~~~~^^^^^^
  File "/home/user/klipper/klippy/gcode.py", line 140, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
                          ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/klipper/klippy/extras/resonance_tester.py", line 337, in cmd_TEST_RESONANCES
    data = self._run_test(
           ~~~~~~~~~~~~~~^
            gcmd, [axis], helper,
            ^^^^^^^^^^^^^^^^^^^^^
            raw_name_suffix=name_suffix if raw_output else None,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            accel_chips=accel_chips, test_point=test_point)[axis]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/klipper/klippy/extras/resonance_tester.py", line 265, in _run_test
    self.executor.run_test(test_seq, axis, gcmd)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/klipper/klippy/extras/resonance_tester.py", line 151, in run_test
    toolhead.cmd_M204(self.gcode.create_gcode_command(
```