### PR TITLE
Improvements to eddy "tap" code

### DIFF
--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -116,12 +116,6 @@ Practically, it ensures that the Eddy's output data absolute value
 change per second (velocity) is high enough - higher than the noise level,
 and that upon collision it always decreases by at least this value.
 
-Before setting it to any other value, it is necessary to install `scipy`:
-
-```bash
-~/klippy-env/bin/pip install scipy
-```
-
 The suggested calibration routine works as follows:
 1. Home Z
 2. Place the toolhead at the center of the bed.

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -160,9 +160,14 @@ class ContinuousTareFilter:
 
     # create a filter design from the parameters
     def design_filter(self, error_func):
-        return trigger_analog.DigitalFilter(self.sps, error_func, self.drift,
-            self.drift_delay, self.buzz, self.buzz_delay, self.notches,
-            self.notch_quality)
+        df = trigger_analog.DigitalFilter(self.sps, error_func)
+        if self.drift:
+            df.add_highpass(self.drift, self.drift_delay)
+        if self.buzz:
+            df.add_lowpass(self.buzz, self.buzz_delay)
+        for notch in self.notches:
+            df.add_notch(notch, self.notch_quality)
+        return df
 
 
 # Combine ContinuousTareFilter and SosFilter into an easy-to-use class

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -520,7 +520,8 @@ class EddyTap:
         # Create SOS filter
         cmd_queue = self._trigger_analog.get_dispatch().get_command_queue()
         mcu = self._sensor_helper.get_mcu()
-        sos_filter = trigger_analog.MCU_SosFilter(mcu, cmd_queue, 5)
+        filter_size = design.get_size()
+        sos_filter = trigger_analog.MCU_SosFilter(mcu, cmd_queue, filter_size)
         self._trigger_analog.setup_sos_filter(sos_filter)
     def _prep_trigger_analog_tap(self, gcmd):
         if not self._tap_threshold:

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -515,8 +515,8 @@ class EddyTap:
         sps = self._sensor_helper.get_samples_per_second()
         design = trigger_analog.DigitalFilter(sps, cfg_error)
         design.add_lowpass(25.0, 4)
-        # Create the derivative (sample to sample difference) post filter
-        self._filter_design = trigger_analog.DerivativeFilter(design)
+        design.add_derivative()
+        self._filter_design = design
         # Create SOS filter
         cmd_queue = self._trigger_analog.get_dispatch().get_command_queue()
         mcu = self._sensor_helper.get_mcu()

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -506,6 +506,7 @@ class EddyTap:
         self._filter_design = None
         self._tap_z_offset = config.getfloat('tap_z_offset', 0.)
         self._tap_threshold = config.getfloat('tap_threshold', 0., above=0.)
+        self._least_squares_cache = {}
         if self._tap_threshold:
             self._setup_tap()
     # Setup for "tap" probe request
@@ -561,8 +562,8 @@ class EddyTap:
                                       s.get_past_mcu_position(pos_time))
                     for s in kin.get_steppers()}
         return kin.calc_position(kin_spos)
-    def _calc_least_squares(self, samples, est_z_contact):
-        # XXX - this implementation is not efficient
+    def _build_ls_matrix(self, samples, est_z_contact):
+        # The function here is only a reference for the optimized version below
         len_samples = len(samples)
         eqs = [[0.] * 4 for i in range(len_samples)]
         ans = [[0.] for i in range(len_samples)]
@@ -583,6 +584,63 @@ class EddyTap:
         eqst = mathutil.mat_transp(eqs)
         eqst_eqs = mathutil.mat_mat_mul(eqst, eqs)
         eqst_ans = mathutil.mat_mat_mul(eqst, ans)
