### PR TITLE
Enhance reactor to support temporarily disabling pauses

### DIFF
--- a/klippy/extras/load_cell.py
+++ b/klippy/extras/load_cell.py
@@ -383,7 +383,7 @@ class LoadCell:
         # startup, when klippy is ready, start capturing data
         printer.register_event_handler("klippy:ready", self._handle_ready)
 
-    def _handle_ready(self):
+    def _handle_do_ready(self, eventtime):
         self.sensor.add_client(self._sensor_data_event)
         self.add_client(self._track_force)
         # announce calibration status on ready
@@ -391,6 +391,8 @@ class LoadCell:
             self.printer.send_event("load_cell:calibrate", self)
         if self.is_tared():
             self.printer.send_event("load_cell:tare", self)
+    def _handle_ready(self):
+        self.printer.get_reactor().register_callback(self._handle_do_ready)
 
     # convert raw counts to grams and broadcast to clients
     def _sensor_data_event(self, msg):

--- a/klippy/extras/motion_queuing.py
+++ b/klippy/extras/motion_queuing.py
@@ -139,8 +139,9 @@ class PrinterMotionQueuing:
         step_gen_time = max(want_step_gen_time, self.last_step_gen_time,
                             flush_time)
         # Invoke flush callbacks (if any)
-        for cb in self.flush_callbacks:
-            cb(flush_time, step_gen_time)
+        with self.reactor.assert_no_pause():
+            for cb in self.flush_callbacks:
+                cb(flush_time, step_gen_time)
         # Determine maximum history to keep
         trapq_free_time = step_gen_time - self.kin_flush_delay
         clear_history_time = self.clear_history_time

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -158,10 +158,11 @@ class Printer:
             return
         try:
             self._set_state(message_ready)
