### PR TITLE
Enhance idle timeout with verbose debug and robustness

### DIFF
--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -27,11 +27,12 @@ class IdleTimeout:
         self.verbose_debug = config.getboolean('verbose_debug', False)
         self.robust_delayed_gcode = config.getboolean('robust_delayed_gcode', False)
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
-        self.idle_gcode = gcode_macro.load_template(config, 'gcode',
-                                                    DEFAULT_IDLE_GCODE)
-        self.gcode.register_command('SET_IDLE_TIMEOUT',
-                                    self.cmd_SET_IDLE_TIMEOUT,
-                                    desc=self.cmd_SET_IDLE_TIMEOUT_help)
+        self.idle_gcode = gcode_macro.load_template(
+            config, 'gcode', DEFAULT_IDLE_GCODE)
+        self.gcode.register_command(
+            'SET_IDLE_TIMEOUT',
+            self.cmd_SET_IDLE_TIMEOUT,
+            desc=self.cmd_SET_IDLE_TIMEOUT_help)
         self.state = "Idle"
         self.last_print_start_systime = 0.
         self.last_idle_start_time = None  # Track when Ready state entered
@@ -47,12 +48,16 @@ class IdleTimeout:
                 idle_time = eventtime - self.last_idle_start_time
                 idle_time_remaining = max(0.0, self.idle_timeout - idle_time)
                 try:
-                    print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
+                    print_time, est_print_time, lookahead_empty = (
+                        self.toolhead.check_busy(eventtime)
+                    )
                 except Exception as e:
                     print_time = est_print_time = 0.0
                     lookahead_empty = True
                     if self.verbose_debug:
-                        logging.error(f"[IdleTimeout] Exception in get_status toolhead.check_busy: {e}")
+                        logging.error(
+                            f"[IdleTimeout] Exception in get_status "
+                            f"toolhead.check_busy: {e}")
                 debug_vals = {
                     'print_time': print_time,
                     'est_print_time': est_print_time,
@@ -64,7 +69,15 @@ class IdleTimeout:
             else:
                 idle_time_remaining = self.idle_timeout
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] get_status called: state={self.state}, printing_time={printing_time}, idle_timeout={self.idle_timeout}, idle_time_remaining={idle_time_remaining}, robust_delayed_gcode={self.robust_delayed_gcode}, debug_vals={debug_vals}")
+            logging.debug(
+                f"[IdleTimeout] get_status called: "
+                f"state={self.state}, "
+                f"printing_time={printing_time}, "
+                f"idle_timeout={self.idle_timeout}, "
+                f"idle_time_remaining={idle_time_remaining}, "
+                f"robust_delayed_gcode={self.robust_delayed_gcode}, "
+                f"debug_vals={debug_vals}"
+            )
         status = {
             "state": self.state,
             "printing_time": printing_time,
@@ -81,8 +94,9 @@ class IdleTimeout:
             logging.debug("[IdleTimeout] handle_ready called")
         self.toolhead = self.printer.lookup_object('toolhead')
         self.timeout_timer = self.reactor.register_timer(self.timeout_handler)
-        self.printer.register_event_handler("toolhead:sync_print_time",
-                                            self.handle_sync_print_time)
+        self.printer.register_event_handler(
+            "toolhead:sync_print_time",
+            self.handle_sync_print_time)
     def transition_idle_state(self, eventtime):
         if self.verbose_debug:
             logging.debug(f"[IdleTimeout] transition_idle_state called at {eventtime}, current state={self.state}")
@@ -103,7 +117,9 @@ class IdleTimeout:
         self.printer.send_event("idle_timeout:idle", print_time)
         return self.reactor.NEVER
     def check_idle_timeout(self, eventtime):
-        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
+        print_time, est_print_time, lookahead_empty = (
+            self.toolhead.check_busy(eventtime)
+        )
         idle_time = est_print_time - print_time
         if self.verbose_debug:
             logging.debug(f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, print_time={print_time}, est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, idle_time={idle_time}, state={self.state}")
@@ -136,38 +152,55 @@ class IdleTimeout:
             if self.last_idle_start_time is None:
                 self.last_idle_start_time = eventtime
             return self.check_idle_timeout(eventtime)
-        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
+        print_time, est_print_time, lookahead_empty = (
+            self.toolhead.check_busy(eventtime)
+        )
         buffer_time = min(2., print_time - est_print_time)
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] timeout_handler: print_time={print_time}, est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, buffer_time={buffer_time}")
+            logging.debug(
+                f"[IdleTimeout] timeout_handler: print_time={print_time}, "
+                f"est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, "
+                f"buffer_time={buffer_time}")
         if not lookahead_empty:
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Toolhead busy, delaying ready state transition")
+                logging.debug(
+                    "[IdleTimeout] Toolhead busy, delaying ready state transition")
             return eventtime + READY_TIMEOUT + max(0., buffer_time)
         if buffer_time > -READY_TIMEOUT:
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Buffer time > -READY_TIMEOUT, waiting")
+                logging.debug(
+                    "[IdleTimeout] Buffer time > -READY_TIMEOUT, waiting")
             return eventtime + READY_TIMEOUT + buffer_time
         if self.gcode.get_mutex().test():
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Gcode class busy, delaying ready state transition")
+                logging.debug(
+                    "[IdleTimeout] Gcode class busy, delaying ready state transition")
             return eventtime + READY_TIMEOUT
         self.state = "Ready"
         self.last_idle_start_time = eventtime  # Set idle start time
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] State transitioned to Ready, sending event idle_timeout:ready")
-        self.printer.send_event("idle_timeout:ready", est_print_time + PIN_MIN_TIME)
+            logging.debug(
+                f"[IdleTimeout] State transitioned to Ready, sending event "
+                f"idle_timeout:ready")
+        self.printer.send_event(
+            "idle_timeout:ready", est_print_time + PIN_MIN_TIME)
         return eventtime + self.idle_timeout
     def handle_sync_print_time(self, curtime, print_time, est_print_time):
         # Only set state to Printing if toolhead is actually busy
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] handle_sync_print_time called: curtime={curtime}, print_time={print_time}, est_print_time={est_print_time}, state={self.state}, robust_delayed_gcode={self.robust_delayed_gcode}")
+            logging.debug(
+                f"[IdleTimeout] handle_sync_print_time called: curtime={curtime}, "
+                f"print_time={print_time}, est_print_time={est_print_time}, "
+                f"state={self.state}, robust_delayed_gcode={self.robust_delayed_gcode}")
         # Check if toolhead is busy
         try:
