### PR TITLE
Fix for M114 command when there are MANUAL_STEPPERs with GCODE_AXIS set

### DIFF
--- a/klippy/extras/gcode_move.py
+++ b/klippy/extras/gcode_move.py
@@ -187,7 +187,14 @@ class GCodeMove:
     def cmd_M114(self, gcmd):
         # Get Current Position
         p = self._get_gcode_position()
-        gcmd.respond_raw("X:%.3f Y:%.3f Z:%.3f E:%.3f" % tuple(p))
+        if len(p)==4:
+            gcmd.respond_raw("X:%.3f Y:%.3f Z:%.3f E:%.3f" % tuple(p))
+        else:
+            toolhead = self.printer.lookup_object('toolhead')
+            axes = ["X","Y","Z"]+[ x.get_axis_gcode_id()
+                for x in toolhead.get_extra_axes() if x is not None]
+            s=" ".join(["%s:%.3f"%(k,v) for k, v in zip(axes,p)])
+            gcmd.respond_raw(s)
     def cmd_M220(self, gcmd):
         # Set speed factor override percentage
         value = gcmd.get_float('S', 100., above=0.) / (60. * 100.)


### PR DESCRIPTION
That fixes crash in unpacking tuple in`respond_raw("X:%.3f Y:%.3f Z:%.3f E:%.3f" % tuple(p))`
that happens when there are extra axes added by `MANUAL_STEPPER` with `GCODE_AXIS` set
Signed-off-by: Maja Stanislawska maja@makershop.ie