### PR TITLE
RFC: Reactor - IO threads

### DIFF
--- a/klippy/extras/aio_executor.py
+++ b/klippy/extras/aio_executor.py
@@ -88,6 +88,22 @@ class FileAIO:
     def __exit__(self, *args):
         self.close()
 
+class BareExecutor:
+    def __init__(self, pool):
+        self.pool = pool
+        self.executor = self.pool.pop()
+    def set_thread_name(self, name):
+        self.executor.set_thread_name(name)
+    def submit(self, fn, *args, **kwargs):
+        self.executor.submit(fn, *args, **kwargs)
+    def finish(self):
+        self.pool.append(self.executor)
+        self.executor = None
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        self.finish()
+
 class Dispatcher:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -123,6 +139,9 @@ class Dispatcher:
     def get_wrapper(self, open_call, *args, **kwargs):
         self._ensure_one_available()
         return FileAIO(self._free_executors, open_call, *args, **kwargs)
+    def get_executor(self):
+        self._ensure_one_available()
+        return BareExecutor(self._free_executors)
 
 def load_config(config):
     return Dispatcher(config)

--- a/klippy/extras/aio_executor.py
+++ b/klippy/extras/aio_executor.py
@@ -1,0 +1,128 @@
+# General threaded executor
+#
+# Copyright (C) 2026  Timofey Titovets <nefelim4ag@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import chelper
+from queue import Queue, Full
+from threading import Thread, Condition, Lock
+
+class Executor:
+    class sentinel: pass
+    def __init__(self, reactor):
+        self.reactor = reactor
+        self._completion = None
+        self._queue = Queue(1)
+        self._qsize = 0
+        self._thread = Thread(target=self._main)
+        self._wait_for_work = True
+        self._thread.start()
+    def _main(self):
+        while self._wait_for_work:
+            try:
+                item = self._queue.get()
+                if item is self.sentinel:
+                    return
+                fn, args, kwargs = item
+                res = fn(*args, **kwargs)
+                self.reactor.async_complete(self._completion, (res, None))
+            except Exception as e:
+                self.reactor.async_complete(self._completion, (None, e))
+    # Single execution flow is assumed
+    # *Any* race condition should lead to an exception in the queue
+    # Public to allow offload function which expects fd as an argument
+    def submit(self, fn, *args, **kwargs):
+        if self._qsize:
+            raise Full
+        self._completion = self.reactor.completion()
+        self._qsize += 1
+        self._queue.put_nowait((fn, args, kwargs))
+        result, exc = self._completion.wait()
+        self._qsize -= 1
+        self._completion = None
+        if exc:
+            raise exc
+        return result
+    def set_thread_name(self, name):
+        name_short = name[:15]
+        stn = chelper.get_ffi()[1].set_thread_name
+        self.submit(stn, name_short.encode('utf-8'))
+    def join(self):
+        self._wait_for_work = False
+        self._queue.put_nowait(self.sentinel)
+        self._thread.join()
+
+class FileAIO:
+    def __init__(self, pool, open_call, *args, **kwargs):
+        self.pool = pool
+        self.executor = self.pool.pop()
+        self.file_object = None
+        try:
+            f = self.executor.submit(open_call, *args, **kwargs)
+            self.file_object = f
+        except:
+            self.close()
+            raise
+    def set_thread_name(self, name):
+        self.executor.set_thread_name(name)
+    def submit(self, fn, *args, **kwargs):
+        self.executor.submit(fn, *args, **kwargs)
+    def get_file_object(self):
+        return self.file_object
+    def close(self):
+        if self.file_object is not None:
+            self.executor.submit(self.file_object.close)
+        self.pool.append(self.executor)
+    # Call any not-implemented function from the wrapped object
+    # Assume it is blocking, so pass to the thread
+    def __getattr__(self, name):
+        attr = getattr(self.file_object, name)
+        if not callable(attr):
+            return attr
+        def proxy(*args, **kwargs):
+            return self.executor.submit(attr, *args, **kwargs)
+        return proxy
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        self.close()
+
+class Dispatcher:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self._all_executors = []
+        self._free_executors = []
+        self.pool_timer = None
+        self.printer.register_event_handler("klippy:disconnect",
+                                            self._handle_disconnect)
+    def _handle_disconnect(self):
+        for executor in self._all_executors:
+            executor.join()
+    # Eventually free unused threads
+    def _recycle(self, eventtime):
+        if self._free_executors:
+            executor = self._free_executors.pop()
+            i = self._all_executors.index(executor)
+            self._all_executors.pop(i)
+            executor.join()
+        if not self._all_executors:
+            self.reactor.unregister_timer(self.pool_timer)
+            self.pool_timer = None
+        return eventtime + 30.0
+    def _ensure_one_available(self):
+        if not self._all_executors:
+            eventtime = self.reactor.monotonic()
+            t = self.reactor.register_timer(self._recycle, eventtime + 30.0)
+            self.pool_timer = t
+        if not self._free_executors:
+            executor = Executor(self.reactor)
+            self._free_executors.append(executor)
+            self._all_executors.append(executor)
+    def get_wrapper(self, open_call, *args, **kwargs):
+        self._ensure_one_available()
+        return FileAIO(self._free_executors, open_call, *args, **kwargs)
+
+def load_config(config):
+    return Dispatcher(config)