-            th_print_time, th_est_print_time, th_lookahead_empty = self.toolhead.check_busy(curtime)
+            th_print_time, th_est_print_time, th_lookahead_empty = (
+                self.toolhead.check_busy(curtime)
+            )
         except Exception as e:
             if self.verbose_debug:
-                logging.error(f"[IdleTimeout] Exception in check_busy: {e}")
+                logging.error(
+                    f"[IdleTimeout] Exception in check_busy: {e}")
             th_lookahead_empty = True
         # If robust_delayed_gcode is enabled, only transition to Printing if toolhead is busy
         if self.robust_delayed_gcode and th_lookahead_empty:
@@ -185,18 +218,21 @@ class IdleTimeout:
         if self.verbose_debug:
             logging.debug(f"[IdleTimeout] State transitioned to Printing, updating timer, check_time={check_time}")
         self.reactor.update_timer(self.timeout_timer, curtime + check_time)
-        self.printer.send_event("idle_timeout:printing", est_print_time + PIN_MIN_TIME)
+        self.printer.send_event(
+            "idle_timeout:printing", est_print_time + PIN_MIN_TIME)
     cmd_SET_IDLE_TIMEOUT_help = "Set the idle timeout in seconds"
     def cmd_SET_IDLE_TIMEOUT(self, gcmd):
         timeout = gcmd.get_float('TIMEOUT', self.idle_timeout, above=0.)
         self.idle_timeout = timeout
         if self.verbose_debug:
             logging.debug(f"[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: timeout set to {timeout}")
-        gcmd.respond_info("idle_timeout: Timeout set to %.2f s" % (timeout,))
+        gcmd.respond_info(
+            "idle_timeout: Timeout set to %.2f s" % (timeout,))
         if self.state == "Ready":
             checktime = self.reactor.monotonic() + timeout
             if self.verbose_debug:
-                logging.debug(f"[IdleTimeout] State is Ready, updating timer to {checktime}")
+                logging.debug(
+                    f"[IdleTimeout] State is Ready, updating timer to {checktime}")
             self.reactor.update_timer(self.timeout_timer, checktime)
 
 def load_config(config):

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -166,13 +166,18 @@ class IdleTimeout:
         if self.verbose_debug:
             logging.debug(
                 f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, "
-                f"print_time={print_time}, est_print_time={est_print_time}, "
-                f"lookahead_empty={lookahead_empty}, idle_time={idle_time}, "
-                f"state={self.state}"
+                f"print_time={print_time},\n"
+                f"  est_print_time={est_print_time},\n"
+                f"  lookahead_empty={lookahead_empty},\n"
+                f"  idle_time={idle_time},\n"
+                f"  state={self.state}"
             )
         if not lookahead_empty or idle_time < 1.:
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Toolhead busy, delaying idle timeout check")
+                logging.debug(
+                    "[IdleTimeout] Toolhead busy, "
+                    "delaying idle timeout check"
+                )
             return eventtime + self.idle_timeout
         if idle_time < self.idle_timeout:
             if self.verbose_debug:
@@ -183,21 +188,36 @@ class IdleTimeout:
             return eventtime + self.idle_timeout - idle_time
         if self.gcode.get_mutex().test():
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Gcode class busy, delaying idle timeout check")
+                logging.debug(
+                    "[IdleTimeout] Gcode class busy, "
+                    "delaying idle timeout check"
+                )
             return eventtime + 1.
         if self.verbose_debug:
-            logging.debug("[IdleTimeout] Idle timeout elapsed, transitioning idle state")
+            logging.debug(
+                "[IdleTimeout] Idle timeout elapsed, "
+                "transitioning idle state"
+            )
         return self.transition_idle_state(eventtime)
     def timeout_handler(self, eventtime):
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] timeout_handler called: eventtime={eventtime}, state={self.state}")
+            logging.debug(
+                f"[IdleTimeout] timeout_handler called: eventtime={eventtime}, "
+                f"state={self.state}"
+            )
         if self.printer.is_shutdown():
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Printer is shutdown, returning NEVER")
+                logging.debug(
+                    "[IdleTimeout] Printer is shutdown, "
+                    "returning NEVER"
+                )
             return self.reactor.NEVER
         if self.state == "Ready":
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] State is Ready, checking idle timeout")
+                logging.debug(
+                    "[IdleTimeout] State is Ready, "
+                    "checking idle timeout"
+                )
             # Set last_idle_start_time if just entered Ready
             if self.last_idle_start_time is None:
                 self.last_idle_start_time = eventtime
