### PR TITLE
ldc1612: Add support for a new 'max_sensor_hz' config parameter

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -2323,6 +2323,12 @@ sensor_type: ldc1612
 #intb_pin:
 #   MCU gpio pin connected to the ldc1612 sensor's INTB pin (if
 #   available). The default is to not use the INTB pin.
+#max_sensor_hz:
+#   Maximum expected resonant frequency reported by the sensor (in
+#   Hz). This is used during internal clock rate configuration. This
+#   value is typically only configured if the software reports a
+#   warning suggesting the value should be increased. The default is
+#   5000000.
 #descend_z:
 #   The nominal distance (in mm) between the nozzle and bed that a
 #   probing attempt should stop at. This parameter must be provided.

--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -1,9 +1,9 @@
 # Support for reading frequency samples from ldc1612
 #
-# Copyright (C) 2020-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2020-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
+import logging, math
 from . import bus, bulk_sensor
 
 MIN_MSG_TIME = 0.100
@@ -76,6 +76,7 @@ class DriveCurrentCalibrate:
 class LDC1612:
     def __init__(self, config, calibration=None):
         self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
         self.calibration = calibration
         self.dccal = DriveCurrentCalibrate(config, self)
         self.data_rate = 400
@@ -89,10 +90,18 @@ class LDC1612:
         self.query_ldc1612_cmd = None
         self.clock_freq = config.getint("frequency", DEFAULT_LDC1612_FREQ,
                                         2000000, 40000000)
-        # Coil frequency divider, assume 12MHz is BTT Eddy
-        # BTT Eddy's coil frequency is > 1/4 of reference clock
-        self.sensor_div = 1 if self.clock_freq != DEFAULT_LDC1612_FREQ else 2
+        # Determine sensor divider (want 4*max_hz < clock_ref)
+        max_hz = config.getfloat("max_sensor_hz", 5000000., 3000000., 20000000.)
+        self.sensor_div = int(math.ceil(4. * max_hz / self.clock_freq))
         self.freq_conv = float(self.clock_freq * self.sensor_div) / (1<<28)
+        if self.calibration is not None:
+            cal_freqs, cal_zpos = self.calibration.get_calibration()
+            if cal_freqs and max(cal_freqs) > max_hz:
+                pconfig = self.printer.lookup_object("configfile")
+                pconfig.runtime_warning(
+                    "ldc1612 %s: Should set 'max_sensor_hz' to at least %d"
+                    % (self.name, math.ceil(max(cal_freqs))))
+        # Configure intb and mcu object
         if config.get('intb_pin', None) is not None:
             ppins = config.get_printer().lookup_object("pins")
             pin_params = ppins.lookup_pin(config.get('intb_pin'))
@@ -115,7 +124,6 @@ class LDC1612:
         self.batch_bulk = bulk_sensor.BatchBulkHelper(
             self.printer, self._process_batch,
             self._start_measurements, self._finish_measurements, BATCH_UPDATES)
-        self.name = config.get_name().split()[-1]
         hdr = ('time', 'frequency', 'z')
         self.batch_bulk.add_mux_endpoint("ldc1612/dump_ldc1612", "sensor",
                                          self.name, {'header': hdr})


### PR DESCRIPTION
Add a new option so that setting of sensor_div is more robust.

This is a follow up to PR #7160.  Some sensors need a higher internal `sensor_div` due to very high sensor resonant frequencies (eg, 8.3Mhz).

FYI, @nefelim4ag .

-Kevin