### PR TITLE
Improve rounding in analog SOS filter

### DIFF
--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -148,7 +148,9 @@ class LDC1612:
         self.batch_bulk.add_client(cb)
     def lookup_sensor_error(self, error):
         return self._sensor_errors.get(error, "Unknown ldc1612 error")
-    def convert_frequency(self, freq):
+    def convert_raw_to_frequency(self, raw_value):
+        return raw_value * self.freq_conv
+    def convert_frequency_to_raw(self, freq):
         return int(freq / self.freq_conv + 0.5)
     # Measurement decoding
     def _convert_samples(self, samples):

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -332,7 +332,7 @@ class LoadCellProbingMove:
         sos_filter.set_offset_scale(int(-tare_counts), gpc, Q17_14_FRAC_BITS)
         # update trigger
         trigger_val = self._config_helper.get_trigger_force_grams(gcmd)
-        trigger_frac_grams = trigger_val * FRAC_GRAMS_CONV
+        trigger_frac_grams = int(trigger_val * FRAC_GRAMS_CONV)
         self._mcu_trigger_analog.set_trigger("abs_ge", trigger_frac_grams)
 
     # Probe towards z_min until the trigger_analog on the MCU triggers

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -328,8 +328,7 @@ class LoadCellProbingMove:
         # update internal tare value
         gpc = self._config_helper.get_grams_per_count() * FRAC_GRAMS_CONV
         sos_filter = self._mcu_trigger_analog.get_sos_filter()
-        Q17_14_FRAC_BITS = 14
-        sos_filter.set_offset_scale(int(-tare_counts), gpc, Q17_14_FRAC_BITS)
+        sos_filter.set_offset_scale(int(-tare_counts), gpc)
         # update trigger
         trigger_val = self._config_helper.get_trigger_force_grams(gcmd)
         trigger_frac_grams = int(trigger_val * FRAC_GRAMS_CONV)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -429,7 +429,7 @@ class EddyDescend:
         sos_filter.set_offset_scale(0, 1.)
         self._trigger_analog.set_raw_range(0, MAX_VALID_RAW_VALUE)
         trigger_freq = self._calibration.height_to_freq(self._descend_z)
-        conv_freq = self._sensor_helper.convert_frequency(trigger_freq)
+        conv_freq = self._sensor_helper.convert_frequency_to_raw(trigger_freq)
         self._trigger_analog.set_trigger('gt', conv_freq)
     # Probe session interface
     def start_probe_session(self, gcmd):
@@ -528,15 +528,18 @@ class EddyTap:
     def _prep_trigger_analog_tap(self, gcmd):
         if not self._tap_threshold:
             raise self._printer.command_error("Tap not configured")
+        # Setup mcu filter (scale internal values to milli-hz)
         sos_filter = self._trigger_analog.get_sos_filter()
         sos_filter.set_filter_design(self._filter_design)
-        sos_filter.set_offset_scale(0, 1., auto_offset=True)
+        FRAC_HZ = 1000.
+        s = FRAC_HZ * self._sensor_helper.convert_raw_to_frequency(1)
+        sos_filter.set_offset_scale(0, s, auto_offset=True)
         self._trigger_analog.set_raw_range(0, MAX_VALID_RAW_VALUE)
-        convert_frequency = self._sensor_helper.convert_frequency
+        # Set mcu trigger to tap_threshold
         tap_threshold = gcmd.get_float("TAP_THRESHOLD",
                                        self._tap_threshold, above=0.)
-        raw_threshold = convert_frequency(tap_threshold)
-        self._trigger_analog.set_trigger('diff_peak_gt', raw_threshold)
+        samp_thresh = int(FRAC_HZ * tap_threshold + 0.5)
+        self._trigger_analog.set_trigger('diff_peak_gt', samp_thresh)
         self._current_tap_threshold = tap_threshold
     # Measurement analysis to determine "tap" position
     def _validate_samples_time(self, measures, start_time, end_time):

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -333,7 +333,7 @@ class MCU_trigger_analog:
             self._set_raw_range_cmd.send(args)
             self._last_range_args = args
         # Update trigger in mcu (if it has changed)
-        args = [self._oid, self._trigger_type, to_fixed_32(self._trigger_value)]
+        args = [self._oid, self._trigger_type, self._trigger_value]
         if args != self._last_trigger_args:
             self._set_trigger_cmd.send(args)
             self._last_trigger_args = args

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -22,7 +22,7 @@ def assert_is_int32(value, frac_bits):
 # convert a floating point value to a 32 bit fixed point representation
 # checks for overflow
 def to_fixed_32(value, frac_bits=0):
-    fixed_val = int(value * (2**frac_bits))
+    fixed_val = int(round(value * (2**frac_bits)))
     return assert_is_int32(fixed_val, frac_bits)
 
 # Pre-generated SOS filters (avoid Scipy package for common installs)