@@ -210,30 +230,39 @@ class IdleTimeout:
         buffer_time = min(2., print_time - est_print_time)
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] timeout_handler: print_time={print_time}, "
-                f"est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, "
-                f"buffer_time={buffer_time}")
+                f"[IdleTimeout] timeout_handler: print_time={print_time},\n"
+                f"  est_print_time={est_print_time},\n"
+                f"  lookahead_empty={lookahead_empty},\n"
+                f"  buffer_time={buffer_time}"
+            )
         if not lookahead_empty:
             if self.verbose_debug:
                 logging.debug(
-                    "[IdleTimeout] Toolhead busy, delaying ready state transition")
+                    "[IdleTimeout] Toolhead busy, "
+                    "delaying ready state transition"
+                )
             return eventtime + READY_TIMEOUT + max(0., buffer_time)
         if buffer_time > -READY_TIMEOUT:
             if self.verbose_debug:
                 logging.debug(
-                    "[IdleTimeout] Buffer time > -READY_TIMEOUT, waiting")
+                    "[IdleTimeout] Buffer time > -READY_TIMEOUT, "
+                    "waiting"
+                )
             return eventtime + READY_TIMEOUT + buffer_time
         if self.gcode.get_mutex().test():
             if self.verbose_debug:
                 logging.debug(
-                    "[IdleTimeout] Gcode class busy, delaying ready state transition")
+                    "[IdleTimeout] Gcode class busy, "
+                    "delaying ready state transition"
+                )
             return eventtime + READY_TIMEOUT
         self.state = "Ready"
         self.last_idle_start_time = eventtime  # Set idle start time
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] State transitioned to Ready, sending event "
-                f"idle_timeout:ready")
+                f"[IdleTimeout] State transitioned to Ready, "
+                f"sending event idle_timeout:ready"
+            )
         self.printer.send_event(
             "idle_timeout:ready",
             est_print_time + PIN_MIN_TIME,
@@ -243,9 +272,13 @@ class IdleTimeout:
         # Only set state to Printing if toolhead is actually busy
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] handle_sync_print_time called: curtime={curtime}, "
-                f"print_time={print_time}, est_print_time={est_print_time}, "
-                f"state={self.state}, robust_delayed_gcode={self.robust_delayed_gcode}")
+                f"[IdleTimeout] handle_sync_print_time called: "
+                f"curtime={curtime}, "
+                f"print_time={print_time}, "
+                f"est_print_time={est_print_time}, "
+                f"state={self.state}, "
+                f"robust_delayed_gcode={self.robust_delayed_gcode}"
+            )
         # Check if toolhead is busy
         try:
             th_print_time, th_est_print_time, th_lookahead_empty = (
@@ -256,17 +289,25 @@ class IdleTimeout:
                 logging.error(
                     f"[IdleTimeout] Exception in check_busy: {e}")
             th_lookahead_empty = True
-        # If robust_delayed_gcode is enabled, only transition to Printing if toolhead is busy
+        # If robust_delayed_gcode is enabled, only transition to Printing
+        # if toolhead is busy
         if self.robust_delayed_gcode and th_lookahead_empty:
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Toolhead not busy (lookahead empty), not transitioning to Printing state.")
+                logging.debug(
+                    "[IdleTimeout] Toolhead not busy (lookahead empty), "
+                    "not transitioning to Printing state."
+                )
             return
         if self.state == "Printing":
             if self.verbose_debug:
-                logging.debug("[IdleTimeout] Already in Printing state, returning")
+                logging.debug(
+                    "[IdleTimeout] Already in Printing state, "
+                    "returning"
+                )
             return
         self.state = "Printing"
-        self.last_idle_start_time = None  # Reset idle timer when printing resumes
+        # Reset idle timer when printing resumes
+        self.last_idle_start_time = None
         self.last_print_start_systime = curtime
         check_time = READY_TIMEOUT + print_time - est_print_time
         if self.verbose_debug:
@@ -274,7 +315,10 @@ class IdleTimeout:
                 f"[IdleTimeout] State transitioned to Printing, "
                 f"updating timer, check_time={check_time}"
             )