+        return eqst_eqs, eqst_ans
+    def _build_sums(self, samples, num_le):
+        sum_le_z = sum_le_z2 = sum_le_freq = sum_le_freq_z = 0.
+        for z, freq in samples[:num_le]:
+            sum_le_z += z
+            sum_le_z2 += z**2
+            sum_le_freq += freq
+            sum_le_freq_z += freq*z
+        sum_gt_z = sum_gt_z2 = sum_gt_z3 = sum_gt_z4 = 0.
+        sum_gt_freq = sum_gt_freq_z = sum_gt_freq_z2 = 0.
+        for z, freq in samples[num_le:]:
+            sum_gt_z += z
+            sum_gt_z2 += z**2
+            sum_gt_z3 += z**3
+            sum_gt_z4 += z**4
+            sum_gt_freq += freq
+            sum_gt_freq_z += freq*z
+            sum_gt_freq_z2 += freq * z**2
+        return (sum_le_z, sum_le_z2, sum_le_freq, sum_le_freq_z,
+                sum_gt_z, sum_gt_z2, sum_gt_z3, sum_gt_z4,
+                sum_gt_freq, sum_gt_freq_z, sum_gt_freq_z2)
+    def _build_ls_matrix_opt(self, samples, est_z_contact):
+        # This function is an optimized version of _build_ls_matrix()
+        num_le = bisect.bisect(samples, (est_z_contact, sys.float_info.max))
+        # Check for previously calculated raw freq/z counters
+        sums = self._least_squares_cache.get(num_le)
+        if sums is None:
+            sums = self._build_sums(samples, num_le)
+            self._least_squares_cache[num_le] = sums
+        (sum_le_z, sum_le_z2, sum_le_freq, sum_le_freq_z,
+         sum_gt_z, sum_gt_z2, sum_gt_z3, sum_gt_z4,
+         sum_gt_freq, sum_gt_freq_z, sum_gt_freq_z2) = sums
+        num_samples = len(samples)
+        ezc = est_z_contact
+        ezc2 = ezc**2
+        ezc3 = ezc**3
+        ezc4 = ezc**4
+        # Build matrices for least squares evaluation
+        eqst_eqs = [[0.] * 4 for i in range(4)]
+        eqst_eqs[0][0] = num_samples
+        eqst_eqs[1][1] = sum_le_z2 - 2*ezc*sum_le_z + num_le*ezc2
+        eqst_eqs[2][2] = sum_gt_z2 + num_le*ezc2
+        eqst_eqs[3][3] = sum_gt_z4 + num_le*ezc4
+        eqst_eqs[0][1] = eqst_eqs[1][0] = sum_le_z - num_le*ezc
+        eqst_eqs[0][2] = eqst_eqs[2][0] = sum_gt_z + num_le*ezc
+        eqst_eqs[0][3] = eqst_eqs[3][0] = sum_gt_z2 + num_le*ezc2
+        eqst_eqs[2][3] = eqst_eqs[3][2] = sum_gt_z3 + num_le*ezc3
+        eqst_eqs[2][1] = eqst_eqs[1][2] = ezc * eqst_eqs[0][1]
+        eqst_eqs[3][1] = eqst_eqs[1][3] = ezc2 * eqst_eqs[0][1]
+        eqst_ans = [[0.] for i in range(4)]
+        eqst_ans[0][0] = sum_le_freq + sum_gt_freq
+        eqst_ans[1][0] = sum_le_freq_z - ezc*sum_le_freq
+        eqst_ans[2][0] = sum_gt_freq_z + ezc*sum_le_freq
+        eqst_ans[3][0] = sum_gt_freq_z2 + ezc2 * sum_le_freq
+        return eqst_eqs, eqst_ans
+    def _calc_least_squares(self, samples, est_z_contact):
+        eqst_eqs, eqst_ans = self._build_ls_matrix_opt(samples, est_z_contact)
         coeffs = mathutil.gaussian_solve(eqst_eqs, eqst_ans)
         if coeffs is not None and coeffs[3][0] < 0.:
             # z**2 factor can't be negative - retry using only linear
@@ -598,6 +656,7 @@ class EddyTap:
     def _find_least_squares(self, data):
         #for d in data:
         #    logging.info("sample: freq=%.3f z=%.6f", d[0], d[1][2])
+        self._least_squares_cache.clear()
         # Change base of freq/z measurements to improve numerical stability
         base_z = .5 * (data[0][1][2] + data[-1][1][2])
         base_freq = .5 * (data[0][0] + data[-1][0])
@@ -630,6 +689,7 @@ class EddyTap:
                     max_z = guess_z
                 else:
                     min_z = guess_z
+        self._least_squares_cache.clear()
         # Return to original freq/z measurement base
         bc = [v[0] for v in best_coeffs]
         final_coeffs = (base_z + best_z,

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -666,7 +666,7 @@ class EddyTap:
         max_z = samples[-1][0]
         best_err = sys.float_info.max
         best_coeffs = [0., 0., 0., 0.]
-        while max_z - min_z > 0.000250:
+        while max_z - min_z > 0.000050:
             # Select z value to check
             mid_z = (min_z + max_z) * .5
             if best_z < mid_z:

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -507,6 +507,7 @@ class EddyTap:
         self._tap_z_offset = config.getfloat('tap_z_offset', 0.)
         self._tap_threshold = config.getfloat('tap_threshold', 0., above=0.)
         self._least_squares_cache = {}
+        self._current_tap_threshold = 0.
         if self._tap_threshold:
             self._setup_tap()
     # Setup for "tap" probe request
@@ -536,6 +537,7 @@ class EddyTap:
                                        self._tap_threshold, above=0.)
         raw_threshold = convert_frequency(tap_threshold)
         self._trigger_analog.set_trigger('diff_peak_gt', raw_threshold)