--- a/klippy/extras/aio_executor.py
+++ b/klippy/extras/aio_executor.py
@@ -1,0 +1,80 @@
+# General threaded executor
+#
+# Copyright (C) 2026  Timofey Titovets <nefelim4ag@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+import chelper
+from queue import Queue
+from threading import Thread
+
+class WrapperAIO:
+    def __init__(self, executor, object):
+        self.object = object
+        self.executor = executor
+    # Call any not-implemented function from the wrapped object
+    # Assume it is blocking, so pass to the thread
+    def __getattr__(self, name):
+        attr = getattr(self.object, name)
+        if not callable(attr):
+            return attr
+        def proxy(*args, **kwargs):
+            return self.executor.submit(attr, *args, **kwargs)
+        return proxy
+
+class Executor:
+    class sentinel: pass
+    def __init__(self, reactor, thread_name=""):
+        self.reactor = reactor
+        self._queue = Queue()
+        self._thread_name = thread_name[:15]
+        self._set_thread_name = chelper.get_ffi()[1].set_thread_name
+        self._thread = Thread(target=self._main)
+        self._wait_for_work = True
+        self._thread.start()
+    def _main(self):
+        try:
+            self._set_thread_name(self._thread_name.encode('utf-8'))
+        except:
+            pass
+        while self._wait_for_work:
+            item = self._queue.get()
+            if item is self.sentinel:
+                return
+            completion, fn, args, kwargs = item
+            try:
+                res = fn(*args, **kwargs)
+                self.reactor.async_complete(completion, (res, None))
+            except Exception as e:
+                self.reactor.async_complete(completion, (None, e))
+    def submit(self, fn, *args, **kwargs):
+        completion = self.reactor.completion()
+        self._queue.put_nowait((completion, fn, args, kwargs))
+        result, exc = completion.wait()
+        if exc:
+            raise exc
+        return result
+    def wrap_obj(self, object):
+        return WrapperAIO(self, object)
+    def join(self):
+        self._wait_for_work = False
+        self._queue.put_nowait(self.sentinel)
+        self._thread.join()
+
+class Dispatcher:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.reactor = self.printer.get_reactor()
+        self._all_executors = []
+        self.printer.register_event_handler("klippy:disconnect",
+                                            self._handle_disconnect)
+    def _handle_disconnect(self):
+        for executor in self._all_executors:
+            executor.join()
+    def allocate_executor(self, name=""):
+        executor = Executor(self.reactor, name)
+        self._all_executors.append(executor)
+        return executor
+
+def load_config(config):
+    return Dispatcher(config)

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -11,6 +11,7 @@ class SaveVariables:
         self.printer = config.get_printer()
         self.filename = os.path.expanduser(config.get('filename'))
         self.allVariables = {}
