### PR TITLE
stm32: f070 add PA9/PA10 i2c bus line

### DIFF
--- a/src/stm32/stm32f0_i2c.c
+++ b/src/stm32/stm32f0_i2c.c
@@ -25,6 +25,10 @@ struct i2c_info {
   DECL_CONSTANT_STR("BUS_PINS_i2c1_PB8_PB9", "PB8,PB9");
   DECL_ENUMERATION("i2c_bus", "i2c1_PB8_PB7", 3);
   DECL_CONSTANT_STR("BUS_PINS_i2c1_PB8_PB7", "PB8,PB7");
+  #if CONFIG_MACH_STM32F070x6
+    DECL_ENUMERATION("i2c_bus", "i2c1_PA9_PA10", 4);
+    DECL_CONSTANT_STR("BUS_PINS_i2c1_PA9_PA10", "PA9,PA10");
+  #endif
   // Deprecated "i2c1a" style mappings
   DECL_ENUMERATION("i2c_bus", "i2c1", 0);
   DECL_CONSTANT_STR("BUS_PINS_i2c1", "PB6,PB7");
@@ -101,6 +105,9 @@ static const struct i2c_info i2c_bus[] = {
     { I2C1, GPIO('F', 1), GPIO('F', 0), GPIO_FUNCTION(1) },
     { I2C1, GPIO('B', 8), GPIO('B', 9), GPIO_FUNCTION(1) },
     { I2C1, GPIO('B', 8), GPIO('B', 7), GPIO_FUNCTION(1) },
+  #if CONFIG_MACH_STM32F070x6
+    { I2C1, GPIO('A', 9), GPIO('A', 10), GPIO_FUNCTION(1) },
+  #endif
 #elif CONFIG_MACH_STM32F7
     { I2C1, GPIO('B', 6), GPIO('B', 7), GPIO_FUNCTION(1) },
 #elif CONFIG_MACH_STM32G0


### PR DESCRIPTION
Requested from: https://klipper.discourse.group/t/need-additonal-i2c-config-in-stm32f0-i2c-c/24772