+        self._current_tap_threshold = tap_threshold
     # Measurement analysis to determine "tap" position
     def _validate_samples_time(self, measures, start_time, end_time):
         cmderr = self._printer.command_error
@@ -697,17 +699,36 @@ class EddyTap:
                         bc[1], bc[2] + 2.*best_z*bc[3], bc[3])
         #logging.info("probe_analysis: coeffs=%s", final_coeffs)
         return final_coeffs
-    def _analyze_pullback(self, measures, start_time, end_time):
+    def _error_detect(self, msg):
+        raise self._printer.command_error("Unable to detect tap: %s" % (msg,))
+    def _analyze_pullback(self, measures, start_time, end_time, speed):
         reactor = self._printer.get_reactor()
         self._validate_samples_time(measures, start_time, end_time)
         # Correlate measurements to toolhead position at time of measurement
         data = [(sensor_freq, self._lookup_toolhead_pos(samp_time))
                 for samp_time, sensor_freq, sensor_z in measures]
         reactor.pause(0.)
+        min_z = data[0][1][2]
+        max_z = data[-1][1][2]
+        if max_z - min_z < 0.350:
+            self._error_detect("insufficient lift (%.6f vs %.6f)"
+                               % (max_z - min_z, 0.350))
         # Find best fit for extracted measurements
         coeffs = self._find_least_squares(data)
         z_contact, freq_contact, depress_slope, slope, slope2 = coeffs
         reactor.pause(0.)
+        sps = self._sensor_helper.get_samples_per_second()
+        contact_slope_delta_per_sample = (depress_slope - slope) * speed / sps
+        if contact_slope_delta_per_sample < self._current_tap_threshold:
+            self._error_detect("insufficient slope delta (%.6f vs %.6f)"
+                               % (contact_slope_delta_per_sample,
+                                  self._current_tap_threshold))
+        if slope >= 0. or slope2 < 0.:
+            self._error_detect("invalid free air slope (s=%.6f s2=%.6f)"
+                               % (slope, slope2))
+        if z_contact - min_z < 0.050 or z_contact - min_z > 0.250:
+            self._error_detect("invalid depress distance (%.6f vs %.6f:%.6f)"
+                               % (z_contact - min_z, 0.050, 0.250))
         # Report probe position
         trig_idx = len(data)-1
         while trig_idx > 0 and data[trig_idx-1][1][2] > z_contact:
@@ -741,7 +762,7 @@ class EddyTap:
         start_time = retract_start_time - 0.010
         end_time = retract_start_time + 0.150
         self._gather.add_probe_request(self._analyze_pullback, start_time,
-                                       end_time, start_time, end_time)
+                                       end_time, start_time, end_time, speed)
     def pull_probed_results(self):
         return self._gather.pull_probed()
     def end_probe_session(self):

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -698,13 +698,16 @@ class EddyTap:
         #logging.info("probe_analysis: coeffs=%s", final_coeffs)
         return final_coeffs
     def _analyze_pullback(self, measures, start_time, end_time):
+        reactor = self._printer.get_reactor()
         self._validate_samples_time(measures, start_time, end_time)
         # Correlate measurements to toolhead position at time of measurement
         data = [(sensor_freq, self._lookup_toolhead_pos(samp_time))
                 for samp_time, sensor_freq, sensor_z in measures]
+        reactor.pause(0.)
         # Find best fit for extracted measurements
         coeffs = self._find_least_squares(data)
         z_contact, freq_contact, depress_slope, slope, slope2 = coeffs
+        reactor.pause(0.)
         # Report probe position
         trig_idx = len(data)-1
         while trig_idx > 0 and data[trig_idx-1][1][2] > z_contact:

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -513,8 +513,8 @@ class EddyTap:
         # Create sos filter "design"
         cfg_error = self._printer.config_error
         sps = self._sensor_helper.get_samples_per_second()
