### PR TITLE
Generate steps in a background thread

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -36,7 +36,7 @@ defs_stepcompress = """
         int step_count, interval, add;
     };
 
-    struct stepcompress *stepcompress_alloc(uint32_t oid);
+    struct stepcompress *stepcompress_alloc(uint32_t oid, char name[16]);
     void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
         , int32_t queue_step_msgtag, int32_t set_next_step_dir_msgtag);
     void stepcompress_set_invert_sdir(struct stepcompress *sc
@@ -66,10 +66,11 @@ defs_steppersync = """
     void steppersync_free(struct steppersync *ss);
     void steppersync_set_time(struct steppersync *ss
         , double time_offset, double mcu_freq);
-    int32_t steppersync_generate_steps(struct steppersync *ss
-        , double gen_steps_time, uint64_t flush_clock);
     void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
-    int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+    void steppersync_start_gen_steps(struct steppersync *ss
+        , double gen_steps_time, uint64_t flush_clock);
+    int32_t steppersync_finalize_gen_steps(struct steppersync *ss
+        , uint64_t flush_clock);
 """
 
 defs_itersolve = """

--- a/klippy/chelper/stepcompress.h
+++ b/klippy/chelper/stepcompress.h
@@ -11,7 +11,7 @@ struct pull_history_steps {
     int step_count, interval, add;
 };
 
-struct stepcompress *stepcompress_alloc(uint32_t oid);
+struct stepcompress *stepcompress_alloc(uint32_t oid, char name[16]);
 void stepcompress_fill(struct stepcompress *sc, uint32_t max_error
                        , int32_t queue_step_msgtag
                        , int32_t set_next_step_dir_msgtag);
@@ -43,8 +43,8 @@ void stepcompress_set_stepper_kinematics(struct stepcompress *sc
                                          , struct stepper_kinematics *sk);
 struct stepper_kinematics *stepcompress_get_stepper_kinematics(
     struct stepcompress *sc);
-int32_t stepcompress_generate_steps(struct stepcompress *sc
-                                    , double gen_steps_time
-                                    , uint64_t flush_clock);
+void stepcompress_start_gen_steps(struct stepcompress *sc, double gen_steps_time
+                                  , uint64_t flush_clock);
+int32_t stepcompress_finalize_gen_steps(struct stepcompress *sc);
 
 #endif // stepcompress.h

--- a/klippy/chelper/steppersync.h
+++ b/klippy/chelper/steppersync.h
@@ -10,9 +10,10 @@ struct steppersync *steppersync_alloc(
 void steppersync_free(struct steppersync *ss);
 void steppersync_set_time(struct steppersync *ss, double time_offset
                           , double mcu_freq);
-int32_t steppersync_generate_steps(struct steppersync *ss, double gen_steps_time
-                                   , uint64_t flush_clock);
 void steppersync_history_expire(struct steppersync *ss, uint64_t end_clock);
-int steppersync_flush(struct steppersync *ss, uint64_t move_clock);
+void steppersync_start_gen_steps(struct steppersync *ss, double gen_steps_time
+                                 , uint64_t flush_clock);
+int32_t steppersync_finalize_gen_steps(struct steppersync *ss
+                                       , uint64_t flush_clock);
 
 #endif // steppersync.h

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -16,8 +16,10 @@ class MCU_queued_pwm:
         self._max_duration = 2.
         self._oid = oid = mcu.create_oid()
         printer = mcu.get_printer()
+        sname = config.get_name().split()[-1]
         self._motion_queuing = printer.load_object(config, 'motion_queuing')
-        self._stepqueue = self._motion_queuing.allocate_stepcompress(mcu, oid)
+        self._stepqueue = self._motion_queuing.allocate_stepcompress(
+            mcu, oid, sname)
         ffi_main, ffi_lib = chelper.get_ffi()
         self._stepcompress_queue_mq_msg = ffi_lib.stepcompress_queue_mq_msg
         mcu.register_config_callback(self._build_config)

--- a/klippy/stepper.py
+++ b/klippy/stepper.py
@@ -44,7 +44,8 @@ class MCU_stepper:
         self._reset_cmd_tag = self._get_position_cmd = None
         self._active_callbacks = []
         motion_queuing = printer.load_object(config, 'motion_queuing')
-        self._stepqueue = motion_queuing.allocate_stepcompress(mcu, oid)
+        sname = self._name.split()[-1]
+        self._stepqueue = motion_queuing.allocate_stepcompress(mcu, oid, sname)
         ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.stepcompress_set_invert_sdir(self._stepqueue, self._invert_dir)
         self._stepper_kinematics = None


### PR DESCRIPTION
This is PR #6992 updated to work with the latest motion_queuing module changes.  The idea is to use a per-stepper thread to implement step generation and compression.  This can better utilize multiple CPU cores that are now common on single-board-computers (SBC).

@nefelim4ag's - I took your idea and updated it to the latest code.  In this implementation, I added all the threading logic to stepcompress.c .  I'm open to alternative implementations though.

Thoughts?
-Kevin