### PR TITLE
chelper: don't dlopen when building, fixes cross compilation

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -318,11 +318,6 @@ def get_ffi():
         FFI_main = cffi.FFI()
         for d in defs_all:
             FFI_main.cdef(d)
-        FFI_lib = FFI_main.dlopen(destlib)
-        # Setup error logging
-        pyhelper_logging_callback = FFI_main.callback("void func(const char *)",
-                                                      logging_callback)
-        FFI_lib.set_python_logging_callback(pyhelper_logging_callback)
     return FFI_main, FFI_lib
 
 


### PR DESCRIPTION
If you're cross compiling, the `.so` file produced is for the target architecture (armv6 for example). So you cannot just dlopen() that, since your host is not armv6.

Why the code is being built, then dlopen'd, is unclear to me anyway. If there is a desire to test things, that should be optional and done in a separate script.