### PR TITLE
Additional devices require i2c_write_noack()

### DIFF
--- a/klippy/extras/bus.py
+++ b/klippy/extras/bus.py
@@ -213,6 +213,9 @@ class MCU_I2C:
             "i2c_read_response oid=%c response=%*s", oid=self.oid,
             cq=self.cmd_queue)
     def i2c_write_noack(self, data, minclock=0, reqclock=0):
+        if self.i2c_write_cmd is None:
+            self._to_write.append(data)
+            return
         self.i2c_write_cmd.send([self.oid, data],
                                 minclock=minclock, reqclock=reqclock)
     def i2c_write(self, data, minclock=0, reqclock=0):

--- a/klippy/extras/pca9533.py
+++ b/klippy/extras/pca9533.py
@@ -27,8 +27,8 @@ class PCA9533:
         minclock = 0
         if print_time is not None:
             minclock = self.i2c.get_mcu().print_time_to_clock(print_time)
-        self.i2c.i2c_write([PCA9533_PLS0, ls0], minclock=minclock,
-                           reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.i2c.i2c_write_noack([PCA9533_PLS0, ls0], minclock=minclock,
+                                 reqclock=BACKGROUND_PRIORITY_CLOCK)
     def get_status(self, eventtime):
         return self.led_helper.get_status(eventtime)
 

--- a/klippy/extras/pca9632.py
+++ b/klippy/extras/pca9632.py
@@ -37,8 +37,8 @@ class PCA9632:
         if self.prev_regs.get(reg) == val:
             return
         self.prev_regs[reg] = val
-        self.i2c.i2c_write([reg, val], minclock=minclock,
-                           reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.i2c.i2c_write_noack([reg, val], minclock=minclock,
+                                 reqclock=BACKGROUND_PRIORITY_CLOCK)
     def handle_connect(self):
         #Configure MODE1
         self.reg_write(PCA9632_MODE1, 0x00)

--- a/klippy/extras/sx1509.py
+++ b/klippy/extras/sx1509.py
@@ -92,7 +92,8 @@ class SX1509(object):
             # Byte
             data += [self.reg_i_on_dict[reg] & 0xFF]
         clock = self._mcu.print_time_to_clock(print_time)
-        self._i2c.i2c_write(data, minclock=self._last_clock, reqclock=clock)
+        self._i2c.i2c_write_noack(data, minclock=self._last_clock,
+                                  reqclock=clock)
         self._last_clock = clock
 
 class SX1509_digital_out(object):


### PR DESCRIPTION
Currently, the LEDHelper() and GCodeRequestQueue() helper classes require that their callbacks do not block.  As a result, the pca9533, pca9632, and sx1509 devices need to use non-blocking i2c write calls.

@nefelim4ag - I noticed this while reviewing the flushing logic.  Basically, `toolhead.register_lookahead_callback()` and `motion_queuing.register_fush_callback()` are both expecting that the callbacks wont pause in the reactor - if a callback did, it could delay flushing and/or lead to situations where the flushing code gets called reentrant.

It's possible we could fix this another way - for example, the LEDHelper code could launch a new reactor task to handle updates.  Handling the flush callbacks is a little more tricky though.

Not sure if this would alter the plan for improving i2c error handling.

-Kevin