-        self.reactor.update_timer(self.timeout_timer, curtime + check_time)
+        self.reactor.update_timer(
+            self.timeout_timer,
+            curtime + check_time,
+        )
         self.printer.send_event(
             "idle_timeout:printing",
             est_print_time + PIN_MIN_TIME,
@@ -296,7 +340,7 @@ class IdleTimeout:
             if self.verbose_debug:
                 logging.debug(
                     f"[IdleTimeout] State is Ready, "
-                    f"updating timer to {checktime}",
+                    f"updating timer to {checktime}"
                 )
             self.reactor.update_timer(
                 self.timeout_timer,

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -165,12 +165,13 @@ class IdleTimeout:
         idle_time = est_print_time - print_time
         if self.verbose_debug:
             logging.debug(
-                "[IdleTimeout] check_idle_timeout: eventtime={}, ".format(eventtime) +
-                "print_time={}, ".format(print_time) +
-                "est_print_time={}, ".format(est_print_time) +
-                "lookahead_empty={}, ".format(lookahead_empty) +
-                "idle_time={}, ".format(idle_time) +
-                "state={}".format(self.state)
+                ("[IdleTimeout] check_idle_timeout: "
+                 "eventtime={}, ".format(eventtime)
+                 + "print_time={}, ".format(print_time)
+                 + "est_print_time={}, ".format(est_print_time)
+                 + "lookahead_empty={}, ".format(lookahead_empty)
+                 + "idle_time={}, ".format(idle_time)
+                 + "state={}".format(self.state))
             )
         if not lookahead_empty or idle_time < 1.:
             if self.verbose_debug:
@@ -182,8 +183,8 @@ class IdleTimeout:
         if idle_time < self.idle_timeout:
             if self.verbose_debug:
                 logging.debug(
-                    "[IdleTimeout] Idle time {} < idle_timeout {} , waiting".format(
-                        idle_time, self.idle_timeout)
+                    ("[IdleTimeout] Idle time {} < idle_timeout {} , waiting"
+                     .format(idle_time, self.idle_timeout))
                 )
             return eventtime + self.idle_timeout - idle_time
         if self.gcode.get_mutex().test():
@@ -230,10 +231,11 @@ class IdleTimeout:
         buffer_time = min(2., print_time - est_print_time)
         if self.verbose_debug:
             logging.debug(
-                "[IdleTimeout] timeout_handler: print_time={},\n"
-                "  est_print_time={},\n"
-                "  lookahead_empty={},\n"
-                "  buffer_time={}".format(print_time, est_print_time, lookahead_empty, buffer_time)
+                ("[IdleTimeout] timeout_handler: "
+                 "print_time={},\n".format(print_time)
+                 + "  est_print_time={},\n".format(est_print_time)
+                 + "  lookahead_empty={},\n".format(lookahead_empty)
+                 + "  buffer_time={}".format(buffer_time))
             )
         if not lookahead_empty:
             if self.verbose_debug:

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -79,8 +79,8 @@ class IdleTimeout:
                     lookahead_empty = True
                     if self.verbose_debug:
                         logging.error(
-                            f"[IdleTimeout] Exception in get_status "
-                            f"toolhead.check_busy: {e}")
+                            "[IdleTimeout] Exception in get_status "
+                            "toolhead.check_busy: {}".format(e))
                 debug_vals = {
                     'print_time': print_time,
                     'est_print_time': est_print_time,
@@ -93,13 +93,13 @@ class IdleTimeout:
                 idle_time_remaining = self.idle_timeout
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] get_status called: "
-                f"state={self.state}, "
-                f"printing_time={printing_time}, "
-                f"idle_timeout={self.idle_timeout}, "
-                f"idle_time_remaining={idle_time_remaining}, "
-                f"robust_delayed_gcode={self.robust_delayed_gcode}, "
-                f"debug_vals={debug_vals}"
+                "[IdleTimeout] get_status called: "
+                "state={}, ".format(self.state) +
+                "printing_time={}, ".format(printing_time) +
+                "idle_timeout={}, ".format(self.idle_timeout) +
+                "idle_time_remaining={}, ".format(idle_time_remaining) +
+                "robust_delayed_gcode={}, ".format(self.robust_delayed_gcode) +
+                "debug_vals={}".format(debug_vals)
             )
         status = {
             "state": self.state,
@@ -128,8 +128,8 @@ class IdleTimeout:
     def transition_idle_state(self, eventtime):
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] transition_idle_state called at {eventtime}, "
-                f"current state={self.state}"
+                "[IdleTimeout] transition_idle_state called at {}, "
+                "current state={}".format(eventtime, self.state)
             )
         self.state = "Printing"
         try:
@@ -140,16 +140,16 @@ class IdleTimeout:
             self.state = "Ready"
             if self.verbose_debug:
                 logging.debug(
-                    f"[IdleTimeout] Exception in idle_gcode, "
-                    f"state set to Ready"
+                    "[IdleTimeout] Exception in idle_gcode, "
+                    "state set to Ready"
                 )
             return eventtime + 1.
         print_time = self.toolhead.get_last_move_time()
         self.state = "Idle"
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] State transitioned to Idle, "
-                f"print_time={print_time}"
+                "[IdleTimeout] State transitioned to Idle, "
+                "print_time={}".format(print_time)
             )
         self.printer.send_event(
             "idle_timeout:idle",
@@ -165,12 +165,12 @@ class IdleTimeout:
         idle_time = est_print_time - print_time
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, "
-                f"print_time={print_time},\n"
-                f"  est_print_time={est_print_time},\n"
-                f"  lookahead_empty={lookahead_empty},\n"
-                f"  idle_time={idle_time},\n"
-                f"  state={self.state}"
+                "[IdleTimeout] check_idle_timeout: eventtime={}, ".format(eventtime) +
+                "print_time={}, ".format(print_time) +
+                "est_print_time={}, ".format(est_print_time) +
+                "lookahead_empty={}, ".format(lookahead_empty) +
+                "idle_time={}, ".format(idle_time) +
+                "state={}".format(self.state)
             )
         if not lookahead_empty or idle_time < 1.:
             if self.verbose_debug:
@@ -182,8 +182,8 @@ class IdleTimeout:
         if idle_time < self.idle_timeout:
             if self.verbose_debug:
                 logging.debug(
-                    f"[IdleTimeout] Idle time {idle_time} < idle_timeout "
-                    f"{self.idle_timeout}, waiting"
+                    "[IdleTimeout] Idle time {} < idle_timeout {} , waiting".format(
+                        idle_time, self.idle_timeout)
                 )
             return eventtime + self.idle_timeout - idle_time
         if self.gcode.get_mutex().test():
@@ -202,8 +202,8 @@ class IdleTimeout:
     def timeout_handler(self, eventtime):
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] timeout_handler called: eventtime={eventtime}, "
-                f"state={self.state}"
+                "[IdleTimeout] timeout_handler called: eventtime={}, "
+                "state={}".format(eventtime, self.state)
             )
         if self.printer.is_shutdown():
             if self.verbose_debug:
