### PR TITLE
Don't transition to toolhead "Priming" state on "G4" dwell

### DIFF
--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -126,6 +126,8 @@ class LookAheadQueue:
         self.junction_flush = LOOKAHEAD_FLUSH_TIME
     def set_flush_time(self, flush_time):
         self.junction_flush = flush_time
+    def is_empty(self):
+        return not self.queue
     def get_last(self):
         if self.queue:
             return self.queue[-1]
@@ -476,8 +478,7 @@ class ToolHead:
             self.print_time, max(buffer_time, 0.), self.print_stall)
     def check_busy(self, eventtime):
         est_print_time = self.mcu.estimated_print_time(eventtime)
-        lookahead_empty = not self.lookahead.queue
-        return self.print_time, est_print_time, lookahead_empty
+        return self.print_time, est_print_time, self.lookahead.is_empty()
     def get_status(self, eventtime):
         print_time = self.print_time
         estimated_print_time = self.mcu.estimated_print_time(eventtime)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -313,36 +313,39 @@ class ToolHead:
         else:
             self._process_lookahead()
         return self.print_time
+    def _check_priming_state(self, eventtime):
+        est_print_time = self.mcu.estimated_print_time(eventtime)
+        if self.check_stall_time:
+            # Was in "NeedPrime" state and got there from idle input
+            if est_print_time < self.check_stall_time:
+                self.print_stall += 1
+            self.check_stall_time = 0.
+        # Transition from "NeedPrime"/"Priming" state to "Priming" state
+        self.special_queuing_state = "Priming"
+        self.need_check_pause = -1.
+        if self.priming_timer is None:
+            self.priming_timer = self.reactor.register_timer(
+                self._priming_handler)
+        buffer_time = self.print_time - est_print_time
+        wtime = eventtime + max(0.100, buffer_time - BUFFER_TIME_HIGH)
+        self.reactor.update_timer(self.priming_timer, wtime)
     def _check_pause(self):
         eventtime = self.reactor.monotonic()
-        est_print_time = self.mcu.estimated_print_time(eventtime)
-        buffer_time = self.print_time - est_print_time
         if self.special_queuing_state:
-            if self.check_stall_time:
-                # Was in "NeedPrime" state and got there from idle input
-                if est_print_time < self.check_stall_time:
-                    self.print_stall += 1
-                self.check_stall_time = 0.
-            # Transition from "NeedPrime"/"Priming" state to "Priming" state
-            self.special_queuing_state = "Priming"
-            self.need_check_pause = -1.
-            if self.priming_timer is None:
-                self.priming_timer = self.reactor.register_timer(
-                    self._priming_handler)
-            wtime = eventtime + max(0.100, buffer_time - BUFFER_TIME_HIGH)
-            self.reactor.update_timer(self.priming_timer, wtime)
+            # In "NeedPrime"/"Priming" state - update priming expiration timer
+            self._check_priming_state(eventtime)
         # Check if there are lots of queued moves and pause if so
         while 1:
+            est_print_time = self.mcu.estimated_print_time(eventtime)
+            buffer_time = self.print_time - est_print_time
             pause_time = buffer_time - BUFFER_TIME_HIGH
             if pause_time <= 0.:
                 break
             if not self.can_pause:
                 self.need_check_pause = self.reactor.NEVER
                 return
-            eventtime = self.reactor.pause(
-                eventtime + max(.005, min(1., pause_time)))
-            est_print_time = self.mcu.estimated_print_time(eventtime)
-            buffer_time = self.print_time - est_print_time
+            pause_time = max(.005, min(1., pause_time))
+            eventtime = self.reactor.pause(eventtime + pause_time)
         if not self.special_queuing_state:
             # In main state - defer pause checking until needed
             self.need_check_pause = est_print_time + BUFFER_TIME_HIGH

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -331,6 +331,9 @@ class ToolHead:
             self.printer.invoke_shutdown("Exception in priming_handler")
         return self.reactor.NEVER
     def _check_priming_state(self, eventtime):
+        if self.lookahead.is_empty():
+            # In "NeedPrime" state and can remain there
+            return
         est_print_time = self.mcu.estimated_print_time(eventtime)
         if self.check_stall_time:
             # Was in "NeedPrime" state and got there from idle input


### PR DESCRIPTION
A `G4` command will currently cause the toolhead code to transition to a "NeedPrime" state and then immediately to a "Priming" state.  That is, it'll register a timer to call `_priming_handler()` to flush any pending moves, but there are no moves to flush.  That behavior is a little surprising so avoid it by staying in the "NeedPrime" state after a dwell.

-Kevin