### PR TITLE
extruder_stepper: define missing public methods methods

### DIFF
--- a/klippy/extras/extruder_stepper.py
+++ b/klippy/extras/extruder_stepper.py
@@ -15,6 +15,8 @@ class PrinterExtruderStepper:
                                             self.handle_connect)
     def handle_connect(self):
         self.extruder_stepper.sync_to_extruder(self.extruder_name)
+    def find_past_position(self, print_time):
+        return self.extruder_stepper.find_past_position(print_time)
     def get_status(self, eventtime):
         return self.extruder_stepper.get_status(eventtime)
 

--- a/test/klippy/extruders.cfg
+++ b/test/klippy/extruders.cfg
@@ -66,3 +66,19 @@ max_velocity: 300
 max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
+
+[filament_switch_sensor runout_switch]
+switch_pin = PD4
+
+[filament_motion_sensor runout_encoder]
+switch_pin = PD5
+detection_length = 4
+extruder = extruder
+
+[filament_switch_sensor runout_switch1]
+switch_pin = PL4
+
+[filament_motion_sensor runout_encoder1]
+switch_pin = PL6
+detection_length = 4
+extruder = extruder_stepper my_extra_stepper


### PR DESCRIPTION
Other modules could access the extruderN by
the printer lookup_object().
That would return this wrapper class.

Specifically, filament_motion_sensor will.
They can try to access missing methods
and klippy would crash.

Reported:
- https://klipper.discourse.group/t/filament-motion-sensor-not-working-with-extruder-stepper/24742
- https://klipper.discourse.group/t/filament-motion-sensor-on-2-in-1-out-hotend/16617/6

I was able to reproduce this with this snippet in batch mode.
<details>
  <summary>Printer.cfg</summary>
  
```
[extruder]
max_extrude_only_distance = 450
max_extrude_cross_section = 2
step_pin = PF9
dir_pin = PF10
enable_pin = !PG2
microsteps = 16
rotation_distance = 22.725
nozzle_diameter = 0.800
filament_diameter = 1.750
heater_pin = PA2
sensor_pin = PF4
sensor_type = EPCOS 100K B57560G104F
min_temp = 0
max_temp = 240
control = pid
pid_kp = 21.801
pid_ki = 1.411
pid_kd = 84.207

[filament_switch_sensor runout_switch]
switch_pin = PG11

[filament_motion_sensor runout_encoder]
switch_pin = PG10
detection_length = 4
extruder = extruder

[extruder_stepper extruder1]
extruder =
step_pin = PC13
dir_pin = PF0
enable_pin = !PF1
rotation_distance = 22.725
microsteps = 16

[filament_switch_sensor runout_switch1]
switch_pin = PF6

[filament_motion_sensor runout_encoder1]
switch_pin = PF5
detection_length = 4
extruder = extruder_stepper extruder1

[mcu]
serial = /dev/serial/by-id/usb-Klipper_stm32f446xx_0D003B000450335331383520-if00
restart_method = command

[printer]
kinematics = none
max_velocity = 1
max_accel = 1
```

</details>