### PR TITLE
stm32: G4 enable katapult request

### DIFF
--- a/src/stm32/stm32g4.c
+++ b/src/stm32/stm32g4.c
@@ -6,6 +6,7 @@
 
 #include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
 #include "board/armcm_boot.h" // VectorTable
+#include "board/armcm_reset.h" // try_request_canboot
 #include "board/irq.h" // irq_disable
 #include "board/misc.h" // bootloader_request
 #include "command.h" // DECL_CONSTANT_STR
@@ -162,6 +163,7 @@ clock_setup(void)
 void
 bootloader_request(void)
 {
+    try_request_canboot();
     dfu_reboot();
 }
 


### PR DESCRIPTION
On STM32G4 it seems impossible to jump into the katapult from the klipper:
```
james@MicronPi:~/katapult/scripts $ python3 flashtool.py -i can0 -r -u 1bcff81feaf9
Connecting to CAN UUID 1bcff81feaf9 on interface can0
Sending bootloader jump command...
Bootloader Request Complete
james@MicronPi:~/katapult/scripts $ python3 flashtool.py -i can0 -q
Resetting all bootloader node IDs...
Checking for Katapult nodes...
Detected UUID: 1bcff81feaf9, Application: Klipper
CANBus UUID Query Complete
```

I'm not fully understanding how it works. This is copy pasted from STM32G0.
So, I hope it works.
Need to be tested on the actual STM32G4 hardware.

-Timofey

---
I guess it is correct: https://github.com/Cartographer3D/MCU-Firmware---Based-on-Klipper/blob/cartographer/src/stm32/stm32g0.c#L154