--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -25,6 +25,21 @@ def to_fixed_32(value, frac_bits=0):
     fixed_val = int(round(value * (2**frac_bits)))
     return assert_is_int32(fixed_val, frac_bits)
 
+# Determine maximum frac bits for a list of values
+def calc_frac_bits(values):
+    if all([v == int(v) for v in values]):
+        return 0
+    mv = max([abs(v) for v in values])
+    frac_bits = 31 - int(mv).bit_length() # 63 - int(mv * (1<<32)).bit_length()
+    if frac_bits <= 0:
+        return 0
+    try:
+        validate = [to_fixed_32(v) for v in values]
+    except OverflowError as e:
+        # Handle rare case where rounding causes an overflow
+        return frac_bits - 1
+    return frac_bits
+
 # Pre-generated SOS filters (avoid Scipy package for common installs)
 GeneratedSOS = {
     ('lowpass', 10.0, 4): [
@@ -112,11 +127,11 @@ class MCU_SosFilter:
         # SOS filter "design"
         self._design = None
         self._coeff_frac_bits = 0
+        self._last_calc_frac_bits = None
         self._start_value = 0.
         # Offset and scaling
         self._offset = 0
         self._scale = 1.
-        self._scale_frac_bits = 0
         self._auto_offset = False
         # MCU commands
         self._oid = self._mcu.create_oid()
@@ -145,11 +160,20 @@ class MCU_SosFilter:
     def get_oid(self):
         return self._oid
 
+    # Determine the frac_bits to use for sos filter coefficients
+    def _calc_coeff_frac_bits(self, filter_sections):
+        coeffs = sum([list(f) for f in filter_sections], [])
+        if not filter_sections or coeffs == self._last_calc_frac_bits:
+            return
+        self._coeff_frac_bits = calc_frac_bits(coeffs)
+        self._last_calc_frac_bits = coeffs
+
     # convert the SciPi SOS filters to fixed point format
     def _convert_filter(self):
         if self._design is None:
             return []
         filter_sections = self._design.get_filter_sections()
+        self._calc_coeff_frac_bits(filter_sections)
         sos_fixed = []
         for section in filter_sections:
             nun_coeff = len(section)
@@ -192,17 +216,14 @@ class MCU_SosFilter:
         self._start_value = start_value
 
     # Set conversion of a raw value 1 to a 1.0 value processed by sos filter
-    def set_offset_scale(self, offset=0, scale=1., scale_frac_bits=0,
-                         auto_offset=False):
+    def set_offset_scale(self, offset=0, scale=1., auto_offset=False):
         self._offset = offset
         self._scale = scale
-        self._scale_frac_bits = scale_frac_bits
         self._auto_offset = auto_offset
 
     # Change the filter coefficients and state at runtime
-    def set_filter_design(self, design, coeff_frac_bits=29):
+    def set_filter_design(self, design):
         self._design = design
-        self._coeff_frac_bits = coeff_frac_bits
 
     # Resets the filter state back to initial conditions at runtime
     def reset_filter(self):
@@ -229,9 +250,9 @@ class MCU_SosFilter:
         for i, state in enumerate(sos_state):
             self._set_state_cmd.send([self._oid, i, state[0], state[1]])
         # Send offset/scale (if they have changed)
-        su = to_fixed_32(self._scale, self._scale_frac_bits)
-        args = (self._oid, self._offset, su, self._scale_frac_bits,
-                self._auto_offset)
+        scale_frac_bits = calc_frac_bits([self._scale])
+        su = to_fixed_32(self._scale, scale_frac_bits)
+        args = (self._oid, self._offset, su, scale_frac_bits, self._auto_offset)
         if args != self._last_sent_offset_scale or self._auto_offset:
             self._set_offset_scale_cmd.send(args)
             self._last_sent_offset_scale = args

--- a/src/sos_filter.c
+++ b/src/sos_filter.c
@@ -41,7 +41,7 @@ fixed_mul(int32_t coeff, int32_t value, uint_fast8_t frac_bits, int32_t *res)
     int64_t result = (int64_t)coeff * (int64_t)value;
     if (frac_bits) {
         // round up at the last bit to be shifted away
-        result += 1 << (frac_bits - 1);
+        result += 1LL << (frac_bits - 1);
         // shift the decimal right to discard the coefficient fractional bits
         result >>= frac_bits;
     }


### PR DESCRIPTION
The analog trigger SOS filter coefficients are currently truncated, and it would be preferable to round them.

This PR also changes the MCU_SosFilter class to automatically determine the fixed point "frac bits" for the coefficients.  The conversion to/from fixed point representation is kinda confusing, so it would be preferable to contain this logic in MCU_SosFilter and not expose it to its callers.

This PR is a minor change.

-Kevin