### PR TITLE
gcode_button: ignore empty templates

### DIFF
--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -40,7 +40,10 @@ class GCodeButton:
         if not state:
             template = self.release_template
         try:
-            self.gcode.run_script(template.render())
+            commands = template.render()
+            if not commands.strip():
+                return
+            self.gcode.run_script(commands)
         except:
             logging.exception("Script running error")
 


### PR DESCRIPTION
A bouncing button can generate a lot of pending G-code
Each G-Code command will lock on the G-Code mutex
Which will crash Python eventually with:
RecursionError: maximum recursion depth exceeded

If at least one template is empty,
ignoring the G-code execution reduces the probability in half

How to reproduce:
```
[gcode_button button_test]
pin: PG15 # tachometer pin
press_gcode: 
debounce_delay: 0.002
```

Enable the fan or any other clock output that can trigger the G-code button.
Then one can run: `G4 P10000` or any command which blocks the mutex long enough (heater wait, bed mesh & etc)

_In my local tests, the button has been triggered about every 10ms._

Thanks,
-Timofey

Reported: https://discord.com/channels/431557959978450984/1472825046883111043
_In the above topic, the G-code button status is used to determine if the toolhead is attached or not, and a magnetic coupling is just bouncing around._
Ref: #7222

---
On second thought, I don't think that any amount of pending events larger than N makes any practical sense, unless someone tries to count the number of events. So, it should be relatively safe to block the addition of new G-code commands on the mutex.

_The other way around is to create the real G-code command queue inside, so one can stack them indefinitely. Not sure._