### PR TITLE
uc1701: allow non blocking i2c writes

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -212,6 +212,9 @@ class MCU_I2C:
             "i2c_read oid=%c reg=%*s read_len=%u",
             "i2c_read_response oid=%c response=%*s", oid=self.oid,
             cq=self.cmd_queue)
+    def i2c_write_noack(self, data, minclock=0, reqclock=0):
+        self.i2c_write_cmd.send([self.oid, data],
+                                minclock=minclock, reqclock=reqclock)
     def i2c_write(self, data, minclock=0, reqclock=0):
         if self.i2c_write_cmd is None:
             self._to_write.append(data)


### PR DESCRIPTION
Purpose fix for i2c displays, which should not block the #7013

The basic idea for now is to do fire and forget.
When there is a migration to a new I2C interface, it could be adjusted.