### PR TITLE
Update FLASH_SIZE defaults for STM32F103x6

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -219,9 +219,9 @@ config CLOCK_FREQ
 
 config FLASH_SIZE
     hex
-    default 0x8000 if MACH_STM32F031 || MACH_STM32F042 || MACH_STM32F070x6
+    default 0x8000 if MACH_STM32F031 || MACH_STM32F042 || MACH_STM32F070x6 || MACH_STM32F103x6
     default 0x20000 if (MACH_STM32F070 || MACH_STM32F072) && !MACH_STM32F070x6
-    default 0x10000 if MACH_STM32F103 || MACH_STM32L412 # Flash size of stm32f103x8 (64KiB)
+    default 0x10000 if (MACH_STM32F103 && !MACH_STM32F103x6) || MACH_STM32L412 # Flash size of stm32f103x8 (64KiB)
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401 || MACH_STM32H723
     default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x20000 if MACH_STM32G0 || MACH_STM32G431
@@ -291,21 +291,21 @@ choice
     config STM32_FLASH_START_2000
         bool "8KiB bootloader" if MACH_STM32F1 || MACH_STM32F070 || MACH_STM32G0 || MACH_STM32G4 || MACH_STM32F0x2
     config STM32_FLASH_START_5000
-        bool "20KiB bootloader" if MACH_STM32F103
+        bool "20KiB bootloader" if MACH_STM32F103 && !MACH_STM32F103x6
     config STM32_FLASH_START_7000
-        bool "28KiB bootloader" if MACH_STM32F1
+        bool "28KiB bootloader" if MACH_STM32F1 && !MACH_STM32F103x6
     config STM32_FLASH_START_8000
-        bool "32KiB bootloader" if MACH_STM32F1 || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7
+        bool "32KiB bootloader" if (MACH_STM32F1 && !MACH_STM32F103x6) || MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7
     config STM32_FLASH_START_8800
-        bool "34KiB bootloader" if MACH_STM32F103
+        bool "34KiB bootloader" if MACH_STM32F103 && !MACH_STM32F103x6
     config STM32_FLASH_START_20200
         bool "128KiB bootloader with 512 byte offset" if MACH_STM32F4x5
     config STM32_FLASH_START_9000
-        bool "36KiB bootloader" if MACH_STM32F1
+        bool "36KiB bootloader" if MACH_STM32F1 && !MACH_STM32F103x6
     config STM32_FLASH_START_C000
         bool "48KiB bootloader" if MACH_STM32F4x5 || MACH_STM32F401
     config STM32_FLASH_START_10000
-        bool "64KiB bootloader" if MACH_STM32F103 || MACH_STM32F4 || MACH_N32G45x
+        bool "64KiB bootloader" if (MACH_STM32F103 && !MACH_STM32F103x6) || MACH_STM32F4 || MACH_N32G45x
 
     config STM32_FLASH_START_800
         bool "2KiB bootloader" if MACH_STM32F103


### PR DESCRIPTION
1.For STM32F103x6, which has only 32KB of flash and 10KB of RAM, modify FLASH_SIZE to 0x8000. 
2.Disable bootloader size bigger then 16KB for STM32F103x6
<img width="1317" height="1342" alt="image" src="https://github.com/user-attachments/assets/ec703a67-a4c1-4f5b-9e7a-db28397b7793" />
