### PR TITLE
Add Tool Selection Menu for Multi-Extruder Printers

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -213,27 +213,6 @@ gcode:
         {% endif %}
     {% endif %}
 
-### menu tool selection ###
-[menu __main __toolhead]
-type: list
-enable: {'extruder1' in printer}
-name: Tool: {'T0' if printer.toolhead.extruder == 'extruder' else 'T1'}
-
-[menu __main __toolhead __t0]
-type: command
-name: Activate T0
-gcode: T0
-
-[menu __main __toolhead __t1]
-type: command
-name: Activate T1
-gcode: T1
-
-### menu control ###
-[menu __main __control]
-type: list
-name: Control
-
 [menu __main __control __home]
 type: command
 enable: {not printer.idle_timeout.state == "Printing"}
@@ -500,6 +479,27 @@ gcode:
     M83
     G1 E{menu.input} F240
     RESTORE_GCODE_STATE NAME=__move__axis
+
+### menu tool selection ###
+[menu __main __toolhead]
+type: list
+enable: {'extruder1' in printer}
+name: Tool: {'T0' if printer.toolhead.extruder == 'extruder' else 'T1'}
+
+[menu __main __toolhead __t0]
+type: command
+name: Activate T0
+gcode: T0
+
+[menu __main __toolhead __t1]
+type: command
+name: Activate T1
+gcode: T1
+
+### menu control ###
+[menu __main __control]
+type: list
+name: Control
 
 ### menu temperature ###
 [menu __main __temp]

--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -213,6 +213,22 @@ gcode:
         {% endif %}
     {% endif %}
 
+### menu tool selection ###
+[menu __main __toolhead]
+type: list
+enable: {'extruder1' in printer}
+name: Tool: {'T0' if printer.toolhead.extruder == 'extruder' else 'T1'}
+
+[menu __main __toolhead __t0]
+type: command
+name: Activate T0
+gcode: T0
+
+[menu __main __toolhead __t1]
+type: command
+name: Activate T1
+gcode: T1
+
 ### menu control ###
 [menu __main __control]
 type: list


### PR DESCRIPTION
Second in series of changes made while setting up an FFCP, starting with #7247 

I was excited to see filament loading was in the display menu. But then disappointed to see it only worked for the right extruder (which doesn't even have a fan in stock config)

So I threw together these macros for the display, as many of the options assume a single extruder

## AI Assisted Summary: Add Tool Selection Menu for Multi-Extruder Printers

This PR adds a top-level "Tool" menu to the default display menu system that allows users with multi-extruder printers to switch between T0 and T1 directly from the LCD display.

### Problem Statement

Users with dual-extruder printers (e.g., FlashForge Creator Pro, Prusa MMU setups, IDEX systems) currently cannot change the active tool from the display menu by default. This creates a usability gap when performing common operations:

- **Filament operations** (load/unload) always apply to the active extruder, but there's no display-based way to switch tools
- **Manual extrusion** via the Move menu operates on the active extruder only
- **Temperature presets** (Preheat PLA/ABS) apply M104 commands without T parameter, affecting only the active tool

Users must either use console commands (T0/T1) or remain connected to a host interface to switch tools, which can be impractical when working at the printer.

### Solution

Added a conditional top-level menu between "SD Card" and "Control" that:
- Appears only when `extruder1` is defined in the configuration
- Shows the currently active tool in the menu label ("Tool: T0" or "Tool: T1")
- Provides submenu options to activate T0 or T1
- Changes system-wide active extruder state for all subsequent menu operations

### Target Audience

Multi-extruder printer users, including:
- **FlashForge Creator Pro** (2016-2020 models) - Several thousand units in active use
- **Dual-extruder Cartesian printers** - Various models with independent or IDEX toolheads  
- **Multi-material systems** - Prusa MMU and similar configurations

Estimated user base (this requires confirmation) is large.

### Testing

Tested on FlashForge Creator Pro 2019 with LCD display:
- Menu appears only when both `extruder` and `extruder1` are defined
- Tool switching commands execute correctly (T0/T1)
- Active tool label updates dynamically after selection
- Filament load/unload operations correctly target the selected extruder
- No impact on single-extruder configurations (menu hidden via enable condition)

### Implementation Details

- Follows existing menu conditional patterns (similar to `z_tilt`, `quad_gantry_level`)
- Parent menu uses `enable: {'extruder1' in printer}` condition
- Child menu items inherit parent visibility (standard menu.py behavior)
- No configuration changes required - automatically available when `extruder1` is present