### PR TITLE
probe_eddy_current: make PROBE work with scan method

### DIFF
--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -133,6 +133,10 @@ class ProbeCommandHelper:
             # Probe position
             probe_session.run_probe(fo_gcmd)
             probe_num += 1
+            method = gcmd.get('METHOD', 'automatic').lower()
+            if method in ('scan', 'rapid_scan'):
+                # there is no move and no sense to retract
+                continue
             # Retract
             pos = toolhead.get_position()
             liftpos = [None, None, pos[2] + params['sample_retract_dist']]

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -203,6 +203,9 @@ class EddyGatherSamples:
         self._printer = printer
         self._sensor_helper = sensor_helper
         self._calibration = calibration
+        self._is_scan_probe = False
+        if z_offset is None:
+            self._is_scan_probe = True
         self._z_offset = z_offset
         # Results storage
         self._samples = []
@@ -277,6 +280,11 @@ class EddyGatherSamples:
             if freq:
                 sensor_z = self._calibration.freq_to_height(freq)
             self._probe_results.append((sensor_z, toolhead_pos))
+            if self._is_scan_probe and sensor_z:
+                epos = toolhead_pos
+                gcode = self._printer.lookup_object('gcode')
+                gcode.respond_info("probe at %.3f,%.3f is z=%.6f, freq=%.3f"
+                                   % (epos[0], epos[1], sensor_z, freq))
             self._probe_times.pop(0)
     def pull_probed(self):
         self._await_samples()
@@ -288,6 +296,10 @@ class EddyGatherSamples:
             if sensor_z <= -OUT_OF_RANGE or sensor_z >= OUT_OF_RANGE:
                 raise self._printer.command_error(
                     "probe_eddy_current sensor not in valid range")
+            if self._is_scan_probe:
+                toolhead_pos[2] = sensor_z
+                results.append(toolhead_pos)
+                continue
             # Callers expect position relative to z_offset, so recalculate
             bed_deviation = toolhead_pos[2] - sensor_z
             toolhead_pos[2] = self._z_offset + bed_deviation
@@ -410,7 +422,11 @@ class EddyScanningProbe:
         self._printer = printer
         self._sensor_helper = sensor_helper
         self._calibration = calibration
-        self._z_offset = z_offset
+        self._is_probe = True
+        if gcmd.get_command() in ('BED_MESH_CALIBRATE', 'Z_TILT_ADJUST'):
+            self._is_probe = False
+        else:
+            z_offset = None
         self._gather = EddyGatherSamples(printer, sensor_helper,
                                          calibration, z_offset)
         self._sample_time_delay = 0.050
@@ -422,12 +438,20 @@ class EddyScanningProbe:
             start_time, start_time + self._sample_time, printtime)
     def run_probe(self, gcmd):
         toolhead = self._printer.lookup_object("toolhead")
-        if self._is_rapid:
+        if self._is_rapid and not self._is_probe:
             toolhead.register_lookahead_callback(self._rapid_lookahead_cb)
             return
-        printtime = toolhead.get_last_move_time()
-        toolhead.dwell(self._sample_time_delay + self._sample_time)
-        start_time = printtime + self._sample_time_delay
+        if not self._is_probe:
+            printtime = toolhead.get_last_move_time()
+            toolhead.dwell(self._sample_time_delay + self._sample_time)
+            start_time = printtime + self._sample_time_delay
+        else:
+            reactor = self._printer.get_reactor()
+            curtime = reactor.monotonic()
+            mcu = self._sensor_helper.get_mcu()
+            printtime = mcu.estimated_print_time(curtime)
+            start_time = printtime
+            reactor.pause(curtime + self._sample_time)
         self._gather.note_probe_and_position(
             start_time, start_time + self._sample_time, start_time)
     def pull_probed_results(self):


### PR DESCRIPTION
Probe interface supports passing different params.
One of them is the `METHOD`.
It is possible to do:
```
PROBE METHOD=scan
PROBE_ACCURACY METHOD=scan
```

Alas, right now they are not working as expected:
- PROBE METHOD=scan - may work, but always returns something +- z_offset which is confusing.
- PROBE_ACCURACY METHOD=scan - retracts and errors out (out of range)

With those changes, it is now possible to do `PROBE` and `PROBE_ACCURACY` with `METHOD=scan` (or `rapid_scan`).
And they would output the actual position where the bed is according to the sensor:
```
$ PROBE METHOD=scan
// probe at 389.980,360.380 is z=1.448167
// Result is z=1.448167
$ GET_POSITION
...
// kinematic: X:389.979687 Y:360.379687 Z:1.500217
// toolhead: X:389.980000 Y:360.380000 Z:1.500000 E:0.000000
// gcode: X:389.980000 Y:360.380000 Z:1.425455 E:0.000000
// gcode base: X:0.000000 Y:0.000000 Z:0.000000 E:0.000000
// gcode homing: X:0.000000 Y:0.000000 Z:0.000000
$ G91
$ G1 Z1
$ PROBE_ACCURACY METHOD=rapid_scan
// PROBE_ACCURACY at X:389.980 Y:360.380 Z:2.495 (samples=10 retract=3.000 speed=3.0 lift_speed=10.0)
// probe at 389.980,360.380 is z=2.442066
// probe at 389.980,360.380 is z=2.442031
// probe at 389.980,360.380 is z=2.442113
// probe at 389.980,360.380 is z=2.442045
// probe at 389.980,360.380 is z=2.442041
// probe at 389.980,360.380 is z=2.442062
// probe at 389.980,360.380 is z=2.442075
// probe at 389.980,360.380 is z=2.442095
// probe at 389.980,360.380 is z=2.442131
// probe at 389.980,360.380 is z=2.442086
// probe accuracy results: maximum 2.442131, minimum 2.442031, range 0.000100, average 2.442074, median 2.442070, standard deviation 0.000031
```

It allows me, instead of explaining what LDC1612 does, to just suggest running this.
As a bonus, it should allow for homing by probe.

(It does not change the behaviour of BED_MESH or Z_TILT, not sure if there are other things to exclude).

Thanks.