### PR TITLE
tmc: use query slots for periodic checks

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -191,6 +191,9 @@ class TMCErrorCheck:
             return
         self.printer.get_reactor().unregister_timer(self.check_timer)
         self.check_timer = None
+    def get_query_slot(self):
+        oid = self.mcu_tmc.get_oid()
+        return oid * 0.01
     def start_checks(self):
         if self.check_timer is not None:
             self.stop_checks()
@@ -201,8 +204,9 @@ class TMCErrorCheck:
                                                  try_clear=self.clear_gstat)
         reactor = self.printer.get_reactor()
         curtime = reactor.monotonic()
+        slot = self.get_query_slot()
         self.check_timer = reactor.register_timer(self._do_periodic_check,
-                                                  curtime + 1.)
+                                                  curtime + 1. + slot)
         if cleared_flags:
             reset_mask = self.fields.all_fields["GSTAT"]["reset"]
             if cleared_flags & reset_mask:

--- a/klippy/extras/tmc2130.py
+++ b/klippy/extras/tmc2130.py
@@ -234,6 +234,8 @@ class MCU_TMC_SPI_chain:
         return (pr[1] << 24) | (pr[2] << 16) | (pr[3] << 8) | pr[4]
     def get_mcu(self):
         return self.spi.get_mcu()
+    def get_oid(self):
+        return self.spi.get_oid()
 
 # Helper to setup an spi daisy chain bus from settings in a config section
 def lookup_tmc_spi_chain(config):
@@ -296,6 +298,8 @@ class MCU_TMC_SPI:
         return self.tmc_frequency
     def get_mcu(self):
         return self.tmc_spi.get_mcu()
+    def get_oid(self):
+        return self.tmc_spi.get_oid()
 
 
 ######################################################################

--- a/klippy/extras/tmc2660.py
+++ b/klippy/extras/tmc2660.py
@@ -233,6 +233,8 @@ class MCU_TMC2660_SPI:
         return None
     def get_mcu(self):
         return self.spi.get_mcu()
+    def get_oid(self):
+        return self.spi.get_oid()
 
 
 ######################################################################

--- a/klippy/extras/tmc_uart.py
+++ b/klippy/extras/tmc_uart.py
@@ -189,6 +189,8 @@ class MCU_TMC_uart_bitbang:
         self.tmcuart_send_cmd.send([self.oid, msg, 0], minclock=minclock)
     def get_mcu(self):
         return self.mcu
+    def get_oid(self):
+        return self.oid
 
 # Lookup a (possibly shared) tmc uart
 def lookup_tmc_uart_bitbang(config, max_addr):
@@ -265,3 +267,5 @@ class MCU_TMC_uart:
         return self.tmc_frequency
     def get_mcu(self):
         return self.mcu_uart.get_mcu()
+    def get_oid(self):
+        return self.mcu_uart.get_oid()


### PR DESCRIPTION
This is just a small optimization to reduce periodic timers blocking.
The code mimics the MCU initialization query slots.

An absolute example is to have 8 UART drivers on one board, where all the motors are enabled at the same time.
(4Z + XY AWD)

Then, all of them would schedule every second, all of them block at the same time on the mutex, add to the waiting list, then unblock one by one, and so every second.

On my system, SPI drivers take about 1ms, and UART drivers take about 8 ms to do the queries.

_It probably makes sense to change the query slot size slightly, or adjust it for SPI/UART, not sure._
_Because it is possible, though, that UART drives can take slightly longer to query than in my setup_

Thanks,
-Timofey

---
_Pre-history:
Initially, I got here because I've encountered `RecursionError` (once?), and I had an assumption that it was somehow related to greenlets, pauses, and maybe stack size is accumulating somewhere inside, but I doubt it_
_And because of this one heavy patched setup with RecursionErrors in random places: https://discord.com/channels/431557959978450984/1472825046883111043_

_Right now, as far as I understand, greenlets' stack length does not sum up_
_Regardless, I hope the query slots make sense on their own_

UPD: it is a gcode_button bouncing around and creating too many callbacks blocked by the gcode mutex
```
[gcode_button button_test]
pin: PG15 # tachometer pin
press_gcode: 
debounce_delay: 0.002
```
And `G4 P10000` 

Not sure how to fix it =\