+        self.printer.load_object(config, 'aio_executor')
         try:
             if not os.path.exists(self.filename):
                 open(self.filename, "w").close()
@@ -23,8 +24,10 @@ class SaveVariables:
     def loadVariables(self):
         allvars = {}
         varfile = configparser.ConfigParser()
+        aio = self.printer.lookup_object('aio_executor')
         try:
-            varfile.read(self.filename)
+            with aio.get_executor() as executor:
+                executor.submit(varfile.read, self.filename)
             if varfile.has_section('Variables'):
                 for name, val in varfile.items('Variables'):
                     allvars[name] = ast.literal_eval(val)
@@ -50,10 +53,13 @@ class SaveVariables:
         varfile.add_section('Variables')
         for name, val in sorted(newvars.items()):
             varfile.set('Variables', name, repr(val))
+        aio = self.printer.lookup_object('aio_executor')
         try:
-            f = open(self.filename, "w")
-            varfile.write(f)
-            f.close()
+            def write_out():
+                with open(self.filename, "w") as f:
+                    varfile.write(f)
+            with aio.get_executor() as executor:
+                executor.submit(write_out)
         except:
             msg = "Unable to save variable"
             logging.exception(msg)

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -11,6 +11,8 @@ class SaveVariables:
         self.printer = config.get_printer()
         self.filename = os.path.expanduser(config.get('filename'))
         self.allVariables = {}
+        aio = self.printer.load_object(config, 'aio_executor')
+        self.executor = aio.allocate_executor("save_variables")
         try:
             if not os.path.exists(self.filename):
                 open(self.filename, "w").close()
@@ -24,7 +26,7 @@ class SaveVariables:
         allvars = {}
         varfile = configparser.ConfigParser()
         try:
-            varfile.read(self.filename)
+            self.executor.submit(varfile.read, self.filename)
             if varfile.has_section('Variables'):
                 for name, val in varfile.items('Variables'):
                     allvars[name] = ast.literal_eval(val)
@@ -51,9 +53,10 @@ class SaveVariables:
         for name, val in sorted(newvars.items()):
             varfile.set('Variables', name, repr(val))
         try:
-            f = open(self.filename, "w")
-            varfile.write(f)
-            f.close()
+            def write_out():
+                with open(self.filename, "w") as f:
+                    varfile.write(f)
+            self.executor.submit(write_out)
         except:
             msg = "Unable to save variable"
             logging.exception(msg)

--- a/klippy/extras/temperature_host.py
+++ b/klippy/extras/temperature_host.py
@@ -23,17 +23,24 @@ class Temperature_HOST:
             return
         self.sample_timer = self.reactor.register_timer(
             self._sample_pi_temperature)
+        aio = self.printer.load_object(config, 'aio_executor')
+        self.executor = aio.allocate_executor("temperature_host")
         try:
-            self.file_handle = open(self.path, "r")
+            self.file_handle = self.executor.submit(open, self.path, "r")
         except:
             raise config.error("Unable to open temperature file '%s'"
                                % (self.path,))
 
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
+        self.printer.register_event_handler("klippy:disconnect",
+                                            self.handle_disconnect)
 
     def handle_connect(self):
         self.reactor.update_timer(self.sample_timer, self.reactor.NOW)
+
+    def handle_disconnect(self):
+        self.file_handle.close()
 
     def setup_minmax(self, min_temp, max_temp):
         self.min_temp = min_temp
@@ -46,9 +53,12 @@ class Temperature_HOST:
         return HOST_REPORT_TIME
 
     def _sample_pi_temperature(self, eventtime):
-        try:
+        def _get_sample():
             self.file_handle.seek(0)
-            self.temp = float(self.file_handle.read())/1000.0
+            return self.file_handle.read()
+        try:
+            raw_value = self.executor.submit(_get_sample)
+            self.temp = float(raw_value)/1000.0
         except Exception:
             logging.exception("temperature_host: Error reading data")
             self.temp = 0.0

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -13,6 +13,45 @@ DEFAULT_ERROR_GCODE = """
 {% endif %}
 """
 
