### PR TITLE
ci: set test timeout 6h -> 30m

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,6 +19,7 @@ jobs:
 
     - name: Test
       run: ./scripts/ci-build.sh 2>&1
+      timeout-minutes: 30
 
     - name: Upload micro-controller data dictionaries
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
In the debug output mode, Klippy should not wait for the MCU response.
If there is a code error introduced, it would make it wait for an ack "forever".
Make CI fail in a more reasonable time 6h -> 30m.

Under normal conditions, the whole CI run takes ~7 minutes.

I hit it several times while working with i2c and send_wait_ack().

So, this is just a suggestion.

Thanks.