### PR TITLE
github: bump checkout and cache actions to node v24

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ci_cache
         key: ${{ runner.os }}-build-${{ hashFiles('scripts/ci-install.sh') }}

--- a/.github/workflows/klipper3d-deploy.yaml
+++ b/.github/workflows/klipper3d-deploy.yaml
@@ -12,12 +12,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('docs/_klipper3d/mkdocs-requirements.txt') }}


### PR DESCRIPTION
Just bump the pipeline dependencies before they break.

"""
Warning: Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/checkout@v3, actions/upload-artifact@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.
Please check if updated versions of these actions are available that support Node.js 24.
To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file.
Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
"""