-        design = trigger_analog.DigitalFilter(sps, cfg_error,
-                                              lowpass=25.0, lowpass_order=4)
+        design = trigger_analog.DigitalFilter(sps, cfg_error)
+        design.add_lowpass(25.0, 4)
         # Create the derivative (sample to sample difference) post filter
         self._filter_design = trigger_analog.DerivativeFilter(design)
         # Create SOS filter

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -561,18 +561,26 @@ class EddyTap:
                                       s.get_past_mcu_position(pos_time))
                     for s in kin.get_steppers()}
         return kin.calc_position(kin_spos)
-    def _calc_least_squares(self, eqs, ans, est_z_contact):
+    def _calc_least_squares(self, samples, est_z_contact):
         # XXX - this implementation is not efficient
-        len_data = len(eqs)
+        len_samples = len(samples)
         import numpy
-        for i in range(len_data):
+        eqs = numpy.zeros((len_samples, 4))
+        ans = numpy.zeros((len_samples,))
+        for i, (step_z, sensor_freq) in enumerate(samples):
+            ans[i] = sensor_freq
             eq = eqs[i]
-            step_z = eq[1]
-            if step_z < est_z_contact:
-                eq[2] = eq[3] = 0.
-                continue
-            eq[2] = (step_z - est_z_contact)
-            eq[3] = (step_z - est_z_contact)**2
+            eq[0] = 1.
+            if step_z <= est_z_contact:
+                # 1*c0 + (z-ezc)*c1 + ezc*c2 + ezc*ezc*c3 = freq
+                eq[1] = step_z - est_z_contact
+                eq[2] = est_z_contact
+                eq[3] = est_z_contact * est_z_contact
+            else:
+                # 1*c0 + 0*c1 + z*c2 + z*z*c3 = freq
+                eq[1] = 0.
+                eq[2] = step_z
+                eq[3] = step_z * step_z
         res = numpy.linalg.lstsq(eqs, ans, rcond=None)
         coeffs = list(res[0])
         if coeffs[3] < 0.:
@@ -586,20 +594,15 @@ class EddyTap:
         #logging.info("z=%.6f err=%.3f coeffs=%s", est_z_contact, err, coeffs)
         return err, coeffs
     def _find_least_squares(self, data):
-        len_data = len(data)
-        import numpy
-        # Populate initial numpy linear least squares arrays
-        eqs = numpy.zeros((len_data, 4))
-        ans = numpy.zeros((len_data,))
-        for i, (sensor_freq, tool_pos) in enumerate(data):
-            ans[i] = sensor_freq
-            eq = eqs[i]
-            eq[0] = 1.
-            eq[1] = tool_pos[2]
-            #logging.info("sample: freq=%.3f z=%.6f", sensor_freq, tool_pos[2])
+        #for d in data:
+        #    logging.info("sample: freq=%.3f z=%.6f", d[0], d[1][2])
+        # Change base of freq/z measurements to improve numerical stability
+        base_z = .5 * (data[0][1][2] + data[-1][1][2])
+        base_freq = .5 * (data[0][0] + data[-1][0])
+        samples = [(d[1][2] - base_z, d[0] - base_freq) for d in data]
         # Run least squares with various z values to reduce residual error
-        min_z = best_z = eqs[0][1]
-        max_z = eqs[-1][1]
+        min_z = best_z = samples[0][0]
+        max_z = samples[-1][0]
         best_err = sys.float_info.max
         best_coeffs = [0., 0., 0., 0.]
         while max_z - min_z > 0.000250:
@@ -610,7 +613,7 @@ class EddyTap:
             else:
                 guess_z = (min_z + best_z) * .5
             # Calculate least squares error for given z
-            guess_err, coeffs = self._calc_least_squares(eqs, ans, guess_z)
+            guess_err, coeffs = self._calc_least_squares(samples, guess_z)
             # Update search bounds
             if guess_err < best_err:
                 if guess_z > best_z:
@@ -625,17 +628,22 @@ class EddyTap:
                     max_z = guess_z
                 else:
                     min_z = guess_z
-        best_coeffs = [float(v) for v in best_coeffs]
-        #logging.info("best: z=%.6f err=%.6f coeffs=%s",
-        #             best_z, best_err, best_coeffs)
-        return float(best_z), best_coeffs
+        # Return to original freq/z measurement base
+        best_z = float(best_z)
+        bc = [float(v) for v in best_coeffs]
+        final_coeffs = (base_z + best_z,
+                        base_freq + bc[0] + best_z*bc[2] + best_z*best_z*bc[3],
+                        bc[1], bc[2] + 2.*best_z*bc[3], bc[3])
+        #logging.info("probe_analysis: coeffs=%s", final_coeffs)
+        return final_coeffs
     def _analyze_pullback(self, measures, start_time, end_time):
         self._validate_samples_time(measures, start_time, end_time)
         # Correlate measurements to toolhead position at time of measurement
         data = [(sensor_freq, self._lookup_toolhead_pos(samp_time))
                 for samp_time, sensor_freq, sensor_z in measures]
         # Find best fit for extracted measurements