@@ -230,10 +230,10 @@ class IdleTimeout:
         buffer_time = min(2., print_time - est_print_time)
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] timeout_handler: print_time={print_time},\n"
-                f"  est_print_time={est_print_time},\n"
-                f"  lookahead_empty={lookahead_empty},\n"
-                f"  buffer_time={buffer_time}"
+                "[IdleTimeout] timeout_handler: print_time={},\n"
+                "  est_print_time={},\n"
+                "  lookahead_empty={},\n"
+                "  buffer_time={}".format(print_time, est_print_time, lookahead_empty, buffer_time)
             )
         if not lookahead_empty:
             if self.verbose_debug:
@@ -260,8 +260,8 @@ class IdleTimeout:
         self.last_idle_start_time = eventtime  # Set idle start time
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] State transitioned to Ready, "
-                f"sending event idle_timeout:ready"
+                "[IdleTimeout] State transitioned to Ready, "
+                "sending event idle_timeout:ready"
             )
         self.printer.send_event(
             "idle_timeout:ready",
@@ -272,12 +272,12 @@ class IdleTimeout:
         # Only set state to Printing if toolhead is actually busy
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] handle_sync_print_time called: "
-                f"curtime={curtime}, "
-                f"print_time={print_time}, "
-                f"est_print_time={est_print_time}, "
-                f"state={self.state}, "
-                f"robust_delayed_gcode={self.robust_delayed_gcode}"
+                "[IdleTimeout] handle_sync_print_time called: "
+                "curtime={}, ".format(curtime) +
+                "print_time={}, ".format(print_time) +
+                "est_print_time={}, ".format(est_print_time) +
+                "state={}, ".format(self.state) +
+                "robust_delayed_gcode={}".format(self.robust_delayed_gcode)
             )
         # Check if toolhead is busy
         try:
@@ -287,7 +287,7 @@ class IdleTimeout:
         except Exception as e:
             if self.verbose_debug:
                 logging.error(
-                    f"[IdleTimeout] Exception in check_busy: {e}")
+                    "[IdleTimeout] Exception in check_busy: {}".format(e))
             th_lookahead_empty = True
         # If robust_delayed_gcode is enabled, only transition to Printing
         # if toolhead is busy
@@ -312,8 +312,8 @@ class IdleTimeout:
         check_time = READY_TIMEOUT + print_time - est_print_time
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] State transitioned to Printing, "
-                f"updating timer, check_time={check_time}"
+                "[IdleTimeout] State transitioned to Printing, "
+                "updating timer, check_time={}".format(check_time)
             )
         self.reactor.update_timer(
             self.timeout_timer,
@@ -329,8 +329,8 @@ class IdleTimeout:
         self.idle_timeout = timeout
         if self.verbose_debug:
             logging.debug(
-                f"[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: "
-                f"timeout set to {timeout}"
+                "[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: "
+                "timeout set to {}".format(timeout)
             )
         gcmd.respond_info(
             "idle_timeout: Timeout set to %.2f s" % (timeout,),
@@ -339,8 +339,8 @@ class IdleTimeout:
             checktime = self.reactor.monotonic() + timeout
             if self.verbose_debug:
                 logging.debug(
-                    f"[IdleTimeout] State is Ready, "
-                    f"updating timer to {checktime}"
+                    "[IdleTimeout] State is Ready, "
+                    "updating timer to {}".format(checktime)
                 )
             self.reactor.update_timer(
                 self.timeout_timer,

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -23,6 +23,9 @@ class IdleTimeout:
         self.toolhead = self.timeout_timer = None
         self.printer.register_event_handler("klippy:ready", self.handle_ready)
         self.idle_timeout = config.getfloat('timeout', 600., above=0.)
+        # New: verbose debug and robust delayed_gcode-agnostic mode
+        self.verbose_debug = config.getboolean('verbose_debug', False)
+        self.robust_delayed_gcode = config.getboolean('robust_delayed_gcode', False)
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.idle_gcode = gcode_macro.load_template(config, 'gcode',
                                                     DEFAULT_IDLE_GCODE)
@@ -31,19 +34,58 @@ class IdleTimeout:
                                     desc=self.cmd_SET_IDLE_TIMEOUT_help)
         self.state = "Idle"
         self.last_print_start_systime = 0.
+        self.last_idle_start_time = None  # Track when Ready state entered
     def get_status(self, eventtime):
         printing_time = 0.
+        idle_time_remaining = 0.0
+        debug_vals = {}
         if self.state == "Printing":
             printing_time = eventtime - self.last_print_start_systime
-        return {"state": self.state,
-                "printing_time": printing_time,
-                "idle_timeout": self.idle_timeout}
+        if self.state == "Ready":
+            # Use wall-clock idle start time for robust countdown
+            if self.last_idle_start_time is not None:
+                idle_time = eventtime - self.last_idle_start_time
+                idle_time_remaining = max(0.0, self.idle_timeout - idle_time)
+                try:
+                    print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
+                except Exception as e:
+                    print_time = est_print_time = 0.0
+                    lookahead_empty = True
+                    if self.verbose_debug:
+                        logging.error(f"[IdleTimeout] Exception in get_status toolhead.check_busy: {e}")
+                debug_vals = {
+                    'print_time': print_time,
+                    'est_print_time': est_print_time,
+                    'lookahead_empty': lookahead_empty,
+                    'idle_time': idle_time,
+                    'idle_time_remaining': idle_time_remaining,
+                    'last_idle_start_time': self.last_idle_start_time
+                }
+            else:
+                idle_time_remaining = self.idle_timeout
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] get_status called: state={self.state}, printing_time={printing_time}, idle_timeout={self.idle_timeout}, idle_time_remaining={idle_time_remaining}, robust_delayed_gcode={self.robust_delayed_gcode}, debug_vals={debug_vals}")
+        status = {
+            "state": self.state,
+            "printing_time": printing_time,
+            "idle_timeout": self.idle_timeout,
+            "idle_time_remaining": idle_time_remaining,
+            "robust_delayed_gcode": self.robust_delayed_gcode,
+            "verbose_debug": self.verbose_debug
+        }
+        if self.verbose_debug:
+            status["debug_vals"] = debug_vals
+        return status
     def handle_ready(self):
+        if self.verbose_debug:
+            logging.debug("[IdleTimeout] handle_ready called")
         self.toolhead = self.printer.lookup_object('toolhead')
         self.timeout_timer = self.reactor.register_timer(self.timeout_handler)
         self.printer.register_event_handler("toolhead:sync_print_time",
                                             self.handle_sync_print_time)
     def transition_idle_state(self, eventtime):
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] transition_idle_state called at {eventtime}, current state={self.state}")
         self.state = "Printing"
         try:
             script = self.idle_gcode.render()
