### PR TITLE
tmc: Fix stepper enable time for tmc virtual enable

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -441,12 +441,16 @@ class TMCCommandHelper:
             logging.warning("Stepper %s phase change (was %d now %d)",
                             self.stepper_name, self.mcu_phase_offset, moff)
         self.mcu_phase_offset = moff
+    def _apply_toff_field(self, toff_val, print_time):
+        reg_name = self.fields.lookup_register("toff")
+        reg_val = self.fields.set_field("toff", toff_val)
+        self.mcu_tmc.set_register(reg_name, reg_val, print_time)
     # Stepper enable/disable tracking
     def _do_enable(self, print_time):
+        self._init_registers()
         if self.toff is not None:
             # Shared enable via comms handling
-            self.fields.set_field("toff", self.toff)
-        self._init_registers()
+            self._apply_toff_field(self.toff, print_time)
         did_reset = self.echeck_helper.start_checks()
         if did_reset:
             self.mcu_phase_offset = None
@@ -463,9 +467,7 @@ class TMCCommandHelper:
             self._handle_sync_mcu_pos(self.stepper)
     def _do_disable(self, print_time):
         if self.toff is not None:
-            val = self.fields.set_field("toff", 0)
-            reg_name = self.fields.lookup_register("toff")
-            self.mcu_tmc.set_register(reg_name, val, print_time)
+            self._apply_toff_field(0, print_time)
         self.echeck_helper.stop_checks()
     def _handle_stepper_enable(self, print_time, is_enable):
         def enable_disable_cb(eventtime):


### PR DESCRIPTION
When using the "Enabling TMC virtual enable for ..." function, motor activation is controlled by the toff register. On motor enable, the toff register value is sent to the tmc via `_do_enable()-->_init_registers()`, which occurs with `print_time=None`. Because of this, actual motor activation may occur earlier, up to ~1 second earlier. 

For example:
```
G4 P1000
SET_STEPPER_ENABLE STEPPER=stepper_x ENABLE=1
```
Which will cause the motor to turn on immediately.

The change consists of moving the sending of the toff register to the required print_time, while the other registers continue to be initialized in advance. Since every on/off operation happens with mutex, everything should be fine.