### PR TITLE
[avr] Fix missing SP definition in newer avr-libc and missing include in adc.c

### DIFF
--- a/src/avr/adc.c
+++ b/src/avr/adc.c
@@ -4,6 +4,7 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include <avr/io.h> // ADCSRA
 #include "autoconf.h" // CONFIG_MACH_atmega644p
 #include "command.h" // shutdown
 #include "gpio.h" // gpio_adc_read

--- a/src/avr/main.c
+++ b/src/avr/main.c
@@ -12,6 +12,12 @@
 #include "irq.h" // irq_enable
 #include "sched.h" // sched_main
 
+// Newer avr-libc headers expose the stack pointer as SP instead of the
+// older AVR_STACK_POINTER_REG alias used by Klipper.
+#ifndef AVR_STACK_POINTER_REG
+#define AVR_STACK_POINTER_REG SP
+#endif
+
 DECL_CONSTANT_STR("MCU", CONFIG_MCU);
 
 

--- a/src/avr/spi.c
+++ b/src/avr/spi.c
@@ -4,6 +4,7 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include <avr/io.h> // SPCR
 #include "autoconf.h" // CONFIG_MACH_atmega644p
 #include "command.h" // shutdown
 #include "gpio.h" // spi_setup


### PR DESCRIPTION
Two small fixes for AVR-328P compilation.

1. Newer avr-libc no longer defines the stack pointer as klipper expects it.
2. In my build at least, `avr/adc.c` an include for `<avr/io.h>` needs to be added , required to get `ADCSRA`.


Signed-off-by: Nicolás Méndez <9phhsyrbm@relay.firefox.com>