### PR TITLE
scripts: add opensuse linux install script

### DIFF
--- a/scripts/install-opensuse.sh
+++ b/scripts/install-opensuse.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# This script installs Klipper on an x86_64 machine running the
+# openSUSE Tumbleweed/Slowroll/Leap 16+ distributions.
+
+PYTHONDIR="${HOME}/klippy-env"
+SYSTEMDDIR="/etc/systemd/system"
+KLIPPER_USER=$USER
+KLIPPER_GROUP=$KLIPPER_USER
+
+# Step 1: Install system packages
+install_packages()
+{
+    # Packages for python cffi
+    PKGLIST="python3-virtualenv libffi-devel patterns-devel-base-devel_basis"
+    # kconfig requirements
+    PKGLIST="${PKGLIST} ncurses-devel"
+    # hub-ctrl
+    PKGLIST="${PKGLIST} libusb-1_0-devel"
+    # AVR chip installation and building
+    PKGLIST="${PKGLIST} avrdude cross-avr-gcc15-bootstrap cross-avr-binutils avr-libc"
+    # ARM chip installation and building
+    PKGLIST="${PKGLIST} cross-arm-none-gcc15-bootstrap cross-arm-binutils cross-arm-linux-glibc-devel stm32flash"
+
+    # Install desired packages
+    report_status "Installing packages..."
+    sudo zypper -n install ${PKGLIST}
+}
+
+# Step 2: Create python virtual environment
+create_virtualenv()
+{
+    report_status "Updating python virtual environment..."
+
+    # Create virtualenv if it doesn't already exist
+    [ ! -d ${PYTHONDIR} ] && virtualenv -p python3 ${PYTHONDIR}
+
+    # Install/update dependencies
+    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
+}
+
+# Step 3: Install startup script
+install_script()
+{
+# Create systemd service file
+    KLIPPER_LOG=/tmp/klippy.log
+    report_status "Installing system start script..."
+    sudo /bin/sh -c "cat > $SYSTEMDDIR/klipper.service" << EOF
+#Systemd service file for klipper
+[Unit]
+Description=Starts klipper on startup
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+User=$KLIPPER_USER
+RemainAfterExit=yes
+ExecStart=${PYTHONDIR}/bin/python ${SRCDIR}/klippy/klippy.py ${HOME}/printer.cfg -l ${KLIPPER_LOG}
+EOF
+# Use systemctl to enable the klipper systemd service script
+    sudo systemctl enable klipper.service
+    report_status "Make sure to add $KLIPPER_USER to the user group controlling your serial printer port"
+}
+
+# Step 4: Start host software
+start_software()
+{
+    report_status "Launching Klipper host software..."
+    sudo systemctl start klipper
+}
+
+# Helper functions
+report_status()
+{
+    echo -e "\n\n###### $1"
+}
+
+verify_ready()
+{
+    if [ "$EUID" -eq 0 ]; then
+        echo "This script must not run as root"
+        exit -1
+    fi
+}
+
+# Force script to exit if an error occurs
+set -e
+
+# Find SRCDIR from the pathname of this script
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+
+# Run installation steps defined above
+verify_ready
+install_packages
+create_virtualenv
+install_script
+start_software

--- a/scripts/install-opensuse.sh
+++ b/scripts/install-opensuse.sh
@@ -19,7 +19,7 @@ install_packages()
     # AVR chip installation and building
     PKGLIST="${PKGLIST} avrdude cross-avr-gcc15-bootstrap cross-avr-binutils avr-libc"
     # ARM chip installation and building
-    PKGLIST="${PKGLIST} cross-arm-none-gcc15-bootstrap cross-arm-binutils cross-arm-linux-glibc-devel stm32flash"
+    PKGLIST="${PKGLIST} cross-arm-none-gcc15-bootstrap cross-arm-binutils cross-arm-linux-glibc-devel cross-arm-none-newlib-devel stm32flash"
 
     # Install desired packages
     report_status "Installing packages..."

--- a/scripts/klipper-uninstall-systemd.sh
+++ b/scripts/klipper-uninstall-systemd.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Uninstall script for systemd type installations
+
+# Stop Klipper Service
+echo "#### Stopping Klipper Service.."
+sudo systemctl stop klipper.service
+
+# Remove Klipper from Startup
+echo
+echo "#### Removing Klipper from Startup.."
+sudo systemctl disable klipper.service
+
+# Remove Klipper from Services
+echo
+echo "#### Removing Klipper Service.."
+sudo rm -f /etc/systemd/system/klipper.service
+
+# Notify user of method to remove Klipper source code
+echo
+echo "The Klipper system files have been removed."
+echo
+echo "The following command is typically used to remove local files:"
+echo "  rm -rf ~/klippy-env ~/klipper"


### PR DESCRIPTION
Automate installation for openSUSE Linux based systems. Supports Tumbleweed, Slowroll and Leap 16+.

This PR also add a simple systemd uninstallation script (not specific to openSUSE).

Tested on my modified Sidewinder X1 with an arm64 board installed with openSUSE Tumbleweed on it.