### PR TITLE
Resonance tester data write

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -85,7 +85,7 @@ class AccelQueryHelper:
                 count += 1
         del samples[count:]
         return self.samples
-    def write_to_file(self, filename):
+    def write_to_file(self, filename, wait=False):
         def write_impl():
             try:
                 # Try to re-nice writing process
@@ -102,6 +102,11 @@ class AccelQueryHelper:
         write_proc = multiprocessing.Process(target=write_impl)
         write_proc.daemon = True
         write_proc.start()
+        if wait:
+            reactor = self.printer.get_reactor()
+            while wait and write_proc.is_alive():
+                reactor.pause(reactor.monotonic() + 0.025)
+            write_proc.join()
 
 # Helper class for G-Code commands
 class AccelCommandHelper:

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -75,7 +75,8 @@ class AccelQueryHelper:
         total = sum([len(m['data']) for m in self.msgs])
         count = 0
         self.samples = samples = [None] * total
-        for msg in self.msgs:
+        while self.msgs:
+            msg = self.msgs.pop(0)
             for samp_time, x, y, z in msg['data']:
                 if samp_time < self.request_start_time:
                     continue

--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -88,21 +88,27 @@ class AccelQueryHelper:
         return self.samples
     def write_to_file(self, filename):
         def write_impl():
+            with open(filename, "w") as f:
+                f.write("#time,accel_x,accel_y,accel_z\n")
+                if not self.msgs:
+                    for samp_time, accel_x, accel_y, accel_z in self.samples:
+                        f.write("%.6f,%.6f,%.6f,%.6f\n" % (
+                            samp_time, accel_x, accel_y, accel_z))
+                    return
+                for msg in self.msgs:
+                    for samp_time, accel_x, accel_y, accel_z in msg['data']:
+                        if samp_time < self.request_start_time:
+                            continue
+                        if samp_time > self.request_end_time:
+                            break
+                        f.write("%.6f,%.6f,%.6f,%.6f\n" % (
+                            samp_time, accel_x, accel_y, accel_z))
+        aio = self.printer.lookup_object('aio_executor')
+        with aio.allocate_executor("aclient") as executor:
             try:
-                # Try to re-nice writing process
-                os.nice(20)
-            except:
-                pass
-            f = open(filename, "w")
-            f.write("#time,accel_x,accel_y,accel_z\n")
-            samples = self.samples or self.get_samples()
-            for t, accel_x, accel_y, accel_z in samples:
-                f.write("%.6f,%.6f,%.6f,%.6f\n" % (
-                    t, accel_x, accel_y, accel_z))
-            f.close()
-        write_proc = multiprocessing.Process(target=write_impl)
-        write_proc.daemon = True
-        write_proc.start()
+                executor.submit(write_impl)
+            except Exception as e:
+                raise self.printer.command_error(str(e))
 
 # Helper class for G-Code commands
 class AccelCommandHelper:
@@ -110,6 +116,8 @@ class AccelCommandHelper:
         self.printer = config.get_printer()
         self.chip = chip
         self.bg_client = None
+        # Ensure executor is loaded for AccelQueryHelper
+        self.printer.load_object(config, 'aio_executor')
         name_parts = config.get_name().split()
         self.base_name = name_parts[0]
         self.name = name_parts[-1]
@@ -163,9 +171,9 @@ class AccelCommandHelper:
             filename = "/tmp/%s-%s.csv" % (self.base_name, name)
         else:
             filename = "/tmp/%s-%s-%s.csv" % (self.base_name, self.name, name)
-        bg_client.write_to_file(filename)
         gcmd.respond_info("Writing raw accelerometer data to %s file"
                           % (filename,))
+        bg_client.write_to_file(filename)
     cmd_ACCELEROMETER_QUERY_help = "Query accelerometer for the current values"
     def cmd_ACCELEROMETER_QUERY(self, gcmd):
         aclient = self.chip.start_internal_client()

--- a/klippy/extras/aio_executor.py
+++ b/klippy/extras/aio_executor.py
@@ -58,10 +58,19 @@ class Executor:
         return result
     def wrap_obj(self, object):
         return WrapperAIO(self, object)
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        self.join()
     def join(self):
+        if not self._wait_for_work:
+            return
         self._wait_for_work = False
         self._queue.put_nowait(self.sentinel)
         self._thread.join()
+        self._queue = None
+        self._thread = None
+        self.reactor = None
 
 class Dispatcher:
     def __init__(self, config):

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -357,10 +357,10 @@ class ResonanceTester:
                                 point if len(test_points) > 1 else None,
                                 chip_name if (accel_chips is not None
                                               or len(raw_values) > 1) else None)
-                        aclient.write_to_file(raw_name)
                         gcmd.respond_info(
                                 "Writing raw accelerometer data to "
                                 "%s file" % (raw_name,))
+                        aclient.write_to_file(raw_name, wait=True)
                 if helper is None:
                     continue
                 for chip_axis, aclient, chip_name in raw_values:

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -350,6 +350,7 @@ class ResonanceTester:
                 self.executor.run_test(test_seq, axis, gcmd)
                 for chip_axis, aclient, chip_name in raw_values:
                     aclient.finish_measurements()
+                for chip_axis, aclient, chip_name in raw_values:
                     if raw_name_suffix is not None:
                         raw_name = self.get_filename(
                                 'raw_data', raw_name_suffix, axis,

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -358,10 +358,10 @@ class ResonanceTester:
                                 point if len(test_points) > 1 else None,
                                 chip_name if (accel_chips is not None
                                               or len(raw_values) > 1) else None)
-                        aclient.write_to_file(raw_name)
                         gcmd.respond_info(
                                 "Writing raw accelerometer data to "
                                 "%s file" % (raw_name,))
+                        aclient.write_to_file(raw_name)
                 if helper is None:
                     continue
                 for chip_axis, aclient, chip_name in raw_values:

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -351,6 +351,7 @@ class ResonanceTester:
                 self.executor.run_test(test_seq, axis, gcmd)
                 for chip_axis, aclient, chip_name in raw_values:
                     aclient.finish_measurements()
+                for chip_axis, aclient, chip_name in raw_values:
                     if raw_name_suffix is not None:
                         raw_name = self.get_filename(
                                 'raw_data', raw_name_suffix, axis,


### PR DESCRIPTION
I've seen some reports with TTC or other errors during the resonance testing.

At least tests that are done one by one, should now be less susceptible to the issues.
```
  TEST_RESONANCES AXIS=x OUTPUT=raw_data POINT={x_center},{y_center},20
  TEST_RESONANCES AXIS=y OUTPUT=raw_data POINT={x_center},{y_center},20
  TEST_RESONANCES AXIS=y OUTPUT=raw_data POINT={x_edge},{y_center},20
```

Additional CPU/memory optimization is possible by freeing the `self.msg` once it is processed.
So, samples would be processed exactly once.

Thanks,
-Timofey