@@ -51,67 +93,110 @@ class IdleTimeout:
         except:
             logging.exception("idle timeout gcode execution")
             self.state = "Ready"
+            if self.verbose_debug:
+                logging.debug(f"[IdleTimeout] Exception in idle_gcode, state set to Ready")
             return eventtime + 1.
         print_time = self.toolhead.get_last_move_time()
         self.state = "Idle"
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] State transitioned to Idle, print_time={print_time}")
         self.printer.send_event("idle_timeout:idle", print_time)
         return self.reactor.NEVER
     def check_idle_timeout(self, eventtime):
-        # Make sure toolhead class isn't busy
-        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(
-            eventtime)
+        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
         idle_time = est_print_time - print_time
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, print_time={print_time}, est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, idle_time={idle_time}, state={self.state}")
         if not lookahead_empty or idle_time < 1.:
-            # Toolhead is busy
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Toolhead busy, delaying idle timeout check")
             return eventtime + self.idle_timeout
         if idle_time < self.idle_timeout:
-            # Wait for idle timeout
+            if self.verbose_debug:
+                logging.debug(f"[IdleTimeout] Idle time {idle_time} < idle_timeout {self.idle_timeout}, waiting")
             return eventtime + self.idle_timeout - idle_time
         if self.gcode.get_mutex().test():
-            # Gcode class busy
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Gcode class busy, delaying idle timeout check")
             return eventtime + 1.
-        # Idle timeout has elapsed
+        if self.verbose_debug:
+            logging.debug("[IdleTimeout] Idle timeout elapsed, transitioning idle state")
         return self.transition_idle_state(eventtime)
     def timeout_handler(self, eventtime):
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] timeout_handler called: eventtime={eventtime}, state={self.state}")
         if self.printer.is_shutdown():
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Printer is shutdown, returning NEVER")
             return self.reactor.NEVER
         if self.state == "Ready":
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] State is Ready, checking idle timeout")
+            # Set last_idle_start_time if just entered Ready
+            if self.last_idle_start_time is None:
+                self.last_idle_start_time = eventtime
             return self.check_idle_timeout(eventtime)
-        # Check if need to transition to "ready" state
-        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(
-            eventtime)
+        print_time, est_print_time, lookahead_empty = self.toolhead.check_busy(eventtime)
         buffer_time = min(2., print_time - est_print_time)
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] timeout_handler: print_time={print_time}, est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, buffer_time={buffer_time}")
         if not lookahead_empty:
-            # Toolhead is busy
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Toolhead busy, delaying ready state transition")
             return eventtime + READY_TIMEOUT + max(0., buffer_time)
         if buffer_time > -READY_TIMEOUT:
-            # Wait for ready timeout
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Buffer time > -READY_TIMEOUT, waiting")
             return eventtime + READY_TIMEOUT + buffer_time
         if self.gcode.get_mutex().test():
-            # Gcode class busy
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Gcode class busy, delaying ready state transition")
             return eventtime + READY_TIMEOUT
-        # Transition to "ready" state
         self.state = "Ready"
-        self.printer.send_event("idle_timeout:ready",
-                                est_print_time + PIN_MIN_TIME)
+        self.last_idle_start_time = eventtime  # Set idle start time
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] State transitioned to Ready, sending event idle_timeout:ready")
+        self.printer.send_event("idle_timeout:ready", est_print_time + PIN_MIN_TIME)
         return eventtime + self.idle_timeout
     def handle_sync_print_time(self, curtime, print_time, est_print_time):
-        if self.state == "Printing":
+        # Only set state to Printing if toolhead is actually busy
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] handle_sync_print_time called: curtime={curtime}, print_time={print_time}, est_print_time={est_print_time}, state={self.state}, robust_delayed_gcode={self.robust_delayed_gcode}")
+        # Check if toolhead is busy
+        try:
+            th_print_time, th_est_print_time, th_lookahead_empty = self.toolhead.check_busy(curtime)
+        except Exception as e:
+            if self.verbose_debug:
+                logging.error(f"[IdleTimeout] Exception in check_busy: {e}")
+            th_lookahead_empty = True
+        # If robust_delayed_gcode is enabled, only transition to Printing if toolhead is busy
+        if self.robust_delayed_gcode and th_lookahead_empty:
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Toolhead not busy (lookahead empty), not transitioning to Printing state.")
             return
-        # Transition to "printing" state
+        if self.state == "Printing":
+            if self.verbose_debug:
+                logging.debug("[IdleTimeout] Already in Printing state, returning")
+            return
         self.state = "Printing"