-        z_contact, coeffs = self._find_least_squares(data)
+        coeffs = self._find_least_squares(data)
+        z_contact, freq_contact, depress_slope, slope, slope2 = coeffs
         # Report probe position
         trig_idx = len(data)-1
         while trig_idx > 0 and data[trig_idx-1][1][2] > z_contact:

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, logging, math, bisect
-import mcu
+import mcu, mathutil
 from . import ldc1612, trigger_analog, probe, manual_probe
 
 OUT_OF_RANGE = 99.9
@@ -564,11 +564,10 @@ class EddyTap:
     def _calc_least_squares(self, samples, est_z_contact):
         # XXX - this implementation is not efficient
         len_samples = len(samples)
-        import numpy
-        eqs = numpy.zeros((len_samples, 4))
-        ans = numpy.zeros((len_samples,))
+        eqs = [[0.] * 4 for i in range(len_samples)]
+        ans = [[0.] for i in range(len_samples)]
         for i, (step_z, sensor_freq) in enumerate(samples):
-            ans[i] = sensor_freq
+            ans[i][0] = sensor_freq
             eq = eqs[i]
             eq[0] = 1.
             if step_z <= est_z_contact:
@@ -581,18 +580,21 @@ class EddyTap:
                 eq[1] = 0.
                 eq[2] = step_z
                 eq[3] = step_z * step_z
-        res = numpy.linalg.lstsq(eqs, ans, rcond=None)
-        coeffs = list(res[0])
-        if coeffs[3] < 0.:
+        eqst = mathutil.mat_transp(eqs)
+        eqst_eqs = mathutil.mat_mat_mul(eqst, eqs)
+        eqst_ans = mathutil.mat_mat_mul(eqst, ans)
+        coeffs = mathutil.gaussian_solve(eqst_eqs, eqst_ans)
+        if coeffs is not None and coeffs[3][0] < 0.:
             # z**2 factor can't be negative - retry using only linear
-            res = numpy.linalg.lstsq(eqs[:][:,:3], ans, rcond=None)
-            coeffs = list(res[0]) + [0.]
-        if not res[1]:
-            err = sys.float_info.max
-        else:
-            err = res[1][0]
-        #logging.info("z=%.6f err=%.3f coeffs=%s", est_z_contact, err, coeffs)
-        return err, coeffs
+            alt_eqst_eqs = [ee[:3] for ee in eqst_eqs[:3]]
+            alt_eqst_ans = eqst_ans[:3]
+            coeffs = mathutil.gaussian_solve(alt_eqst_eqs, alt_eqst_ans)
+            if coeffs is not None:
+                coeffs = coeffs + [[0.]]
+        if coeffs is None:
+            return sys.float_info.max, [[0.]] * 4
+        rel_err = -sum([c[0]*a[0] for c, a in zip(coeffs, eqst_ans)])
+        return rel_err, coeffs
     def _find_least_squares(self, data):
         #for d in data:
         #    logging.info("sample: freq=%.3f z=%.6f", d[0], d[1][2])
@@ -629,8 +631,7 @@ class EddyTap:
                 else:
                     min_z = guess_z
         # Return to original freq/z measurement base
-        best_z = float(best_z)
-        bc = [float(v) for v in best_coeffs]
+        bc = [v[0] for v in best_coeffs]
         final_coeffs = (base_z + best_z,
                         base_freq + bc[0] + best_z*bc[2] + best_z*best_z*bc[3],
                         bc[1], bc[2] + 2.*best_z*bc[3], bc[3])

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -68,6 +68,8 @@ class DigitalFilter:
         if self.initial_state is None:
             return [[0., 0.]] * len(self.filter_sections)
         return self.initial_state
+    def get_size(self):
+        return len(self.filter_sections)
 
 # Control an `sos_filter` object on the MCU
 class MCU_SosFilter:

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -25,6 +25,33 @@ def to_fixed_32(value, frac_bits=0):
     fixed_val = int(value * (2**frac_bits))
     return assert_is_int32(fixed_val, frac_bits)
 
