### PR TITLE
mcu: send init cmds in clock order

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -713,6 +713,11 @@ class MCU:
                 for c in self._restart_cmds:
                     self._serial.send(c)
             # Transmit init messages
+            def clock_sort(line):
+                if "clock=" in line:
+                    return int(line.split('clock=')[1].split()[0])
+                return 0
+            self._init_cmds.sort(key=clock_sort)
             for c in self._init_cmds:
                 self._serial.send(c)
         except msgproto.enumeration_error as e:


### PR DESCRIPTION
While I was working on refactoring serialqueue, I was got a strange behavior where I receive Timer Too Close upon firmware restart. I was stambled for some time. I was sure that I probably brake something, so messages goes not in the order.
But it seems they are.

It seems that all config entries are initialized in order, and the `add_config_cmd(,init=True)` happens in order.
In that order, they arrive in the init_cmd queue.
```
MCU: mcu, cmd: query_analog_in oid=20 clock=2184000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=9031 max_value=32275 range_check_count=4
MCU: mcu, cmd: queue_digital_out oid=21 clock=1591207901 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=22 clock=1591223090 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=23 clock=1591232374 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=24 clock=1591241101 on_ticks=0
MCU: mcu, cmd: query_analog_in oid=25 clock=2210000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=3640 max_value=32275 range_check_count=4
MCU: mcu, cmd: queue_digital_out oid=26 clock=1591256521 on_ticks=520000
MCU: mcu, cmd: query_counter oid=1 clock=2085200000 poll_ticks=156000 sample_ticks=520000000
MCU: mcu, cmd: queue_digital_out oid=27 clock=1591271132 on_ticks=148200
MCU: mcu, cmd: queue_digital_out oid=28 clock=1591279675 on_ticks=0
MCU: mcu, cmd: query_analog_in oid=29 clock=2230800000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=5523 max_value=8044 range_check_count=4
MCU: mcu, cmd: query_analog_in oid=30 clock=2236000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=32275 range_check_count=4
MCU: mcu, cmd: query_counter oid=2 clock=2090400000 poll_ticks=104000 sample_ticks=520000000
MCU: mcu, cmd: query_analog_in oid=32 clock=2246400000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=31991 range_check_count=4
MCU: mcu, cmd: queue_digital_out oid=33 clock=1591342935 on_ticks=0
```

That can happen, that all previous messages, let it be `query_analog_in` in my case, can hit the max message count limit, and the later ones `queue_digital_out` got delayed enough, that upon their arrival they would trigger TTC.

```
MCU 'mcu' shutdown: Timer too close
clocksync state: mcu_freq=520000000 last_clock=1432241797 clock_est=(170695.797 759109400 520102684.777) min_half_rtt=0.000056 min_rtt_time=170695.735 time_avg=170695.797(0.075) clock_avg=759109400.895(38826355.039) pred_variance=219976818557.624
Dumping serial stats: bytes_write=1486 bytes_read=5125 bytes_retransmit=9 bytes_invalid=0 send_seq=131 receive_seq=131 retransmit_seq=2 srtt=0.001 rttvar=0.000 rto=0.025 ready_bytes=0 upcoming_bytes=0
...
Sent 98 170697.198913 170697.198913 62: seq: 11, query_analog_in oid=29 clock=2230800000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=5523 max_value=8044 range_check_count=4, query_analog_in oid=30 clock=2236000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=32275 range_check_count=4, query_counter oid=2 clock=2090400000 poll_ticks=104000 sample_ticks=520000000
Sent 99 170698.076336 170698.076336 37: seq: 12, query_analog_in oid=32 clock=2246400000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=31991 range_check_count=4, queue_digital_out oid=33 clock=1591342935 on_ticks=0, get_config, get_clock
...
Receive: 98 170697.196704 170697.195918 10: seq: 19, config is_config=0 crc=0 is_shutdown=0 move_count=0
Receive: 99 170698.076778 170698.076336 12: seq: 13, shutdown clock=1944504545 static_string_id=Timer too close
Transition to shutdown state: MCU shutdown
```

I would guess the root cause is that `MCU_pwm` and `MCU_adc` use different logic to estimate the time, and the `queue_digital_out` estimates shorter timings.

idk, how I trigger that, but it seems wrong to send them in initialization order, instead of req_clock order (which is empty in this case).

From my brief checking of the code, it seems that most `add_config_cmd(,init=True)` do schedule something with a clock.
And all config phase was done either in the `_config_cmds` or `_restart_cmds`.
So, it seems that I can safely sort them by the `clock` value.

```
Sending MCU 'mcu' printer configuration...
MCU: mcu, cmd: queue_digital_out oid=21 clock=1598538126 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=22 clock=1598559007 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=23 clock=1598570670 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=24 clock=1598580012 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=26 clock=1598598157 on_ticks=520000
MCU: mcu, cmd: queue_digital_out oid=27 clock=1598616052 on_ticks=148200
MCU: mcu, cmd: queue_digital_out oid=28 clock=1598624373 on_ticks=0
MCU: mcu, cmd: queue_digital_out oid=33 clock=1598776151 on_ticks=0
MCU: mcu, cmd: query_counter oid=1 clock=2085200000 poll_ticks=156000 sample_ticks=520000000
MCU: mcu, cmd: query_counter oid=2 clock=2090400000 poll_ticks=104000 sample_ticks=520000000
MCU: mcu, cmd: query_analog_in oid=20 clock=2184000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=9031 max_value=32275 range_check_count=4
MCU: mcu, cmd: query_analog_in oid=25 clock=2210000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=3640 max_value=32275 range_check_count=4
MCU: mcu, cmd: query_analog_in oid=29 clock=2230800000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=5523 max_value=8044 range_check_count=4
MCU: mcu, cmd: query_analog_in oid=30 clock=2236000000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=32275 range_check_count=4
MCU: mcu, cmd: query_analog_in oid=32 clock=2246400000 sample_ticks=520000 sample_count=8 rest_ticks=156000000 min_value=13762 max_value=31991 range_check_count=4
```

A more sophisticated fix, probably, is to create temporary queues per oid probably, and populate the req_clock.
So, the serial queue logic can send them in the necessary order.

Hope that sounds sane.

Thanks.

---
I don't know if there is a simple way to trigger it under normal circumstances. I can show my refactoring if that makes sense. My refactoring seems to trigger it "always" for me on `FIRMWARE_RESTART`, and it seems that the above sorting fixes it.