-            for cb in self.event_handlers.get("klippy:ready", []):
-                if self.state_message is not message_ready:
-                    return
-                cb()
+            with self.reactor.assert_no_pause():
+                for cb in self.event_handlers.get("klippy:ready", []):
+                    if self.state_message is not message_ready:
+                        return
+                    cb()
         except Exception as e:
             logging.exception("Unhandled exception during ready callback")
             self.invoke_shutdown("Internal error during ready callback: %s"

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -206,11 +206,12 @@ class Printer:
         logging.error("Transition to shutdown state: %s", msg)
         self.in_shutdown_state = True
         self._set_state(msg)
-        for cb in self.event_handlers.get("klippy:shutdown", []):
-            try:
-                cb()
-            except:
-                logging.exception("Exception during shutdown handler")
+        with self.reactor.assert_no_pause():
+            for cb in self.event_handlers.get("klippy:shutdown", []):
+                try:
+                    cb()
+                except:
+                    logging.exception("Exception during shutdown handler")
         logging.info("Reactor garbage collection: %s",
                      self.reactor.get_gc_stats())
         self.send_event("klippy:notify_mcu_shutdown", msg, details)

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -10,6 +10,9 @@ import chelper, util
 _NOW = 0.
 _NEVER = 9999999999999999.
 
+class ReactorError(Exception):
+    pass
+
 class ReactorTimer:
     def __init__(self, callback, waketime):
         self.callback = callback
@@ -90,6 +93,14 @@ class ReactorMutex:
         self.next_pending = True
         self.reactor.update_timer(self.queue[0].timer, self.reactor.NOW)
 
+class ReactorPreventPause:
+    def __init__(self, reactor):
+        self.reactor = reactor
+    def __enter__(self):
+        self.reactor._prevent_pause_count += 1
+    def __exit__(self, type=None, value=None, tb=None):
+        self.reactor._prevent_pause_count -= 1
+
 class SelectReactor:
     NOW = _NOW
     NEVER = _NEVER
@@ -118,6 +129,7 @@ class SelectReactor:
         self._g_dispatch = None
         self._greenlets = []
         self._all_greenlets = []
+        self._prevent_pause_count = 0
     def get_gc_stats(self):
         return tuple(self._last_gc_times)
     # Timers
@@ -219,8 +231,12 @@ class SelectReactor:
             if self._g_dispatch is None:
                 return self._sys_pause(waketime)
             # Switch to _check_timers (via g.timer.callback return)
+            if self._prevent_pause_count:
+                self.verify_can_pause()
             return self._g_dispatch.switch(waketime)
         # Pausing the dispatch greenlet - prepare a new greenlet to do dispatch
+        if self._prevent_pause_count:
+            self.verify_can_pause()
         if self._greenlets:
             g_next = self._greenlets.pop()
         else:
@@ -242,6 +258,12 @@ class SelectReactor:
         self._g_dispatch.switch(self.NEVER)
         # This greenlet reactivated from pause() - return to main dispatch loop
         self._g_dispatch = g_old
+    # Temporarily disabling pause support
+    def assert_no_pause(self):
+        return ReactorPreventPause(self)
+    def verify_can_pause(self):
+        if self._prevent_pause_count:
+            raise ReactorError("Internal error - reactor pause disabled")
     # Mutexes
     def mutex(self, is_locked=False):
         return ReactorMutex(self, is_locked)
@@ -301,6 +323,7 @@ class SelectReactor:
         if self._pipe_fds is None:
             self._setup_async_callbacks()
         self._process = True
+        self._prevent_pause_count = 0
         g_next = ReactorGreenlet(run=self._dispatch_loop)
         self._all_greenlets.append(g_next)
         g_next.switch()

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -273,21 +273,22 @@ class ToolHead:
             self._calc_print_time()
         # Queue moves into trapezoid motion queue (trapq)
         next_move_time = self.print_time
-        for move in moves:
-            if move.is_kinematic_move:
-                self.trapq_append(
-                    self.trapq, next_move_time,
-                    move.accel_t, move.cruise_t, move.decel_t,
-                    move.start_pos[0], move.start_pos[1], move.start_pos[2],
-                    move.axes_r[0], move.axes_r[1], move.axes_r[2],
-                    move.start_v, move.cruise_v, move.accel)
-            for e_index, ea in enumerate(self.extra_axes):
-                if move.axes_d[e_index + 3]:
-                    ea.process_move(next_move_time, move, e_index + 3)
-            next_move_time = (next_move_time + move.accel_t
-                              + move.cruise_t + move.decel_t)
-            for cb in move.timing_callbacks:
-                cb(next_move_time)
+        with self.reactor.assert_no_pause():
+            for move in moves:
+                if move.is_kinematic_move:
+                    self.trapq_append(
+                        self.trapq, next_move_time,
+                        move.accel_t, move.cruise_t, move.decel_t,
+                        move.start_pos[0], move.start_pos[1], move.start_pos[2],
+                        move.axes_r[0], move.axes_r[1], move.axes_r[2],
+                        move.start_v, move.cruise_v, move.accel)
+                for e_index, ea in enumerate(self.extra_axes):
+                    if move.axes_d[e_index + 3]:
+                        ea.process_move(next_move_time, move, e_index + 3)
+                next_move_time = (next_move_time + move.accel_t
+                                  + move.cruise_t + move.decel_t)
+                for cb in move.timing_callbacks:
+                    cb(next_move_time)
         # Generate steps for moves
         self._advance_move_time(next_move_time)
         self.motion_queuing.note_mcu_movequeue_activity(next_move_time)


### PR DESCRIPTION
There are some low-level parts of the code where pausing the current task could result in subtle errors.  For example, if a callback called from `toolhead.register_lookahead_callback()` were to pause it could result in the toolhead being called reentrant which could corrupt its internal state.

Add a new `reactor.assert_no_pause()` helper that can be used to verify that a block of code never attempts to pause the current task.  If something does then the reactor will raise an error.

The goal of this change is to make it easier to track down subtle issues like this.  Instead of subtly corrupting state, the log should show a clear error trace of the problem.

This PR adds the check to four low-level mechanisms: "klippy:shutdown" event handlers, "klippy:ready" event handlers, `motion_queuing.register_flush_callback()` callbacks, and `toolhead.register_lookahead_callback()` callbacks.

This feature was discussed at #7067.

@nefelim4ag - FYI.

-Kevin