### PR TITLE
Increase Default Frequency Limits for Resonance Testing and Input Shaper Max Shaper Freq

### DIFF
--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -57,7 +57,7 @@ def _parse_axis(gcmd, raw_axis):
 class VibrationPulseTestGenerator:
     def __init__(self, config):
         self.min_freq = config.getfloat('min_freq', 5., minval=1.)
-        self.max_freq = config.getfloat('max_freq', 135.,
+        self.max_freq = config.getfloat('max_freq', 200.,
                                         minval=self.min_freq, maxval=300.)
         self.max_freq_z = config.getfloat('max_freq_z', 100.,
                                           minval=self.min_freq, maxval=300.)

--- a/klippy/extras/shaper_calibrate.py
+++ b/klippy/extras/shaper_calibrate.py
@@ -9,7 +9,7 @@ shaper_defs = importlib.import_module('.shaper_defs', 'extras')
 MIN_FREQ = 5.
 MAX_FREQ = 200.
 WINDOW_T_SEC = 0.5
-MAX_SHAPER_FREQ = 150.
+MAX_SHAPER_FREQ = 200.
 
 TEST_DAMPING_RATIOS=[0.075, 0.1, 0.15]
 


### PR DESCRIPTION
Current default input shaper calibration limits can result in artificial truncation of the observable frequency response of motion systems that end users will not be aware of.

Pull request changes the following values

resonance_tester.py
 - class VibrationPulseTestGenerator default value in resonance_tester.py increased from 135 to 200

shaper_calibrate.py
 - MAX_SHAPER_FREQ increased from 150 to 200

Justification:
- The default max_freq used by resonance_tester (via printer.cfg) limits the excitation bandwidth of the ADXL in use. Unless set by the user in their Resonance Tester section of their printer.cfg by way of Max_Freq: , this will default to 135hz
- While users can manually increase this value, this requires prior knowledge that the limit exists and is something that could be affecting their results.

However, even when the excitation range is increased, the final processed results remain constrained by the fitting limits defined in shaper_calibrate.py culling any extra raw frequency response data over 150hz.

- The MAX_SHAPER_FREQ parameter caps the maximum frequency data considered during shaper fitting.
- When the system’s dominant modes exceed this range, the calibration process converges to boundary-limited solutions rather than the true resonance.

This produces characteristic artifacts:
- Repeated shaper recommendations clustering near the upper limit
- Mismatch between PSD peaks and fitted shaper frequencies
- Reduced sensitivity in derived tuning parameters

As a result, the current defaults can cause the calibration process to reflect the imposed limits rather than the actual system behavior, particularly in higher-stiffness or higher-frequency motion systems. 

This change increases the default limits to ensure that:
- That possible issues like double peak response of direct drive extruders or other possible real world motion system issues are not hidden from the end user
- The excitation range is sufficient to stimulate possible higher-frequency modes that could be present
- The fitting process can evaluate those modes without artificial constraints effecting the results

Example of how on the same printer system the ADXL information returned at 135hz vs 150hz 
<img width="2312" height="934" alt="image" src="https://github.com/user-attachments/assets/69a7c370-f8e5-470f-b450-f64e9e999c77" />

Another Example of how multiple recommended input shaper values are capped at 149.8hz
<img width="831" height="217" alt="image" src="https://github.com/user-attachments/assets/40c9391f-ce41-4564-99e5-5ce10e6ef95d" />