+# Pre-generated SOS filters (avoid Scipy package for common installs)
+GeneratedSOS = {
+    ('lowpass', 10.0, 4): [
+        [0.004824343357716228, 0.009648686715432456, 0.004824343357716228,
+         1.0, -1.0485995763626117, 0.2961403575616696],
+        [1.0, 2.0, 1.0, 1.0, -1.3209134308194264, 0.6327387928852766],
+    ],
+}
+
+# Helper tool to pre-generate SOS filters.  Run with something like:
+#  python -c 'import trigger_analog as m; m.pre_gen_filt("lowpass", 250, 25, 4)'
+def pre_gen_filt(btype, sps, freq, order):
+    global GeneratedSOS
+    GeneratedSOS = {}
+    # Create filter
+    df = DigitalFilter(sps, ImportError)
+    fs = df._butter(freq, btype, order)
+    # Write filter info to stdout
+    msgs = []
+    msgs.append("    ('%s', %s, %d): [" % (btype, repr(float(sps)/freq), order))
+    for data in fs:
+        coeffs = ", ".join([repr(float(c)) for c in data])
+        msgs.append("        [%s]," % coeffs,)
+    msgs.append("    ],")
+    msgs.append("")
+    import sys
+    sys.stdout.write("\n".join(msgs))
 
 # Digital filter designer and container
 class DigitalFilter:
@@ -59,6 +86,9 @@ class DigitalFilter:
             return
         self.initial_state = signal.sosfilt_zi(self.filter_sections)
     def _butter(self, frequency, btype, order):
+        key = (btype, float(self.sample_frequency)/frequency, int(order))
+        if key in GeneratedSOS:
+            return GeneratedSOS[key]
         signal = self.get_scipy_signal()
         return signal.butter(order, Wn=frequency, btype=btype,
             fs=self.sample_frequency, output='sos')

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -28,53 +28,43 @@ def to_fixed_32(value, frac_bits=0):
 
 # Digital filter designer and container
 class DigitalFilter:
-    def __init__(self, sps, cfg_error, highpass=None, highpass_order=1,
-            lowpass=None, lowpass_order=1, notches=None, notch_quality=2.0):
+    def __init__(self, sps, cfg_error):
         self.filter_sections = []
-        self.initial_state = []
+        self.initial_state = None
         self.sample_frequency = sps
-        # an empty filter can be created without SciPi/numpy
-        if not (highpass or lowpass or notches):
-            return
+        self.cfg_error = cfg_error
+    def get_scipy_signal(self):
         try:
             import scipy.signal as signal
-            import numpy
         except:
-            raise cfg_error("DigitalFilter require the SciPy module")
-        if highpass:
-            self.filter_sections.extend(
-                self._butter(highpass, "highpass", highpass_order))
-        if lowpass:
-            self.filter_sections.extend(
-                self._butter(lowpass, "lowpass", lowpass_order))
-        if notches is None:
-            notches = []
-        for notch_freq in notches:
-            self.filter_sections.append(self._notch(notch_freq, notch_quality))
-        if len(self.filter_sections) > 0:
-            self.initial_state = signal.sosfilt_zi(self.filter_sections)
-
+            raise self.cfg_error("DigitalFilter require the SciPy module")
+        return signal
+    def add_highpass(self, highpass, highpass_order):
+        f = self._butter(highpass, "highpass", highpass_order)
+        self.filter_sections.extend(f)
+    def add_lowpass(self, lowpass, lowpass_order):
+        f = self._butter(lowpass, "lowpass", lowpass_order)
+        self.filter_sections.extend(f)
+    def add_notch(self, notch_freq, notch_quality):
+        signal = self.get_scipy_signal()
+        b, a = signal.iirnotch(notch_freq, Q=notch_quality,
+                               fs=self.sample_frequency)
+        f = signal.tf2sos(b, a)[0]
+        self.filter_sections.append(f)
+    def setup_initial_state(self):
+        if not self.filter_sections:
+            return
+        self.initial_state = signal.sosfilt_zi(self.filter_sections)
     def _butter(self, frequency, btype, order):
-        import scipy.signal as signal
+        signal = self.get_scipy_signal()
         return signal.butter(order, Wn=frequency, btype=btype,
             fs=self.sample_frequency, output='sos')
-
-    def _notch(self, freq, quality):
-        import scipy.signal as signal
-        b, a = signal.iirnotch(freq, Q=quality, fs=self.sample_frequency)
-        return signal.tf2sos(b, a)[0]
-
     def get_filter_sections(self):
         return self.filter_sections
-
     def get_initial_state(self):
+        if self.initial_state is None:
+            return [[0., 0.]] * len(self.filter_sections)
         return self.initial_state
