### PR TITLE
Example Config Update: Flashforge Creator Pro

### DIFF
--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -5,6 +5,11 @@
 # Use the following command to flash the board:
 #  avrdude -c stk500v2 -p m2560 -P /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_557373136313514061A2-if00 -b 57600 -D -U out/klipper.elf.hex
 
+# Note: 2019 models may use a different serial ID, e.g.:
+#   /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_85633323630351A090F0-if00
+# Check for yourself and update here and below accordingly. 
+
+
 # See docs/Config_Reference.md for a description of parameters.
 
 [stepper_x]
@@ -128,6 +133,8 @@ screw3_name: Back Right
 
 [mcu]
 serial: /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_557373136313514061A2-if00
+# Note: 2019 models may use a different serial ID, e.g.:
+#   /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_85633323630351A090F0-if00
 restart_method: command
 
 [printer]

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -97,9 +97,11 @@ gcode:
 
 [heater_fan extruder_fan]
 pin: PH4
+heater: extruder
 
 [heater_fan extruder1_fan]
 pin: PB6
+heater: extruder1
 
 [fan]
 pin: PL5

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -177,6 +177,12 @@ back_pin: ^PJ2
 up_pin: ^PJ4
 down_pin: ^PJ3
 
+[pwm_cycle_time beeper]
+pin: PG5
+value: 0
+shutdown_value: 0
+cycle_time: 0.001
+
 [pca9533 led_strip]
 i2c_bus: twi
 i2c_address: 98

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -21,7 +21,8 @@ rotation_distance: 34
 endstop_pin: ^!PL1
 position_endstop: 116
 position_max: 116
-position_min: -116
+# 116 + 34mm for extruder offset, so right extruder can reach left edge.
+position_min: -150
 homing_speed: 50
 
 [stepper_y]

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -7,7 +7,7 @@
 
 # Note: 2019 models may use a different serial ID, e.g.:
 #   /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_85633323630351A090F0-if00
-# Check for yourself and update here and below accordingly. 
+# Check for yourself and update here and below accordingly.
 
 
 # See docs/Config_Reference.md for a description of parameters.
@@ -47,6 +47,7 @@ position_endstop: -0.25
 position_max: 181
 position_min: -0.25
 
+# Right extruder, as defined by stock firmware
 [extruder]
 step_pin: PA3
 dir_pin: !PA2
@@ -68,6 +69,7 @@ pid_kd: 144.566
 min_temp: 0
 max_temp: 260
 
+# Left extruder, as defined by stock firmware
 [extruder1]
 step_pin: PA7
 dir_pin: PA6

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -115,6 +115,14 @@ pid_kd: 645.290
 min_temp: 0
 max_temp: 130
 
+[bed_screws]
+screw1: 0, -65
+screw1_name: Front Center
+screw2: -50, 65
+screw2_name: Back Left
+screw3: 50, 65
+screw3_name: Back Right
+
 [mcu]
 serial: /dev/serial/by-id/usb-MakerBot_Industries_The_Replicator_557373136313514061A2-if00
 restart_method: command

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -105,6 +105,7 @@ heater: extruder1
 
 [fan]
 pin: PL5
+kick_start_time: 0.5
 
 [heater_bed]
 heater_pin: PL4

--- a/config/printer-flashforge-creator-pro-2018.cfg
+++ b/config/printer-flashforge-creator-pro-2018.cfg
@@ -45,7 +45,8 @@ microsteps: 16
 rotation_distance: 8
 endstop_pin: !PL6
 position_endstop: -0.25
-position_max: 181
+# Conservative maximum (-6mm from empirical max)
+position_max: 170
 position_min: -0.25
 
 # Right extruder, as defined by stock firmware


### PR DESCRIPTION
Hey all!

Nice place you've got here. 

New contributor, new to the 3D printing space and Klipper, more generally. Went through the docs to calibrate a hand-me-down printer and I thought other folks could benefit from some of this effort. Opening a few PR's with some of my edits (for this and, more generally, multi-extruder setups). This, I hope, is the least controversial haha.

### AI-Assisted Summary:

This PR enhances the sample configuration for the FlashForge Creator Pro 2018 with several practical improvements based on real-world testing.
 
### Changes
 
1. **Manual Bed Leveling** - Adds `bed_screws` configuration with theoretical screw positions based on the printer's bed dimensions (232×160mm usable area) for fear that my motors/belts are more off than others'. Enables the `BED_SCREWS_ADJUST` command
 
2. **Beeper Support** - Enables the onboard buzzer via PWM control, allowing M300 commands and menu feedback
 
3. **Heater Fan Association** - Associates each extruder's cooling fan with its corresponding heater, preventing both fans from running when only T0 is active (and never for T1)
 
4. **Fan Kick Start** - Adds 0.5s kick start time to the part cooling fan to improve reliability with PWM control (real-world motivated)
 
5. **Serial ID Documentation** - Documents that 2019 models may use a different USB serial identifier
 
### Testing
 
Tested on FlashForge Creator Pro 2019 model running Klipper. All features verified functional:
- Bed leveling routine works correctly with calculated positions
- Beeper provides audible feedback
- Heater fans now activate independently per extruder
- Part cooling fan starts reliably at low speeds
 
### Target Audience
 
FlashForge Creator Pro users (2016-2020 models) - a popular dual-extruder printer whose stock firmware requires `x3g`/SD card workflows, making it a good candidate for Klipper. These improvements address common usability gaps in the "stock" configuration.