### PR TITLE
Add cr10 smart cr fdm config

### DIFF
--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
@@ -133,6 +133,15 @@ enable_force_move: True
 # - Main board interface: 2x7 pin (14-pin) + 2x8 pin (16-pin) connectors
 # - Pin 1 identification: Square pad on PCB, remaining pins are circular
 #
+# CONFIRMED PIN ASSIGNMENTS (STM32F103RET6 main board):
+# Motors: PB3,PB4 (Z), PB5,PB6 (Y), PB7,PB8 (X), PB9,PC2 (E), PC3 (Enable)
+# Endstops: PC4 (X), PC5 (Y), PB2 (Z-physical)
+# Heaters: PB13 (Bed), PB14 (Hotend)
+# Thermistors: PB0 (Bed), PB1 (Hotend)  
+# Fans/Outputs: PB15 (Part fan), PC13 (Lights), PA0 (Power)
+# Sensors: PA7 (Filament sensor)
+# Communication: PA9,PA10 (USART1 to host)
+#
 # CONNECTOR 1 - 2x8 (16-pin) - HOTEND & COOLING:
 # Pin 1: HT+, Pin 2: HT+, Pin 3: HT-, Pin 4: TH (Thermistor)
 # Pin 5: Fan/LED VCC, Pin 6: Layer Fan Signal, Pin 7: STM Pin 10, Pin 8: LED Signal
@@ -142,20 +151,42 @@ enable_force_move: True
 # Pin 1-2: Xd/Xb (X Motor), Pin 3-4: Ed/Eb (Extruder), Pin 5-6: X-/FilSensor
 # Pin 7-8: GND, Pin 9: FilRunout, Pin 10: X-, Pin 11-12: Ea/Ec, Pin 13-14: Xa/Xc
 #
-# Known probe pins when enabled: PA4 (probe signal), PA5 (tare control)
+# Probe pins (UNCONFIRMED): PA4 (probe signal?), PA5 (tare control?)
+# WARNING: Pin assignments are speculative based on available pins only
+# Strain gauge probe communication protocol completely unknown
+# PA4/PA5 chosen because they are freed when probe is disabled, but actual
+# probe pins may be different or require secondary board firmware modifications
 # Communication with main board via dedicated pins (not USART1)
+#
+# STM32F103RET6 pins NOT identified in this configuration:
+# Available for future investigation or custom modifications:
+# PA1, PA2, PA3, PA6, PA8, PA11, PA12, PA15
+# PB0 (bed thermistor - could be repurposed if bed sensor moved)
+# PB1 (hotend thermistor - could be repurposed if sensor moved)  
+# PC0, PC1, PC6, PC7, PC8, PC9, PC10, PC11, PC12, PC14, PC15
+# PD0, PD1 (if available on this package)
+#
+# Notes for developers:
+# - PA9/PA10: Reserved for USART1 (host communication)
+# - PA4/PA5: Suspected probe/tare pins (unconfirmed)
+# - Some pins may be connected to secondary board connectors
+# - Verify pin availability before use in custom configurations
 
 # Optional: Probe configuration (commented out for Z endstop operation)
-# Before using probe, comment out the stepper_z endstop_pin above
-# and uncomment the probe section below
+# EXPERIMENTAL: Strain gauge probe functionality completely unverified
+# Pin assignments below are speculative and likely incorrect
+# No successful probe operation achieved - use physical Z endstop for reliability
+# Before attempting probe, comment out the stepper_z endstop_pin above
+# and uncomment the probe section below (expect failures)
 #[probe]
-#pin: ~PA4
+#pin: ~PA4  # UNCONFIRMED: May not be correct pin
 #z_offset: -0.75
 #samples: 2
 
 # Optional: Probe tare pin (used with probe configuration above)
+# EXPERIMENTAL: Pin assignment unconfirmed, functionality unknown
 #[output_pin PROBE_TARE_PIN]
-#pin: PA5
+#pin: PA5  # UNCONFIRMED: May not be correct pin
 #value: 0
 
 # Optional: Safe Z homing (used with probe configuration above)

