### PR TITLE
serialqueue: track USB bittime

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -200,7 +200,7 @@ defs_serialqueue = """
     void serialqueue_pull(struct serialqueue *sq
         , struct pull_queue_message *pqm);
     void serialqueue_set_wire_frequency(struct serialqueue *sq
-        , double frequency);
+        , double frequency, int bridge);
     void serialqueue_set_receive_window(struct serialqueue *sq
         , int receive_window);
     void serialqueue_set_clock_est(struct serialqueue *sq, double est_freq

--- a/klippy/chelper/serialqueue.h
+++ b/klippy/chelper/serialqueue.h
@@ -42,7 +42,8 @@ void serialqueue_send(struct serialqueue *sq, struct command_queue *cq
                       , uint8_t *msg, int len, uint64_t min_clock
                       , uint64_t req_clock, uint64_t notify_id);
 void serialqueue_pull(struct serialqueue *sq, struct pull_queue_message *pqm);
-void serialqueue_set_wire_frequency(struct serialqueue *sq, double frequency);
+void serialqueue_set_wire_frequency(struct serialqueue *sq, double frequency
+                                    , int bridge);
 void serialqueue_set_receive_window(struct serialqueue *sq, int receive_window);
 void serialqueue_set_clock_est(struct serialqueue *sq, double est_freq
                                , double conv_time, uint64_t conv_clock

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -108,9 +108,13 @@ class SerialReader:
             wire_freq = msgparser.get_constant_float('CANBUS_FREQUENCY', None)
         else:
             wire_freq = msgparser.get_constant_float('SERIAL_BAUD', None)
+        is_bridge = 0
+        if msgparser.get_constant('RESERVE_PINS_USB', 0):
+            is_bridge = 1
+            wire_freq = 12000000
         if wire_freq is not None:
             self.ffi_lib.serialqueue_set_wire_frequency(self.serialqueue,
-                                                        wire_freq)
+                                                        wire_freq, is_bridge)
         receive_window = msgparser.get_constant_int('RECEIVE_WINDOW', None)
         if receive_window is not None:
             self.ffi_lib.serialqueue_set_receive_window(


### PR DESCRIPTION
After the recent i2c write debugging (and over the whole time).
I was somewhat annoyed that for the sent queue, there is no info about when the message has been received,
because the sent time is equal to the received time.
Well, now I realized this is only true for USB Bridges (UART/CAN).
(So, I reworked the PR, to pure USB Bridge timings.)

USB is slightly beyond my knowledge horizon, so I did my best to interpret the: http://esd.cs.ucr.edu/webres/usb11.pdf
Chapter 5 -> 5.9.3 Calculating Bus Transaction Times
Chapter 8: Protocol Layer

It should be pretty close to the real value, somewhere, still optimistic.

```
MCU 'mcu' shutdown: Command request
...
Sent 94 4049.200403 4049.200396 6: seq: 11, get_clock
Sent 95 4049.314712 4049.314701 11: seq: 12, i2c_transfer oid=0 write=b'\xe0\x00' read_len=6
Sent 96 4050.184589 4050.184582 6: seq: 13, get_clock
Sent 97 4050.316003 4050.315992 11: seq: 14, i2c_transfer oid=0 write=b'\xe0\x00' read_len=6
Sent 98 4051.168941 4051.168933 6: seq: 15, get_clock
Receive: 55 4049.200973 4049.200403 11: seq: 12, clock clock=1594323131
Receive: 59 4049.315155 4049.314712 15: seq: 13, i2c_response oid=0 i2c_bus_status=SUCCESS response=b'd)Y\x82?\x90'
Receive: 77 4050.185020 4050.184589 11: seq: 14, clock clock=2106053271
Receive: 78 4050.316975 4050.316003 15: seq: 15, i2c_response oid=0 i2c_bus_status=SUCCESS response=b'd.\xce\x82W\x92'
Receive: 97 4051.169064 4051.168941 11: seq: 16, clock clock=2617781613
...
MCU 'ebb42' shutdown: Command request
Sent 97 4049.861519 4049.861511 6: seq: 1d, get_clock
Sent 98 4050.845943 4050.845935 6: seq: 1e, get_clock
Receive: 87 4049.862033 4049.861519 10: seq: 1e, clock clock=40804717
Receive: 96 4050.846077 4050.845943 10: seq: 1f, clock clock=103784049
```

Thanks.