### PR TITLE
Avoid flushing steps far into the future

### DIFF
--- a/klippy/chelper/trapq.c
+++ b/klippy/chelper/trapq.c
@@ -49,6 +49,7 @@ trapq_alloc(void)
     list_init(&tq->moves);
     list_init(&tq->history);
     struct move *head_sentinel = move_alloc(), *tail_sentinel = move_alloc();
+    head_sentinel->print_time = -1.0;
     tail_sentinel->print_time = tail_sentinel->move_t = NEVER_TIME;
     list_add_head(&head_sentinel->node, &tq->moves);
     list_add_tail(&tail_sentinel->node, &tq->moves);

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -50,7 +50,6 @@ class PrinterMotionQueuing:
         if self.mcu.is_fileoutput():
             self.can_pause = False
         # Kinematic step generation scan window time tracking
-        self.need_calc_kin_flush_delay = True
         self.kin_flush_delay = SDS_CHECK_TIME
         # Register handlers
         printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
@@ -129,8 +128,7 @@ class PrinterMotionQueuing:
     # Kinematic step generation scan window time tracking
     def get_kin_flush_delay(self):
         return self.kin_flush_delay
-    def _calc_kin_flush_delay(self):
-        self.need_calc_kin_flush_delay = False
+    def check_step_generation_scan_windows(self):
         ffi_main, ffi_lib = chelper.get_ffi()
         kin_flush_delay = SDS_CHECK_TIME
         for mcu, sc in self.stepcompress:
@@ -175,11 +173,8 @@ class PrinterMotionQueuing:
             if flush_time >= want_flush_time:
                 break
     def flush_all_steps(self):
-        self.need_calc_kin_flush_delay = True
         self.advance_flush_time(self.need_step_gen_time)
     def calc_step_gen_restart(self, est_print_time):
-        if self.need_calc_kin_flush_delay:
-            self._calc_kin_flush_delay()
         kin_time = max(est_print_time + MIN_KIN_TIME, self.last_step_gen_time)
         return kin_time + self.kin_flush_delay
     def _flush_handler(self, eventtime):

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -75,6 +75,8 @@ class ExtruderStepper:
             # Need full kinematic flush to change the smooth time
             toolhead.flush_step_generation()
             espa(self.sk_extruder, 0., pressure_advance, new_smooth_time)
+            motion_queuing = self.printer.lookup_object('motion_queuing')
+            motion_queuing.check_step_generation_scan_windows()
         else:
             toolhead.register_lookahead_callback(
                 lambda print_time: espa(self.sk_extruder, print_time,


### PR DESCRIPTION
This PR is continuation of the recent motion queuing work (PRs #7001, #7014, #7034).

During normal printing the current code will generate steps (and flush them) each time moves are pulled from the lookahead queue.  Normally the host lookahead code tries to stay ~2 seconds ahead of the actual live printer motor movement.  However, if a large move is queued (eg, a single move that takes 60 seconds) then when the move is pulled from the queue the code will go on to perform step generation for it, which will result in steps generated far in the future (eg, 62+ seconds).

This PR decouples the lookahead flushing from step generation.  Now step generation is primarily done from a timer implemented in the motion_queuing module.  With this code, step generation (and flushing) should stay about 450-700ms ahead of the actual live printer movement.  This places an upper bound on how far into the future the host will calculate a detailed step schedule.

There are a couple (mostly minor) advantages to this:
* In a multi-mcu setup, if step generation is performed far into the future (eg, 60+ seconds) then we have to generate the schedule using the estimated mcu timing at the beginning of the move.  If we defer step generation until the steps are needed then we can utilize the latest clock synchronization measurements throughout the move.
* If some future code wants to generate stepper movement asynchronously this PR reduces the worst case latency between an event and the time that we can generate steps for it.  (Step generation and flushing is a global action in Klipper - movement for all steppers is calculated together in batches and once a batch time is completed, no stepper can generate movement prior to that batch time).

The main advantage I'd say is internal - this PR further decouples the toolhead class from the motion_queuing class.  After this PR, the toolhead class is mostly just another user of the motion_queuing class.

After this PR, I have one further change planned.  I'd like to change Klipper to try to stay ~1 second ahead of printer movement (reduced from ~2 seconds today).  This should make Klipper feel more responsive to user commands during a print (eg, pausing a print, changing Z offsets, changing extrusion ratios).  After this PR, that change should just be:
```diff
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -190,7 +190,7 @@ class LookAheadQueue:
         # Check if enough moves have been queued to reach the target flush time.
         return self.junction_flush <= 0.
 
-BUFFER_TIME_HIGH = 2.0
+BUFFER_TIME_HIGH = 1.0
 BUFFER_TIME_START = 0.250
 
 # Main code to track events (and their timing) on the printer toolhead
```
However, it will require a bit of rollout coordination, so best for a separate PR.

@dmbutyugin , @nefelim4ag - fyi.

-Kevin