--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
@@ -1,5 +1,12 @@
 # This file contains pin mappings for the Creality CR-10 Smart
 # with a CR-FDM-v2.5.S1 mainboard (STM32F103RET6).
+#
+# Hardware architecture:
+# - Main board: STM32F103RET6 microcontroller
+# - Secondary strain gauge board: Dedicated load cell controller with
+#   its own STM microcontroller, communicates with main board via I2C/UART
+# - This configuration uses physical Z endstop instead of strain gauge probe
+#   to free up communication pins and ensure reliable operation
 
 # To use this config, during "make menuconfig" select the STM32F103
 # with a "64KiB bootloader" and serial (on USART1 PA10/PA9) communication.

--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
@@ -1,5 +1,5 @@
-# This file contains pin mappings for the Creality CR-10 Smart
-# with a CR-FDM-v2.5.S1 mainboard (STM32F103RET6).
+﻿# This file contains pin mappings for the Creality CR-10 Smart
+# with a CR-FDM-v2.5.S1 -100 mainboard (STM32F103RET6).
 #
 # Hardware architecture:
 # - Main board: STM32F103RET6 microcontroller
@@ -7,7 +7,7 @@
 #   Connectors: 2x7 pin (14-pin) and 2x8 pin (16-pin) headers to main board
 #   Communicates with main board via I2C/UART for strain gauge data
 # - This configuration uses physical Z endstop instead of strain gauge probe
-#   to free up communication pins and ensure reliable operation
+#   to ensure reliable operation
 
 # To use this config, during "make menuconfig" select the STM32F103
 # with a "64KiB bootloader" and serial (on USART1 PA10/PA9) communication.
@@ -73,7 +73,7 @@ pid_Kp: 22.865
 pid_Ki: 1.292
 pid_Kd: 101.178
 min_temp: 0
-max_temp: 300  
+max_temp: 300
 
 [heater_bed]
 heater_pin: PB13
@@ -137,7 +137,7 @@ enable_force_move: True
 # Motors: PB3,PB4 (Z), PB5,PB6 (Y), PB7,PB8 (X), PB9,PC2 (E), PC3 (Enable)
 # Endstops: PC4 (X), PC5 (Y), PB2 (Z-physical)
 # Heaters: PB13 (Bed), PB14 (Hotend)
-# Thermistors: PB0 (Bed), PB1 (Hotend)  
+# Thermistors: PB0 (Bed), PB1 (Hotend)
 # Fans/Outputs: PB15 (Part fan), PC13 (Lights), PA0 (Power)
 # Sensors: PA7 (Filament sensor)
 # Communication: PA9,PA10 (USART1 to host)
@@ -147,7 +147,7 @@ enable_force_move: True
 # Pin 5: Fan/LED VCC, Pin 6: Layer Fan Signal, Pin 7: STM Pin 10, Pin 8: LED Signal
 # Pin 9-10: R11/R10 (TBD), Pin 11: VCC, Pin 12: GND, Pin 13: TH, Pin 14-16: HT-/HT+
 #
-# CONNECTOR 2 - 2x7 (14-pin) - MOTORS & ENDSTOPS:  
+# CONNECTOR 2 - 2x7 (14-pin) - MOTORS & ENDSTOPS:
 # Pin 1-2: Xd/Xb (X Motor), Pin 3-4: Ed/Eb (Extruder), Pin 5-6: X-/FilSensor
 # Pin 7-8: GND, Pin 9: FilRunout, Pin 10: X-, Pin 11-12: Ea/Ec, Pin 13-14: Xa/Xc
 #
@@ -161,8 +161,6 @@ enable_force_move: True
 # STM32F103RET6 pins NOT identified in this configuration:
 # Available for future investigation or custom modifications:
 # PA1, PA2, PA3, PA6, PA8, PA11, PA12, PA15
-# PB0 (bed thermistor - could be repurposed if bed sensor moved)
-# PB1 (hotend thermistor - could be repurposed if sensor moved)  
 # PC0, PC1, PC6, PC7, PC8, PC9, PC10, PC11, PC12, PC14, PC15
 # PD0, PD1 (if available on this package)
 #
