### PR TITLE
Display: make render and flush decoupled

### DIFF
--- a/klippy/extras/display/aip31068_spi.py
+++ b/klippy/extras/display/aip31068_spi.py
@@ -152,6 +152,8 @@ class aip31068_spi:
         for new_data, old_data, fb_cmnd in self.all_framebuffers:
             if new_data == old_data:
                 continue
+            # Make intermediate copy
+            new_data = new_data[:]
             # Find the position of all changed bytes in this framebuffer
             diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
                      if n != o]

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -71,6 +71,8 @@ class HD44780:
         for new_data, old_data, fb_id in self.all_framebuffers:
             if new_data == old_data:
                 continue
+            # Make intermediate copy
+            new_data = new_data[:]
             # Find the position of all changed bytes in this framebuffer
             diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
                      if n != o]

--- a/klippy/extras/display/hd44780_spi.py
+++ b/klippy/extras/display/hd44780_spi.py
@@ -62,6 +62,8 @@ class hd44780_spi:
         for new_data, old_data, fb_id in self.all_framebuffers:
             if new_data == old_data:
                 continue
+            # Make intermediate copy
+            new_data = new_data[:]
             # Find the position of all changed bytes in this framebuffer
             diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
                      if n != o]

--- a/klippy/extras/display/st7920.py
+++ b/klippy/extras/display/st7920.py
@@ -37,6 +37,8 @@ class DisplayBase:
         for new_data, old_data, fb_id in self.all_framebuffers:
             if new_data == old_data:
                 continue
+            # Make intermediate copy
+            new_data = new_data[:]
             # Find the position of all changed bytes in this framebuffer
             diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
                      if n != o]

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -30,6 +30,8 @@ class DisplayBase:
         for new_data, old_data, page in self.all_framebuffers:
             if new_data == old_data:
                 continue
+            # Make intermediate copy
+            new_data = new_data[:]
             # Find the position of all changed bytes in this framebuffer
             diffs = [[i, 1] for i, (n, o) in enumerate(zip(new_data, old_data))
                      if n != o]


### PR DESCRIPTION
After the switch of all i2c_writes to synchronous mode, there is a report that sh1106 has become unresponsive (what is expected), and sometimes displays garbled data (which is not expected).
Reported by: @gravy-train and @mvoss96

The reason for the garbled screen data, is that synchronous i2c_write can now block and give in execution flow to other code.
At the same time, other code could be triggered by the button/key event, which would call the request_redraw, which, inside, would trigger another execution of timer code with render (which calls flush inside).
So, now there are 2 concurrent flushes.
(Should already be fixed in mainline).

The decoupling would allow us to redraw the screen as fast as possible.
While the flush would write the latest data that is available.
That will decrease latency and fix the garbling of the screen.
But that will introduce intermediate screen tearing.
Because data is written to the screen while the buffers could be updated.
To avoid inter-flush data race, there is a high-level lock, so only one flush is running at a time.
Other flushes are stuck on top of each other.
Because flushes internally only send diffs, later flushes probably would be noops.

Thanks.

---
Ref: #7013
Introduced in: #7020 