### PR TITLE
klippy: track the device model

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -327,12 +327,14 @@ def main():
     extra_git_desc += "\nTracked URL: %s" % (git_info["url"])
     start_args['software_version'] = git_vers
     start_args['cpu_info'] = util.get_cpu_info()
+    start_args['device'] = util.get_device_info()
     if bglogger is not None:
         versions = "\n".join([
             "Args: %s" % (sys.argv,),
             "Git version: %s%s" % (repr(start_args['software_version']),
                                    extra_git_desc),
             "CPU: %s" % (start_args['cpu_info'],),
+            "Device: %s" % (start_args['device']),
             "Python: %s" % (repr(sys.version),)])
         logging.info(versions)
     elif not options.debugoutput:

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -127,7 +127,12 @@ def get_cpu_info():
 
 def get_device_info():
     try:
-        f = open('/proc/device-tree/model', 'r')
+        path = '/proc/device-tree/model'
+        if not os.access(path, os.F_OK):
+            path = "/sys/class/dmi/id/product_name"
+            if not os.access(path, os.F_OK):
+                return "?"
+        f = open(path, 'r')
         data = f.read()
         f.close()
     except (IOError, OSError) as e:

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -125,6 +125,17 @@ def get_cpu_info():
     model_name = dict(lines).get("model name", "?")
     return "%d core %s" % (core_count, model_name)
 
+def get_device_info():
+    try:
+        f = open('/proc/device-tree/model', 'r')
+        data = f.read()
+        f.close()
+    except (IOError, OSError) as e:
+        logging.debug("Exception on read /proc/device-tree/model: %s",
+                      traceback.format_exc())
+        return "?"
+    return data.rstrip(' \0')
+
 def get_version_from_file(klippy_src):
     try:
         with open(os.path.join(klippy_src, '.version')) as h:


### PR DESCRIPTION
It looks like there is less respect for the `/proc/cpuinfo` in recent days.
So, in the log, there would often be: `CPU: 4 core ?`
This is somewhat limiting in a sense to get an idea what we are working with.

From my point of view, the current code prints it, to give people who are reading the log,
the idea of what sort of hardware Klippy is running on.
From my sparse check of some SBCs in different chats, it seems `cpuinfo` lacks of any info.
Even on the Rasbian on Raspberry PI 5 (which I would expect to have good compliance and support):
```
processor       : 0
BogoMIPS        : 108.00
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x4
CPU part        : 0xd0b
CPU revision    : 1
...
Revision        : c04170
Serial          : 287b796f3957159f
Model           : Raspberry Pi 5 Model B Rev 1.0
```
(There is no 'model name').
Most SBC devices do not write even the model here.

It is possible, though, to parse the `lscpu` output:
```
Architecture:                aarch64
  CPU op-mode(s):            32-bit, 64-bit
  Byte Order:                Little Endian
CPU(s):                      4
  On-line CPU(s) list:       0-3
Vendor ID:                   ARM
  Model name:                Cortex-A76
    Model:                   1
    Thread(s) per core:      1
    Core(s) per cluster:     4
    Socket(s):               -
    Cluster(s):              1
    Stepping:                r4p1
    CPU(s) scaling MHz:      100%
    CPU max MHz:             2000.0000
    CPU min MHz:             2000.0000
    BogoMIPS:                108.00
```

But it seems to me that the information: Cortex-A76 is a little useless from a practical standpoint.
(Just max MHz probably gives more info than the core architecture for me, I mean >1.2Ghz seems fast :D).

So, while I try to find where to get even approximate info about what sort of the chip is installed, I stumbled upon:
`/proc/device-tree/model`, which seems to be used in different places, or at least available:
- https://github.com/search?q=%2Fproc%2Fdevice-tree%2Fmodel&type=code
- https://dietpi.com/forum/t/after-upgrade-emmc-died-and-the-new-installation-via-sd-card-does-not-connect-to-the-network/22129/27?page=2
- https://software-dl.ti.com/jacinto7/esd/processor-sdk-linux-jacinto7/latest/exports/docs/linux/How_to_Guides/FAQ/How_to_Check_Device_Tree_Info.html

This is probably not the best solution, but it seems better than nothing on average. The example outputs are:
```
Raspberry Pi 5 Model B Rev 1.0
BigTreeTech CB2
FriendlyARM ZeroPi 
Rockchip RK3308B-S evb analog mic v11 board
OrangePi 3 LTS
```

So, the purposal is to print that info in the log. It would be empty on X86 machines, where there is ACPI and normal cpu models, but it seems to be populated with non-zero chances on most ARM SBCs.

Btw, there is also (https://docs.kernel.org/devicetree/usage-model.html#platform-identification):
```
$ grep -a . /proc/device-tree/*
...
/proc/device-tree/compatible:raspberrypi,5-model-bbrcm,bcm2712
```

Thanks.

---
Not directly related, but there are benchmarks: https://dietpi.com/survey/#benchmark