### PR TITLE
usb_cdc: export receive window for host flow control

### DIFF
--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -90,6 +90,8 @@ console_sendf(const struct command_encoder *ce, va_list args)
 static struct task_wake usb_bulk_out_wake;
 static uint8_t receive_buf[128], receive_pos;
 
+DECL_CONSTANT("RECEIVE_WINDOW", sizeof(receive_buf));
+
 void
 usb_notify_bulk_out(void)
 {


### PR DESCRIPTION
This PR matches the behavior already used by the UART and CAN serial transports, which expose their MCU-side receive window to the host so that Klipper can throttle outstanding command data appropriately.

## Hardware / Reproduction Setup

This was tested on:

- Duet3D Mini 5+ with SAME54P20A
- USB CDC connection to the Klipper host
- Raspberry Pi 4B running Klipper / Moonraker
- EBB36 Tool Board connected with USB as well

## Issue I had:
During normal prints, the main MCU connection would sporadically enter phases where `bytes_retransmit` increased rapidly and eventually caused a shutdown. `bytes_invalid` stayed at zero, and the EBB connection did not show the same behavior.

## After fix applied:
After exporting `RECEIVE_WINDOW` for USB CDC, the same print workload passed the previous retransmit escalation window without the main MCU retry counter rising.