+        self.last_idle_start_time = None  # Reset idle timer when printing resumes
         self.last_print_start_systime = curtime
         check_time = READY_TIMEOUT + print_time - est_print_time
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] State transitioned to Printing, updating timer, check_time={check_time}")
         self.reactor.update_timer(self.timeout_timer, curtime + check_time)
-        self.printer.send_event("idle_timeout:printing",
-                                est_print_time + PIN_MIN_TIME)
+        self.printer.send_event("idle_timeout:printing", est_print_time + PIN_MIN_TIME)
     cmd_SET_IDLE_TIMEOUT_help = "Set the idle timeout in seconds"
     def cmd_SET_IDLE_TIMEOUT(self, gcmd):
         timeout = gcmd.get_float('TIMEOUT', self.idle_timeout, above=0.)
         self.idle_timeout = timeout
+        if self.verbose_debug:
+            logging.debug(f"[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: timeout set to {timeout}")
         gcmd.respond_info("idle_timeout: Timeout set to %.2f s" % (timeout,))
         if self.state == "Ready":
             checktime = self.reactor.monotonic() + timeout
+            if self.verbose_debug:
+                logging.debug(f"[IdleTimeout] State is Ready, updating timer to {checktime}")
             self.reactor.update_timer(self.timeout_timer, checktime)
 
 def load_config(config):

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -5,12 +5,14 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
-DEFAULT_IDLE_GCODE = """
+DEFAULT_IDLE_GCODE = (
+     """
 {% if 'heaters' in printer %}