@@ -203,3 +201,4 @@ enable_force_move: True
 #mesh_min: 10,10
 #mesh_max: 290,290
 #probe_count: 6,6
+

--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
@@ -1,0 +1,149 @@
+# This file contains pin mappings for the Creality CR-10 Smart
+# with a CR-FDM-v2.5.S1 mainboard (STM32F103RET6).
+
+# To use this config, during "make menuconfig" select the STM32F103
+# with a "64KiB bootloader" and serial (on USART1 PA10/PA9) communication.
+
+# Flash this firmware by copying "out/klipper.bin" to a SD card and
+# turning the printer on with the card inserted. The firmware filename
+# must end in ".bin" and must not match the last filename that was flashed.
+
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[stepper_x]
+step_pin: PB8
+dir_pin: !PB7
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: PC4
+position_min: -5
+position_endstop: -5
+position_max: 305
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB6
+dir_pin: PB5
+enable_pin: !PC3
+rotation_distance: 40
+microsteps: 16
+endstop_pin: PC5
+position_min: -2
+position_endstop: -2
+position_max: 302
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB4
+dir_pin: !PB3
+enable_pin: !PC3
+rotation_distance: 8
+microsteps: 16
+endstop_pin: !PB2
+position_endstop: 0
+position_min: -3
+position_max: 400
+homing_speed: 4
+second_homing_speed: 1
+homing_retract_dist: 2.0
+
+[extruder]
+step_pin: PC2
+dir_pin: PB9
+enable_pin: !PC3
+rotation_distance: 22.0115
+microsteps: 16
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB14
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+control: pid
+pid_Kp: 22.865
+pid_Ki: 1.292
+pid_Kd: 101.178
+min_temp: 0
+max_temp: 300  
+
+[heater_bed]
+heater_pin: PB13
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB0
+control: pid
+pid_Kp: 72.49
+pid_Ki: 0.844
+pid_Kd: 1542.189
+min_temp: 0
+max_temp: 120
+
+[fan]
+pin: PB15
+kick_start_time: 0.5
+
+[mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 500
+max_accel: 4000
+square_corner_velocity: 5.0
+max_z_velocity: 10
+max_z_accel: 1000
+
+# Filament runout sensor
+[filament_switch_sensor runout_sensor]
+pause_on_runout: True
+switch_pin: ^!PA7
+
+# Power control - turn off printer with M81
+[output_pin power]
+pin: PA0
+value: 1
+shutdown_value: 1
+
+# Case lighting
+[output_pin lights]
+pin: PC13
+value: 1
+
+# Board temperature sensor
+[temperature_sensor Board_MCU]
+sensor_type: temperature_mcu
+min_temp: 0
+max_temp: 100
+
+# Enable force moves for calibration
+[force_move]
+enable_force_move: True
+
+# Optional: Probe configuration (commented out for Z endstop operation)
+# Before using probe, comment out the stepper_z endstop_pin above
+# and uncomment the probe section below
+#[probe]
+#pin: ~PA4
+#z_offset: -0.75
+#samples: 2
+
+# Optional: Probe tare pin (used with probe configuration above)
+#[output_pin PROBE_TARE_PIN]
+#pin: PA5
+#value: 0
+
+# Optional: Safe Z homing (used with probe configuration above)
+#[safe_z_home]
+#home_xy_position: 150,150
+#speed: 80
+#z_hop: 3
+#z_hop_speed: 5
+
+# Optional: Bed mesh (used with probe configuration above)
+#[bed_mesh]
+#speed: 120
+#horizontal_move_z: 5
+#mesh_min: 10,10
+#mesh_max: 290,290
+#probe_count: 6,6

--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1-2022.cfg
@@ -3,8 +3,9 @@
 #
 # Hardware architecture:
 # - Main board: STM32F103RET6 microcontroller
-# - Secondary strain gauge board: Dedicated load cell controller with
-#   its own STM microcontroller, communicates with main board via I2C/UART
+# - Secondary strain gauge board: STM32F030F4P6 + NX711 load cell ADC
+#   Connectors: 2x7 pin (14-pin) and 2x8 pin (16-pin) headers to main board
+#   Communicates with main board via I2C/UART for strain gauge data
 # - This configuration uses physical Z endstop instead of strain gauge probe
 #   to free up communication pins and ensure reliable operation
 
@@ -126,6 +127,23 @@ max_temp: 100
 # Enable force moves for calibration
 [force_move]
 enable_force_move: True
+
+# Secondary strain gauge board details:
+# - MCU: STM32F030F4P6 with NX711 load cell ADC chip
+# - Main board interface: 2x7 pin (14-pin) + 2x8 pin (16-pin) connectors
+# - Pin 1 identification: Square pad on PCB, remaining pins are circular
+#
+# CONNECTOR 1 - 2x8 (16-pin) - HOTEND & COOLING:
+# Pin 1: HT+, Pin 2: HT+, Pin 3: HT-, Pin 4: TH (Thermistor)
+# Pin 5: Fan/LED VCC, Pin 6: Layer Fan Signal, Pin 7: STM Pin 10, Pin 8: LED Signal
+# Pin 9-10: R11/R10 (TBD), Pin 11: VCC, Pin 12: GND, Pin 13: TH, Pin 14-16: HT-/HT+
+#
+# CONNECTOR 2 - 2x7 (14-pin) - MOTORS & ENDSTOPS:  
+# Pin 1-2: Xd/Xb (X Motor), Pin 3-4: Ed/Eb (Extruder), Pin 5-6: X-/FilSensor
+# Pin 7-8: GND, Pin 9: FilRunout, Pin 10: X-, Pin 11-12: Ea/Ec, Pin 13-14: Xa/Xc
+#
+# Known probe pins when enabled: PA4 (probe signal), PA5 (tare control)
+# Communication with main board via dedicated pins (not USART1)
 
 # Optional: Probe configuration (commented out for Z endstop operation)
 # Before using probe, comment out the stepper_z endstop_pin above

--- a/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1.cfg
+++ b/config/printer-creality-cr10-smart-cr-fdm-v2.5.s1.cfg
@@ -1,6 +1,11 @@
 ﻿# This file contains pin mappings for the Creality CR-10 Smart
 # with a CR-FDM-v2.5.S1 -100 mainboard (STM32F103RET6).
 #
+# NOTE: This configuration was created because the existing CR-10 Smart
+# examples in config/printer-creality-cr10-smart-*.cfg did not work with
+# this specific CR-FDM-v2.5.S1 mainboard variant. This config is based on
+# reverse-engineered pin analysis and confirmed working configuration.
+#
 # Hardware architecture:
 # - Main board: STM32F103RET6 microcontroller
 # - Secondary strain gauge board: STM32F030F4P6 + NX711 load cell ADC


### PR DESCRIPTION
Add example configuration for Creality CR-10 Smart printer with CR-FDM-v2.5.S1 mainboard (STM32F103RET6).

**Hardware Architecture:**
- Main board: STM32F103RET6 microcontroller with 64KiB bootloader
- Secondary interface board: STM32F030F4P6 + NX711 load cell ADC
- Interface connectors: 2x7 pin (motors/endstops) + 2x8 pin (hotend/cooling)
- Pin identification: Square pad = Pin 1, circular pads = remaining pins

**Reverse-engineered connector pinout included:**
- Complete confirmed pin assignments for all functions
- Detailed interface connector documentation with motor phases
- Honest experimental warnings for unverified probe functionality
- Available pins list for future development and custom modifications

**Configuration supports:**
- USART1 PA9/PA10 communication
- Physical Z endstop on PB2 (reliable operation)
- Filament sensor on PA7, Power control on PA0, Case lighting on PC13
- Optional strain gauge probe configuration (experimental, unverified)

This provides both a working configuration and complete technical reference for the CR-10 Smart CR-FDM v2.5.S1 hardware, enabling reliable operation and future development work.