### PR TITLE
Report OS version in log

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -328,6 +328,7 @@ def main():
     start_args['software_version'] = git_vers
     start_args['cpu_info'] = util.get_cpu_info()
     start_args['device'] = util.get_device_info()
+    start_args['linux_version'] = util.get_linux_version()
     if bglogger is not None:
         versions = "\n".join([
             "Args: %s" % (sys.argv,),
@@ -335,6 +336,7 @@ def main():
                                    extra_git_desc),
             "CPU: %s" % (start_args['cpu_info'],),
             "Device: %s" % (start_args['device']),
+            "Linux: %s" % (start_args['linux_version']),
             "Python: %s" % (repr(sys.version),)])
         logging.info(versions)
     elif not options.debugoutput:

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -129,7 +129,7 @@ def get_device_info():
         data = _try_read_file("/sys/class/dmi/id/product_name")
         if data is None:
             return "?"
-    return data.rstrip(' \0')
+    return data.rstrip(' \0').strip()
 
 def get_version_from_file(klippy_src):
     data = _try_read_file(os.path.join(klippy_src, '.version'))

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -51,6 +51,15 @@ def create_pty(ptyname):
 # Helper code for extracting mcu build info
 ######################################################################
 
+def _try_read_file(filename, maxsize=32*1024):
+    try:
+        with open(filename, 'r') as f:
+            return f.read(maxsize)
+    except (IOError, OSError) as e:
+        logging.debug("Exception on read %s: %s", filename,
+                      traceback.format_exc())
+        return None
+
 def dump_file_stats(build_dir, filename):
     fname = os.path.join(build_dir, filename)
     try:
@@ -66,20 +75,14 @@ def dump_mcu_build():
     build_dir = os.path.join(os.path.dirname(__file__), '..')
     # Try to log last mcu config
     dump_file_stats(build_dir, '.config')
-    try:
-        f = open(os.path.join(build_dir, '.config'), 'r')
-        data = f.read(32*1024)
-        f.close()
+    data = _try_read_file(os.path.join(build_dir, '.config'))
+    if data is not None:
         logging.info("========= Last MCU build config =========\n%s"
                      "=======================", data)
-    except:
-        pass
     # Try to log last mcu build version
     dump_file_stats(build_dir, 'out/klipper.dict')
     try:
-        f = open(os.path.join(build_dir, 'out/klipper.dict'), 'r')
-        data = f.read(32*1024)
-        f.close()
+        data = _try_read_file(os.path.join(build_dir, 'out/klipper.dict'))
         data = json.loads(data)
         logging.info("Last MCU build version: %s", data.get('version', ''))
         logging.info("Last MCU build tools: %s", data.get('build_versions', ''))
@@ -111,13 +114,8 @@ setup_python2_wrappers()
 ######################################################################
 
 def get_cpu_info():
-    try:
-        f = open('/proc/cpuinfo', 'r')
-        data = f.read()
-        f.close()
-    except (IOError, OSError) as e:
-        logging.debug("Exception on read /proc/cpuinfo: %s",
-                      traceback.format_exc())
+    data = _try_read_file('/proc/cpuinfo', maxsize=1024*1024)
+    if data is None:
         return "?"
     lines = [l.split(':', 1) for l in data.split('\n')]
     lines = [(l[0].strip(), l[1].strip()) for l in lines if len(l) == 2]
@@ -126,28 +124,18 @@ def get_cpu_info():
     return "%d core %s" % (core_count, model_name)
 
 def get_device_info():
-    try:
-        path = '/proc/device-tree/model'
-        if not os.access(path, os.F_OK):
-            path = "/sys/class/dmi/id/product_name"
-            if not os.access(path, os.F_OK):
-                return "?"
-        f = open(path, 'r')
-        data = f.read()
-        f.close()
-    except (IOError, OSError) as e:
-        logging.debug("Exception on read /proc/device-tree/model: %s",
-                      traceback.format_exc())
-        return "?"
+    data = _try_read_file('/proc/device-tree/model')
+    if data is None:
+        data = _try_read_file("/sys/class/dmi/id/product_name")
+        if data is None:
+            return "?"
     return data.rstrip(' \0')
 
 def get_version_from_file(klippy_src):
-    try:
-        with open(os.path.join(klippy_src, '.version')) as h:
-            return h.read().rstrip()
-    except IOError:
-        pass
-    return "?"
+    data = _try_read_file(os.path.join(klippy_src, '.version'))
+    if data is None:
+        return "?"
+    return data.rstrip()
 
 def _get_repo_info(gitdir):
     repo_info = {"branch": "?", "remote": "?", "url": "?"}

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -131,6 +131,12 @@ def get_device_info():
             return "?"
     return data.rstrip(' \0').strip()
 
+def get_linux_version():
+    data = _try_read_file('/proc/version')
+    if data is None:
+        return "?"
+    return data.strip()
+
 def get_version_from_file(klippy_src):
     data = _try_read_file(os.path.join(klippy_src, '.version'))
     if data is None:


### PR DESCRIPTION
It's useful to have the OS Kernel version reported in the log - in particular when diagnosing issues with canbus.

@nefelim4ag - fyi.

-Kevin