### PR TITLE
spi_temperature.py: add tc_report_time option

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2906,6 +2906,9 @@ sensor_pin:
 #   The above parameters control the sensor parameters of MAX31856
 #   chips. The defaults for each parameter are next to the parameter
 #   name in the above list.
+#tc_report_time: 0.3
+#   Interval in seconds between readings. Minimum is 0.1, maximum
+#   is 1.5
 #rtd_nominal_r: 100
 #rtd_reference_r: 430
 #rtd_num_of_wires: 2

--- a/klippy/extras/spi_temperature.py
+++ b/klippy/extras/spi_temperature.py
@@ -5,14 +5,13 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math, logging
-from . import bus
+from . import bus, heaters
 
 
 ######################################################################
 # SensorBase
 ######################################################################
 
-REPORT_TIME = 0.300
 MAX_INVALID_COUNT = 3
 
 class SensorBase:
@@ -22,6 +21,9 @@ class SensorBase:
         self._callback = None
         self.min_sample_value = self.max_sample_value = 0
         self._report_clock = 0
+        self._report_time = config.getfloat(
+            "tc_report_time", default=0.3, minval=0.1,
+            maxval=heaters.MAX_HEAT_TIME/2)
         self.spi = bus.MCU_SPI_from_config(
             config, spi_mode, pin_option="sensor_pin", default_speed=4000000)
         if config_cmd is not None:
@@ -39,13 +41,13 @@ class SensorBase:
     def setup_callback(self, cb):
         self._callback = cb
     def get_report_time_delta(self):
-        return REPORT_TIME
+        return self._report_time
     def _build_config(self):
         self.mcu.add_config_cmd(
             "config_thermocouple oid=%u spi_oid=%u thermocouple_type=%s" % (
                 self.oid, self.spi.get_oid(), self.chip_type))
         clock = self.mcu.get_query_slot(self.oid)
-        self._report_clock = self.mcu.seconds_to_clock(REPORT_TIME)
+        self._report_clock = self.mcu.seconds_to_clock(self._report_time)
         self.mcu.add_config_cmd(
             "query_thermocouple oid=%u clock=%u rest_ticks=%u"
             " min_value=%u max_value=%u max_invalid_count=%u" % (


### PR DESCRIPTION
I wanted to set `pwm_cycle_time` to a somewhat higher value than the default (0.1s) since the low cycle time in combination with a zero-crossing SSR caused a slightly noticable flickering of my lights. However, `pwm_cycle_time` is not allowed to be set to a higher value than the REPORT_TIME of the temperature sensor, which is 0.3s. I would like to be able to increase this value in the config file.

Another advantage is that people can set a much lower report time for a better response time. This could probably be useful for hotends with a very low heat capacity.

This PR only adds a `tc_report_time` option for the SPI sensors. But adding a report_time option to all sensor would probably be preferred?