### PR TITLE
Unify and improve explicit stepper enable handling

### DIFF
--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -50,15 +50,9 @@ class ManualStepper:
             self.next_cmd_time = print_time
     def do_enable(self, enable):
         self.sync_print_time()
+        stepper_names = [s.get_name() for s in self.steppers]
         stepper_enable = self.printer.lookup_object('stepper_enable')
-        if enable:
-            for s in self.steppers:
-                se = stepper_enable.lookup_enable(s.get_name())
-                se.motor_enable(self.next_cmd_time)
-        else:
-            for s in self.steppers:
-                se = stepper_enable.lookup_enable(s.get_name())
-                se.motor_disable(self.next_cmd_time)
+        stepper_enable.set_motors_enable(stepper_names, enable)
         self.sync_print_time()
     def do_set_position(self, setpos):
         toolhead = self.printer.lookup_object('toolhead')

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -49,11 +49,9 @@ class ManualStepper:
         else:
             self.next_cmd_time = print_time
     def do_enable(self, enable):
-        self.sync_print_time()
         stepper_names = [s.get_name() for s in self.steppers]
         stepper_enable = self.printer.lookup_object('stepper_enable')
         stepper_enable.set_motors_enable(stepper_names, enable)
-        self.sync_print_time()
     def do_set_position(self, setpos):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.flush_step_generation()

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -88,30 +88,30 @@ class PrinterStepperEnable:
         name = mcu_stepper.get_name()
         enable = setup_enable_pin(self.printer, config.get('enable_pin', None))
         self.enable_lines[name] = EnableTracking(mcu_stepper, enable)
+    def set_motors_enable(self, stepper_names, enable):
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.dwell(DISABLE_STALL_TIME)
+        print_time = toolhead.get_last_move_time()
+        did_change = False
+        for stepper_name in stepper_names:
+            el = self.enable_lines[stepper_name]
+            was_enabled = el.is_motor_enabled()
+            if enable:
+                el.motor_enable(print_time)
+            else:
+                el.motor_disable(print_time)
+            if was_enabled != el.is_motor_enabled():
+                did_change = True
+        toolhead.dwell(DISABLE_STALL_TIME)
+        return did_change
     def motor_off(self):
+        self.set_motors_enable(self.get_steppers(), False)
         toolhead = self.printer.lookup_object('toolhead')
-        toolhead.dwell(DISABLE_STALL_TIME)
-        print_time = toolhead.get_last_move_time()
-        for el in self.enable_lines.values():
-            el.motor_disable(print_time)
         toolhead.get_kinematics().clear_homing_state("xyz")
-        self.printer.send_event("stepper_enable:motor_off", print_time)
-        toolhead.dwell(DISABLE_STALL_TIME)
-    def motor_debug_enable(self, stepper, enable):
-        toolhead = self.printer.lookup_object('toolhead')
-        toolhead.dwell(DISABLE_STALL_TIME)
-        print_time = toolhead.get_last_move_time()
-        el = self.enable_lines[stepper]
-        if enable:
-            el.motor_enable(print_time)
-            logging.info("%s has been manually enabled", stepper)
-        else:
-            el.motor_disable(print_time)
-            logging.info("%s has been manually disabled", stepper)
-        toolhead.dwell(DISABLE_STALL_TIME)
+        self.printer.send_event("stepper_enable:motor_off")
     def get_status(self, eventtime):
         steppers = { name: et.is_motor_enabled()
-                           for (name, et) in self.enable_lines.items() }
+                     for (name, et) in self.enable_lines.items() }
         return {'steppers': steppers}
     def _handle_request_restart(self, print_time):
         self.motor_off()
@@ -126,7 +126,11 @@ class PrinterStepperEnable:
                               % (stepper_name,))
             return
         stepper_enable = gcmd.get_int('ENABLE', 1)
-        self.motor_debug_enable(stepper_name, stepper_enable)
+        self.set_motors_enable([stepper_name], stepper_enable)
+        if stepper_enable:
+            logging.info("%s has been manually enabled", stepper_name)
+        else:
+            logging.info("%s has been manually disabled", stepper_name)
     def lookup_enable(self, name):
         if name not in self.enable_lines:
             raise self.printer.config_error("Unknown stepper '%s'" % (name,))

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -79,7 +79,7 @@ class ZAdjustStatus:
         self.applied = False
     def get_status(self, eventtime):
         return {'applied': self.applied}
-    def _motor_off(self, print_time):
+    def _motor_off(self):
         self.reset()
 
 class RetryHelper:


### PR DESCRIPTION
There were several slightly different implementations of explicit stepper motor enabling/disabling in the force_move, stepper_enable, and manual_stepper modules.  Introduce a new `set_motors_enable()` method and use this in all implementations.  This simplifies the code and reduces the chance of obscure timing issues.
    
This should hopefully fix a manual_stepper error introduced in commit 9399e738 (PR #7001) and reported at https://klipper.discourse.group/t/timer-too-close-only-when-print-is-finished/24692 .

@nefelim4ag - fyi.

-Kevin