### PR TITLE
reactor: Prevent update_timer() from running a single timer multiple times

### DIFF
--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -236,6 +236,8 @@ class PrinterLCD:
         except:
             logging.exception("Error during display screen update")
         self.lcd_chip.flush()
+        if self.redraw_request_pending:
+            return self.redraw_time
         return eventtime + REDRAW_TIME
     def request_redraw(self):
         if self.redraw_request_pending:


### PR DESCRIPTION
The "lazy" greenlet implementation could allow the same timer to run multiple times in parallel if the first timer instance calls pause() and another task calls update_timer().  This is confusing and can cause hard to debug errors.  Add a new timer_is_running flag to prevent it.

-Kevin