### PR TITLE
input_shaper: Fix shaper_freq not updated by SET_INPUT_SHAPER

### DIFF
--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -45,6 +45,7 @@ class InputShaperParams:
                         gcmd.error)
         self.damping_ratio = damping_ratio
         self.shaper_type = shaper_type.lower()
+        self.shaper_freq = shaper_freq
     def get_shaper(self, shaper_type=None, shaper_freq=None,
                    damping_ratio=None, error=None):
         if not self.shaper_freq:


### PR DESCRIPTION
Fixes a regression introduced in db10e92e9 ("shaper_defs: Support
parameterized shaper initialization"), where the SHAPER_FREQ_X /
SHAPER_FREQ_Y parameters of `SET_INPUT_SHAPER` are read into a local
variable for validation but never written back to `self.shaper_freq`.

### Reproduce (before fix)

With any [input_shaper] configured:

    SET_INPUT_SHAPER SHAPER_FREQ_X=20 SHAPER_FREQ_Y=20
    SET_INPUT_SHAPER

Reports the original startup frequency, not 20.

### After fix

The reported `shaper_freq_x` / `shaper_freq_y` reflect the requested
values, restoring the runtime frequency change behaviour that existed
prior to db10e92e9.

### Impact

Affects slicer input-shaper tuning towers (e.g. OrcaSlicer) and
toolchanger configurations that issue `SET_INPUT_SHAPER` with explicit
frequencies per tool. `SET_INPUT_SHAPER` calls without `SHAPER_FREQ_*`
are not affected.