### PR TITLE
Pid calibrate: use First Order Plus Dead Time model for PID estimation

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1158,8 +1158,8 @@ The pid_calibrate module is automatically loaded if a heater is defined
 in the config file.
 
 #### PID_CALIBRATE
-`PID_CALIBRATE HEATER=<config_name> TARGET=<temperature>
-[WRITE_FILE=1]`: Perform a PID calibration test. The specified heater
+`PID_CALIBRATE HEATER=<config_name> TARGET=<temperature> [WRITE_FILE=1]
+[MAX_POWER=1.0]`: Perform a PID calibration test. The specified heater
 will be enabled until the specified target temperature is reached, and
 then the heater will be turned off and on for several cycles. If the
 WRITE_FILE parameter is enabled, then the file /tmp/heattest.txt will

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1159,7 +1159,7 @@ in the config file.
 
 #### PID_CALIBRATE
 `PID_CALIBRATE HEATER=<config_name> TARGET=<temperature> [WRITE_FILE=1]
-[MAX_POWER=1.0]`: Perform a PID calibration test. The specified heater
+[MAX_POWER=0.75]`: Perform a PID calibration test. The specified heater
 will be enabled until the specified target temperature is reached, and
 then the heater will be turned off and on for several cycles. If the
 WRITE_FILE parameter is enabled, then the file /tmp/heattest.txt will

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -30,8 +30,10 @@ class PIDCalibrate:
         pheaters = self.printer.lookup_object('heaters')
         heater = pheaters.lookup_heater(heater_name)
         cfg_max_power = heater.get_max_power()
-        max_power = gcmd.get_float('MAX_POWER', cfg_max_power,
+        max_power = gcmd.get_float('MAX_POWER', cfg_max_power * 0.75,
                                    maxval=cfg_max_power, above=0.)
+        gcmd.respond_info("heat up pwm: %.2f, cycle pwm: %.2f" % (
+                          max_power, cfg_max_power))
         self.printer.lookup_object('toolhead').get_last_move_time()
         reactor = self.printer.get_reactor()
         eventtime = reactor.monotonic()
@@ -84,6 +86,8 @@ class PIDCalibrate:
 class ControlAutoTune:
     def __init__(self, heater, target, max_power):
         self.heater = heater
+        self.cycle_max_power = heater.get_max_power()
+        self.heat_up_max_power = max_power
         self.heater_max_power = max_power
         self.calibrate_temp = target
         # Heating control
@@ -167,6 +171,8 @@ class ControlAutoTune:
             self.peak = -9999999.
         if len(self.peaks) < 2:
             return
+        # Control the balance between tight and sluggish control
+        self.heater_max_power = self.cycle_max_power
         self.track_dead_time()
     def initial_heatup(self):
         if self.heatup_samples:
@@ -236,7 +242,7 @@ class ControlAutoTune:
         adj_params = ('gain', 'time_constant', 'tau_b')
         new_params = mathutil.background_coordinate_descent(
             printer, adj_params, params, self.least_squares_error)
-        self.gain = new_params['gain'] / self.heater_max_power
+        self.gain = new_params['gain'] / self.heat_up_max_power
         self.tau = new_params['time_constant']
         self.tau_b = new_params['tau_b']
     def calc_final_pid(self):
@@ -254,7 +260,7 @@ class ControlAutoTune:
         Kp = Kc * heaters.PID_PARAM_BASE
         Ki = Kp / Ti
         Kd = Kp * Td
-        msg = "Autotune: %.3fC/%.3f | " % (peak_temp, self.heater_max_power)
+        msg = "Autotune: %.3fC/%.3f | " % (peak_temp, self.heat_up_max_power)
         msg += "Gain=%.3f Tau=%.3f DeadT=%.3f TauB=%.3f | " % (
                 gain, tau, theta, self.tau_b)
         msg += "Kp=%f Ki=%f Kd=%f" % (Kp, Ki, Kd)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -7,6 +7,7 @@ import math, mathutil, logging
 from . import heaters
 
 TUNE_HYSTERESIS = 2.5
+HIGH_AMBIENT = 50.0
 
 class PIDCalibrate:
     def __init__(self, config):
@@ -40,6 +41,9 @@ class PIDCalibrate:
         ctemp, target_temp = heater.get_temp(eventtime)
         if ctemp > target - TUNE_HYSTERESIS * 2:
            raise gcmd.error("Starting temperature should be less than target")
+        if ctemp > 50.0:
+            gcmd.respond_raw("!! Test may be inaccurate, start temperature "
+                             "%.1fC > %.1fC\n" % (ctemp, HIGH_AMBIENT))
         calibrate = ControlAutoTune(heater, target, max_power)
         old_control = heater.set_control(calibrate)
         try:

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -72,6 +72,8 @@ class ControlAutoTune:
         self.last_pwm = 0.
         self.pwm_samples = []
         self.temp_samples = []
+        # Track dead time
+        self.dead_time = []
     # Heater control
     def set_pwm(self, read_time, value):
         if value != self.last_pwm:
@@ -105,13 +107,29 @@ class ControlAutoTune:
         if self.heating or len(self.peaks) < 12:
             return True
         return False
+    def track_dead_time(self):
+        if not self.pwm_samples:
+            return
+        last_pwm = self.pwm_samples[-1]
+        # We can only forcefully add power to the system
+        if last_pwm[1] == 0:
+            return
+        peak_time = self.peaks[-1][0]
+        control_time = last_pwm[0]
+        dead_time = max(peak_time - control_time, self.heater.get_pwm_delay())
+        self.dead_time.append((control_time, dead_time))
     # Analysis
     def check_peaks(self):
-        self.peaks.append((self.peak_time, self.peak))
+        # Filter initial dummy 0, 0 peak
+        if self.peak_time:
+            self.peaks.append((self.peak_time, self.peak))
         if self.heating:
             self.peak = 9999999.
         else:
             self.peak = -9999999.
+        if len(self.peaks) < 2:
+            return
+        self.track_dead_time()
         if len(self.peaks) < 4:
             return
         self.calc_pid(len(self.peaks)-1)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -82,6 +82,10 @@ class ControlAutoTune:
         self.dead_time = []
         # Track initial heat-up curve
         self.heatup_samples = []
+        # First Order Plus Dead Time model params
+        self.gain = .0
+        self.tau = .0
+        self.dead_time_avg = .0
     # Heater control
     def set_pwm(self, read_time, value):
         if value != self.last_pwm:
@@ -159,10 +163,24 @@ class ControlAutoTune:
                 min_temp = temp
         while self.heatup_samples[0][0] < min_time:
             self.heatup_samples.pop(0)
+        _, start_temp = self.heatup_samples[0]
+        _, end_temp = self.heatup_samples[-1]
+        self.gain = end_temp - start_temp
+        # Tau is the time when the temperature reaches 63.2% of plateau
+        # Describes how dynamic the system is
+        temp_at_tau = start_temp + self.gain * 0.632
+        for sample in self.heatup_samples:
+            if sample[1] > temp_at_tau:
+                self.tau = sample[0] - self.heatup_samples[0][0]
+                break
         return self.heatup_samples
     def calc_pid(self, pos):
         temp_diff = self.peaks[pos][1] - self.peaks[pos-1][1]
         time_diff = self.peaks[pos][0] - self.peaks[pos-2][0]
+        self.initial_heatup()
+        # dead time is theta
+        dead_time = [dtime for _, dtime in self.dead_time]
+        self.dead_time_avg = max(0.6, sum(dead_time)/len(dead_time))
         # Use Astrom-Hagglund method to estimate Ku and Tu
         amplitude = .5 * abs(temp_diff)
         Ku = 4. * self.heater_max_power / (math.pi * amplitude)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -75,8 +75,7 @@ class ControlAutoTune:
     # Heater control
     def set_pwm(self, read_time, value):
         if value != self.last_pwm:
-            self.pwm_samples.append(
-                (read_time + self.heater.get_pwm_delay(), value))
+            self.pwm_samples.append((read_time, value))
             self.last_pwm = value
         self.heater.set_pwm(read_time, value)
     def temperature_update(self, read_time, temp, target_temp):

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -178,24 +178,25 @@ class ControlAutoTune:
                 break
         return self.heatup_samples
     def calc_pid(self, pos):
-        temp_diff = self.peaks[pos][1] - self.peaks[pos-1][1]
-        time_diff = self.peaks[pos][0] - self.peaks[pos-2][0]
+        peak_temp = max([temp for time, temp in self.peaks])
         self.initial_heatup()
         # dead time is theta
         dead_time = [dtime for _, dtime in self.dead_time]
         self.dead_time_avg = max(0.6, sum(dead_time)/len(dead_time))
-        # Use Astrom-Hagglund method to estimate Ku and Tu
-        amplitude = .5 * abs(temp_diff)
-        Ku = 4. * self.heater_max_power / (math.pi * amplitude)
-        Tu = time_diff
-        # Use Ziegler-Nichols method to generate PID parameters
-        Ti = 0.5 * Tu
-        Td = 0.125 * Tu
-        Kp = 0.6 * Ku * heaters.PID_PARAM_BASE
+        # Use Skogestad IMC to estimate Kc, Ti
+        gain = self.gain
+        tau = self.tau
+        theta = self.dead_time_avg
+        Kc = (1 / gain) * tau / (theta + theta)
+        Ti = min(tau, 8 * theta)
+        Td = theta / 2
+        Kp = Kc * heaters.PID_PARAM_BASE
         Ki = Kp / Ti
         Kd = Kp * Td
-        logging.info("Autotune: raw=%f/%f Ku=%f Tu=%f  Kp=%f Ki=%f Kd=%f",
-                     temp_diff, self.heater_max_power, Ku, Tu, Kp, Ki, Kd)
+        msg = "Autotune: %.3fC/%.3f | " % (peak_temp, self.heater_max_power)
+        msg += "Gain=%.3f Tau=%.3f DeadT=%.3f | " % (gain, tau, theta)
+        msg += "Kp=%f Ki=%f Kd=%f" % (Kp, Ki, Kd)
+        logging.info(msg)
         return Kp, Ki, Kd
     def calc_final_pid(self):
         cycle_times = [(self.peaks[pos][0] - self.peaks[pos-2][0], pos)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -80,6 +80,8 @@ class ControlAutoTune:
         self.temp_samples = []
         # Track dead time
         self.dead_time = []
+        # Track initial heat-up curve
+        self.heatup_samples = []
     # Heater control
     def set_pwm(self, read_time, value):
         if value != self.last_pwm:
@@ -139,6 +141,25 @@ class ControlAutoTune:
         if len(self.peaks) < 4:
             return
         self.calc_pid(len(self.peaks)-1)
+    def initial_heatup(self):
+        if self.heatup_samples:
+            return self.heatup_samples
+        self.heatup_samples = self.temp_samples[:]
+        end_time, _ = self.pwm_samples[1]
+        while self.heatup_samples[-1][0] > end_time:
+            self.heatup_samples.pop(-1)
+        start_time, _ = self.pwm_samples[0]
+        while self.heatup_samples[0][0] < start_time:
+            self.heatup_samples.pop(0)
+        # Find minimum temperature as a start point
+        min_time, min_temp = self.heatup_samples[0]
+        for time, temp in self.heatup_samples:
+            if temp <= min_temp:
+                min_time = time
+                min_temp = temp
+        while self.heatup_samples[0][0] < min_time:
+            self.heatup_samples.pop(0)
+        return self.heatup_samples
     def calc_pid(self, pos):
         temp_diff = self.peaks[pos][1] - self.peaks[pos-1][1]
         time_diff = self.peaks[pos][0] - self.peaks[pos-2][0]

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -9,19 +9,24 @@ from . import heaters
 class PIDCalibrate:
     def __init__(self, config):
         self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_connect)
+    def _handle_connect(self):
         gcode = self.printer.lookup_object('gcode')
-        gcode.register_command('PID_CALIBRATE', self.cmd_PID_CALIBRATE,
-                               desc=self.cmd_PID_CALIBRATE_help)
+        pheaters = self.printer.lookup_object('heaters')
+        all_heaters = pheaters.get_all_heaters()
+        for name in all_heaters:
+            short_name = name.split()[-1]
+            gcode.register_mux_command('PID_CALIBRATE', 'HEATER', short_name,
+                                       self.cmd_PID_CALIBRATE,
+                                       desc=self.cmd_PID_CALIBRATE_help)
     cmd_PID_CALIBRATE_help = "Run PID calibration test"
     def cmd_PID_CALIBRATE(self, gcmd):
         heater_name = gcmd.get('HEATER')
         target = gcmd.get_float('TARGET')
         write_file = gcmd.get_int('WRITE_FILE', 0)
         pheaters = self.printer.lookup_object('heaters')
-        try:
-            heater = pheaters.lookup_heater(heater_name)
-        except self.printer.config_error as e:
-            raise gcmd.error(str(e))
+        heater = pheaters.lookup_heater(heater_name)
         self.printer.lookup_object('toolhead').get_last_move_time()
         calibrate = ControlAutoTune(heater, target)
         old_control = heater.set_control(calibrate)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import math, logging
+import math, mathutil, logging
 from . import heaters
 
 TUNE_HYSTERESIS = 5.0
@@ -51,6 +51,8 @@ class PIDCalibrate:
         if calibrate.check_busy(0., 0., 0.):
             raise gcmd.error("pid_calibrate interrupted")
         # Log and report results
+        calibrate.initial_heatup()
+        calibrate.fit(self.printer)
         Kp, Ki, Kd = calibrate.calc_final_pid()
         logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
         gcmd.respond_info(
@@ -88,6 +90,7 @@ class ControlAutoTune:
         # First Order Plus Dead Time model params
         self.gain = .0
         self.tau = .0
+        self.tau_b = .0
         self.dead_time_avg = .0
     # Heater control
     def set_pwm(self, read_time, value):
@@ -145,9 +148,6 @@ class ControlAutoTune:
         if len(self.peaks) < 2:
             return
         self.track_dead_time()
-        if len(self.peaks) < 4:
-            return
-        self.calc_pid(len(self.peaks)-1)
     def initial_heatup(self):
         if self.heatup_samples:
             return self.heatup_samples
@@ -177,13 +177,54 @@ class ControlAutoTune:
                 self.tau = sample[0] - self.heatup_samples[0][0]
                 break
         return self.heatup_samples
-    def calc_pid(self, pos):
+    def model(self, params):
+        gain = params['gain']
+        time_constant = params['time_constant']
+        tau_b = params['tau_b']
+        samples = self.heatup_samples
+        T0 = samples[0][1]
+        start_time = samples[0][0]
+        for time, temp in samples:
+            dt = time - start_time
+            if dt <= .0:
+                yield T0
+            else:
+                x = (1.0 - math.exp(-dt/time_constant))
+                x2 = (1.0 - math.exp(-dt/tau_b))
+                yield T0 + gain * x * x2
+    def least_squares_error(self, params):
+        gain = params['gain']
+        time_constant = params['time_constant']
+        tau_b = params['tau_b']
+        if gain <= 0. or time_constant <= 0. or tau_b <= 0.:
+            return 9.9e99
+        temps = (temp for time, temp in self.heatup_samples)
+        temps_fit = self.model(params)
+        err = .0
+        for temp, temp_fit in zip(temps, temps_fit):
+            err += (temp_fit - temp)**2
+        return err
+    def fit(self, printer):
+        params = {
+            'gain': self.gain,
+            'time_constant': self.tau,
+            # Allow filtering the first-order term from the S curve for free
+            # Roughly represents secondary lag in the system
+            'tau_b': 1.0
+        }
+        # Fit FOPDT model to measured temperatures
+        adj_params = ('gain', 'time_constant', 'tau_b')
+        new_params = mathutil.background_coordinate_descent(
+            printer, adj_params, params, self.least_squares_error)
+        self.gain = new_params['gain'] / self.heater_max_power
+        self.tau = new_params['time_constant']
+        self.tau_b = new_params['tau_b']
+    def calc_final_pid(self):
         peak_temp = max([temp for time, temp in self.peaks])
-        self.initial_heatup()
         # dead time is theta
         dead_time = [dtime for _, dtime in self.dead_time]
         self.dead_time_avg = max(0.6, sum(dead_time)/len(dead_time))
-        # Use Skogestad IMC to estimate Kc, Ti
+        # Use Skogestad IMC to estimate Kc, Ti, Td
         gain = self.gain
         tau = self.tau
         theta = self.dead_time_avg
@@ -194,15 +235,11 @@ class ControlAutoTune:
         Ki = Kp / Ti
         Kd = Kp * Td
         msg = "Autotune: %.3fC/%.3f | " % (peak_temp, self.heater_max_power)
-        msg += "Gain=%.3f Tau=%.3f DeadT=%.3f | " % (gain, tau, theta)
+        msg += "Gain=%.3f Tau=%.3f DeadT=%.3f TauB=%.3f | " % (
+                gain, tau, theta, self.tau_b)
         msg += "Kp=%f Ki=%f Kd=%f" % (Kp, Ki, Kd)
         logging.info(msg)
         return Kp, Ki, Kd
-    def calc_final_pid(self):
-        cycle_times = [(self.peaks[pos][0] - self.peaks[pos-2][0], pos)
-                       for pos in range(4, len(self.peaks))]
-        midpoint_pos = sorted(cycle_times)[len(cycle_times)//2][1]
-        return self.calc_pid(midpoint_pos)
     # Offline analysis helper
     def write_file(self, filename):
         pwm = ["pwm: %.3f %.3f" % (time, value)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -108,7 +108,7 @@ class ControlAutoTune:
         return False
     # Analysis
     def check_peaks(self):
-        self.peaks.append((self.peak, self.peak_time))
+        self.peaks.append((self.peak_time, self.peak))
         if self.heating:
             self.peak = 9999999.
         else:
@@ -117,8 +117,8 @@ class ControlAutoTune:
             return
         self.calc_pid(len(self.peaks)-1)
     def calc_pid(self, pos):
-        temp_diff = self.peaks[pos][0] - self.peaks[pos-1][0]
-        time_diff = self.peaks[pos][1] - self.peaks[pos-2][1]
+        temp_diff = self.peaks[pos][1] - self.peaks[pos-1][1]
+        time_diff = self.peaks[pos][0] - self.peaks[pos-2][0]
         # Use Astrom-Hagglund method to estimate Ku and Tu
         amplitude = .5 * abs(temp_diff)
         Ku = 4. * self.heater_max_power / (math.pi * amplitude)
@@ -133,7 +133,7 @@ class ControlAutoTune:
                      temp_diff, self.heater_max_power, Ku, Tu, Kp, Ki, Kd)
         return Kp, Ki, Kd
     def calc_final_pid(self):
-        cycle_times = [(self.peaks[pos][1] - self.peaks[pos-2][1], pos)
+        cycle_times = [(self.peaks[pos][0] - self.peaks[pos-2][0], pos)
                        for pos in range(4, len(self.peaks))]
         midpoint_pos = sorted(cycle_times)[len(cycle_times)//2][1]
         return self.calc_pid(midpoint_pos)

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -6,6 +6,8 @@
 import math, logging
 from . import heaters
 
+TUNE_HYSTERESIS = 5.0
+
 class PIDCalibrate:
     def __init__(self, config):
         self.printer = config.get_printer()
@@ -28,6 +30,11 @@ class PIDCalibrate:
         pheaters = self.printer.lookup_object('heaters')
         heater = pheaters.lookup_heater(heater_name)
         self.printer.lookup_object('toolhead').get_last_move_time()
+        reactor = self.printer.get_reactor()
+        eventtime = reactor.monotonic()
+        ctemp, target_temp = heater.get_temp(eventtime)
+        if ctemp > target - TUNE_HYSTERESIS * 2:
+           raise gcmd.error("Starting temperature should be less than target")
         calibrate = ControlAutoTune(heater, target)
         old_control = heater.set_control(calibrate)
         try:
@@ -55,8 +62,6 @@ class PIDCalibrate:
         configfile.set(cfgname, 'pid_Ki', "%.3f" % (Ki,))
         configfile.set(cfgname, 'pid_Kd', "%.3f" % (Kd,))
 
-TUNE_PID_DELTA = 5.0
-
 class ControlAutoTune:
     def __init__(self, heater, target):
         self.heater = heater
@@ -66,6 +71,7 @@ class ControlAutoTune:
         self.heating = False
         self.peak = 0.
         self.peak_time = 0.
+        self.hysteresis = TUNE_HYSTERESIS
         # Peak recording
         self.peaks = []
         # Sample recording
@@ -87,7 +93,7 @@ class ControlAutoTune:
         if self.heating and temp >= target_temp:
             self.heating = False
             self.check_peaks()
-            self.heater.alter_target(self.calibrate_temp - TUNE_PID_DELTA)
+            self.heater.alter_target(self.calibrate_temp - self.hysteresis)
         elif not self.heating and temp <= target_temp:
             self.heating = True
             self.check_peaks()

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -74,7 +74,8 @@ class PIDCalibrate:
         Kp, Ki, Kd = calibrate.calc_final_pid()
         logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
         gcmd.respond_info(
-            "Heater to thermistor lag: %.3f s" % (calibrate.dead_time_avg))
+            "Heater to thermistor lag: %.3f s, %.3f s" % (
+                calibrate.dead_time_avg, calibrate.tau_b))
         gcmd.respond_info(
             "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
             "The SAVE_CONFIG command will update the printer config file\n"
@@ -260,7 +261,8 @@ class ControlAutoTune:
         theta = self.dead_time_avg
         Kc = (1 / gain) * tau / (theta + theta)
         Ti = min(tau, 8 * theta)
-        Td = theta / 2
+        # Real dead time can be less than what we can measure
+        Td = min(theta / 2, self.tau_b)
         Kp = Kc * heaters.PID_PARAM_BASE
         Ki = Kp / Ti
         Kd = Kp * Td

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -6,7 +6,7 @@
 import math, mathutil, logging
 from . import heaters
 
-TUNE_HYSTERESIS = 5.0
+TUNE_HYSTERESIS = 2.5
 
 class PIDCalibrate:
     def __init__(self, config):
@@ -142,7 +142,7 @@ class ControlAutoTune:
         if not self.heatup_samples:
             return False
         # Oscillation stage
-        if self.heating or len(self.peaks) < 12:
+        if self.heating or len(self.peaks) < 9:
             return True
         return False
     def track_dead_time(self):

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -29,13 +29,16 @@ class PIDCalibrate:
         write_file = gcmd.get_int('WRITE_FILE', 0)
         pheaters = self.printer.lookup_object('heaters')
         heater = pheaters.lookup_heater(heater_name)
+        cfg_max_power = heater.get_max_power()
+        max_power = gcmd.get_float('MAX_POWER', cfg_max_power,
+                                   maxval=cfg_max_power, above=0.)
         self.printer.lookup_object('toolhead').get_last_move_time()
         reactor = self.printer.get_reactor()
         eventtime = reactor.monotonic()
         ctemp, target_temp = heater.get_temp(eventtime)
         if ctemp > target - TUNE_HYSTERESIS * 2:
            raise gcmd.error("Starting temperature should be less than target")
-        calibrate = ControlAutoTune(heater, target)
+        calibrate = ControlAutoTune(heater, target, max_power)
         old_control = heater.set_control(calibrate)
         try:
             pheaters.set_temperature(heater, target, True)
@@ -63,9 +66,9 @@ class PIDCalibrate:
         configfile.set(cfgname, 'pid_Kd', "%.3f" % (Kd,))
 
 class ControlAutoTune:
-    def __init__(self, heater, target):
+    def __init__(self, heater, target, max_power):
         self.heater = heater
-        self.heater_max_power = heater.get_max_power()
+        self.heater_max_power = max_power
         self.calibrate_temp = target
         # Heating control
         self.heating = False

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -42,6 +42,20 @@ class PIDCalibrate:
         old_control = heater.set_control(calibrate)
         try:
             pheaters.set_temperature(heater, target, True)
+            if self.printer.is_shutdown():
+                raise self.printer.command_error("shutdown")
+            calibrate.initial_heatup()
+            calibrate.fit(self.printer)
+            gcmd.respond_info(
+                "Expected temperature +%.1f C at 100%% power\n"
+                "Time constant: %.1f s" % (
+                    calibrate.gain, calibrate.tau
+                )
+            )
+            time_step = heater.get_pwm_delay()
+            while calibrate.check_busy(0., 0., 0.):
+                now = reactor.monotonic()
+                reactor.pause(now + time_step)
         except self.printer.command_error as e:
             heater.set_control(old_control)
             raise
@@ -51,10 +65,10 @@ class PIDCalibrate:
         if calibrate.check_busy(0., 0., 0.):
             raise gcmd.error("pid_calibrate interrupted")
         # Log and report results
-        calibrate.initial_heatup()
-        calibrate.fit(self.printer)
         Kp, Ki, Kd = calibrate.calc_final_pid()
         logging.info("Autotune: final: Kp=%f Ki=%f Kd=%f", Kp, Ki, Kd)
+        gcmd.respond_info(
+            "Heater to thermistor lag: %.3f s" % (calibrate.dead_time_avg))
         gcmd.respond_info(
             "PID parameters: pid_Kp=%.3f pid_Ki=%.3f pid_Kd=%.3f\n"
             "The SAVE_CONFIG command will update the printer config file\n"
@@ -122,6 +136,12 @@ class ControlAutoTune:
                 self.peak = temp
                 self.peak_time = read_time
     def check_busy(self, eventtime, smoothed_temp, target_temp):
+        # Heat up stage
+        if self.heating or len(self.peaks) <= 2:
+            return True
+        if not self.heatup_samples:
+            return False
+        # Oscillation stage
         if self.heating or len(self.peaks) < 12:
             return True
         return False


### PR DESCRIPTION
TLDR:
This is an attempt to make one PID calibrator to rule them all.

The basic idea is that one can make a model of the hotend.
We have a gain over the initial heat-up, we have dead time from the relay test, and we can fit the time constant over the initial heat curve to estimate where the heater settles at a specific power.

This data can be used within the internal model control method within the First-Order Plus Dead Time model.

From this data, we can estimate the specific PID values for a specific heater.

So, what it does:
- Records the initial heating curve
- Fit over this curve (it makes calculations more stable over different MAX_POWER values).
- Calculate the gain, where I later used the estimated gain from the fit for the same purposes.

~~It seems to produce okayish values for the PD, where I is always too small and, as a result, the output PID is sluggish.~~
~~As we have relatively short dead time and low inertia on the hotend, there is a "hack" to increase I.~~

Because of how the model works, normally the output is pretty conservative (it tries not to overshoot and keep the control smooth), ~~lambda is zeroed to prefer fast responses~~.

One can calibrate with reduced MAX_POWER as in the #7209, to get the initial heating up closer to the asymptote.
It seems to work fine without that.
There are 2 "extreme" scenarios for the tuning.
One with 100% power (default), and with the least required power.

The least required power should generally provide a better fit, because this is what the model tries to estimate.
One can run the tuned heater at the target temperature, record the average PWM, for example 30%.
That PWM is the least required power to do the test.

It can be long, or it can trigger verify_heater errors, it is recommended to use some margin +5% for example.

<img width="1348" height="528" alt="image" src="https://github.com/user-attachments/assets/5744d1c3-762b-435a-8727-ee124bb972d8" />

Just steady state graphs, extruder:
<img width="1358" height="444" alt="image" src="https://github.com/user-attachments/assets/086af560-db9c-4492-863b-9fc1fbb33855" />
```
Autotune: raw=7.618107/0.450000 | Tu=11.100615/DeadT=1.350078 Gain=1043.620833 tau=105.350765 | Kp=19.188908 Ki=3.553297 Kd=12.870788
Autotune: raw=-7.978697/0.450000 | Tu=11.400670/DeadT=1.350071 Gain=773.799418 tau=70.234177 | Kp=17.308440 Ki=3.205099 Kd=11.572582
Autotune: raw=7.834107/0.450000 | Tu=11.400545/DeadT=1.350055 Gain=597.414908 tau=46.823118 | Kp=15.017210 Ki=2.780851 Kd=9.992967
Autotune: raw=-7.293205/0.450000 | Tu=11.100456/DeadT=1.350052 Gain=483.753974 tau=62.430490 | Kp=24.639525 Ki=4.562698 Kd=16.454413
Autotune: raw=7.834107/0.450000 | Tu=11.400545/DeadT=1.400057 Gain=506.543530 tau=51.938975 | Kp=18.927158 Ki=3.379712 Kd=13.073347
Autotune: final: Kp=18.927158 Ki=3.379712 Kd=13.073347
```

Where one can interpret the Gain and Tau (time constant), like this:
Gain is where the heater will settle with the requested power percentage.
Tau is 63.2%, which is a time where gain will reach ~63.2% of the set temperature.
<img width="2560" height="1472" alt="image" src="https://github.com/user-attachments/assets/c13eb8ef-b13c-485d-9cd3-5b64d194530e" />

Bed:
<img width="1358" height="444" alt="image" src="https://github.com/user-attachments/assets/a8ee92f4-84d3-4043-8013-6632a1c0d983" />

```
Autotune: raw=-6.273359/1.000000 | Tu=161.700000/DeadT=3.150000 Gain=62.092383 tau=70.234177 | Kp=93.620563 Ki=7.430203 Kd=144.218294
Autotune: raw=6.180337/1.000000 | Tu=161.700000/DeadT=3.300000 Gain=46.271708 tau=93.645236 | Kp=159.140931 Ki=12.056131 Kd=258.036022
Autotune: raw=-6.173799/1.000000 | Tu=173.700000/DeadT=3.300000 Gain=56.845383 tau=78.037863 | Kp=108.323635 Ki=8.206336 Kd=175.033169
Autotune: raw=6.260284/1.000000 | Tu=134.100000/DeadT=2.300000 Gain=51.715770 tau=84.380185 | Kp=183.361755 Ki=19.930626 Kd=208.030810
Autotune: final: Kp=183.361755 Ki=19.930626 Kd=208.030810
```

It is possible that it simply overfitted and produced critically dumped results only for me.
So, I will be glad to see the data from others.

Thanks,
-Timofey

---
_P.S.
I would expect that MAX_POWER reduction suggested in #7209, which produces the symmetric relay test, should work fine. But it didn't work for the large/slow heaters, and didn't work for some with fast response times, so... I got myself drawn into the rabbit hole.
Where I hope that now, I have some understanding of WHY it works in a way that it works - I think, it is hard to define magic ZN numbers for every possible case, and the "proper" relay method is more complicated, so here we are._

---
~~Deadtime detection is suboptimal and may be susceptible to the noise of the sensor.~~
I hope the time between the control signal and the peak is a good enough estimation for our short dead time.

---
Links, because I will lose them:
- https://www.ijireeice.com/upload/2016/may-16/IJIREEICE%2047.pdf - IMC-PID
- https://www.researchgate.net/publication/288897834_The_SIMC_method_for_smooth_PID_controller_tuning - Simple IMC PID - Sigurd Skogestad
- https://apmonitor.com/pdc/index.php/Main/ProportionalIntegralDerivative - a nice site with more generic explanations of everything :D

---
Testing:
```
cd ~/klipper
git fetch origin pull/7243/head
git checkout FETCH_HEAD
sudo systemctl restart klipper
```

---
#6706 does not make sense anymore, as we take dead time into account