-   TURN_OFF_HEATERS
+    TURN_OFF_HEATERS
 {% endif %}
 M84
 """
+)
 
 PIN_MIN_TIME = 0.100
 READY_TIMEOUT = .500
@@ -21,21 +23,42 @@ class IdleTimeout:
         self.reactor = self.printer.get_reactor()
         self.gcode = self.printer.lookup_object('gcode')
         self.toolhead = self.timeout_timer = None
-        self.printer.register_event_handler("klippy:ready", self.handle_ready)
-        self.idle_timeout = config.getfloat('timeout', 600., above=0.)
+        self.printer.register_event_handler(
+            "klippy:ready",
+            self.handle_ready,
+        )
+        self.idle_timeout = config.getfloat(
+            'timeout',
+            600.,
+            above=0.,
+        )
         # New: verbose debug and robust delayed_gcode-agnostic mode
-        self.verbose_debug = config.getboolean('verbose_debug', False)
-        self.robust_delayed_gcode = config.getboolean('robust_delayed_gcode', False)
-        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.verbose_debug = config.getboolean(
+            'verbose_debug',
+            False,
+        )
+        self.robust_delayed_gcode = config.getboolean(
+            'robust_delayed_gcode',
+            False,
+        )
+        gcode_macro = self.printer.load_object(
+            config,
+            'gcode_macro',
+        )
         self.idle_gcode = gcode_macro.load_template(
-            config, 'gcode', DEFAULT_IDLE_GCODE)
+            config,
+            'gcode',
+            DEFAULT_IDLE_GCODE,
+        )
         self.gcode.register_command(
             'SET_IDLE_TIMEOUT',
             self.cmd_SET_IDLE_TIMEOUT,
-            desc=self.cmd_SET_IDLE_TIMEOUT_help)
+            desc=self.cmd_SET_IDLE_TIMEOUT_help,
+        )
         self.state = "Idle"
         self.last_print_start_systime = 0.
-        self.last_idle_start_time = None  # Track when Ready state entered
+        # Track when Ready state entered
+        self.last_idle_start_time = None
     def get_status(self, eventtime):
         printing_time = 0.
         idle_time_remaining = 0.0
@@ -64,7 +87,7 @@ class IdleTimeout:
                     'lookahead_empty': lookahead_empty,
                     'idle_time': idle_time,
                     'idle_time_remaining': idle_time_remaining,
-                    'last_idle_start_time': self.last_idle_start_time
+                    'last_idle_start_time': self.last_idle_start_time,
                 }
             else:
                 idle_time_remaining = self.idle_timeout
@@ -84,22 +107,30 @@ class IdleTimeout:
             "idle_timeout": self.idle_timeout,
             "idle_time_remaining": idle_time_remaining,
             "robust_delayed_gcode": self.robust_delayed_gcode,
-            "verbose_debug": self.verbose_debug
+            "verbose_debug": self.verbose_debug,
         }
         if self.verbose_debug:
             status["debug_vals"] = debug_vals
         return status
     def handle_ready(self):
         if self.verbose_debug:
-            logging.debug("[IdleTimeout] handle_ready called")
+            logging.debug(
+                "[IdleTimeout] handle_ready called"
+            )
         self.toolhead = self.printer.lookup_object('toolhead')
-        self.timeout_timer = self.reactor.register_timer(self.timeout_handler)
+        self.timeout_timer = self.reactor.register_timer(
+            self.timeout_handler,
+        )
         self.printer.register_event_handler(
             "toolhead:sync_print_time",
-            self.handle_sync_print_time)
+            self.handle_sync_print_time,
+        )
     def transition_idle_state(self, eventtime):
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] transition_idle_state called at {eventtime}, current state={self.state}")
+            logging.debug(
+                f"[IdleTimeout] transition_idle_state called at {eventtime}, "
+                f"current state={self.state}"
+            )
         self.state = "Printing"
         try:
             script = self.idle_gcode.render()
@@ -108,28 +139,47 @@ class IdleTimeout:
             logging.exception("idle timeout gcode execution")
             self.state = "Ready"
             if self.verbose_debug:
-                logging.debug(f"[IdleTimeout] Exception in idle_gcode, state set to Ready")
+                logging.debug(
+                    f"[IdleTimeout] Exception in idle_gcode, "
+                    f"state set to Ready"
+                )
             return eventtime + 1.
         print_time = self.toolhead.get_last_move_time()
         self.state = "Idle"
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] State transitioned to Idle, print_time={print_time}")
-        self.printer.send_event("idle_timeout:idle", print_time)
+            logging.debug(
+                f"[IdleTimeout] State transitioned to Idle, "
+                f"print_time={print_time}"
+            )
+        self.printer.send_event(
+            "idle_timeout:idle",
+            print_time,
+        )
         return self.reactor.NEVER
     def check_idle_timeout(self, eventtime):
         print_time, est_print_time, lookahead_empty = (
-            self.toolhead.check_busy(eventtime)
+            self.toolhead.check_busy(
+                eventtime,
+            )
         )
         idle_time = est_print_time - print_time
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, print_time={print_time}, est_print_time={est_print_time}, lookahead_empty={lookahead_empty}, idle_time={idle_time}, state={self.state}")
+            logging.debug(
+                f"[IdleTimeout] check_idle_timeout: eventtime={eventtime}, "
+                f"print_time={print_time}, est_print_time={est_print_time}, "
+                f"lookahead_empty={lookahead_empty}, idle_time={idle_time}, "
+                f"state={self.state}"
+            )
         if not lookahead_empty or idle_time < 1.:
             if self.verbose_debug:
                 logging.debug("[IdleTimeout] Toolhead busy, delaying idle timeout check")
             return eventtime + self.idle_timeout
         if idle_time < self.idle_timeout:
             if self.verbose_debug:
-                logging.debug(f"[IdleTimeout] Idle time {idle_time} < idle_timeout {self.idle_timeout}, waiting")
+                logging.debug(
+                    f"[IdleTimeout] Idle time {idle_time} < idle_timeout "
+                    f"{self.idle_timeout}, waiting"
+                )
             return eventtime + self.idle_timeout - idle_time
         if self.gcode.get_mutex().test():
             if self.verbose_debug:
@@ -153,7 +203,9 @@ class IdleTimeout:
                 self.last_idle_start_time = eventtime
             return self.check_idle_timeout(eventtime)
         print_time, est_print_time, lookahead_empty = (
-            self.toolhead.check_busy(eventtime)
+            self.toolhead.check_busy(
+                eventtime,
+            )
         )
         buffer_time = min(2., print_time - est_print_time)
         if self.verbose_debug:
@@ -183,7 +235,9 @@ class IdleTimeout:
                 f"[IdleTimeout] State transitioned to Ready, sending event "
                 f"idle_timeout:ready")
         self.printer.send_event(
-            "idle_timeout:ready", est_print_time + PIN_MIN_TIME)
+            "idle_timeout:ready",
+            est_print_time + PIN_MIN_TIME,
+        )
         return eventtime + self.idle_timeout
     def handle_sync_print_time(self, curtime, print_time, est_print_time):
         # Only set state to Printing if toolhead is actually busy
@@ -216,24 +270,38 @@ class IdleTimeout:
         self.last_print_start_systime = curtime
         check_time = READY_TIMEOUT + print_time - est_print_time
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] State transitioned to Printing, updating timer, check_time={check_time}")
+            logging.debug(
+                f"[IdleTimeout] State transitioned to Printing, "
+                f"updating timer, check_time={check_time}"
+            )
         self.reactor.update_timer(self.timeout_timer, curtime + check_time)
         self.printer.send_event(
-            "idle_timeout:printing", est_print_time + PIN_MIN_TIME)
+            "idle_timeout:printing",
+            est_print_time + PIN_MIN_TIME,
+        )
     cmd_SET_IDLE_TIMEOUT_help = "Set the idle timeout in seconds"
     def cmd_SET_IDLE_TIMEOUT(self, gcmd):
         timeout = gcmd.get_float('TIMEOUT', self.idle_timeout, above=0.)
         self.idle_timeout = timeout
         if self.verbose_debug:
-            logging.debug(f"[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: timeout set to {timeout}")
+            logging.debug(
+                f"[IdleTimeout] cmd_SET_IDLE_TIMEOUT called: "
+                f"timeout set to {timeout}"
+            )
         gcmd.respond_info(
-            "idle_timeout: Timeout set to %.2f s" % (timeout,))
+            "idle_timeout: Timeout set to %.2f s" % (timeout,),
+        )
         if self.state == "Ready":
             checktime = self.reactor.monotonic() + timeout
             if self.verbose_debug:
                 logging.debug(
-                    f"[IdleTimeout] State is Ready, updating timer to {checktime}")
-            self.reactor.update_timer(self.timeout_timer, checktime)
+                    f"[IdleTimeout] State is Ready, "
+                    f"updating timer to {checktime}",
+                )
+            self.reactor.update_timer(
+                self.timeout_timer,
+                checktime,
+            )
 
 def load_config(config):
     return IdleTimeout(config)


### PR DESCRIPTION
Added verbose debug logging to troubleshoot idle_timeout not triggering when using delayed_gcode blocks. Add a robust delayed gcode-agnostic mode to the idle timeout functionality that still times out idle time when using delayed_gcode implementations in macros.

Add two new variable to enable verbose debugging and robust mode.

```
[idle_timeout]
gcode: 
    IDLE_TIMEOUT
timeout: 120
verbose_debug: True
robust_delayed_gcode: True
```