### PR TITLE
toolhead: Simplify LookAheadQueue.flush() code

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -156,7 +156,7 @@ class LookAheadQueue:
                     # This move can both accel and decel, or this is a
                     # full accel move followed by a full decel move
                     if update_flush_count and peak_cruise_v2:
-                        flush_count = i
+                        flush_count = i + pending_cv2_assign
                         update_flush_count = False
                     peak_cruise_v2 = (mcr_start_v2 + reach_mcr_start_v2) * .5
                 cruise_v2 = min((start_v2 + reachable_start_v2) * .5


### PR DESCRIPTION
The current lookahead calculation code has a complicated system for managing an internal `delayed` queue.  Replace that with an explicit second pass through the pending move queue.

This is only intended to make the code a little easier to understand.  There should be no user visible changes.

@dmbutyugin - fyi.

-Kevin