### PR TITLE
input_shaper: Updated definitions of *EI input shapers

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,10 @@ All dates in this document are approximate.
 
 ## Changes
 
+20250916: The definitions of EI, 2HUMP_EI, and 3HUMP_EI input shapers
+were updated. For best performance it is recommended to recalibrate
+input shapers, especially if some of these shapers are currently used.
+
 20250811: Support for the `max_accel_to_decel` parameter in the
 `[printer]` config section has been removed and support for the
 `ACCEL_TO_DECEL` parameter in the `SET_VELOCITY_LIMIT` command has


### PR DESCRIPTION
This pull requests updates the definitions of EI, 2HUMP_EI, and 3HUMP_EI input shapers to their canonical variants. These variants typically offer somewhat better shaper performance (stronger reduction of the vibrations) at the ends of the interval where they reduce vibrations, and that interval itself is typically larger for the same shaper duration. All this means that the new shaper definitions typically offer better vibration reduction and higher attainable accelerations. The improvements are not very significant, but are still typically quite noticeable:

|Old version|New version|
|:-----:|:------:|
| <img width="800" height="600" alt="y_ei_old" src="https://github.com/user-attachments/assets/07c2338f-2ab9-40d3-9d98-8e701c330f31" />| <img width="800" height="600" alt="y_ei_new" src="https://github.com/user-attachments/assets/36c329bf-2064-45e7-a1f0-61c3b5b8df8f" /> |
| <img width="800" height="600" alt="y_2hump_ei_old" src="https://github.com/user-attachments/assets/d14c0472-b9a8-4a27-99e3-0f18ffd009bb" /> | <img width="800" height="600" alt="y_2hump_ei_new" src="https://github.com/user-attachments/assets/cf25bfc2-6825-4cbf-92c1-e1ad40acbb69" /> |
| <img width="800" height="600" alt="y_tool0_t01_center_3hump_ei_old" src="https://github.com/user-attachments/assets/b1f21a2f-1e49-4d8a-8762-361fe08d1704" /> | <img width="800" height="600" alt="y_tool0_t01_center_3hump_ei_new" src="https://github.com/user-attachments/assets/1b348e3d-380b-46df-a01d-aa9b2f33f01c" /> |

Notably, RRF has had these canonical shaper definitions for many years already.