### PR TITLE
Make I2c writes synchronous

### DIFF
--- a/klippy/extras/bme280.py
+++ b/klippy/extras/bme280.py
@@ -284,7 +284,7 @@ class BME280:
                 self.chip_type, self.i2c.i2c_address))
 
         # Reset chip
-        self.write_register('RESET', [RESET_CHIP_VALUE], wait=True)
+        self.write_register('RESET', [RESET_CHIP_VALUE])
         self.reactor.pause(self.reactor.monotonic() + .5)
 
         # Make sure non-volatile memory has been copied to registers
@@ -394,7 +394,7 @@ class BME280:
                 self.write_register('CTRL_HUM', self.os_hum)
             # Enter normal (periodic) mode
             meas = self.os_temp << 5 | self.os_pres << 2 | MODE_PERIODIC
-            self.write_register('CTRL_MEAS', meas, wait=True)
+            self.write_register('CTRL_MEAS', meas)
 
         if self.chip_type == 'BME680':
             self.write_register('CONFIG', self.iir_filter << 2)
@@ -528,7 +528,7 @@ class BME280:
 
         # Enter forced mode
         meas = self.os_temp << 5 | self.os_pres << 2 | MODE
-        self.write_register('CTRL_MEAS', meas, wait=True)
+        self.write_register('CTRL_MEAS', meas)
         max_sample_time = self.max_sample_time
         if run_gas:
             max_sample_time += self.gas_heat_duration / 1000
@@ -776,15 +776,12 @@ class BME280:
         params = self.i2c.i2c_read(regs, read_len)
         return bytearray(params['response'])
 
-    def write_register(self, reg_name, data, wait = False):
+    def write_register(self, reg_name, data):
         if type(data) is not list:
             data = [data]
         reg = self.chip_registers[reg_name]
         data.insert(0, reg)
-        if not wait:
-            self.i2c.i2c_write(data)
-        else:
-            self.i2c.i2c_write_wait_ack(data)
+        self.i2c.i2c_write(data)
 
     def get_status(self, eventtime):
         data = {

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -182,6 +182,7 @@ class MCU_I2C:
         self.i2c_write_cmd = self.i2c_read_cmd = None
         printer = self.mcu.get_printer()
         printer.register_event_handler("klippy:connect", self._handle_connect)
+        self._debugoutput = printer.get_start_args().get('debugoutput')
         # backward support i2c_write inside the init section
         self._to_write = []
     def _handle_connect(self):
@@ -216,8 +217,12 @@ class MCU_I2C:
         if self.i2c_write_cmd is None:
             self._to_write.append(data)
             return
-        self.i2c_write_cmd.send([self.oid, data],
-                                minclock=minclock, reqclock=reqclock)
+        if self._debugoutput is not None:
+            self.i2c_write_cmd.send([self.oid, data],
+                                    minclock=minclock, reqclock=reqclock)
+            return
+        self.i2c_write_cmd.send_wait_ack([self.oid, data],
+                                         minclock=minclock, reqclock=reqclock)
     def i2c_write_wait_ack(self, data, minclock=0, reqclock=0):
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
                                 minclock=minclock, reqclock=reqclock)

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -223,9 +223,6 @@ class MCU_I2C:
             return
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
                                          minclock=minclock, reqclock=reqclock)
-    def i2c_write_wait_ack(self, data, minclock=0, reqclock=0):
-        self.i2c_write_cmd.send_wait_ack([self.oid, data],
-                                minclock=minclock, reqclock=reqclock)
     def i2c_read(self, write, read_len, retry=True):
         return self.i2c_read_cmd.send([self.oid, write, read_len], retry)
 

--- a/klippy/extras/sht3x.py
+++ b/klippy/extras/sht3x.py
@@ -80,10 +80,10 @@ class SHT3X:
 
     def _init_sht3x(self):
         # Device Soft Reset
-        self.i2c.i2c_write_wait_ack(SHT3X_CMD['OTHER']['BREAK'])
+        self.i2c.i2c_write(SHT3X_CMD['OTHER']['BREAK'])
         # Break takes ~ 1ms
         self.reactor.pause(self.reactor.monotonic() + .0015)
-        self.i2c.i2c_write_wait_ack(SHT3X_CMD['OTHER']['SOFTRESET'])
+        self.i2c.i2c_write(SHT3X_CMD['OTHER']['SOFTRESET'])
         # Wait <=1.5ms after reset
         self.reactor.pause(self.reactor.monotonic() + .0015)
 
@@ -97,7 +97,7 @@ class SHT3X:
             logging.warning("sht3x: Reading status - checksum error!")
 
         # Enable periodic mode
-        self.i2c.i2c_write_wait_ack(
+        self.i2c.i2c_write(
             SHT3X_CMD['PERIODIC']['2HZ']['HIGH_REP']
         )
         # Wait <=15.5ms for first measurement


### PR DESCRIPTION
When `i2c_writes` would start to return the NACK status, it would become blocking and would wait for the response.
That could affect callers.

Make the migration preliminary.

From my brief recheck of callers, it seems to me that most of them do not care about actual timing or write blocking.
The only possible exceptions are:
- PCA9632, which could notice small lags of LED status updates (it does support auto increment register write)
- Maybe the SX1509. Because of the update of the PWM pin, the code path would be blocked. If there is a high frequency of changes, the next one could probably be late. (It also supports the auto increment, btw).

Thanks.

---
Depends on: #7012
Child of: #7013