### PR TITLE
axis_twist_compensation: fix coordinate space mismatch in compensation lookup

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -57,14 +57,14 @@ class AxisTwistCompensation:
             zo = 0.
             if self.z_compensations:
                 zo += self._get_interpolated_z_compensation(
-                    pos.test_x, self.z_compensations,
+                    pos.bed_x, self.z_compensations,
                     self.compensation_start_x,
                     self.compensation_end_x
                     )
 
             if self.zy_compensations:
                 zo += self._get_interpolated_z_compensation(
-                    pos.test_y, self.zy_compensations,
+                    pos.bed_y, self.zy_compensations,
                     self.compensation_start_y,
                     self.compensation_end_y
                     )


### PR DESCRIPTION
## Summary

`_update_z_compensation_value` looks up twist compensation using `pos.test_x`/`pos.test_y` (probe coordinates), but `compensation_start_x/y` and `compensation_end_x/y` are stored in nozzle coordinates during calibration. When a probe has a non-zero offset, the compensation is applied at the wrong physical bed location.

This affects any probe with `y_offset != 0` using Y-axis twist compensation (Beacon, Cartographer, offset BLTouch, etc.). X compensation is similarly affected for probes with `x_offset != 0`.

## Fix

Use `pos.bed_x`/`pos.bed_y` (nozzle coordinates) instead of `pos.test_x`/`pos.test_y` for the interpolation lookup, matching the coordinate space of the stored boundaries.

## Evidence

- Bed mesh diffs with Y twist compensation enabled show the compensation pattern applied at wrong Y positions — shifted by the probe's y_offset (22.9mm in my case)
- Independently reported by another user with a Cartographer probe (y_offset ~23.7mm) in Discourse topic [#21633](https://klipper.discourse.group/t/something-strange-is-happening-with-axis-twist-compensations/21633)