### PR TITLE
Display: fix I2C display driver issues 

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5541,4 +5541,10 @@ All other Klipper micro-controllers use a
 #   The Klipper implementation on most micro-controllers is hard-coded
 #   to 100000 and changing this value has no effect. The default is
 #   100000. Linux, RP2040 and ATmega support 400000.
+#i2c_async:
+#   Indicates whether the I2C bus should use asynchronous
+#   (pre-v0.13.0 behavior) or synchronous communication. 
+#   This parameter can have some effects on performance of some I2C
+#   display drivers like the SSD1306.
+#   Default value: false
 ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5543,7 +5543,7 @@ All other Klipper micro-controllers use a
 #   100000. Linux, RP2040 and ATmega support 400000.
 #i2c_async:
 #   Indicates whether the I2C bus should use asynchronous
-#   (pre-v0.13.0 behavior) or synchronous communication. 
+#   (pre-v0.13.0 behavior) or synchronous communication.
 #   This parameter can have some effects on performance of some I2C
 #   display drivers like the SSD1306.
 #   Default value: false

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -212,9 +212,13 @@ class MCU_I2C:
             "i2c_read oid=%c reg=%*s read_len=%u",
             "i2c_read_response oid=%c response=%*s", oid=self.oid,
             cq=self.cmd_queue)
-    def i2c_write(self, data, minclock=0, reqclock=0):
+    def i2c_write(self, data, minclock=0, reqclock=0, wait=True):
         if self.i2c_write_cmd is None:
             self._to_write.append(data)
+            return        
+        if not wait:
+            self.i2c_write_cmd.send([self.oid, data], 
+                                    minclock=minclock, reqclock=reqclock)
             return
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
                                          minclock=minclock, reqclock=reqclock)

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -216,9 +216,9 @@ class MCU_I2C:
     def i2c_write(self, data, minclock=0, reqclock=0):
         if self.i2c_write_cmd is None:
             self._to_write.append(data)
-            return        
+            return
         if self.is_async:
-            self.i2c_write_cmd.send([self.oid, data], 
+            self.i2c_write_cmd.send([self.oid, data],
                                     minclock=minclock, reqclock=reqclock)
             return
         self.i2c_write_cmd.send_wait_ack([self.oid, data],
@@ -226,7 +226,8 @@ class MCU_I2C:
     def i2c_read(self, write, read_len, retry=True):
         return self.i2c_read_cmd.send([self.oid, write, read_len], retry)
 
-def MCU_I2C_from_config(config, default_addr=None, default_speed=100000, default_is_async=False):
+def MCU_I2C_from_config(config, default_addr=None, default_speed=100000, 
+                        default_is_async=False):
     # Load bus parameters
     printer = config.get_printer()
     i2c_mcu = mcu.get_printer_mcu(printer, config.get('i2c_mcu', 'mcu'))

--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -226,7 +226,7 @@ class MCU_I2C:
     def i2c_read(self, write, read_len, retry=True):
         return self.i2c_read_cmd.send([self.oid, write, read_len], retry)
 
-def MCU_I2C_from_config(config, default_addr=None, default_speed=100000, 
+def MCU_I2C_from_config(config, default_addr=None, default_speed=100000,
                         default_is_async=False):
     # Load bus parameters
     printer = config.get_printer()

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -130,7 +130,7 @@ class SPI4wire:
 class I2C:
     def __init__(self, config, default_addr, default_is_async):
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=default_addr,
-                                           default_speed=400000, 
+                                           default_speed=400000,
                                            default_is_async=default_is_async)
     def send(self, cmds, is_data=False):
         if is_data:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -138,7 +138,7 @@ class I2C:
             hdr = 0x00
         cmds = bytearray(cmds)
         cmds.insert(0, hdr)
-        self.i2c.i2c_write(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.i2c.i2c_write(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK, wait=False)
 
 # Helper code for toggling a reset pin on startup
 class ResetHelper:

--- a/klippy/extras/display/uc1701.py
+++ b/klippy/extras/display/uc1701.py
@@ -128,9 +128,10 @@ class SPI4wire:
 
 # IO wrapper for i2c bus
 class I2C:
-    def __init__(self, config, default_addr):
+    def __init__(self, config, default_addr, default_is_async):
         self.i2c = bus.MCU_I2C_from_config(config, default_addr=default_addr,
-                                           default_speed=400000)
+                                           default_speed=400000, 
+                                           default_is_async=default_is_async)
     def send(self, cmds, is_data=False):
         if is_data:
             hdr = 0x40
@@ -138,7 +139,7 @@ class I2C:
             hdr = 0x00
         cmds = bytearray(cmds)
         cmds.insert(0, hdr)
-        self.i2c.i2c_write(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK, wait=False)
+        self.i2c.i2c_write(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
 
 # Helper code for toggling a reset pin on startup
 class ResetHelper:
@@ -199,7 +200,7 @@ class SSD1306(DisplayBase):
     def __init__(self, config, columns=128, x_offset=0):
         cs_pin = config.get("cs_pin", None)
         if cs_pin is None:
-            io = I2C(config, 60)
+            io = I2C(config, 60, True)
             io_bus = io.i2c
         else:
             io = SPI4wire(config, "dc_pin")


### PR DESCRIPTION
The change to synchronous I2C command handling introduced a few issues with screens using I2C, as reported and confirmed by multiple sources:
- (https://www.reddit.com/r/VORONDesign/comments/1n9pa49/slow_graphical_interface/)
- (https://www.reddit.com/r/klippers/comments/1n9iaht/voron_v0display_laggy_after_update/)
- (https://www.reddit.com/r/klippers/comments/1nf2yv3/i2c_oled_display_issues/)

The issues are:
- corrupted screen buffers: seems like leftover data is displayed on parts of the screen that were not updated recently.
- speed issues: visible rendering scanline
- overall responsiveness: buttons and encoders are "laggy"

Affected displays: SSD1306 and its variants using I2C bus (for example: Voron 0 display)

I understand there is a pull request by @nefelim4ag [to decouple rendering and flush](https://github.com/Klipper3d/klipper/pull/7028) but it only addresses the first issue

Changes are tested on an SH1106 display and restore performance to original levels.
I made it configurable, per MCU_I2C bus object, this way it shouldn't affect other I2C applications

---------------

Issue introduced in: [#7020](https://github.com/Klipper3d/klipper/pull/7020)