-
-    def filtfilt(self, data):
-        import scipy.signal as signal
-        import numpy
-        data = numpy.array(data)
-        return signal.sosfiltfilt(self.filter_sections, data)
 
 # Produce sample to sample difference (derivative) of a DigitalFilter
 class DerivativeFilter:

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -51,6 +51,9 @@ class DigitalFilter:
                                fs=self.sample_frequency)
         f = signal.tf2sos(b, a)[0]
         self.filter_sections.append(f)
+    def add_derivative(self):
+        # Sample to sample difference (derivative) as stage in SOS filter
+        self.filter_sections.append((1., -1., 0., 1., 0., 0.))
     def setup_initial_state(self):
         if not self.filter_sections:
             return
@@ -65,22 +68,6 @@ class DigitalFilter:
         if self.initial_state is None:
             return [[0., 0.]] * len(self.filter_sections)
         return self.initial_state
-
-# Produce sample to sample difference (derivative) of a DigitalFilter
-class DerivativeFilter:
-    def __init__(self, main_filter):
-        self._main_filter = main_filter
-
-    def get_main_filter(self):
-        return self._main_filter
-
-    def get_filter_sections(self):
-        s = list(self._main_filter.get_filter_sections())
-        return s + [(1., -1., 0., 1., 0., 0.)]
-
-    def get_initial_state(self):
-        s = list(self._main_filter.get_initial_state())
-        return s + [(-1., 0.)]
 
 # Control an `sos_filter` object on the MCU
 class MCU_SosFilter:

--- a/klippy/kinematics/generic_cartesian.py
+++ b/klippy/kinematics/generic_cartesian.py
@@ -11,28 +11,6 @@ from . import kinematic_stepper as ks
 
 VALID_AXES = ['x', 'y', 'z']
 
-def mat_mul(a, b):
-    if len(a[0]) != len(b):
-        return None
-    res = []
-    for i in range(len(a)):
-        res.append([])
-        for j in range(len(b[0])):
-            res[i].append(sum(a[i][k] * b[k][j] for k in range(len(b))))
-    return res
-
-def mat_transp(a):
-    res = []
-    for i in range(len(a[0])):
-        res.append([a[j][i] for j in range(len(a))])
-    return res
-
-def mat_pseudo_inverse(m):
-    mt = mat_transp(m)
-    mtm = mat_mul(mt, m)
-    pinv = mat_mul(mathutil.matrix_inv(mtm), mt)
-    return pinv
-
 class MainCarriage:
     def __init__(self, config):
         self.rail = stepper.GenericPrinterRail(config)
@@ -276,8 +254,9 @@ class GenericCartesianKinematics:
                  for s in self.kin_steppers])
     def _check_kinematics(self, report_error):
         matr, _ = self._get_kinematics_coeffs()
