### PR TITLE
Support for Oled display driver SSD1363

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4850,9 +4850,9 @@ lcd_type: ssd1363
 #   False.
 #x_offset: 8
 #   Set the horizontal offset value on SH1106 displays. The valid range
-#   is between 0 and 79 The default is 8. 
+#   is between 0 and 79 The default is 8.
 #effect: emboss
-#   Gives a 3d like feel to icons/text and other graphics on the display. 
+#   Gives a 3d like feel to icons/text and other graphics on the display.
 #   Possible options are emboss or none. Default is emboss
 ...
 ```

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4538,8 +4538,8 @@ Support for a display attached to the micro-controller.
 [display]
 lcd_type:
 #   The type of LCD chip in use. This may be "hd44780", "hd44780_spi",
-#   "aip31068_spi", "st7920", "emulated_st7920", "uc1701", "ssd1306", or
-#   "sh1106".
+#   "aip31068_spi", "st7920", "emulated_st7920", "uc1701", "ssd1306",
+#   "ssd1363", "sh1106".
 #   See the display sections below for information on each type and
 #   additional parameters they provide. This parameter must be
 #   provided.
@@ -4807,6 +4807,56 @@ lcd_type:
 #   0.
 ...
 ```
+
+#### ssd1363 display
+
+Information on configuring ssd1363 display.
+
+```
+[display]
+lcd_type: ssd1363
+#i2c_mcu:
+#i2c_bus:
+#i2c_software_scl_pin:
+#i2c_software_sda_pin:
+#i2c_speed:
+#   Optional parameters available for displays connected via an i2c
+#   bus. See the "common I2C settings" section for a description of
+#   the above parameters.
+#cs_pin:
+#dc_pin:
+#spi_speed:
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   The pins connected to the lcd when in "4-wire" spi mode. See the
+#   "common SPI settings" section for a description of the parameters
+#   that start with "spi_". The default is to use i2c mode for the
+#   display.
+#reset_pin:
+#   A reset pin may be specified on the display. If it is not
+#   specified then the hardware must have a pull-up on the
+#   corresponding lcd line.
+#contrast:
+#   The contrast to set. The value may range from 0 to 256 and the
+#   default is 239.
+#vcomh: 0
+#   Set the Vcomh value on the display. This value is associated with
+#   a "smearing" effect on some OLED displays. The value may range
+#   from 0 to 7. Default is 0.
+#invert: False
+#   TRUE inverts the pixels on certain OLED displays.  The default is
+#   False.
+#x_offset: 8
+#   Set the horizontal offset value on SH1106 displays. The valid range
+#   is between 0 and 79 The default is 8. 
+#effect: emboss
+#   Gives a 3d like feel to icons/text and other graphics on the display. 
+#   Possible options are emboss or none. Default is emboss
+...
+```
+
 
 ### [display_data]
 

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5432,6 +5432,27 @@ latch_pin:
 #   above parameters.
 ```
 
+### [shift_register_stepper_dir]
+
+Map a manual_stepper's direction pin to a shift register pin. This
+automatically updates the shift register direction bit before each
+move, allowing stepper direction control through a 74HC595 without
+modifying macros or higher-level code. The stepper's config should
+use a dummy dir_pin (any unused MCU GPIO), while the actual direction
+signal is routed through the shift register.
+
+```
+[shift_register_stepper_dir my_stepper_dir]
+manual_stepper:
+#   The name of the manual_stepper section to hook into (e.g.
+#   "gear_stepper" for [manual_stepper gear_stepper]). This
+#   parameter must be provided.
+dir_pin:
+#   The shift register pin to use for direction control (e.g.
+#   "mmu2:PIN_0"). Supports the "!" invert prefix. This parameter
+#   must be provided.
+```
+
 ### [samd_sercom]
 
 SAMD SERCOM configuration to specify which pins to use on a given

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5393,6 +5393,45 @@ i2c_address:
 #   above parameters.
 ```
 
