### PR TITLE
temperature_probe: use tap for calibration

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1578,13 +1578,15 @@ The following commands are available when a
 is enabled.
 
 #### TEMPERATURE_PROBE_CALIBRATE
-`TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]`:
+`TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]
+[METHOD=<method>]`:
 Initiates probe drift calibration for eddy current based probes.  The `TARGET`
 is a target temperature for the last sample.  When the temperature recorded
 during a sample exceeds the `TARGET` calibration will complete.  The `STEP`
 parameter sets temperature delta (in C) between samples. After a sample has
 been taken, this delta is used to schedule a call to `TEMPERATURE_PROBE_NEXT`.
-The default `STEP` is 2.
+The default `STEP` is 2. The `METHOD` only supports `tap` as an option,
+if specified, probing will be automated.
 
 #### TEMPERATURE_PROBE_NEXT
 `TEMPERATURE_PROBE_NEXT`: After calibration has started this command is run to

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1584,13 +1584,15 @@ The following commands are available when a
 is enabled.
 
 #### TEMPERATURE_PROBE_CALIBRATE
-`TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]`:
+`TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]
+[METHOD=<method>]`:
 Initiates probe drift calibration for eddy current based probes.  The `TARGET`
 is a target temperature for the last sample.  When the temperature recorded
 during a sample exceeds the `TARGET` calibration will complete.  The `STEP`
 parameter sets temperature delta (in C) between samples. After a sample has
 been taken, this delta is used to schedule a call to `TEMPERATURE_PROBE_NEXT`.
-The default `STEP` is 2.
+The default `STEP` is 2. The `METHOD` only supports `tap` as an option,
+if specified, probing will be automated.
 
 #### TEMPERATURE_PROBE_NEXT
 `TEMPERATURE_PROBE_NEXT`: After calibration has started this command is run to

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -120,6 +120,7 @@ class TemperatureProbe:
         self.last_temp_read_time = 0.
         self.last_measurement = (0., 99999999., 0.,)
         # Calibration State
+        self._method = "manual"
         self.cal_helper = None
         self.next_auto_temp = 99999999.
         self.target_temp = 0
@@ -348,7 +349,19 @@ class TemperatureProbe:
     cmd_TEMPERATURE_PROBE_CALIBRATE_help = (
         "Calibrate probe temperature drift compensation"
     )
+    def _auto_probe(self, gcmd):
+        fo_params = dict(gcmd.get_command_parameters())
+        fo_params['METHOD'] = self._method
+        gcode = self.printer.lookup_object('gcode')
+        fo_gcmd = gcode.create_gcode_command("PROBE", "PROBE", fo_params)
+        pprobe = self.printer.lookup_object("probe")
+        probe_session = pprobe.start_probe_session(fo_gcmd)
+        probe_session.run_probe(fo_gcmd)
+        pos = probe_session.pull_probed_results()[0]
+        probe_session.end_probe_session()
+        self._manual_probe_finalize(pos)
     def cmd_TEMPERATURE_PROBE_CALIBRATE(self, gcmd):
+        self._method = gcmd.get('METHOD', 'manual').lower()
         if self.cal_helper is None:
             raise gcmd.error(
                 "No calibration helper registered for [%s]"
@@ -411,6 +424,9 @@ class TemperatureProbe:
         # Capture start position and begin initial probe
         toolhead = self.printer.lookup_object("toolhead")
         self.start_pos = toolhead.get_position()[:2]
+        if self._method == "tap":
+            self._auto_probe(gcmd)
+            return
         manual_probe.ManualProbeHelper(
             self.printer, gcmd, self._manual_probe_finalize
         )
@@ -433,6 +449,9 @@ class TemperatureProbe:
         curpos[2] = start_z
         toolhead.manual_move(curpos, probe_speed)
         self.gcode.register_command("ABORT", None)
+        if self._method == "tap":
+            self._auto_probe(gcmd)
+            return
         manual_probe.ManualProbeHelper(
             self.printer, gcmd, self._manual_probe_finalize
         )


### PR DESCRIPTION
On the other side of the coin, if the tap works correctly and returns a reliable offset.
Temperature compensation calibration can be fully automated.

```
TEMPERATURE_PROBE_CALIBRATE PROBE=ldc1612 TARGET=50 METHOD=tap
```

I have zero experience with temperature compensation (this was my first successful attempt),
I need time to check if everything works correctly.

Thanks,
-Timofey