### PR TITLE
config: define generic_cartesian corexy example

### DIFF
--- a/config/example-generic-caretesian-corexy.cfg
+++ b/config/example-generic-caretesian-corexy.cfg
@@ -1,0 +1,96 @@
+# This file is an example config file for cartesian style printers.
+# One may copy and edit this file to configure a new printer with
+# a generic cartesian kinematics.
+
+# DO NOT COPY THIS FILE WITHOUT CAREFULLY READING AND UPDATING IT
+# FIRST. Incorrectly configured parameters may cause damage.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+[carriage carriage_x]
+axis: x
+position_endstop: 0
+position_max: 300
+homing_speed: 50
+endstop_pin: ^PE5
+
+[carriage carriage_y]
+axis: y
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+endstop_pin: ^PJ1
+
+[carriage carriage_z]
+axis: z
+position_endstop: 0.5
+position_max: 100
+endstop_pin: ^PD3
+
+[stepper my_stepper_a] # stepper_x
+carriages: carriage_x+carriage_y
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+
+[stepper my_stepper_b] # stepper_y
+carriages: carriage_x-carriage_y
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+
+[stepper my_stepper_z0]
+carriages: carriage_z
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+
+[stepper my_stepper_z1]
+carriages: carriage_z
+step_pin: PG1
+dir_pin: PG0
+enable_pin: !PH3
+microsteps: 16
+rotation_distance: 8
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 110
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: generic_cartesian
+max_velocity: 500
+max_accel: 3000
+max_z_velocity: 20
+max_z_accel: 100


### PR DESCRIPTION
Simply config reference for CoreXY over generic_cartesian.
Where it should be pretty straightforward to add additional steppers to enable a ratrig-like hybrid CoreXY kinematics.

I did one print after the migration :D

_I personally like generic cartesian defenitions for CoreXY over existing CoreXY, because there is no inherently confusing stepper_x and stepper_y definitions._

Thanks,
-Timofey

Ref: https://klipper.discourse.group/t/support-for-hybrid-corexy/25641

---
Where RatRig style hybrid probably should work with additional:
```
[stepper stepper_y0]
carriage: carriage_y

[stepper stepper_y1]
carriage: carriage_y
```