+### [shift_register]
+
+Configure a 74HC595 shift register as a GPIO expander. Due to the
+delay incurred by SPI communication you should NOT use shift register
+pins as stepper step pins or endstop pins. They are suitable for
+stepper enable, direction, LEDs, or other pins that do not require
+high-frequency updates. Multiple 74HC595 chips may be daisy-chained
+by connecting QH' of one chip to SER of the next. One may define any
+number of sections with a "shift_register" prefix. Each section
+provides a set of pins (PIN_0 to PIN_N) which can be used in the
+printer configuration.
+
+```
+[shift_register my_sr]
+latch_pin:
+#   The pin connected to the RCLK (latch/storage clock) pin of the
+#   74HC595. This pin is used as the SPI chip-select and latches the
+#   shifted data to the output pins on the rising edge after each
+#   SPI transfer. This parameter must be provided.
+#chain_count: 1
+#   The number of daisy-chained 74HC595 chips. Each chip provides
+#   8 output pins. For example, 2 chained chips provide PIN_0
+#   through PIN_15. The default is 1 (8 pins: PIN_0 to PIN_7).
+#output_enable_pin:
+#   The pin connected to the OE (output enable) pin of the 74HC595.
+#   The OE pin is active-low. If provided, it will be driven low to
+#   enable outputs. If not provided, OE must be wired to GND on the
+#   board. This parameter is optional.
+#spi_speed: 4000000
+#   The SPI speed (in hz) to use when communicating with the shift
+#   register. The default is 4000000.
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   See the "common SPI settings" section for a description of the
+#   above parameters.
+```
+
 ### [samd_sercom]
 
 SAMD SERCOM configuration to specify which pins to use on a given

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5393,6 +5393,34 @@ i2c_address:
 #   above parameters.
 ```
 
+### [hc595]
+
+Configure a 74HC595 shift register with firmware-level GPIO support.
+This provides virtual GPIO pins (PG0-PG7 for the first chip,
+PH0-PH7 for the second) that can be used directly as stepper
+dir_pin and enable_pin in the printer configuration. Unlike the
+host-side [shift_register] approach, direction and enable changes
+happen entirely within the MCU firmware, eliminating SPI bus traffic
+and USB contention issues. Requires firmware compiled with
+CONFIG_HAVE_HC595_SHIFT_REG=y (currently ATmega32u4 only).
+
+```
+[hc595 my_sr]
+data_pin:
+#   The pin connected to the SER (serial data input) pin of the
+#   74HC595. This parameter must be provided.
+latch_pin:
+#   The pin connected to the RCLK (latch/storage clock) pin of the
+#   74HC595. Data is latched to outputs on the rising edge. This
+#   parameter must be provided.
+clock_pin:
+#   The pin connected to the SRCLK (shift register clock) pin of
+#   the 74HC595. This parameter must be provided.
+#chain_count: 2
+#   The number of daisy-chained 74HC595 chips. Must match the
+#   CONFIG_HC595_LENGTH setting in the firmware. The default is 2.
+```
+
 ### [shift_register]
 
 Configure a 74HC595 shift register as a GPIO expander. Due to the

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -143,6 +143,100 @@ text: { render("_print_status") }
 
 
 ######################################################################
+# Default home screen for 32x8 display with large font (SSD1363 256x128 OLED)
+# Large font mode: 2× width × height = 16px × 28px chars, 16 cols × 4 rows.
+# Row 0: extruder temperature (full row)
+# Row 1: bed temperature (left) | printing time (right)
+# Row 2: speed factor (left)
+# Row 3: progress percentage + full-width progress bar
+######################################################################
+
+# Layout (16 large-font cols x 4 rows):
+# Row 0: ~extruder~ temp [0..9]  |  ~fan~ speed [10..15]
+# Row 1: ~bed~ temp      [0..9]  |  ~feedrate~ % [10..15]
+# Row 2: bar [0..9]    |  time [10..15]
+# Row 3: status text [0..15]
+
+[display_data _default_home_large extruder]
+position: 0, 0
+text:
+  {% set active_extruder = printer.toolhead.extruder %}
+  { render("_heater_temperature", param_heater_name=active_extruder) }
+
+[display_data _default_home_large fan]
+position: 0, 10
+text: { render("_fan_speed") }
+
+[display_data _default_home_large heater_bed]
+position: 1, 0
+text: { render("_heater_temperature", param_heater_name="heater_bed") }
+
+[display_data _default_home_large speed_factor]
+position: 1, 10
+text:
+  ~feedrate~
+  { "{:>4.0%}".format(printer.gcode_move.speed_factor) }
+
+[display_data _default_home_large progress_bar]
+position: 2, 0 # Draw graphical progress bar after text is written
+text: { draw_progress_bar(2, 0, 10, printer.display_status.progress) }
+
+[display_data _default_home_large printing_time]
+position: 2, 10
+text: { "%6s" % (render("_printing_time").strip(),) }
+
+[display_data _default_home_large print_status]
+position: 3, 0
+text: { render("_print_status") }
+
+
+######################################################################
+# Default 32x8 display (SSD1363 256x128 OLED)
+# Grid: 32 text columns x 8 rows, 8px per column, 14px per row.
+# Row 0: extruder temp (col 0)        | fan speed (col 20)
+# Row 1: bed temp     (col 0)        | printing time (col 20)
+# Row 2: speed factor (col 0)
+# Row 4: print progress % (centred 32 chars) + 256px wide progress bar
+# Row 6: print status message (full width)
+######################################################################
+
+[display_data _default_32x8 extruder]
+position: 0, 0
+text:
+  {% set active_extruder = printer.toolhead.extruder %}
+  { render("_heater_temperature", param_heater_name=active_extruder) }
+
+[display_data _default_32x8 fan]
+position: 0, 20
+text: { render("_fan_speed") }
+
+[display_data _default_32x8 heater_bed]
+position: 1, 0
+text: { render("_heater_temperature", param_heater_name="heater_bed") }
+
+[display_data _default_32x8 printing_time]
+position: 1, 20
+text: { "%12s" % (render("_printing_time").strip(),) }
+
+[display_data _default_32x8 speed_factor]
+position: 2, 0
+text:
+  ~feedrate~
+  { "{:>4.0%}".format(printer.gcode_move.speed_factor) }
+
+[display_data _default_32x8 print_progress]
+position: 4, 0
+text: { "{:^32.0%}".format(printer.display_status.progress) }
+[display_data _default_32x8 progress_bar]
+position: 4, 1 # Draw graphical progress bar after text is written
+text: { draw_progress_bar(4, 0, 32, printer.display_status.progress) }
+
+[display_data _default_32x8 print_status]
+position: 6, 0
+text: { render("_print_status") }
+
+
+######################################################################
 # Default 20x4 display
 ######################################################################
 

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -6,7 +6,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, os, ast
-from . import aip31068_spi, hd44780, hd44780_spi, st7920, uc1701, menu
+from . import aip31068_spi, hd44780, hd44780_spi, st7920, uc1701, menu, ssd1363
 
 # Normal time between each screen redraw
 REDRAW_TIME = 0.500
@@ -17,6 +17,7 @@ LCD_chips = {
     'st7920': st7920.ST7920, 'emulated_st7920': st7920.EmulatedST7920,
     'hd44780': hd44780.HD44780, 'uc1701': uc1701.UC1701,
     'ssd1306': uc1701.SSD1306, 'sh1106': uc1701.SH1106,
+    'ssd1363': ssd1363.SSD1363,
     'hd44780_spi': hd44780_spi.hd44780_spi,
     'aip31068_spi':aip31068_spi.aip31068_spi
 }
@@ -194,6 +195,11 @@ class PrinterLCD:
         dgroup = "_default_16x4"
         if self.lcd_chip.get_dimensions()[0] == 20:
             dgroup = "_default_20x4"
+        elif self.lcd_chip.get_dimensions()[0] == 32:
+            if hasattr(self.lcd_chip, 'set_large_font'):
+                dgroup = "_default_home_large"
+            else:
+                dgroup = "_default_32x8"
         dgroup = config.get('display_group', dgroup)
         self.show_data_group = self.display_data_groups.get(dgroup)
         if self.show_data_group is None:
@@ -231,10 +237,15 @@ class PrinterLCD:
                 self.lcd_chip.flush()
                 return eventtime + REDRAW_TIME
         # Update normal display
+        set_lf = getattr(self.lcd_chip, 'set_large_font', None)
+        if set_lf is not None:
+            set_lf(True)
         try:
             self.show_data_group.show(self, self.display_templates, eventtime)
         except:
             logging.exception("Error during display screen update")
+        if set_lf is not None:
+            set_lf(False)
         self.lcd_chip.flush()
         if self.redraw_request_pending:
             return self.redraw_time

--- a/klippy/extras/display/ssd1363.py
+++ b/klippy/extras/display/ssd1363.py
@@ -28,14 +28,14 @@ class DisplayBase:
         self.font = [self._swizzle_bits(bytearray(c))
                      for c in font8x14.VGA_FONT]
         self.icons = {}
-        # Large font mode (2× width and height): 16px wide × 28px tall,
-        # giving a 16-column × 4-row grid.  Font is precomputed at init time.
+        # Large font mode (2x width and height): 16px wide x 28px tall,
+        # giving a 16-column x 4-row grid.  Font is precomputed at init time.
         self._large_font = False
         self.font_large = self._build_font_large()
         self.icons_large = {}
     @staticmethod
     def _double_bits(b):
-        # Expand 8 input bits to 16 output bits: bit i → bits 2i and 2i+1.
+        # Expand 8 input bits to 16 output bits: bit i -> bits 2i and 2i+1.
         # Uses a sequence of spread-and-mask steps (no loop needed).
         x = b & 0xFF
         x = (x | (x << 4)) & 0x0F0F
@@ -43,7 +43,7 @@ class DisplayBase:
         x = (x | (x << 1)) & 0x5555
         return (x | (x << 1)) & 0xFFFF
     def _build_font_large(self):
-        # Pre-compute 2× scaled glyphs (16px wide × 32px tall in 4 VRAM pages).
+        # Pre-compute 2x scaled glyphs (16px wide x 32px tall in 4 VRAM pages).
         # Source glyph: (top, bot) each 8 bytes = 8 source columns.
         # Output: (p0, p1, p2, p3) each 16 bytes = 16 output columns.
         font_large = []
@@ -53,8 +53,8 @@ class DisplayBase:
             p2 = bytearray(16)
             p3 = bytearray(16)
             for k in range(8):
-                dt = self._double_bits(top[k])   # rows 0-7 → rows 0-15
-                db = self._double_bits(bot[k])   # rows 8-15 → rows 16-31
+                dt = self._double_bits(top[k])   # rows 0-7 -> rows 0-15
+                db = self._double_bits(bot[k])   # rows 8-15 -> rows 16-31
                 p0[k*2] = p0[k*2+1] = dt & 0xFF
                 p1[k*2] = p1[k*2+1] = (dt >> 8) & 0xFF
                 p2[k*2] = p2[k*2+1] = db & 0xFF
@@ -62,7 +62,7 @@ class DisplayBase:
             font_large.append((p0, p1, p2, p3))
         return font_large
     def _build_icon_large(self, icon_top, icon_bot):
-        # Pre-compute 2× scaled icon from 16-byte (top, bot) column arrays.
+        # Pre-compute 2x scaled icon from 16-byte (top, bot) column arrays.
         # Output: (p0, p1, p2, p3) each 32 bytes = 32 output columns.
         p0 = bytearray(32)
         p1 = bytearray(32)
@@ -114,7 +114,7 @@ class DisplayBase:
             page_bot[pix_x:pix_x+8] = bits_bot
             pix_x += 8
     def _write_text_large(self, x, y, data):
-        # Large font path: 16px wide × 28px tall chars, 16 cols × 4 rows grid.
+        # Large font path: 16px wide x 28px tall chars, 16 cols x 4 rows grid.
         if x + len(data) > 16:
             data = data[:16 - min(x, 16)]
         pix_x = x * 16 + self.x_offset
@@ -294,8 +294,8 @@ class SSD1363(DisplayBase):
         # Matches u8g2 default_x_offset=8.  Override via x_offset in [display].
         self.chip_col_offset = config.getint('x_offset', 8, minval=0, maxval=79)
         # effect: selects the greyscale 3D rendering mode.
-        # 'emboss' — raised look
-        # 'none'   — original behaviour
+        # 'emboss' -- raised look
+        # 'none'   -- original behaviour
         self._effect = config.get('effect', 'emboss')
         if self._effect not in ('emboss', 'none'):
             raise config.error(
@@ -311,9 +311,9 @@ class SSD1363(DisplayBase):
         # Reference: u8g2-src/clib/u8x8_d_ssd1363.c
         #
         # CAD=011 I2C protocol (u8x8_cad_011_ssd13xx_i2c):
-        #   command → own I2C transaction [0x00, cmd]
-        #   arg     → own I2C transaction [0x40, arg]   (one per byte)
-        #   data    → I2C transaction(s)  [0x40, ...data] (chunked at 32 bytes)
+        #   command -> own I2C transaction [0x00, cmd]
+        #   arg     -> own I2C transaction [0x40, arg]   (one per byte)
+        #   data    -> I2C transaction(s)  [0x40, ...data] (chunked at 32 bytes)
         # Unlock display
         io.send_cmd(0xFD); io.send_arg(0x12)
         # Display off
@@ -369,7 +369,7 @@ class SSD1363(DisplayBase):
                 old_data[:] = new_data
                 continue
             # Coalesce into runs: merge tile j into current run if the gap is
-            # ≤ 3 tiles (re-sending ≤ 96 unchanged bytes saves 7 transactions).
+            # <= 3 tiles (re-sending <= 96 unchanged bytes saves 7 transactions).
             runs = []
             run_start = run_end = dirty[0]
             for j in dirty[1:]:
@@ -391,8 +391,8 @@ class SSD1363(DisplayBase):
     def _8to32(self, ptr, left_col=0, right_col=0):
         """Convert 8 bytes of 1bpp tile data to 32 bytes of 4bpp SSD1363 format.
 
-        effect='none'  — every ON pixel at full brightness 0xF.
-        effect='emboss'— per-pixel brightness from top-left edge detection:
+        effect='none'  -- every ON pixel at full brightness 0xF.
+        effect='emboss'-- per-pixel brightness from top-left edge detection:
                          highlight(0xF) / interior(0xC) / shadow(0x8).
         left_col / right_col: VRAM column bytes bordering this tile (cross-tile
         edge detection for emboss).
@@ -401,7 +401,7 @@ class SSD1363(DisplayBase):
         if not any(ptr):
             return dest
         effect = getattr(self, '_effect', 'none')
-        # Column index → dest byte offset within each 4-byte row group.
+        # Column index -> dest byte offset within each 4-byte row group.
         #   col:  0  1  2  3  4  5  6  7
         _bo = (1, 1, 0, 0, 3, 3, 2, 2)
         if effect == 'none':

--- a/klippy/extras/display/ssd1363.py
+++ b/klippy/extras/display/ssd1363.py
@@ -1,0 +1,461 @@
+# Support for UC1701 (and similar) 128x64 graphics LCD displays
+#
+# Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018  Eric Callahan  <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from .. import bus
+from . import font8x14
+
+BACKGROUND_PRIORITY_CLOCK = 0x7fffffff00000000
+
+TextGlyphs = { 'right_arrow': b'\x1a', 'degrees': b'\xf8' }
+
+class DisplayBase:
+    def __init__(self, io, columns=256, x_offset=0):
+        self.send = io.send
+        # framebuffers
+        self.columns = columns
+        self.x_offset = x_offset
+        self.vram = [bytearray(self.columns) for i in range(16)]
+        self.all_framebuffers = [(self.vram[i], bytearray(b'~'*self.columns), i)
+                                 for i in range(16)]
+        # Cache fonts and icons in display byte order
+        self.font = [self._swizzle_bits(bytearray(c))
+                     for c in font8x14.VGA_FONT]
+        self.icons = {}
+        # Large font mode (2× width and height): 16px wide × 28px tall,
+        # giving a 16-column × 4-row grid.  Font is precomputed at init time.
+        self._large_font = False
+        self.font_large = self._build_font_large()
+        self.icons_large = {}
+    @staticmethod
+    def _double_bits(b):
+        # Expand 8 input bits to 16 output bits: bit i → bits 2i and 2i+1.
+        # Uses a sequence of spread-and-mask steps (no loop needed).
+        x = b & 0xFF
+        x = (x | (x << 4)) & 0x0F0F
+        x = (x | (x << 2)) & 0x3333
+        x = (x | (x << 1)) & 0x5555
+        return (x | (x << 1)) & 0xFFFF
+    def _build_font_large(self):
+        # Pre-compute 2× scaled glyphs (16px wide × 32px tall in 4 VRAM pages).
+        # Source glyph: (top, bot) each 8 bytes = 8 source columns.
+        # Output: (p0, p1, p2, p3) each 16 bytes = 16 output columns.
+        font_large = []
+        for top, bot in self.font:
+            p0 = bytearray(16)
+            p1 = bytearray(16)
+            p2 = bytearray(16)
+            p3 = bytearray(16)
+            for k in range(8):
+                dt = self._double_bits(top[k])   # rows 0-7 → rows 0-15
+                db = self._double_bits(bot[k])   # rows 8-15 → rows 16-31
+                p0[k*2] = p0[k*2+1] = dt & 0xFF
+                p1[k*2] = p1[k*2+1] = (dt >> 8) & 0xFF
+                p2[k*2] = p2[k*2+1] = db & 0xFF
+                p3[k*2] = p3[k*2+1] = (db >> 8) & 0xFF
+            font_large.append((p0, p1, p2, p3))
+        return font_large
+    def _build_icon_large(self, icon_top, icon_bot):
+        # Pre-compute 2× scaled icon from 16-byte (top, bot) column arrays.
+        # Output: (p0, p1, p2, p3) each 32 bytes = 32 output columns.
+        p0 = bytearray(32)
+        p1 = bytearray(32)
+        p2 = bytearray(32)
+        p3 = bytearray(32)
+        for k in range(16):
+            dt = self._double_bits(icon_top[k])
+            db = self._double_bits(icon_bot[k])
+            p0[k*2] = p0[k*2+1] = dt & 0xFF
+            p1[k*2] = p1[k*2+1] = (dt >> 8) & 0xFF
+            p2[k*2] = p2[k*2+1] = db & 0xFF
+            p3[k*2] = p3[k*2+1] = (db >> 8) & 0xFF
+        return (p0, p1, p2, p3)
+    def set_large_font(self, enabled):
+        self._large_font = bool(enabled)
+    def _swizzle_bits(self, data):
+        # Convert from "rows of pixels" format to "columns of pixels"
+        top = bot = 0
+        for row in range(8):
+            spaced = (data[row] * 0x8040201008040201) & 0x8080808080808080
+            top |= spaced >> (7 - row)
+            spaced = (data[row + 8] * 0x8040201008040201) & 0x8080808080808080
+            bot |= spaced >> (7 - row)
+        bits_top = [(top >> s) & 0xff for s in range(0, 64, 8)]
+        bits_bot = [(bot >> s) & 0xff for s in range(0, 64, 8)]
+        return (bytearray(bits_top), bytearray(bits_bot))
+    def set_glyphs(self, glyphs):
+        for glyph_name, glyph_data in glyphs.items():
+            icon = glyph_data.get('icon16x16')
+            if icon is not None:
+                top1, bot1 = self._swizzle_bits(icon[0])
+                top2, bot2 = self._swizzle_bits(icon[1])
+                self.icons[glyph_name] = (top1 + top2, bot1 + bot2)
+                self.icons_large[glyph_name] = self._build_icon_large(
+                    top1 + top2, bot1 + bot2)
+    def write_text(self, x, y, data):
+        if self._large_font:
+            self._write_text_large(x, y, data)
+            return
+        if x + len(data) > 32:
+            data = data[:32 - min(x, 32)]
+        pix_x = x * 8
+        pix_x += self.x_offset
+        page_top = self.vram[y * 2]
+        page_bot = self.vram[y * 2 + 1]
+        for c in bytearray(data):
+            bits_top, bits_bot = self.font[c]
+            page_top[pix_x:pix_x+8] = bits_top
+            page_bot[pix_x:pix_x+8] = bits_bot
+            pix_x += 8
+    def _write_text_large(self, x, y, data):
+        # Large font path: 16px wide × 28px tall chars, 16 cols × 4 rows grid.
+        if x + len(data) > 16:
+            data = data[:16 - min(x, 16)]
+        pix_x = x * 16 + self.x_offset
+        p0 = self.vram[y * 4]
+        p1 = self.vram[y * 4 + 1]
+        p2 = self.vram[y * 4 + 2]
+        p3 = self.vram[y * 4 + 3]
+        for c in bytearray(data):
+            lp0, lp1, lp2, lp3 = self.font_large[c]
+            p0[pix_x:pix_x+16] = lp0
+            p1[pix_x:pix_x+16] = lp1
+            p2[pix_x:pix_x+16] = lp2
+            p3[pix_x:pix_x+16] = lp3
+            pix_x += 16
+    def write_graphics(self, x, y, data):
+        if self._large_font:
+            self._write_graphics_large(x, y, data)
+            return
+        if x >= 32 or y >= 8 or len(data) != 16:
+            return
+        bits_top, bits_bot = self._swizzle_bits(data)
+        pix_x = x * 8
+        pix_x += self.x_offset
+        page_top = self.vram[y * 2]
+        page_bot = self.vram[y * 2 + 1]
+        for i in range(8):
+            page_top[pix_x + i] ^= bits_top[i]
+            page_bot[pix_x + i] ^= bits_bot[i]
+    def _write_graphics_large(self, x, y, data):
+        # Large font path: each graphic column is 16px wide, 4 VRAM pages tall.
+        if x >= 16 or y >= 4 or len(data) != 16:
+            return
+        top, bot = self._swizzle_bits(data)
+        pix_x = x * 16 + self.x_offset
+        p0 = self.vram[y * 4]
+        p1 = self.vram[y * 4 + 1]
+        p2 = self.vram[y * 4 + 2]
+        p3 = self.vram[y * 4 + 3]
+        for k in range(8):
+            dt = self._double_bits(top[k])
+            db = self._double_bits(bot[k])
+            c0 = dt & 0xFF
+            c1 = (dt >> 8) & 0xFF
+            c2 = db & 0xFF
+            c3 = (db >> 8) & 0xFF
+            for j in (k * 2, k * 2 + 1):
+                p0[pix_x + j] ^= c0
+                p1[pix_x + j] ^= c1
+                p2[pix_x + j] ^= c2
+                p3[pix_x + j] ^= c3
+    def write_glyph(self, x, y, glyph_name):
+        if self._large_font:
+            return self._write_glyph_large(x, y, glyph_name)
+        icon = self.icons.get(glyph_name)
+        if icon is not None and x < 31:
+            # Draw icon in graphics mode
+            pix_x = x * 8
+            pix_x += self.x_offset
+            page_idx = y * 2
+            self.vram[page_idx][pix_x:pix_x+16] = icon[0]
+            self.vram[page_idx + 1][pix_x:pix_x+16] = icon[1]
+            return 2
+        char = TextGlyphs.get(glyph_name)
+        if char is not None:
+            # Draw character
+            self.write_text(x, y, char)
+            return 1
+        return 0
+    def _write_glyph_large(self, x, y, glyph_name):
+        # Large font path: icons are 32px wide (2 large cols), 4 VRAM pages tall.
+        icon = self.icons_large.get(glyph_name)
+        if icon is not None and x < 15:
+            pix_x = x * 16 + self.x_offset
+            page_idx = y * 4
+            self.vram[page_idx][pix_x:pix_x+32] = icon[0]
+            self.vram[page_idx + 1][pix_x:pix_x+32] = icon[1]
+            self.vram[page_idx + 2][pix_x:pix_x+32] = icon[2]
+            self.vram[page_idx + 3][pix_x:pix_x+32] = icon[3]
+            return 2
+        char = TextGlyphs.get(glyph_name)
+        if char is not None:
+            self._write_text_large(x, y, char)
+            return 1
+        return 0
+    def clear(self):
+        zeros = bytearray(self.columns)
+        for page in self.vram:
+            page[:] = zeros
+    def get_dimensions(self):
+        return (32, 8)
+
+# IO wrapper for "4 wire" spi bus (spi bus with an extra data/control line)
+class SPI4wire:
+    def __init__(self, config, data_pin_name):
+        self.spi = bus.MCU_SPI_from_config(config, 0, default_speed=10000000)
+        dc_pin = config.get(data_pin_name)
+        self.mcu_dc = bus.MCU_bus_digital_out(self.spi.get_mcu(), dc_pin,
+                                              self.spi.get_command_queue())
+    def send(self, cmds, is_data=False):
+        self.mcu_dc.update_digital_out(is_data,
+                                       reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.spi.spi_send(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_cmd(self, cmd):
+        self.mcu_dc.update_digital_out(0, reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.spi.spi_send([cmd], reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_arg(self, arg):
+        self.mcu_dc.update_digital_out(1, reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.spi.spi_send([arg], reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_data(self, data):
+        self.mcu_dc.update_digital_out(1, reqclock=BACKGROUND_PRIORITY_CLOCK)
+        self.spi.spi_send(data, reqclock=BACKGROUND_PRIORITY_CLOCK)
+
+# IO wrapper for i2c bus
+class I2C:
+    def __init__(self, config, default_addr):
+        self.i2c = bus.MCU_I2C_from_config(config, default_addr=default_addr,
+                                           default_speed=400000,
+                                           async_write_only=True)
+    def send(self, cmds, is_data=False):
+        hdr = 0x40 if is_data else 0x00
+        cmds = bytearray(cmds)
+        cmds.insert(0, hdr)
+        self.i2c.i2c_write_noack(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_cmd(self, cmd):
+        # CAD=011: command byte in its own I2C transaction with 0x00 control byte
+        self.i2c.i2c_write_noack(bytearray([0x00, cmd]),
+                                  reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_arg(self, arg):
+        # CAD=011: each argument byte in its own I2C transaction with 0x40 control byte
+        self.i2c.i2c_write_noack(bytearray([0x40, arg]),
+                                  reqclock=BACKGROUND_PRIORITY_CLOCK)
+    def send_data(self, data):
+        # CAD=011: data chunked at 32 bytes per I2C transaction with 0x40 control byte
+        data = bytearray(data)
+        pos = 0
+        while pos < len(data):
+            chunk = data[pos:pos + 32]
+            self.i2c.i2c_write_noack(bytearray([0x40]) + chunk,
+                                      reqclock=BACKGROUND_PRIORITY_CLOCK)
+            pos += 32
+
+# Helper code for toggling a reset pin on startup
+class ResetHelper:
+    def __init__(self, pin_desc, io_bus):
+        self.mcu_reset = None
+        if pin_desc is None:
+            return
+        self.mcu_reset = bus.MCU_bus_digital_out(io_bus.get_mcu(), pin_desc,
+                                                 io_bus.get_command_queue())
+    def init(self):
+        if self.mcu_reset is None:
+            return
+        mcu = self.mcu_reset.get_mcu()
+        curtime = mcu.get_printer().get_reactor().monotonic()
+        print_time = mcu.estimated_print_time(curtime)
+        # Toggle reset
+        minclock = mcu.print_time_to_clock(print_time + .100)
+        self.mcu_reset.update_digital_out(0, minclock=minclock)
+        minclock = mcu.print_time_to_clock(print_time + .200)
+        self.mcu_reset.update_digital_out(1, minclock=minclock)
+        # Force a delay to any subsequent commands on the command queue
+        minclock = mcu.print_time_to_clock(print_time + .300)
+        self.mcu_reset.update_digital_out(1, minclock=minclock)
+
+
+# The SSD1363 supports both i2c and "4-wire" spi
+class SSD1363(DisplayBase):
+    def __init__(self, config, columns=256):
+        cs_pin = config.get("cs_pin", None)
+        if cs_pin is None:
+            io = I2C(config, 60)
+            io_bus = io.i2c
+        else:
+            io = SPI4wire(config, "dc_pin")
+            io_bus = io.spi
+        self.reset = ResetHelper(config.get("reset_pin", None), io_bus)
+        self.io = io
+        # chip_col_offset: SSD1363 chip supports 320px (80 col addrs) but the
+        # panel is 256px wide.  Offset 8 centres the 256px panel: (80-64)/2=8.
+        # Matches u8g2 default_x_offset=8.  Override via x_offset in [display].
+        self.chip_col_offset = config.getint('x_offset', 8, minval=0, maxval=79)
+        # effect: selects the greyscale 3D rendering mode.
+        #   'emboss' — raised look, light from top-left (highlight/interior/shadow)
+        #   'none'   — flat full-white, original behaviour
+        self._effect = config.get('effect', 'emboss')
+        if self._effect not in ('emboss', 'none'):
+            raise config.error(
+                "effect must be 'emboss' or 'none'")
+        DisplayBase.__init__(self, io, columns, 0)
+        self.contrast = config.getint('contrast', 239, minval=0, maxval=255)
+        self.vcomh = config.getint('vcomh', 0, minval=0, maxval=7)
+        self.invert = config.getboolean('invert', False)
+    def init(self):
+        self.reset.init()
+        io = self.io
+        # Init sequence synced with u8g2 u8x8_d_ssd1363_256x128_init_seq.
+        # Reference: u8g2-src/clib/u8x8_d_ssd1363.c
+        # Datasheet: https://admin.osptek.com/uploads/SSD_1363_0_10_to_Ri_Tdisplay_withcommandtable_aa469a71c2.pdf
+        #
+        # CAD=011 I2C protocol (u8x8_cad_011_ssd13xx_i2c):
+        #   command → own I2C transaction [0x00, cmd]
+        #   arg     → own I2C transaction [0x40, arg]   (one per byte)
+        #   data    → I2C transaction(s)  [0x40, ...data] (chunked at 32 bytes)
+        io.send_cmd(0xFD); io.send_arg(0x12)        # Unlock display
+        io.send_cmd(0xAE)                            # Display off
+        io.send_cmd(0xB3); io.send_arg(0x30)        # Clock divide ratio / oscillator freq
+        io.send_cmd(0xCA); io.send_arg(127)          # Multiplex ratio (3..159)
+        io.send_cmd(0xA2); io.send_arg(0x20)        # Display offset
+        io.send_cmd(0xA1); io.send_arg(0x00)        # Display start line
+        io.send_cmd(0xA0); io.send_arg(0x32); io.send_arg(0x00)  # Re-Map / Dual COM
+        io.send_cmd(0xB4); io.send_arg(0x32); io.send_arg(0x0C) # Display Enhancement A
+        io.send_cmd(0xC1); io.send_arg(self.contrast)            # Contrast
+        io.send_cmd(0xBA); io.send_arg(0x03)        # Voltage config (Vp cap)
+        io.send_cmd(0xB9)                            # Linear greyscale table
+        io.send_cmd(0xAD); io.send_arg(0x90)        # Internal IREF (0x80 = external)
+        io.send_cmd(0xB1); io.send_arg(0x74)        # Phase 1/2 period adjustment
+        io.send_cmd(0xBB); io.send_arg(0x0C)        # Pre-charge voltage
+        io.send_cmd(0xB6); io.send_arg(0xC8)        # 2nd pre-charge period
+        io.send_cmd(0xBE); io.send_arg(0x04)        # VCOMH deselect level
+        io.send_cmd(0xA7 if self.invert else 0xA6)  # Invert / normal display
+        io.send_cmd(0xA9)                            # Exit partial display
+        io.send_cmd(0xAF)                            # Display on
+        self.flush()
+
+    def flush(self):
+        # Find dirty tile runs and coalesce nearby ones to minimise I2C
+        # transactions.  Each run shares a single column-window command and
+        # one send_data() call instead of separate commands per tile.
+        for new_data, old_data, page in self.all_framebuffers:
+            if new_data == old_data:
+                continue
+            num_tiles = self.columns // 8
+            # Collect indices of dirty tiles.
+            dirty = [i for i in range(num_tiles)
+                     if new_data[i*8:(i+1)*8] != old_data[i*8:(i+1)*8]]
+            if not dirty:
+                old_data[:] = new_data
+                continue
+            # Coalesce into runs: merge tile j into current run if the gap is
+            # ≤ 3 tiles (re-sending ≤ 96 unchanged bytes saves 7 transactions).
+            runs = []
+            run_start = run_end = dirty[0]
+            for j in dirty[1:]:
+                if j <= run_end + 3:
+                    run_end = j
+                else:
+                    runs.append((run_start, run_end))
+                    run_start = run_end = j
+            runs.append((run_start, run_end))
+            for run_start, run_end in runs:
+                tiles = [bytearray(new_data[i*8:(i+1)*8])
+                         for i in range(run_start, run_end + 1)]
+                lc = new_data[run_start * 8 - 1] if run_start > 0 else 0
+                rc = (new_data[(run_end + 1) * 8]
+                      if (run_end + 1) * 8 < self.columns else 0)
+                self.draw_tile(run_start, page, tiles, lc, rc)
+            old_data[:] = new_data
+
+    def _8to32(self, ptr, left_col=0, right_col=0):
+        """Convert 8 bytes of 1bpp tile data to 32 bytes of 4bpp SSD1363 format.
+
+        effect='none'  — every ON pixel at full brightness 0xF.
+        effect='emboss'— per-pixel brightness from top-left edge detection:
+                         highlight(0xF) / interior(0xC) / shadow(0x8).
+        left_col / right_col: VRAM column bytes bordering this tile (cross-tile
+        edge detection for emboss).
+        """
+        dest = bytearray(32)
+        if not any(ptr):
+            return dest
+        effect = getattr(self, '_effect', 'none')
+        # Column index → dest byte offset within each 4-byte row group.
+        #   col:  0  1  2  3  4  5  6  7
+        _bo = (1, 1, 0, 0, 3, 3, 2, 2)
+        if effect == 'none':
+            # Flat mode: every ON pixel at full brightness (0xF).
+            a = 1
+            for i in range(8):
+                if ptr[0] & a: dest[i*4 + 1] |= 0x0f
+                if ptr[1] & a: dest[i*4 + 1] |= 0xf0
+                if ptr[2] & a: dest[i*4 + 0] |= 0x0f
+                if ptr[3] & a: dest[i*4 + 0] |= 0xf0
+                if ptr[4] & a: dest[i*4 + 3] |= 0x0f
+                if ptr[5] & a: dest[i*4 + 3] |= 0xf0
+                if ptr[6] & a: dest[i*4 + 2] |= 0x0f
+                if ptr[7] & a: dest[i*4 + 2] |= 0xf0
+                a <<= 1
+            return dest
+        if effect == 'emboss':
+            # Raised look: brightness determined by which edges are exposed.
+            for r in range(8):
+                mask = 1 << r
+                for c in range(8):
+                    if not (ptr[c] & mask):
+                        continue
+                    above = (ptr[c] >> (r - 1)) & 1 if r > 0 else 0
+                    below = (ptr[c] >> (r + 1)) & 1 if r < 7 else 0
+                    left  = (left_col  >> r) & 1 if c == 0 else (ptr[c - 1] >> r) & 1
+                    right = (right_col >> r) & 1 if c == 7 else (ptr[c + 1] >> r) & 1
+                    if not above or not left:
+                        grey = 0xF
+                    elif not below or not right:
+                        grey = 0x4
+                    else:
+                        grey = 0x9
+                    bo = _bo[c]
+                    if c & 1:
+                        dest[r * 4 + bo] |= grey << 4
+                    else:
+                        dest[r * 4 + bo] |= grey
+            return dest
+
+        return dest
+
+    def draw_tile(self, x_pos, y_pos, tiles, left_col=0, right_col=0):
+        """Write tile data to display (mirrors U8X8_MSG_DISPLAY_DRAW_TILE).
+        tiles: list of 8-byte bytearrays, one per tile column.
+        left_col / right_col: VRAM column bytes bordering the first/last tile
+        (cross-tile edge detection for emboss).
+        """
+        x = x_pos * 2 + self.chip_col_offset  # each tile = 2 SSD1363 column addresses (8 pixels)
+        y = y_pos * 8                   # each tile = 8 rows
+
+        # Set row address once for all tiles in this row (CAD=011: cmd + 2 args)
+        self.io.send_cmd(0x75)
+        self.io.send_arg(y)
+        self.io.send_arg(y + 7)
+
+        # Set column window to span all tiles, then write-to-RAM once so all
+        # tile data streams as a single send_data() call.
+        x_end = x + len(tiles) * 2 - 1
+        self.io.send_cmd(0x15)              # set column address
+        self.io.send_arg(x)                 # start
+        self.io.send_arg(x_end)             # end
+        self.io.send_cmd(0x5C)              # write to RAM
+
+        converted = []
+        for idx, tile in enumerate(tiles):
+            lc = tiles[idx - 1][7] if idx > 0 else left_col
+            rc = tiles[idx + 1][0] if idx < len(tiles) - 1 else right_col
+            converted.append(self._8to32(tile, lc, rc))
+        # SSD1363 uses row-major addressing: for each row, all column bytes must
+        # be consecutive across tiles before advancing to the next row.
+        buf = bytearray()
+        for r in range(8):
+            for tile_data in converted:
+                buf += tile_data[r*4:r*4+4]
+        self.io.send_data(buf)

--- a/klippy/extras/display/ssd1363.py
+++ b/klippy/extras/display/ssd1363.py
@@ -2,7 +2,8 @@
 # Based off uc1701 klipper implementation and
 # U8G2 orginal implementation for ssd1363
 #
-# Copyright holders are preserved as i consider this a derivative work of both implementations.
+# Copyright holders are preserved as i consider this a derivative
+# work of both implementations.
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 # Copyright (C) 2018  Eric Callahan  <arksine.code@gmail.com>
 #
@@ -183,7 +184,7 @@ class DisplayBase:
             return 1
         return 0
     def _write_glyph_large(self, x, y, glyph_name):
-        # Large font path: icons are 32px wide (2 large cols), 4 VRAM pages tall.
+        # Large font path: Icons are double in size
         icon = self.icons_large.get(glyph_name)
         if icon is not None and x < 15:
             pix_x = x * 16 + self.x_offset
@@ -238,15 +239,12 @@ class I2C:
         cmds.insert(0, hdr)
         self.i2c.i2c_write_noack(cmds, reqclock=BACKGROUND_PRIORITY_CLOCK)
     def send_cmd(self, cmd):
-        # CAD=011: command byte in its own I2C transaction with 0x00 control byte
         self.i2c.i2c_write_noack(bytearray([0x00, cmd]),
                                   reqclock=BACKGROUND_PRIORITY_CLOCK)
     def send_arg(self, arg):
-        # CAD=011: each argument byte in its own I2C transaction with 0x40 control byte
         self.i2c.i2c_write_noack(bytearray([0x40, arg]),
                                   reqclock=BACKGROUND_PRIORITY_CLOCK)
     def send_data(self, data):
-        # CAD=011: data chunked at 32 bytes per I2C transaction with 0x40 control byte
         data = bytearray(data)
         pos = 0
         while pos < len(data):
@@ -296,8 +294,8 @@ class SSD1363(DisplayBase):
         # Matches u8g2 default_x_offset=8.  Override via x_offset in [display].
         self.chip_col_offset = config.getint('x_offset', 8, minval=0, maxval=79)
         # effect: selects the greyscale 3D rendering mode.
-        #   'emboss' — raised look, light from top-left (highlight/interior/shadow)
-        #   'none'   — flat full-white, original behaviour
+        # 'emboss' — raised look
+        # 'none'   — original behaviour
         self._effect = config.get('effect', 'emboss')
         if self._effect not in ('emboss', 'none'):
             raise config.error(
@@ -311,31 +309,49 @@ class SSD1363(DisplayBase):
         io = self.io
         # Init sequence synced with u8g2 u8x8_d_ssd1363_256x128_init_seq.
         # Reference: u8g2-src/clib/u8x8_d_ssd1363.c
-        # Datasheet: https://admin.osptek.com/uploads/SSD_1363_0_10_to_Ri_Tdisplay_withcommandtable_aa469a71c2.pdf
         #
         # CAD=011 I2C protocol (u8x8_cad_011_ssd13xx_i2c):
         #   command → own I2C transaction [0x00, cmd]
         #   arg     → own I2C transaction [0x40, arg]   (one per byte)
         #   data    → I2C transaction(s)  [0x40, ...data] (chunked at 32 bytes)
-        io.send_cmd(0xFD); io.send_arg(0x12)        # Unlock display
-        io.send_cmd(0xAE)                            # Display off
-        io.send_cmd(0xB3); io.send_arg(0x30)        # Clock divide ratio / oscillator freq
-        io.send_cmd(0xCA); io.send_arg(127)          # Multiplex ratio (3..159)
-        io.send_cmd(0xA2); io.send_arg(0x20)        # Display offset
-        io.send_cmd(0xA1); io.send_arg(0x00)        # Display start line
-        io.send_cmd(0xA0); io.send_arg(0x32); io.send_arg(0x00)  # Re-Map / Dual COM
-        io.send_cmd(0xB4); io.send_arg(0x32); io.send_arg(0x0C) # Display Enhancement A
-        io.send_cmd(0xC1); io.send_arg(self.contrast)            # Contrast
-        io.send_cmd(0xBA); io.send_arg(0x03)        # Voltage config (Vp cap)
-        io.send_cmd(0xB9)                            # Linear greyscale table
-        io.send_cmd(0xAD); io.send_arg(0x90)        # Internal IREF (0x80 = external)
-        io.send_cmd(0xB1); io.send_arg(0x74)        # Phase 1/2 period adjustment
-        io.send_cmd(0xBB); io.send_arg(0x0C)        # Pre-charge voltage
-        io.send_cmd(0xB6); io.send_arg(0xC8)        # 2nd pre-charge period
-        io.send_cmd(0xBE); io.send_arg(0x04)        # VCOMH deselect level
-        io.send_cmd(0xA7 if self.invert else 0xA6)  # Invert / normal display
-        io.send_cmd(0xA9)                            # Exit partial display
-        io.send_cmd(0xAF)                            # Display on
+        # Unlock display
+        io.send_cmd(0xFD); io.send_arg(0x12)
+        # Display off
+        io.send_cmd(0xAE)
+        # Clock divide ratio / oscillator freq
+        io.send_cmd(0xB3); io.send_arg(0x30)
+        # Multiplex ratio (3..159)
+        io.send_cmd(0xCA); io.send_arg(127)
+        # Display offset
+        io.send_cmd(0xA2); io.send_arg(0x20)
+        # Display start line
+        io.send_cmd(0xA1); io.send_arg(0x00)
+        # Re-Map / Dual COM
+        io.send_cmd(0xA0); io.send_arg(0x32); io.send_arg(0x00)
+        # Display Enhancement A
+        io.send_cmd(0xB4); io.send_arg(0x32); io.send_arg(0x0C)
+        # Contrast
+        io.send_cmd(0xC1); io.send_arg(self.contrast)
+        # Voltage config (Vp cap)
+        io.send_cmd(0xBA); io.send_arg(0x03)
+        # Linear greyscale table
+        io.send_cmd(0xB9)
+        # Internal IREF (0x80 = external)
+        io.send_cmd(0xAD); io.send_arg(0x90)
+        # Phase 1/2 period adjustment
+        io.send_cmd(0xB1); io.send_arg(0x74)
+        # Pre-charge voltage
+        io.send_cmd(0xBB); io.send_arg(0x0C)
+        # 2nd pre-charge period
+        io.send_cmd(0xB6); io.send_arg(0xC8)
+        # VCOMH deselect level
+        io.send_cmd(0xBE); io.send_arg(0x04)
+        # Invert / normal display
+        io.send_cmd(0xA7 if self.invert else 0xA6)
+        # Exit partial display
+        io.send_cmd(0xA9)
+        # Display on
+        io.send_cmd(0xAF)
         self.flush()
 
     def flush(self):
@@ -411,8 +427,10 @@ class SSD1363(DisplayBase):
                         continue
                     above = (ptr[c] >> (r - 1)) & 1 if r > 0 else 0
                     below = (ptr[c] >> (r + 1)) & 1 if r < 7 else 0
-                    left  = (left_col  >> r) & 1 if c == 0 else (ptr[c - 1] >> r) & 1
-                    right = (right_col >> r) & 1 if c == 7 else (ptr[c + 1] >> r) & 1
+                    left  = ((left_col  >> r) & 1 if c == 0
+                             else (ptr[c - 1] >> r) & 1)
+                    right = ((right_col >> r) & 1 if c == 7
+                             else (ptr[c + 1] >> r) & 1)
                     if not above or not left:
                         grey = 0xF
                     elif not below or not right:
@@ -434,10 +452,12 @@ class SSD1363(DisplayBase):
         left_col / right_col: VRAM column bytes bordering the first/last tile
         (cross-tile edge detection for emboss).
         """
-        x = x_pos * 2 + self.chip_col_offset  # each tile = 2 SSD1363 column addresses (8 pixels)
-        y = y_pos * 8                   # each tile = 8 rows
-
-        # Set row address once for all tiles in this row (CAD=011: cmd + 2 args)
+        # each tile = 2 SSD1363 column addresses (8 pixels)
+        x = x_pos * 2 + self.chip_col_offset
+        # each tile = 8 rows
+        y = y_pos * 8
+        # Set row address once for all tiles in this row
+        # (CAD=011: cmd + 2 args)
         self.io.send_cmd(0x75)
         self.io.send_arg(y)
         self.io.send_arg(y + 7)
@@ -455,8 +475,9 @@ class SSD1363(DisplayBase):
             lc = tiles[idx - 1][7] if idx > 0 else left_col
             rc = tiles[idx + 1][0] if idx < len(tiles) - 1 else right_col
             converted.append(self._8to32(tile, lc, rc))
-        # SSD1363 uses row-major addressing: for each row, all column bytes must
-        # be consecutive across tiles before advancing to the next row.
+        # SSD1363 uses row-major addressing:
+        # for each row, all column bytes must be consecutive
+        # across tiles before advancing to the next row.
         buf = bytearray()
         for r in range(8):
             for tile_data in converted:

--- a/klippy/extras/display/ssd1363.py
+++ b/klippy/extras/display/ssd1363.py
@@ -369,7 +369,7 @@ class SSD1363(DisplayBase):
                 old_data[:] = new_data
                 continue
             # Coalesce into runs: merge tile j into current run if the gap is
-            # <= 3 tiles (re-sending <= 96 unchanged bytes saves 7 transactions).
+            # <= 3 tiles
             runs = []
             run_start = run_end = dirty[0]
             for j in dirty[1:]:

--- a/klippy/extras/display/ssd1363.py
+++ b/klippy/extras/display/ssd1363.py
@@ -1,5 +1,8 @@
-# Support for UC1701 (and similar) 128x64 graphics LCD displays
+# Support for SSD1363 256x128 OLED display
+# Based off uc1701 klipper implementation and
+# U8G2 orginal implementation for ssd1363
 #
+# Copyright holders are preserved as i consider this a derivative work of both implementations.
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
 # Copyright (C) 2018  Eric Callahan  <arksine.code@gmail.com>
 #

--- a/klippy/extras/hc595.py
+++ b/klippy/extras/hc595.py
@@ -1,0 +1,70 @@
+# Host module for SNx4HC595 shift register with firmware-level GPIO support
+#
+# Copyright (C) 2026
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+import pins
+
+
+class HC595:
+    """Configures a 74HC595 shift register chain with firmware-level support.
+
+    The firmware exposes shift register outputs as virtual GPIO pins
+    (PG0-PG7 for the first chip, PH0-PH7 for the second). Stepper
+    dir_pin and enable_pin can reference these directly, allowing the
+    firmware to toggle them natively in the stepper ISR without any
+    host involvement.
+
+    This module sends the config_hc595 command to set up the bitbang
+    pins, and provides hc595_update for host-driven state changes
+    (e.g. LED control on the second chip).
+    """
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[1]
+        ppins = self.printer.lookup_object('pins')
+        # Resolve MCU from data_pin (any pin on the target MCU)
+        data_pin_name = config.get('data_pin')
+        data_params = ppins.lookup_pin(data_pin_name)
+        self.mcu = data_params['chip']
+        self.data_pin = data_params['pin']
+        latch_params = ppins.lookup_pin(config.get('latch_pin'))
+        self.latch_pin = latch_params['pin']
+        clock_params = ppins.lookup_pin(config.get('clock_pin'))
+        self.clock_pin = clock_params['pin']
+        # Validate all pins are on the same MCU
+        if latch_params['chip'] is not self.mcu:
+            raise config.error("hc595: latch_pin must be on same MCU as "
+                               "data_pin")
+        if clock_params['chip'] is not self.mcu:
+            raise config.error("hc595: clock_pin must be on same MCU as "
+                               "data_pin")
+        self.chain_count = config.getint('chain_count', 2, minval=1, maxval=4)
+        self.oid = self.mcu.create_oid()
+        self.mcu.register_config_callback(self._build_config)
+        self.update_cmd = None
+        self.printer.register_event_handler(
+            "klippy:connect", self._handle_connect)
+    def _build_config(self):
+        self.mcu.add_config_cmd(
+            "config_hc595 oid=%d data_pin=%s latch_pin=%s clock_pin=%s"
+            % (self.oid, self.data_pin, self.latch_pin, self.clock_pin))
+        cmd_queue = self.mcu.alloc_command_queue()
+        self.update_cmd = self.mcu.lookup_command(
+            "hc595_update oid=%c data=%*s", cq=cmd_queue)
+    def _handle_connect(self):
+        logging.info("hc595 '%s': configured on %s (oid=%d, chain=%d)",
+                     self.name, self.mcu.get_name(), self.oid,
+                     self.chain_count)
+    def get_mcu(self):
+        return self.mcu
+    def update_state(self, data):
+        """Send full state update to shift register (e.g. for LED control).
+        data should be a bytes/bytearray of length chain_count."""
+        if self.update_cmd is not None:
+            self.update_cmd.send([self.oid, data])
+
+
+def load_config_prefix(config):
+    return HC595(config)

--- a/klippy/extras/shift_register.py
+++ b/klippy/extras/shift_register.py
@@ -210,7 +210,4 @@ class ShiftRegisterStepperDir:
 
 
 def load_config_prefix(config):
-    name = config.get_name()
-    if name.startswith('shift_register_stepper_dir '):
-        return ShiftRegisterStepperDir(config)
     return ShiftRegister74HC595(config)

--- a/klippy/extras/shift_register.py
+++ b/klippy/extras/shift_register.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2026
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
 import pins
 from . import bus
 
@@ -54,7 +55,6 @@ class ShiftRegister74HC595:
         self._printer = config.get_printer()
         self._name = config.get_name().split()[1]
         self._chain_count = config.getint('chain_count', 1, minval=1, maxval=8)
-        total_pins = self._chain_count * 8
         # State tracking: one byte per chip in the chain
         self._state = bytearray(self._chain_count)
         self._shutdown_state = bytearray(self._chain_count)
@@ -82,6 +82,8 @@ class ShiftRegister74HC595:
         self._spi.spi_send(self._state)
     def get_mcu(self):
         return self._mcu
+    def get_name(self):
+        return self._name
     def set_bit(self, byte_index, bitmask):
         self._state[byte_index] |= bitmask
     def clear_bit(self, byte_index, bitmask):
@@ -96,31 +98,119 @@ class ShiftRegister74HC595:
         self._spi.spi_send(self._state, minclock=self._last_clock,
                            reqclock=clock)
         self._last_clock = clock
-    def setup_pin(self, pin_type, pin_params):
-        if pin_type != 'digital_out':
-            raise pins.error("Shift register only supports digital_out pins")
-        pin = pin_params['pin']
-        if pin.startswith('PIN_'):
-            try:
-                pin_number = int(pin[4:])
-            except ValueError:
-                raise pins.error("Invalid shift register pin '%s'" % (pin,))
-        else:
+    def _parse_pin_number(self, pin):
+        if not pin.startswith('PIN_'):
             raise pins.error(
                 "Shift register pin must be named PIN_N (e.g. PIN_0), "
                 "got '%s'" % (pin,))
+        try:
+            pin_number = int(pin[4:])
+        except ValueError:
+            raise pins.error("Invalid shift register pin '%s'" % (pin,))
         total_pins = self._chain_count * 8
         if pin_number < 0 or pin_number >= total_pins:
             raise pins.error(
                 "Shift register pin %d out of range (0-%d for %d chained "
                 "chips)" % (pin_number, total_pins - 1, self._chain_count))
+        return pin_number
+    def get_pin_indices(self, pin_number):
         # PIN_0 is bit 0 of the first chip (furthest from MCU in chain).
         # SPI sends bytes MSB-first and the first byte sent ends up in the
         # last chip of the chain, so we reverse the byte index.
         chip_index = pin_number // 8
         bit_index = pin_number % 8
         byte_index = self._chain_count - 1 - chip_index
+        return byte_index, bit_index
+    def setup_pin(self, pin_type, pin_params):
+        if pin_type != 'digital_out':
+            raise pins.error("Shift register only supports digital_out pins")
+        pin_number = self._parse_pin_number(pin_params['pin'])
+        byte_index, bit_index = self.get_pin_indices(pin_number)
         return ShiftRegisterPin(self, byte_index, bit_index, pin_params)
 
+
+class ShiftRegisterStepperDir:
+    """Hooks into a manual_stepper to manage direction via a shift register.
+
+    This allows a manual_stepper's physical direction pin to be on a 74HC595
+    shift register while the firmware uses a dummy dir_pin. Before each move,
+    this module updates the shift register direction bit via SPI, timed to
+    complete before stepping begins.
+    """
+    def __init__(self, config):
+        self._printer = config.get_printer()
+        self._name = config.get_name().split(None, 1)[1]
+        # Locate the shift register and pin
+        ppins = self._printer.lookup_object('pins')
+        dir_pin_desc = config.get('dir_pin')
+        dir_pin_params = ppins.parse_pin(dir_pin_desc, can_invert=True)
+        self._sr = dir_pin_params['chip']
+        if not isinstance(self._sr, ShiftRegister74HC595):
+            raise config.error(
+                "%s: dir_pin must be on a shift_register chip" % (
+                    config.get_name(),))
+        pin_number = self._sr._parse_pin_number(dir_pin_params['pin'])
+        byte_index, bit_index = self._sr.get_pin_indices(pin_number)
+        self._byte_index = byte_index
+        self._bitmask = 1 << bit_index
+        self._invert = dir_pin_params['invert']
+        self._last_dir = -1
+        # Locate the manual_stepper to hook into
+        self._stepper_name = config.get('manual_stepper')
+        self._printer.register_event_handler(
+            "klippy:ready", self._handle_ready)
+    def _handle_ready(self):
+        stepper_obj = self._printer.lookup_object(
+            'manual_stepper ' + self._stepper_name)
+        # Wrap do_move to update direction before each move
+        orig_do_move = stepper_obj.do_move
+        def wrapped_do_move(movepos, speed, accel, sync=True):
+            self._update_dir(stepper_obj, movepos)
+            return orig_do_move(movepos, speed, accel, sync)
+        stepper_obj.do_move = wrapped_do_move
+        # Wrap do_homing_move to update direction before homing
+        orig_do_homing_move = stepper_obj.do_homing_move
+        def wrapped_do_homing_move(movepos, speed, accel,
+                                   probe_pos, triggered, check_trigger):
+            self._update_dir(stepper_obj, movepos)
+            return orig_do_homing_move(movepos, speed, accel,
+                                       probe_pos, triggered, check_trigger)
+        stepper_obj.do_homing_move = wrapped_do_homing_move
+        # Wrap process_move for gcode axis mode
+        orig_process_move = stepper_obj.process_move
+        def wrapped_process_move(print_time, move, ea_index):
+            axis_r = move.axes_r[ea_index]
+            start_pos = move.start_pos[ea_index]
+            end_pos = move.end_pos[ea_index]
+            if end_pos != start_pos:
+                new_dir = 1 if end_pos > start_pos else 0
+                self._set_dir(print_time, new_dir)
+            return orig_process_move(print_time, move, ea_index)
+        stepper_obj.process_move = wrapped_process_move
+        logging.info("shift_register_stepper_dir: hooked into '%s' "
+                     "for direction control via shift register '%s'",
+                     self._stepper_name, self._sr.get_name())
+    def _update_dir(self, stepper_obj, movepos):
+        cp = stepper_obj.commanded_pos
+        if movepos == cp:
+            return
+        new_dir = 1 if movepos > cp else 0
+        stepper_obj.sync_print_time()
+        self._set_dir(stepper_obj.next_cmd_time, new_dir)
+    def _set_dir(self, print_time, new_dir):
+        if new_dir == self._last_dir:
+            return
+        self._last_dir = new_dir
+        value = new_dir ^ self._invert
+        if value:
+            self._sr.set_bit(self._byte_index, self._bitmask)
+        else:
+            self._sr.clear_bit(self._byte_index, self._bitmask)
+        self._sr.send_state(print_time)
+
+
 def load_config_prefix(config):
+    name = config.get_name()
+    if name.startswith('shift_register_stepper_dir '):
+        return ShiftRegisterStepperDir(config)
     return ShiftRegister74HC595(config)

--- a/klippy/extras/shift_register.py
+++ b/klippy/extras/shift_register.py
@@ -1,0 +1,126 @@
+# Support for 74HC595 shift register based GPIO expanders
+#
+# Copyright (C) 2026
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import pins
+from . import bus
+
+PIN_MIN_TIME = 0.100
+
+class ShiftRegisterPin:
+    def __init__(self, shift_register, byte_index, bit_index, pin_params):
+        self._shift_register = shift_register
+        self._mcu = shift_register.get_mcu()
+        self._byte_index = byte_index
+        self._bit_index = bit_index
+        self._bitmask = 1 << bit_index
+        self._invert = pin_params['invert']
+        self._start_value = self._shutdown_value = self._invert
+        self._max_duration = 2.
+        self._mcu.register_config_callback(self._build_config)
+    def _build_config(self):
+        if self._max_duration:
+            raise pins.error(
+                "Shift register pins are not suitable for heaters")
+    def get_mcu(self):
+        return self._mcu
+    def setup_max_duration(self, max_duration):
+        self._max_duration = max_duration
+    def setup_cycle_time(self, cycle_time, hardware_pwm=False):
+        if hardware_pwm:
+            raise pins.error(
+                "Shift register pins do not support hardware PWM")
+    def setup_start_value(self, start_value, shutdown_value):
+        self._start_value = (not not start_value) ^ self._invert
+        self._shutdown_value = (not not shutdown_value) ^ self._invert
+        if self._start_value:
+            self._shift_register.set_bit(self._byte_index, self._bitmask)
+        else:
+            self._shift_register.clear_bit(self._byte_index, self._bitmask)
+        self._shift_register.set_shutdown_bit(
+            self._byte_index, self._bitmask, self._shutdown_value)
+    def set_digital(self, print_time, value):
+        if int(value) ^ self._invert:
+            self._shift_register.set_bit(self._byte_index, self._bitmask)
+        else:
+            self._shift_register.clear_bit(self._byte_index, self._bitmask)
+        self._shift_register.send_state(print_time)
+    def set_pwm(self, print_time, value, cycle_time=None):
+        self.set_digital(print_time, value >= 0.5)
+
+class ShiftRegister74HC595:
+    def __init__(self, config):
+        self._printer = config.get_printer()
+        self._name = config.get_name().split()[1]
+        self._chain_count = config.getint('chain_count', 1, minval=1, maxval=8)
+        total_pins = self._chain_count * 8
+        # State tracking: one byte per chip in the chain
+        self._state = bytearray(self._chain_count)
+        self._shutdown_state = bytearray(self._chain_count)
+        self._last_clock = 0
+        # Setup SPI - latch_pin acts as CS (active-low: latches on rising edge
+        # after transfer completes, which is standard SPI CS behavior)
+        self._spi = bus.MCU_SPI_from_config(
+            config, 0, pin_option="latch_pin",
+            default_speed=4000000)
+        self._mcu = self._spi.get_mcu()
+        # Register chip with pin system
+        ppins = self._printer.lookup_object('pins')
+        ppins.register_chip(self._name, self)
+        # Optional output enable pin (active-low on 74HC595)
+        oe_pin = config.get('output_enable_pin', None)
+        if oe_pin is not None:
+            self._oe = ppins.setup_pin('digital_out', oe_pin)
+            self._oe.setup_max_duration(0.)
+            self._oe.setup_start_value(0, 0)
+        # Finalize shutdown and initial state after all pins are configured
+        self._printer.register_event_handler(
+            "klippy:connect", self._handle_connect)
+    def _handle_connect(self):
+        self._spi.setup_shutdown_msg(self._shutdown_state)
+        self._spi.spi_send(self._state)
+    def get_mcu(self):
+        return self._mcu
+    def set_bit(self, byte_index, bitmask):
+        self._state[byte_index] |= bitmask
+    def clear_bit(self, byte_index, bitmask):
+        self._state[byte_index] &= ~bitmask
+    def set_shutdown_bit(self, byte_index, bitmask, value):
+        if value:
+            self._shutdown_state[byte_index] |= bitmask
+        else:
+            self._shutdown_state[byte_index] &= ~bitmask
+    def send_state(self, print_time):
+        clock = self._mcu.print_time_to_clock(print_time)
+        self._spi.spi_send(self._state, minclock=self._last_clock,
+                           reqclock=clock)
+        self._last_clock = clock
+    def setup_pin(self, pin_type, pin_params):
+        if pin_type != 'digital_out':
+            raise pins.error("Shift register only supports digital_out pins")
+        pin = pin_params['pin']
+        if pin.startswith('PIN_'):
+            try:
+                pin_number = int(pin[4:])
+            except ValueError:
+                raise pins.error("Invalid shift register pin '%s'" % (pin,))
+        else:
+            raise pins.error(
+                "Shift register pin must be named PIN_N (e.g. PIN_0), "
+                "got '%s'" % (pin,))
+        total_pins = self._chain_count * 8
+        if pin_number < 0 or pin_number >= total_pins:
+            raise pins.error(
+                "Shift register pin %d out of range (0-%d for %d chained "
+                "chips)" % (pin_number, total_pins - 1, self._chain_count))
+        # PIN_0 is bit 0 of the first chip (furthest from MCU in chain).
+        # SPI sends bytes MSB-first and the first byte sent ends up in the
+        # last chip of the chain, so we reverse the byte index.
+        chip_index = pin_number // 8
+        bit_index = pin_number % 8
+        byte_index = self._chain_count - 1 - chip_index
+        return ShiftRegisterPin(self, byte_index, bit_index, pin_params)
+
+def load_config_prefix(config):
+    return ShiftRegister74HC595(config)

--- a/klippy/extras/shift_register.py
+++ b/klippy/extras/shift_register.py
@@ -74,12 +74,19 @@ class ShiftRegister74HC595:
             self._oe = ppins.setup_pin('digital_out', oe_pin)
             self._oe.setup_max_duration(0.)
             self._oe.setup_start_value(0, 0)
-        # Finalize shutdown and initial state after all pins are configured
+        # Send initial state (all zeros) as MCU init command.
+        # At this point spi_send_cmd is None, so this queues an init
+        # command that runs after MCU config is complete.
+        self._spi.spi_send(self._state)
+        # After connect, send the actual configured state (with
+        # start values set by setup_start_value calls from other modules)
         self._printer.register_event_handler(
             "klippy:connect", self._handle_connect)
     def _handle_connect(self):
-        self._spi.setup_shutdown_msg(self._shutdown_state)
-        self._spi.spi_send(self._state)
+        reactor = self._mcu.get_printer().get_reactor()
+        curtime = reactor.monotonic()
+        print_time = self._mcu.estimated_print_time(curtime)
+        self.send_state(print_time)
     def get_mcu(self):
         return self._mcu
     def get_name(self):

--- a/klippy/extras/shift_register_stepper_dir.py
+++ b/klippy/extras/shift_register_stepper_dir.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2026
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-from . import shift_register
+from .shift_register import ShiftRegisterStepperDir
 
 def load_config_prefix(config):
-    return shift_register.ShiftRegisterStepperDir(config)
+    return ShiftRegisterStepperDir(config)

--- a/klippy/extras/shift_register_stepper_dir.py
+++ b/klippy/extras/shift_register_stepper_dir.py
@@ -1,0 +1,9 @@
+# Support for stepper direction control via shift register
+#
+# Copyright (C) 2026
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from . import shift_register
+
+def load_config_prefix(config):
+    return shift_register.ShiftRegisterStepperDir(config)

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -159,6 +159,17 @@ config SIMULAVR
          instead of for real hardware. This disables support for "U2X
          baud" mode which is not supported on simulavr.
 
+config HAVE_HC595_SHIFT_REG
+    bool "Include SNx4HC595 shift register support (MMU2)"
+    depends on MACH_atmega32u4
+    default n
+
+config HC595_LENGTH
+    int "Number of chained HC595 ICs"
+    depends on HAVE_HC595_SHIFT_REG
+    default 2
+    range 1 4
+
          If unsure, select "N".
 
 endif

--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -170,6 +170,4 @@ config HC595_LENGTH
     default 2
     range 1 4
 
-         If unsure, select "N".
-
 endif

--- a/src/avr/Makefile
+++ b/src/avr/Makefile
@@ -18,6 +18,7 @@ src-$(CONFIG_WANT_HARD_PWM) += avr/hard_pwm.c
 src-$(CONFIG_AVR_WATCHDOG) += avr/watchdog.c
 src-$(CONFIG_USBSERIAL) += avr/usbserial.c generic/usb_cdc.c
 src-$(CONFIG_SERIAL) += avr/serial.c generic/serial_irq.c
+src-$(CONFIG_HAVE_HC595_SHIFT_REG) += avr/hc595.c
 
 # Suppress broken "misspelled signal handler" warnings on gcc 4.8.1
 CFLAGS_klipper.elf := $(CFLAGS_klipper.elf) $(if $(filter 4.8.1, $(shell $(CC) -dumpversion)), -w)

--- a/src/avr/gpio.c
+++ b/src/avr/gpio.c
@@ -12,6 +12,11 @@
 #include "pgm.h" // PROGMEM
 #include "sched.h" // sched_shutdown
 
+#if CONFIG_HAVE_HC595_SHIFT_REG
+#include "hc595.h"
+static struct gpio_digital_regs hc595_sentinel_regs;
+#endif
+
 #ifdef PINA
 DECL_ENUMERATION_RANGE("pin", "PA0", GPIO('A', 0), 8);
 #endif
@@ -34,6 +39,10 @@ DECL_ENUMERATION_RANGE("pin", "PH0", GPIO('H', 0), 8);
 DECL_ENUMERATION_RANGE("pin", "PJ0", GPIO('J', 0), 8);
 DECL_ENUMERATION_RANGE("pin", "PK0", GPIO('K', 0), 8);
 DECL_ENUMERATION_RANGE("pin", "PL0", GPIO('L', 0), 8);
+#endif
+#if CONFIG_HAVE_HC595_SHIFT_REG && !defined(PING)
+DECL_ENUMERATION_RANGE("pin", "PG0", GPIO('G', 0), 8);
+DECL_ENUMERATION_RANGE("pin", "PH0", GPIO('H', 0), 8);
 #endif
 
 volatile uint8_t * const digital_regs[] PROGMEM = {
@@ -69,12 +78,25 @@ gpio_out_setup(uint8_t pin, uint8_t val)
     gpio_out_reset(g, val);
     return g;
 fail:
+#if CONFIG_HAVE_HC595_SHIFT_REG
+    if (GPIO2PORT(pin) < ARRAY_SIZE(digital_regs) + CONFIG_HC595_LENGTH) {
+        struct gpio_out sg = { .regs=&hc595_sentinel_regs, .bit=pin };
+        gpio_out_reset(sg, val);
+        return sg;
+    }
+#endif
     shutdown("Not an output pin");
 }
 
 void
 gpio_out_reset(struct gpio_out g, uint8_t val)
 {
+#if CONFIG_HAVE_HC595_SHIFT_REG
+    if (g.regs == &hc595_sentinel_regs) {
+        hc595_set_bit(g.bit - ARRAY_SIZE(digital_regs) * 8, val);
+        return;
+    }
+#endif
     irqstatus_t flag = irq_save();
     uint8_t newmode = g.regs->mode | g.bit;
     uint8_t newout = val ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
@@ -86,6 +108,12 @@ gpio_out_reset(struct gpio_out g, uint8_t val)
 void
 gpio_out_toggle_noirq(struct gpio_out g)
 {
+#if CONFIG_HAVE_HC595_SHIFT_REG
+    if (g.regs == &hc595_sentinel_regs) {
+        hc595_toggle_bit(g.bit - ARRAY_SIZE(digital_regs) * 8);
+        return;
+    }
+#endif
     g.regs->in = g.bit;
 }
 
@@ -98,6 +126,12 @@ gpio_out_toggle(struct gpio_out g)
 void
 gpio_out_write(struct gpio_out g, uint8_t val)
 {
+#if CONFIG_HAVE_HC595_SHIFT_REG
+    if (g.regs == &hc595_sentinel_regs) {
+        hc595_set_bit(g.bit - ARRAY_SIZE(digital_regs) * 8, val);
+        return;
+    }
+#endif
     irqstatus_t flag = irq_save();
     g.regs->out = val ? (g.regs->out | g.bit) : (g.regs->out & ~g.bit);
     irq_restore(flag);

--- a/src/avr/hc595.c
+++ b/src/avr/hc595.c
@@ -1,0 +1,85 @@
+// SNx4HC595 shift register support for AVR
+//
+// Copyright (C) 2018 Trevor Jones <trevorjones141@gmail.com>
+// Copyright (C) 2026
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_HC595_LENGTH
+#include "basecmd.h" // oid_alloc
+#include "board/gpio.h" // gpio_out_setup
+#include "command.h" // DECL_COMMAND
+#include "compiler.h" // ARRAY_SIZE
+#include "hc595.h"
+
+struct hc595 *hc595_sr;
+
+void
+command_config_hc595(uint32_t *args)
+{
+    hc595_sr = oid_alloc(args[0], command_config_hc595, sizeof(*hc595_sr));
+    hc595_sr->data_pin = gpio_out_setup(args[1], 0);
+    hc595_sr->latch_pin = gpio_out_setup(args[2], 1);
+    hc595_sr->clock_pin = gpio_out_setup(args[3], 0);
+}
+DECL_COMMAND(command_config_hc595,
+             "config_hc595 oid=%c data_pin=%c latch_pin=%c clock_pin=%c");
+
+void
+hc595_set_bit(uint8_t bit, uint8_t value)
+{
+    uint8_t ic = bit / 8;
+    uint8_t ic_bit = bit % 8;
+    uint8_t mask = 1 << ic_bit;
+    if (value)
+        hc595_sr->val[ic] |= mask;
+    else
+        hc595_sr->val[ic] &= ~mask;
+    hc595_flush();
+}
+
+void
+hc595_toggle_bit(uint8_t bit)
+{
+    uint8_t ic = bit / 8;
+    uint8_t ic_bit = bit % 8;
+    uint8_t mask = 1 << ic_bit;
+    hc595_sr->val[ic] ^= mask;
+    hc595_flush();
+}
+
+void
+hc595_flush(void)
+{
+    // Latch low (prepare for data)
+    gpio_out_write(hc595_sr->latch_pin, 0);
+    // Shift out each bit, MSB first, last IC first (daisy chain order)
+    for (int ic = ARRAY_SIZE(hc595_sr->val) - 1; ic >= 0; --ic) {
+        for (int bit = 7; bit >= 0; --bit) {
+            uint8_t mask = 1 << bit;
+            gpio_out_write(hc595_sr->data_pin,
+                           (hc595_sr->val[ic] & mask) ? 1 : 0);
+            // Clock pulse: rising edge shifts data in
+            gpio_out_write(hc595_sr->clock_pin, 1);
+            gpio_out_write(hc595_sr->clock_pin, 0);
+        }
+    }
+    // Latch high (transfer shift register to output register)
+    gpio_out_write(hc595_sr->latch_pin, 1);
+}
+
+// Host command to update entire shift register state (for LEDs etc.)
+void
+command_hc595_update(uint32_t *args)
+{
+    uint8_t oid = args[0];
+    struct hc595 *sr = oid_lookup(oid, command_config_hc595);
+    uint8_t data_len = args[1];
+    uint8_t *data = command_decode_ptr(args[2]);
+    uint8_t len = data_len < CONFIG_HC595_LENGTH
+                  ? data_len : CONFIG_HC595_LENGTH;
+    for (uint8_t i = 0; i < len; i++)
+        sr->val[i] = data[i];
+    hc595_flush();
+}
+DECL_COMMAND(command_hc595_update, "hc595_update oid=%c data=%*s");

--- a/src/avr/hc595.h
+++ b/src/avr/hc595.h
@@ -1,0 +1,20 @@
+#ifndef __AVR_HC595_H
+#define __AVR_HC595_H
+// SNx4HC595 shift register support for AVR
+
+#include "autoconf.h" // CONFIG_HC595_LENGTH
+#include <stdint.h> // uint8_t
+#include "gpio.h" // gpio_out
+
+struct hc595 {
+    struct gpio_out data_pin, latch_pin, clock_pin;
+    uint8_t val[CONFIG_HC595_LENGTH];
+};
+
+extern struct hc595 *hc595_sr;
+
+void hc595_set_bit(uint8_t bit, uint8_t value);
+void hc595_toggle_bit(uint8_t bit);
+void hc595_flush(void);
+
+#endif // hc595.h


### PR DESCRIPTION
This PR has been created to add support for the oled display driver SSD1363 

My rational for adding this support is i wanted a larger display voron v0 display and the SSD1309 display was indeed a bigger display, but the pixels got 'too chonky' for my taste. 

as a disclaimer: **AI was used** to create this code and it was asked to copy the instructions used in this issue reference
https://github.com/olikraus/u8g2/issues/2298

The instruction set in SSD1306 vs SSD1363 while similar were not a one to one mapping, due to the difference in protocol specification and the available instructions

as a note; I have intentionally left all of the AI comments, while they might be redundant for any seasoned developer, they do highlight alot of my thought process for getting this implementation done. 

A couple of implementation notes for consideration and discussion if you want to merge this upstream; 

1. I added support for enlarged icons/text/glyphs in the home menu - The thought behind this was that the status menu should be easily read/observed from a distance, therefore the extra readability could go a long way. 
  - Should this be made configurable for anyone wishing to not use the enlarged home menu?
3. the menu system is currently in half of the size as the main menu - the thought here is that you are so close to the display that readability should not be of an issue. 
  - Should this also be configurable to cater for people wanting big letters instead? 
5. due to the extra amount of extra pixels avaliable, i thought it would be nice to utilize the greyscale avaliable in the SSD1636 - the 'emboss' config mapping makes the letters look more '3d like' 

For now this picture is how its currently looking; 
![homemenu-embossed](https://github.com/user-attachments/assets/1a2cae8e-4ac1-45f4-8306-1727b9684895)
![navigationmenu-embossed](https://github.com/user-attachments/assets/36f09bac-4d0c-4d4d-8f57-d27e94d5748e)
![homingmenu-embossed](https://github.com/user-attachments/assets/83c7302e-1fdb-4125-a4c9-8ffc38bd00d8)

![homemenu-none](https://github.com/user-attachments/assets/2e237227-1c21-4f38-91ab-5fcce7029dc2)
![navigationmenu-none](https://github.com/user-attachments/assets/90e2e3c1-64fa-4da1-abcc-f8e97b9a0ece)

See videoclip for navigation look and feel; 
https://github.com/user-attachments/assets/500edab2-bcfb-4460-8c05-610639063705

