### PR TITLE
probe_eddy_current: runtime calibration curve adjustment

### DIFF
--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -18,6 +18,7 @@ class EddyCalibration:
         # Current calibration data
         self.cal_freqs = []
         self.cal_zpos = []
+        self._cal_zpos_offset = .0
         cal = config.get('calibrate', None)
         if cal is not None:
             cal = [list(map(float, d.strip().split(':', 1)))
@@ -34,6 +35,10 @@ class EddyCalibration:
         gcode.register_command('Z_OFFSET_APPLY_PROBE',
                                self.cmd_Z_OFFSET_APPLY_PROBE,
                                desc=self.cmd_Z_OFFSET_APPLY_PROBE_help)
+        gcode.register_mux_command('PROBE_EDDY_CURRENT_CALIBRATION_OFFSET',
+                                    "CHIP", cname,
+                                    self.cmd_CALIBRATION_OFFSET,
+                                    desc=self.cmd_CALIBRATION_OFFSET_help)
     def get_printer(self):
         return self.printer
     def verify_calibrated(self):
@@ -62,6 +67,7 @@ class EddyCalibration:
                 gain = (this_zpos - prev_zpos) / (this_freq - prev_freq)
                 offset = prev_zpos - prev_freq * gain
                 zpos = adj_freq * gain + offset
+            zpos += self._cal_zpos_offset
             samples[i] = (samp_time, freq, round(zpos, 6))
     def freq_to_height(self, freq):
         dummy_sample = [(0., freq, 0.)]
@@ -277,6 +283,15 @@ class EddyCalibration:
         z_freq_pairs = zip(cal_zpos, self.cal_freqs)
         z_freq_pairs = sorted(z_freq_pairs)
         self._save_calibration(z_freq_pairs)
+    cmd_CALIBRATION_OFFSET_help = "Runtime curve height adjustment"
+    def cmd_CALIBRATION_OFFSET(self, gcmd):
+        is_update = gcmd.get('OFFSET', None)
+        if is_update is None:
+            msg = "Calibration OFFSET=%.6f" % self._cal_zpos_offset
+            gcmd.respond_info(msg)
+            return
+        self._cal_zpos_offset = gcmd.get_float("OFFSET", minval=-0.5,
+                                               maxval=0.5)
     def register_drift_compensation(self, comp):
         self.drift_comp = comp
 


### PR DESCRIPTION
Eddy coils without temperature compensation will suffer from temperature drift.
Proportional to the sensor to bed distance.
Make non-tap methods useful by adding configurable offset correction.

Example macro:
```
[gcode_macro _ADJ_SCAN_FROM_TAP]
gcode:
    {% set OFFSET = printer.probe.last_probe_position.z %}
    PROBE_EDDY_CURRENT_CALIBRATION_OFFSET CHIP=ldc1612 OFFSET={OFFSET}

[gcode_macro SET_SCAN_FROM_TAP]
gcode:
    SET_Z_FROM_PROBE METHOD=tap
    # Move to the tap point
    {% set is_absolute = printer.gcode_move.absolute_coordinates %}
    G90
    {% set cf = printer.configfile.settings %}
    {% set eddy = cf["probe_eddy_current ldc1612"] %}
    {% set amap = printer.gcode_move.axis_map %}
    {% set tpos = printer.gcode_move.position %}
    G0 Z5 F300 # Z-Hop
    G0 Y{tpos[amap["Y"]] - eddy.y_offset} X{tpos[amap["X"]] - eddy.x_offset} F3000
    G0 Z{eddy.z_offset} F300
    PROBE METHOD=scan
    _ADJ_SCAN_FROM_TAP
    {% if not is_absolute %}
    G91
    {% endif %}
```

Because thermal drift is non-linear, for scan/rapid_scan,
it is only valid if BED_MESH_CALIBRATE happens at ~ `z_offset` height.

So, it can be used like that in the start macro:
```
    SET_SCAN_FROM_TAP
    # For best results should match the previous command "scan" height
    {% set scan_height = printer.configfile.settings["probe_eddy_current ldc1612"].z_offset  %}
    BED_MESH_CALIBRATE ADAPTIVE=1 METHOD=scan HORIZONTAL_MOVE_Z={scan_height}
```   

---
Child of: #7125
