### PR TITLE
Removal of Filament Diameter Check

### DIFF
--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -149,7 +149,7 @@ class PrinterExtruder:
         # Setup kinematic checks
         self.nozzle_diameter = config.getfloat('nozzle_diameter', above=0.)
         filament_diameter = config.getfloat(
-            'filament_diameter', minval=self.nozzle_diameter)
+            'filament_diameter')
         self.filament_area = math.pi * (filament_diameter * .5)**2
         def_max_cross_section = 4. * self.nozzle_diameter**2
         def_max_extrude_ratio = def_max_cross_section / self.filament_area

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -149,7 +149,7 @@ class PrinterExtruder:
         # Setup kinematic checks
         self.nozzle_diameter = config.getfloat('nozzle_diameter', above=0.)
         filament_diameter = config.getfloat(
-            'filament_diameter')
+            'filament_diameter', above=0.)
         self.filament_area = math.pi * (filament_diameter * .5)**2
         def_max_cross_section = 4. * self.nozzle_diameter**2
         def_max_extrude_ratio = def_max_cross_section / self.filament_area


### PR DESCRIPTION
Recently, nozzles thicker(2.0mm etc) than the standard filament diameter (1.75 mm) have become available and are being used. The diameter check causes issues where the printer cannot print when a thicker nozzle is installed.
https://shop.kaika-tecdia.com/blog/2021/12/24/134114

Signed-off-by: Noriaki Tambo <gear2nd.droid@gmail.com>