-        det = mathutil.matrix_det(mat_mul(mat_transp(matr), matr))
-        if abs(det) < 0.00001:
+        mtm = mathutil.mat_mat_mul(mathutil.mat_transp(matr), matr)
+        res = mathutil.gaussian_solve(mtm, [[]] * len(mtm))
+        if res is None:
             raise report_error(
                     "Verify configured stepper(s) and their 'carriages' "
                     "specifications, the current configuration does not "
@@ -285,9 +264,10 @@ class GenericCartesianKinematics:
     def calc_position(self, stepper_positions):
         matr, offs = self._get_kinematics_coeffs()
         spos = [stepper_positions[s.get_name()] for s in self.kin_steppers]
-        pinv = mat_pseudo_inverse(matr)
-        pos = mat_mul([[sp-o for sp, o in zip(spos, offs)]], mat_transp(pinv))
-        for i in range(3):
+        pinv = mathutil.pseudo_inverse(matr)
+        pos = mathutil.mat_mat_mul([[sp-o for sp, o in zip(spos, offs)]],
+                                   mathutil.mat_transp(pinv))
+        for i in range(len(pinv)):
             if not any(pinv[i]):
                 pos[0][i] = None
         return pos[0]

--- a/klippy/mathutil.py
+++ b/klippy/mathutil.py
@@ -1,9 +1,10 @@
 # Simple math helper functions
 #
 # Copyright (C) 2018-2019  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2025-2026  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import math, logging, multiprocessing, traceback
+import copy, math, logging, multiprocessing, traceback
 import queuelogger
 
 
@@ -137,16 +138,64 @@ def matrix_mul(m1, s):
     return [m1[0]*s, m1[1]*s, m1[2]*s]
 
 ######################################################################
-# Matrix helper functions for 3x3 matrices
+# Matrix helper functions for NxM matrices
 ######################################################################
 
-def matrix_det(a):
-    x0, x1, x2 = a
-    return matrix_dot(x0, matrix_cross(x1, x2))
+def mat_mat_mul(a, b):
+    if len(a[0]) != len(b):
+        return None
+    res = []
+    for i in range(len(a)):
+        res.append([])
+        for j in range(len(b[0])):
+            res[i].append(sum(a[i][k] * b[k][j] for k in range(len(b))))
+    return res
 
-def matrix_inv(a):
-    x0, x1, x2 = a
-    inv_det = 1. / matrix_det(a)
-    return [matrix_mul(matrix_cross(x1, x2), inv_det),
-            matrix_mul(matrix_cross(x2, x0), inv_det),
-            matrix_mul(matrix_cross(x0, x1), inv_det)]
+def mat_transp(a):
+    res = []
+    for i in range(len(a[0])):
+        res.append([a[j][i] for j in range(len(a))])
+    return res
+
+def gaussian_solve(a, rhs):
+    res = copy.deepcopy(rhs)
+    m = copy.deepcopy(a)
+    n = len(m)
+    # Perform the LU-decomposition through Gaussian elimination
+    for i in range(n):
+        # Find a pivot and swap the corresponding rows
+        abs_col = [abs(m[j][i]) for j in range(i, n)]
+        j = abs_col.index(max(abs_col)) + i
+        if i != j:
+            m[i], m[j] = m[j], m[i]
+            res[i], res[j] = res[j], res[i]
+
+        if abs(m[i][i]) < 1e-10:
+            return None
+        # Scale the i-th row
+        recipr = 1. / m[i][i]
+        for j in range(i+1, n):
+            m[i][j] *= recipr
+        for j in range(len(res[i])):
+            res[i][j] *= recipr
+        m[i][i] = 1.
+
+        # Zero-out the i-th column after the row i
+        for j in range(i+1, n):
+            c = m[j][i]
+            for k in range(i, n):
+                m[j][k] -= c * m[i][k]
+            for k in range(len(res[j])):
+                res[j][k] -= c * res[i][k]
+
+    # Solve the system with the upper-triangular matrix
+    for i in range(n-2, -1, -1):
+        for j in range(i+1, n):
+            for k in range(len(res[j])):
+                res[i][k] -= m[i][j] * res[j][k]
+    return res
+
+def pseudo_inverse(m):
+    mt = mat_transp(m)
+    mtm = mat_mat_mul(mt, m)
+    return gaussian_solve(mtm, mt)


### PR DESCRIPTION
This is a follow-up to PR #7220.  It add some improvements to the new detect "tap" on lift system.

The improvements include:
1. The "tap" logic no longer requires the scipy package to be installed.  Installing the scipy package can be problematic on older rpi machines (and likely other single board computers).  We actually only need 10 constants from the scipy package (the calculated SOS filter constants for a 25hz low-pass filter at 250sps), and it is straight forward to pre-generate those 10 constants to avoid users requiring the full package.
2. Similarly, the "tap" logic no longer requires the numpy package.  We were only using numpy for it's least squares solving code.  However, @dmbutyugin already has a simple pure python implementation for that (for the generic_cartesian code).  The pure python implementation isn't as fast as the numpy implementation, but for the simple 4x4 matrices that we are solving here it does not really matter.
3. The "tap" code implements a kind of non-linear least squares solver that iteratively calls an ordinary linear least squares solver.  In practice, we can cache the results between iterations to reduce the overhead.  This PR implements that caching.  It also improves the final search range to a 50 nanometer window (down from 250nm previously).  Now that results are cached between solver invocations, the handful of additional calls only add a trivial amount of additional overhead.
4. I've added several "sanity checks" to the tap detection logic.  If a tap attempt doesn't actually succeed, for example due to sensor noise causing the toolhead to stop before actually contacting the bed, then there is now a much better chance the user will get an error instead of silently getting an incorrect probe Z report.  The new code checks that the toolhead lifts at least 350um during retraction, that the bed is depressed between 50um to 250um, and that the pre-contact to post-contact rate of change to the sensor frequency is at least as large as the specified `tap_threshold`.  That last check (eg, `Unable to analyze tap: insufficient slope delta (-958.695010 vs 600.000000)`) seems very good at catching incorrect `tap_threshold` settings in my tests.

@nefelim4ag , @freakydude , @ifreislich - fyi.

-Kevin