### PR TITLE
servo/led: sync pwm output

### DIFF
--- a/klippy/extras/multi_pin.py
+++ b/klippy/extras/multi_pin.py
@@ -46,6 +46,8 @@ class PrinterMultiPin:
     def set_digital(self, print_time, value):
         for mcu_pin in self.mcu_pins:
             mcu_pin.set_digital(print_time, value)
+    def next_aligned_print_time(self, print_time):
+        return print_time
     def set_pwm(self, print_time, value):
         for mcu_pin in self.mcu_pins:
             mcu_pin.set_pwm(print_time, value)

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -46,6 +46,10 @@ class GCodeRequestQueue:
                 if action == "discard":
                     del rqueue[:pos+1]
                     continue
+                if action == "reschedule":
+                    del rqueue[:pos]
+                    rqueue[0] = (min_wait, req_val)
+                    continue
                 if action == "delay":
                     pos -= 1
             del rqueue[:pos+1]

--- a/klippy/extras/replicape.py
+++ b/klippy/extras/replicape.py
@@ -67,6 +67,8 @@ class pca9685_pwm:
         cmd_queue = self._mcu.alloc_command_queue()
         self._set_cmd = self._mcu.lookup_command(
             "queue_pca9685_out oid=%c clock=%u value=%hu", cq=cmd_queue)
+    def next_aligned_print_time(self, print_time):
+        return print_time
     def set_pwm(self, print_time, value):
         clock = self._mcu.print_time_to_clock(print_time)
         if self._invert:

--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -47,6 +47,11 @@ class PrinterServo:
     def _set_pwm(self, print_time, value):
         if value == self.last_value:
             return "discard", 0.
+        aligned_ptime = self.mcu_servo.next_aligned_print_time(print_time)
+        sched_slack = 0.001
+        if aligned_ptime > print_time + sched_slack:
+            return "reschedule", aligned_ptime
+        print_time = aligned_ptime
         self.last_value = value
         self.mcu_servo.set_pwm(print_time, value)
     def _get_pwm_from_angle(self, angle):

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -178,6 +178,8 @@ class SX1509_pwm(object):
         self._shutdown_value = max(0., min(1., shutdown_value))
         self._sx1509.set_register(self._i_on_reg,
                                   ~int(255 * self._start_value) & 0xFF)
+    def next_aligned_print_time(self, print_time):
+        return print_time
     def set_pwm(self, print_time, value):
         self._sx1509.set_register(self._i_on_reg, ~int(255 * value)
                                   if not self._invert

--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -422,6 +422,7 @@ class MCU_pwm:
         self._invert = pin_params['invert']
         self._start_value = self._shutdown_value = float(self._invert)
         self._last_clock = 0
+        self._last_value = .0
         self._pwm_max = 0.
         self._set_cmd = None
     def get_mcu(self):
@@ -437,6 +438,7 @@ class MCU_pwm:
             shutdown_value = 1. - shutdown_value
         self._start_value = max(0., min(1., start_value))
         self._shutdown_value = max(0., min(1., shutdown_value))
+        self._last_value = self._start_value
     def _build_config(self):
         if self._max_duration and self._start_value != self._shutdown_value:
             raise pins.error("Pin with max duration must have start"
@@ -488,6 +490,20 @@ class MCU_pwm:
             % (self._oid, self._last_clock, svalue), is_init=True)
         self._set_cmd = self._mcu.lookup_command(
             "queue_digital_out oid=%c clock=%u on_ticks=%u", cq=cmd_queue)
+    def next_aligned_print_time(self, print_time):
+        # Filter cases where there is no need to sync anything
+        if self._hardware_pwm:
+            return print_time
+        if self._last_value == 1. or self._last_value == .0:
+            return print_time
+        # Simplify the calling and allow scheduling slightly earlier
+        req_ptime = print_time - 0.001
+        cycle_ticks = self._mcu.seconds_to_clock(self._cycle_time)
+        req_clock = self._mcu.print_time_to_clock(req_ptime)
+        last_clock = self._last_clock
+        pulses = (req_clock - last_clock + cycle_ticks - 1) // cycle_ticks
+        next_clock = last_clock + pulses * cycle_ticks
+        return self._mcu.clock_to_print_time(next_clock)
     def set_pwm(self, print_time, value):
         if self._invert:
             value = 1. - value
@@ -496,6 +512,7 @@ class MCU_pwm:
         self._set_cmd.send([self._oid, clock, v],
                            minclock=self._last_clock, reqclock=clock)
         self._last_clock = clock
+        self._last_value = v
 
 class MCU_adc:
     def __init__(self, mcu, pin_params):


### PR DESCRIPTION
After the #6698, I had a small debt with myself. Sync seems to be easy, and I can't fully get it.
For some reason, after the recent refactoring and reading around, something clicked inside.

So, there is my anti-flickering for the LEDs.

upd: I reused clock logic from BLTouch.

<details>
  <summary>My test gcode of someone curious</summary>
  
```
SET_LED LED=led WHITE=0.01
SET_LED LED=led WHITE=0.0101
SET_LED LED=led WHITE=0.0105
SET_LED LED=led WHITE=0.011
SET_LED LED=led WHITE=0.0115
SET_LED LED=led WHITE=0.012
SET_LED LED=led WHITE=0.0115
SET_LED LED=led WHITE=0.011
SET_LED LED=led WHITE=0.0105
SET_LED LED=led WHITE=0.0101
SET_LED LED=led WHITE=0.01
```

</details>

Thanks.

_Hmmm, probably it requires some initialization after the `mcu_pin.setup_start_value(color[idx], 0.)`
To set the correct `last_print_time` value._

Meh, not worth it, I think. It would require extending or replacing the setup_start_value.
To avoid the first/once flickering.

---
@viesturz maybe something similiar would help you with your servos