### PR TITLE
docs: Corrected the z_thermal_adjust example

### DIFF
--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -360,11 +360,12 @@ Set up z_thermal_adjust to reference the `extruder` as the source of temperature
 data. E.g.:
 
 ```
-[z_thermal_adjust nozzle]
+[z_thermal_adjust]
 temp_coeff=-0.00045455
 sensor_type: temperature_combined
 sensor_list: extruder
 combination_method: max
+maximum_deviation: 999
 min_temp: 0
 max_temp: 400
 max_z_adjustment: 0.1


### PR DESCRIPTION
Hello,

I was playing around with z_thermal_adjust and noticed that the example in the LoadCell document leads to syntax errors. 

This pull request corrects the example. Works with my Voron.

Best regards,
freakyDude