+PAGE_SIZE = 8192
+DATA_PREV = 1024
+DATA_NEXT = 128
+
+class FilePager:
+    def __init__(self, file_object):
+        self.file_object = file_object
+        self.pages = {}
+        self._pos = file_object.tell()
+    def seek(self, pos):
+        self._pos = pos
+    def tell(self):
+        return self._pos
+    def _page_index(self, pos):
+        return pos // PAGE_SIZE
+    def _page_offset(self, pos):
+        return pos % PAGE_SIZE
+    def cache_offset(self, offset):
+        offset = max(offset, 0)
+        page_num = self._page_index(offset)
+        if self.pages.get(page_num, None) is not None:
+            return
+        data_offset = max(page_num * PAGE_SIZE - PAGE_SIZE, 0)
+        self.file_object.seek(data_offset)
+        self.pages[page_num] = self.file_object.read(PAGE_SIZE)
+    def read(self):
+        self.cache_offset(self._pos)
+        page_num = self._page_index(self._pos)
+        page_offset = self._page_offset(self._pos)
+        data = self.pages[page_num][page_offset:]
+        self._pos += len(data)
+        # Recycle
+        if self.pages.get(page_num - 3, None) is not None:
+            del self.pages[page_num - 3]
+        return data
+    def __getattr__(self, name):
+        attr = getattr(self.file_object, name)
+        return attr
+
 class VirtualSD:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -49,11 +88,15 @@ class VirtualSD:
     def _handle_analyze_shutdown(self, msg, details):
         if self.work_timer is not None:
             self.must_pause_work = True
+            readpos = max(self.file_position - DATA_PREV, 0)
+            readcount = self.file_position - readpos
+            page_num = readpos // PAGE_SIZE
+            offset_in_page = readpos % PAGE_SIZE
             try:
-                readpos = max(self.file_position - 1024, 0)
-                readcount = self.file_position - readpos
-                self.current_file.seek(readpos)
-                data = self.current_file.read(readcount + 128)
+                data = self.current_file.pages.get(page_num, "")
+                data = data[offset_in_page:]
+                data += self.current_file.pages.get(page_num + 1, "")
+                data = data[:readcount + DATA_NEXT]
             except:
                 logging.exception("virtual_sdcard shutdown read")
                 return
@@ -192,7 +235,7 @@ class VirtualSD:
             raise gcmd.error("Unable to open file")
         gcmd.respond_raw("File opened:%s Size:%d" % (filename, fsize))
         gcmd.respond_raw("File selected")
-        self.current_file = f
+        self.current_file = FilePager(f)
         self.file_position = 0
         self.file_size = fsize
         self.print_stats.set_current_file(filename)
@@ -240,7 +283,7 @@ class VirtualSD:
             if not lines:
                 # Read more data
                 try:
-                    data = self.current_file.read(8192)
+                    data = self.current_file.read()
                 except:
                     logging.exception("virtual_sdcard read")
                     break

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -69,6 +69,7 @@ class VirtualSD:
         self.work_timer = None
         # Error handling
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.printer.load_object(config, 'aio_executor')
         self.on_error_gcode = gcode_macro.load_template(
             config, 'on_error_gcode', DEFAULT_ERROR_GCODE)
         # Register commands
@@ -222,11 +223,13 @@ class VirtualSD:
         flist = [f[0] for f in files]
         files_by_lower = { fname.lower(): fname for fname, fsize in files }
         fname = filename
+        aio = self.printer.lookup_object('aio_executor')
         try:
             if fname not in flist:
                 fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
-            f = io.open(fname, 'r', newline='')
+            f = aio.get_wrapper(io.open, fname, 'r', newline='')
+            f.set_thread_name(filename)
             f.seek(0, os.SEEK_END)
             fsize = f.tell()
             f.seek(0)

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -47,19 +47,24 @@ class VirtualSD:
         self.printer.register_event_handler("klippy:analyze_shutdown",
                                             self._handle_analyze_shutdown)
     def _handle_analyze_shutdown(self, msg, details):
-        if self.work_timer is not None:
-            self.must_pause_work = True
+        if self.work_timer is None:
+            return
+        file_position = self.file_position
+        current_file = self.current_file
+        self.must_pause_work = True
+        def log_debug_data(eventtime):
             try:
-                readpos = max(self.file_position - 1024, 0)
-                readcount = self.file_position - readpos
-                self.current_file.seek(readpos)
-                data = self.current_file.read(readcount + 128)
+                readpos = max(file_position - 1024, 0)
+                readcount = file_position - readpos
+                current_file.seek(readpos)
+                data = current_file.read(readcount + 128)
             except:
                 logging.exception("virtual_sdcard shutdown read")
                 return
             logging.info("Virtual sdcard (%d): %s\nUpcoming (%d): %s",
                          readpos, repr(data[:readcount]),
-                         self.file_position, repr(data[readcount:]))
+                         file_position, repr(data[readcount:]))
+        self.reactor.register_callback(log_debug_data)
     def stats(self, eventtime):
         if self.work_timer is None:
             return False, ""

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -30,6 +30,8 @@ class VirtualSD:
         self.work_timer = None
         # Error handling
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        aio = self.printer.load_object(config, 'aio_executor')
+        self.executor = aio.allocate_executor("virtual_sdcard")
         self.on_error_gcode = gcode_macro.load_template(
             config, 'on_error_gcode', DEFAULT_ERROR_GCODE)
         # Register commands
@@ -188,10 +190,13 @@ class VirtualSD:
             if fname not in flist:
                 fname = files_by_lower[fname.lower()]
             fname = os.path.join(self.sdcard_dirname, fname)
-            f = io.open(fname, 'r', newline='')
+            f = self.executor.submit(io.open, fname, 'rb', buffering=0)
+            f = self.executor.wrap_obj(f)
+            f = io.BufferedReader(f)
             f.seek(0, os.SEEK_END)
             fsize = f.tell()
             f.seek(0)
+            f = io.TextIOWrapper(f, newline='')
         except:
             logging.exception("virtual_sdcard file open")
             raise gcmd.error("Unable to open file")

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -447,7 +447,12 @@ class GCodeIO:
         self.pipe_is_active = True
         # Special handling for debug file input EOF
         if not data and self.is_fileinput:
-            if not self.is_processing_data:
+            # Workaround virtual_sdcard
+            obj = self.printer.lookup_object("virtual_sdcard", None)
+            wait_virtual_input = False
+            if obj is not None:
+                wait_virtual_input = obj.get_status(eventtime)["is_active"]
+            if not self.is_processing_data and not wait_virtual_input:
                 self.reactor.unregister_fd(self.fd_handle)
                 self.fd_handle = None
                 self.gcode.request_restart('exit')


### PR DESCRIPTION
There are several places where the reactor's greenlet can be used to do blocking file IO.
Unfortunately, it is not possible to do file IO in a non-blocking fashion.

In some places, it is handled with a daemon (adxl345.py), which is cumbersome.
In others, ignored (virtual_sdcard).
~~Somewhere, it is threads (palette2.py)~~

This is my attempt to solve the possible IO blocks inside the virtual_sdcard code.
Because it is a somewhat generic problem, I've tried to make a generic solution to do so across the code.
Hence, the weird way of wrapping the FileIO wrapper. So, it can wrap whatever wrapper supports the blocking read/write.

I did a base test, where I triggered the ENOSPC on write, and checked the virtual_sdcard reading with a large file with dummy commands.

Thanks,
-Timofey

---
- Fixed: ~~I have to figure out how to read during the analyze shutdown event =\ where I should not pause.~~
- Fixed: ~~Hmmm, the test exits before the first read happens, because do_resume expects that the next timer is blocking~~.