### PR TITLE
Support homing with probe_eddy_current and load_cell_probe

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20260525: The internal implementation of "probe:z_virtual_endstop" has
+changed. Most users will not observe a change in behavior. Previously
+it was technically possible to mix "probe:z_virtual_endstop" with
+other types of Z endstops and this behavior is no longer valid.
+
 20260501: The handling of the `[probe_eddy_current]` `tap_threshold`
 config option and associated `TAP_THRESHOLD` G-Code parameter has
 changed. It will be necessary to recalibrate the value. See the

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -10,11 +10,6 @@ coil within the sensor. The closer that coil is to a metal bed the
 higher the coil's resonant frequency. The frequency measurements can
 thus be used to estimate the distance between sensor and bed.
 
-The Klipper eddy current sensor support is primarily intended for bed
-probing. It is possible to "home" the Z axis with an eddy current
-probe, but see the [homing correction](#homing-correction-macros)
-section for important information.
-
 ## Probing mechanisms
 
 Unlike traditional bed probes an eddy current sensor supports four
@@ -363,43 +358,11 @@ as a starting point for manual attempts. Once a successful probe
 attempt is completed then one can return to the main steps described
 above starting at the "refine" stage.
 
-## Homing correction macros
-
-It is possible to use an eddy current probe to home a Z axis. However,
-due to software limitations, the homing operation does not provide an
-accurate result and it is therefore necessary to perform a multi-step
-process to achieve acceptable accuracy.
-
-To use this process, make sure the `[stepper_z]` config section has
-the `endstop_pin` set to `probe:z_virtual_endstop`. Also make sure the
-[force move](Config_Reference.md#force_move) section is defined and
-ensure its `enable_force_move` option is present and set to true.
-Finally, define the following macros:
-
-```
-[gcode_macro _RELOAD_Z_OFFSET_FROM_PROBE]
-gcode:
-  {% set Z = printer.toolhead.position.z %}
-  SET_KINEMATIC_POSITION Z={Z - printer.probe.last_probe_position.z}
-
-[gcode_macro SET_Z_FROM_PROBE]
-gcode:
-  PROBE
-  _RELOAD_Z_OFFSET_FROM_PROBE
-```
-
-To home the Z axis, perform an initial Z home using a `G28 Z0` command
-and then run `SET_Z_FROM_PROBE` to obtain an accurate Z position.
-
-It is important that the `SET_Z_FROM_PROBE` macro is used after every
-`G28 Z0` (and similar) homing command. If the Z axis is ever homed
-without running the correction macro then the internal Z positions
-will not be accurate which could lead to nozzle/bed collisions and
-very poor print results. One may wish to consider using a
-`[homing_override]` config section to ensure the correction macro is
-always run.
-
 ### Performing initial calibration when homing with probe
+
+It is possible to use an eddy current probe to home a Z axis. To use
+this process, set the `[stepper_z]` config section `endstop_pin` to
+`probe:z_virtual_endstop`.
 
 In order to home with an eddy probe it is necessary to first calibrate
 the probe via the `PROBE_EDDY_CURRENT_CALIBRATE` command. However,
@@ -411,9 +374,9 @@ the very first calibration:
 1. Define a `[probe_eddy_current]` config section in the printer.cfg
    file as described in the [configuration section](#configuration).
 
-2. Setup the macros and config sections for Z homing with a probe as
-   described in the main
-   [homing correction macros](#homing-correction-macros) section.
+2. Make sure a [force move](Config_Reference.md#force_move) section is
+   defined and ensure its `enable_force_move` option is present and
+   set to true.
 
 3. Manually adjust the carriages so that the toolhead is near the
    center of the bed and roughly 20mm away from the bed. Issue

--- a/docs/Load_Cell.md
+++ b/docs/Load_Cell.md
@@ -238,57 +238,6 @@ carefully to look for issues.
 Load cell probes don't support the `QUERY_ENDSTOPS` or `QUERY_PROBE`
 commands. Use `LOAD_CELL_TEST_TAP` for testing functionality before probing.
 
-### Homing Macros
-
-Load cell probe is not an endstop and doesn't support `endstop:
-prove:z_virtual_endstop`. For the time being you'll need to configure your z
-axis with an MCU pin as its endstop. You won't actually be using the pin but
-for the time being you have to configure something.
-
-To home the axis with just the probe you need to set up a custom homing
-macro. This requires setting up
-[homing_override](Config_Reference.md#homing_override).
-
-Here is a simple macro that can accomplish this. Note that the
-`_HOME_Z_FROM_LAST_PROBE` macro has to be separate because of the way macros
-work. The sub-call is needed so that the `_HOME_Z_FROM_LAST_PROBE` macro can
-see the result of the probe in `printer.probe.last_probe_position`.
-
-```gcode
-[gcode_macro _HOME_Z_FROM_LAST_PROBE]
-gcode:
-    {% set z_probed = printer.probe.last_probe_position.z %}
-    {% set z_position = printer.toolhead.position[2] %}
-    {% set z_actual = z_position - z_probed %}
-    SET_KINEMATIC_POSITION Z={z_actual}
-
-[gcode_macro _HOME_Z]
-gcode:
-    SET_GCODE_OFFSET Z=0  # load cell probes dont need a Z offset
-    # position toolhead for homing Z, edit for your printers size
-    #G90  # absolute move
-    #G1 Y50 X50 F{5 * 60}  # move to X/Y position for homing
-
-    # soft home the z axis to its limit so it can be moved:
-    SET_KINEMATIC_POSITION Z={printer.toolhead.axis_maximum[2]}
-
-    # Fast approach and tap
-    PROBE PROBE_SPEED={5 * 60}  # override the speed for faster homing
-    _HOME_Z_FROM_LAST_PROBE
-
-    # lift z to 2mm
-    G91  # relative move
-    G1 Z2 F{5 * 60}
-
-    # probe at standard speed
-    PROBE
-    _HOME_Z_FROM_LAST_PROBE
-
-    # lift z to 10mm for clearance
-    G91  # relative move
-    G1 Z10 F{5 * 60}
-```
-
 ### Suggested Probing Temperature
 
 Currently, we suggest keeping the nozzle temperature below the level that causes

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -24,7 +24,7 @@ Commands = {
 
 # BLTouch "endstop" wrapper
 class BLTouchProbe:
-    def __init__(self, config):
+    def __init__(self, config, probe_offsets, param_helper):
         self.printer = config.get_printer()
         self.stow_on_each_sample = config.getboolean('stow_on_each_sample',
                                                      True)
@@ -57,6 +57,10 @@ class BLTouchProbe:
         self.get_steppers = self.mcu_endstop.get_steppers
         self.home_wait = self.mcu_endstop.home_wait
         self.query_endstop = self.mcu_endstop.query_endstop
+        # Probing via homing to endstop
+        self.homing_helper = probe.DescendToEndstopHelper(
+            config, self, probe_offsets, param_helper,
+            always_check_movement=True)
         # multi probes state
         self.multi = 'OFF'
         # Register BLTOUCH_DEBUG command
@@ -165,19 +169,13 @@ class BLTouchProbe:
                 raise self.printer.command_error(msg)
             self.gcode.respond_info(msg + '; retrying.')
             self._send_cmd('reset', duration=RETRY_RESET_TIME)
-    def multi_probe_begin(self):
-        if self.stow_on_each_sample:
-            return
-        self.multi = 'FIRST'
-    def multi_probe_end(self):
-        if self.stow_on_each_sample:
-            return
-        self._sync_print_time()
-        self._raise_probe()
-        self._verify_raise_probe()
-        self._sync_print_time()
-        self.multi = 'OFF'
-    def probe_prepare(self):
+    # Probe session
+    def start_probe_session(self, gcmd):
+        self.homing_helper.clear_trigger_positions()
+        if not self.stow_on_each_sample:
+            self.multi = 'FIRST'
+        return self
+    def _probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self._lower_probe()
             if self.multi == 'FIRST':
@@ -196,11 +194,30 @@ class BLTouchProbe:
         self.finish_home_complete.wait()
         if self.multi == 'OFF':
             self._raise_probe()
-    def probe_finish(self):
+    def _probe_finish(self):
         self.wait_trigger_complete.wait()
         if self.multi == 'OFF':
             self._verify_raise_probe()
         self._sync_print_time()
+    def run_probe(self, gcmd):
+        self._probe_prepare()
+        try:
+            self.homing_helper.descend_until_trigger(gcmd)
+        except self.printer.command_error as e:
+            self._probe_finish()
+            raise
+        self._probe_finish()
+    def pull_probed_results(self):
+        return self.homing_helper.pull_trigger_positions()
+    def end_probe_session(self):
+        self.homing_helper.clear_trigger_positions()
+        if not self.stow_on_each_sample:
+            self._sync_print_time()
+            self._raise_probe()
+            self._verify_raise_probe()
+            self._sync_print_time()
+            self.multi = 'OFF'
+    # Output mode setting
     def _set_output_mode(self, mode):
         # If this is inadvertently/purposely issued for a
         # BLTOUCH pre V3.0 and clones:
@@ -264,16 +281,14 @@ class BLTouchProbe:
 class PrinterBLTouch:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.mcu_probe = BLTouchProbe(config)
-        self.cmd_helper = probe.ProbeCommandHelper(config, self,
-                                                   self.mcu_probe.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.DescendToEndstopHelper(
-            config, self.mcu_probe, self.probe_offsets, self.param_helper,
-            always_check_movement=True)
+        self.mcu_probe = BLTouchProbe(config, self.probe_offsets,
+                                      self.param_helper)
         self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
+            config, self.param_helper, self.mcu_probe.start_probe_session)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self,
+                                                   self.mcu_probe.query_endstop)
     def get_probe_params(self, gcmd=None):
         return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self, gcmd=None):

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -65,7 +65,7 @@ class BLTouchProbe:
             config, self, self.mcu_endstop.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.HomingViaProbeHelper(
+        self.homing_helper = probe.DescendToEndstopHelper(
             config, self, self.probe_offsets, self.param_helper)
         self.probe_session = probe.ProbeSessionHelper(
             config, self.param_helper, self.homing_helper.start_probe_session)

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -67,28 +67,28 @@ class BLTouchProbe:
                                     desc=self.cmd_BLTOUCH_STORE_help)
         # Register events
         self.printer.register_event_handler("klippy:connect",
-                                            self.handle_connect)
-    def handle_connect(self):
-        self.sync_mcu_print_time()
+                                            self._handle_connect)
+    def _handle_connect(self):
+        self._sync_mcu_print_time()
         self.next_cmd_time += 0.200
-        self.set_output_mode(self.output_mode)
+        self._set_output_mode(self.output_mode)
         try:
-            self.raise_probe()
-            self.verify_raise_probe()
+            self._raise_probe()
+            self._verify_raise_probe()
         except self.printer.command_error as e:
             logging.warning("BLTouch raise probe error: %s", str(e))
-    def sync_mcu_print_time(self):
+    def _sync_mcu_print_time(self):
         curtime = self.printer.get_reactor().monotonic()
         est_time = self.mcu_pwm.get_mcu().estimated_print_time(curtime)
         self.next_cmd_time = max(self.next_cmd_time, est_time + MIN_CMD_TIME)
-    def sync_print_time(self):
+    def _sync_print_time(self):
         toolhead = self.printer.lookup_object('toolhead')
         print_time = toolhead.get_last_move_time()
         if self.next_cmd_time > print_time:
             toolhead.dwell(self.next_cmd_time - print_time)
         else:
             self.next_cmd_time = print_time
-    def send_cmd(self, cmd, duration=MIN_CMD_TIME):
+    def _send_cmd(self, cmd, duration=MIN_CMD_TIME):
         # Translate duration to ticks to avoid any secondary mcu clock skew
         mcu = self.mcu_pwm.get_mcu()
         cmd_clock = mcu.print_time_to_clock(self.next_cmd_time)
@@ -101,7 +101,7 @@ class BLTouchProbe:
         # Update time tracking
         self.action_end_time = self.next_cmd_time + duration
         self.next_cmd_time = max(self.action_end_time, end_time + MIN_CMD_TIME)
-    def verify_state(self, triggered):
+    def _verify_state(self, triggered):
         # Perform endstop check to verify bltouch reports desired state
         self.mcu_endstop.home_start(self.action_end_time, ENDSTOP_SAMPLE_TIME,
                                     ENDSTOP_SAMPLE_COUNT, ENDSTOP_REST_TIME,
@@ -112,17 +112,17 @@ class BLTouchProbe:
         except self.printer.command_error as e:
             return False
         return trigger_time > 0.
-    def raise_probe(self):
-        self.sync_mcu_print_time()
+    def _raise_probe(self):
+        self._sync_mcu_print_time()
         if not self.pin_up_not_triggered:
-            self.send_cmd('reset')
-        self.send_cmd('pin_up', duration=self.pin_move_time)
-    def verify_raise_probe(self):
+            self._send_cmd('reset')
+        self._send_cmd('pin_up', duration=self.pin_move_time)
+    def _verify_raise_probe(self):
         if not self.pin_up_not_triggered:
             # No way to verify raise attempt
             return
         for retry in range(3):
-            success = self.verify_state(False)
+            success = self._verify_state(False)
             if success:
                 # The "probe raised" test completed successfully
                 break
@@ -131,16 +131,16 @@ class BLTouchProbe:
                     "BLTouch failed to raise probe")
             msg = "Failed to verify BLTouch probe is raised; retrying."
             self.gcode.respond_info(msg)
-            self.sync_mcu_print_time()
-            self.send_cmd('reset', duration=RETRY_RESET_TIME)
-            self.send_cmd('pin_up', duration=self.pin_move_time)
-    def lower_probe(self):
-        self.test_sensor()
-        self.sync_print_time()
-        self.send_cmd('pin_down', duration=self.pin_move_time)
+            self._sync_mcu_print_time()
+            self._send_cmd('reset', duration=RETRY_RESET_TIME)
+            self._send_cmd('pin_up', duration=self.pin_move_time)
+    def _lower_probe(self):
+        self._test_sensor()
+        self._sync_print_time()
+        self._send_cmd('pin_down', duration=self.pin_move_time)
         if self.probe_touch_mode:
-            self.send_cmd('touch_mode')
-    def test_sensor(self):
+            self._send_cmd('touch_mode')
+    def _test_sensor(self):
         if not self.pin_up_touch_triggered:
             # Nothing to test
             return
@@ -150,12 +150,12 @@ class BLTouchProbe:
             self.next_test_time = print_time + TEST_TIME
             return
         # Raise the bltouch probe and test if probe is raised
-        self.sync_print_time()
+        self._sync_print_time()
         for retry in range(3):
-            self.send_cmd('pin_up', duration=self.pin_move_time)
-            self.send_cmd('touch_mode')
-            success = self.verify_state(True)
-            self.sync_print_time()
+            self._send_cmd('pin_up', duration=self.pin_move_time)
+            self._send_cmd('touch_mode')
+            success = self._verify_state(True)
+            self._sync_print_time()
             if success:
                 # The "bltouch connection" test completed successfully
                 self.next_test_time = print_time + TEST_TIME
@@ -164,7 +164,7 @@ class BLTouchProbe:
             if retry >= 2:
                 raise self.printer.command_error(msg)
             self.gcode.respond_info(msg + '; retrying.')
-            self.send_cmd('reset', duration=RETRY_RESET_TIME)
+            self._send_cmd('reset', duration=RETRY_RESET_TIME)
     def multi_probe_begin(self):
         if self.stow_on_each_sample:
             return
@@ -172,17 +172,17 @@ class BLTouchProbe:
     def multi_probe_end(self):
         if self.stow_on_each_sample:
             return
-        self.sync_print_time()
-        self.raise_probe()
-        self.verify_raise_probe()
-        self.sync_print_time()
+        self._sync_print_time()
+        self._raise_probe()
+        self._verify_raise_probe()
+        self._sync_print_time()
         self.multi = 'OFF'
     def probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':
-            self.lower_probe()
+            self._lower_probe()
             if self.multi == 'FIRST':
                 self.multi = 'ON'
-        self.sync_print_time()
+        self._sync_print_time()
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
         rest_time = min(rest_time, ENDSTOP_REST_TIME)
@@ -190,18 +190,18 @@ class BLTouchProbe:
             print_time, sample_time, sample_count, rest_time, triggered)
         # Schedule wait_for_trigger callback
         r = self.printer.get_reactor()
-        self.wait_trigger_complete = r.register_callback(self.wait_for_trigger)
+        self.wait_trigger_complete = r.register_callback(self._wait_for_trigger)
         return self.finish_home_complete
-    def wait_for_trigger(self, eventtime):
+    def _wait_for_trigger(self, eventtime):
         self.finish_home_complete.wait()
         if self.multi == 'OFF':
-            self.raise_probe()
+            self._raise_probe()
     def probe_finish(self):
         self.wait_trigger_complete.wait()
         if self.multi == 'OFF':
-            self.verify_raise_probe()
-        self.sync_print_time()
-    def set_output_mode(self, mode):
+            self._verify_raise_probe()
+        self._sync_print_time()
+    def _set_output_mode(self, mode):
         # If this is inadvertently/purposely issued for a
         # BLTOUCH pre V3.0 and clones:
         #   No reaction at all.
@@ -210,12 +210,12 @@ class BLTouchProbe:
         if mode is None:
             return
         logging.info("BLTouch set output mode: %s", mode)
-        self.sync_mcu_print_time()
+        self._sync_mcu_print_time()
         if mode == '5V':
-            self.send_cmd('set_5V_output_mode')
+            self._send_cmd('set_5V_output_mode')
         if mode == 'OD':
-            self.send_cmd('set_OD_output_mode')
-    def store_output_mode(self, mode):
+            self._send_cmd('set_OD_output_mode')
+    def _store_output_mode(self, mode):
         # If this command is inadvertently/purposely issued for a
         # BLTOUCH pre V3.0 and clones:
         #   No reaction at all to this sequence apart from a pin-down/pin-up
@@ -226,18 +226,18 @@ class BLTouchProbe:
         #   This will set the mode and store it in the eeprom.
         #   The pin-up is not needed but does not hurt
         logging.info("BLTouch store output mode: %s", mode)
-        self.sync_print_time()
-        self.send_cmd('pin_down')
+        self._sync_print_time()
+        self._send_cmd('pin_down')
         if mode == '5V':
-            self.send_cmd('set_5V_output_mode')
+            self._send_cmd('set_5V_output_mode')
         else:
-            self.send_cmd('set_OD_output_mode')
-        self.send_cmd('output_mode_store')
+            self._send_cmd('set_OD_output_mode')
+        self._send_cmd('output_mode_store')
         if mode == '5V':
-            self.send_cmd('set_5V_output_mode')
+            self._send_cmd('set_5V_output_mode')
         else:
-            self.send_cmd('set_OD_output_mode')
-        self.send_cmd('pin_up')
+            self._send_cmd('set_OD_output_mode')
+        self._send_cmd('pin_up')
     cmd_BLTOUCH_DEBUG_help = "Send a command to the bltouch for debugging"
     def cmd_BLTOUCH_DEBUG(self, gcmd):
         cmd = gcmd.get('COMMAND', None)
@@ -246,9 +246,9 @@ class BLTouchProbe:
                 ", ".join(sorted([c for c in Commands if c is not None]))))
             return
         gcmd.respond_info("Sending BLTOUCH_DEBUG COMMAND=%s" % (cmd,))
-        self.sync_print_time()
-        self.send_cmd(cmd, duration=self.pin_move_time)
-        self.sync_print_time()
+        self._sync_print_time()
+        self._send_cmd(cmd, duration=self.pin_move_time)
+        self._sync_print_time()
     cmd_BLTOUCH_STORE_help = "Store an output mode in the BLTouch EEPROM"
     def cmd_BLTOUCH_STORE(self, gcmd):
         cmd = gcmd.get('MODE', None)
@@ -256,9 +256,9 @@ class BLTouchProbe:
             gcmd.respond_info("BLTouch output modes: 5V, OD")
             return
         gcmd.respond_info("Storing BLTouch output mode: %s" % (cmd,))
-        self.sync_print_time()
-        self.store_output_mode(cmd)
-        self.sync_print_time()
+        self._sync_print_time()
+        self._store_output_mode(cmd)
+        self._sync_print_time()
 
 # Main external probe interface
 class PrinterBLTouch:

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -1,6 +1,6 @@
 # BLTouch support
 #
-# Copyright (C) 2018-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2018-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -59,16 +59,6 @@ class BLTouchProbe:
         self.query_endstop = self.mcu_endstop.query_endstop
         # multi probes state
         self.multi = 'OFF'
-        # Common probe implementation helpers
-        self.cmd_helper = probe.ProbeCommandHelper(
-            config, self, self.mcu_endstop.query_endstop)
-        self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.DescendToEndstopHelper(
-            config, self, self.probe_offsets, self.param_helper,
-            always_check_movement=True)
-        self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,
@@ -78,14 +68,6 @@ class BLTouchProbe:
         # Register events
         self.printer.register_event_handler("klippy:connect",
                                             self.handle_connect)
-    def get_probe_params(self, gcmd=None):
-        return self.param_helper.get_probe_params(gcmd)
-    def get_offsets(self, gcmd=None):
-        return self.probe_offsets.get_offsets(gcmd)
-    def get_status(self, eventtime):
-        return self.cmd_helper.get_status(eventtime)
-    def start_probe_session(self, gcmd):
-        return self.probe_session.start_probe_session(gcmd)
     def handle_connect(self):
         self.sync_mcu_print_time()
         self.next_cmd_time += 0.200
@@ -278,7 +260,30 @@ class BLTouchProbe:
         self.store_output_mode(cmd)
         self.sync_print_time()
 
+# Main external probe interface
+class PrinterBLTouch:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.mcu_probe = BLTouchProbe(config)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self,
+                                                   self.mcu_probe.query_endstop)
+        self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        self.param_helper = probe.ProbeParameterHelper(config)
+        self.homing_helper = probe.DescendToEndstopHelper(
+            config, self.mcu_probe, self.probe_offsets, self.param_helper,
+            always_check_movement=True)
+        self.probe_session = probe.ProbeSessionHelper(
+            config, self.param_helper, self.homing_helper.start_probe_session)
+    def get_probe_params(self, gcmd=None):
+        return self.param_helper.get_probe_params(gcmd)
+    def get_offsets(self, gcmd=None):
+        return self.probe_offsets.get_offsets(gcmd)
+    def get_status(self, eventtime):
+        return self.cmd_helper.get_status(eventtime)
+    def start_probe_session(self, gcmd):
+        return self.probe_session.start_probe_session(gcmd)
+
 def load_config(config):
-    blt = BLTouchProbe(config)
+    blt = PrinterBLTouch(config)
     config.get_printer().add_object('probe', blt)
     return blt

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -195,7 +195,7 @@ class BLTouchProbe:
         self.verify_raise_probe()
         self.sync_print_time()
         self.multi = 'OFF'
-    def probe_prepare(self, hmove):
+    def probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self.lower_probe()
             if self.multi == 'FIRST':
@@ -214,13 +214,11 @@ class BLTouchProbe:
         self.finish_home_complete.wait()
         if self.multi == 'OFF':
             self.raise_probe()
-    def probe_finish(self, hmove):
+    def probe_finish(self):
         self.wait_trigger_complete.wait()
         if self.multi == 'OFF':
             self.verify_raise_probe()
         self.sync_print_time()
-        if hmove.check_no_movement() is not None:
-            raise self.printer.command_error("BLTouch failed to deploy")
     def get_position_endstop(self):
         return self.position_endstop
     def set_output_mode(self, mode):

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -66,7 +66,8 @@ class BLTouchProbe:
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
         self.homing_helper = probe.DescendToEndstopHelper(
-            config, self, self.probe_offsets, self.param_helper)
+            config, self, self.probe_offsets, self.param_helper,
+            always_check_movement=True)
         self.probe_session = probe.ProbeSessionHelper(
             config, self.param_helper, self.homing_helper.start_probe_session)
         # Register BLTOUCH_DEBUG command

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -26,7 +26,6 @@ Commands = {
 class BLTouchProbe:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.position_endstop = config.getfloat('z_offset', minval=0.)
         self.stow_on_each_sample = config.getboolean('stow_on_each_sample',
                                                      True)
         self.probe_touch_mode = config.getboolean('probe_with_touch_mode',
@@ -220,8 +219,6 @@ class BLTouchProbe:
         if self.multi == 'OFF':
             self.verify_raise_probe()
         self.sync_print_time()
-    def get_position_endstop(self):
-        return self.position_endstop
     def set_output_mode(self, mode):
         # If this is inadvertently/purposely issued for a
         # BLTOUCH pre V3.0 and clones:

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -285,7 +285,7 @@ class PrinterBLTouch:
         self.param_helper = probe.ProbeParameterHelper(config)
         self.mcu_probe = BLTouchProbe(config, self.probe_offsets,
                                       self.param_helper)
-        self.probe_session = probe.ProbeSessionHelper(
+        self.probe_session = probe.SampleAveragingHelper(
             config, self.param_helper, self.mcu_probe.start_probe_session)
         self.cmd_helper = probe.ProbeCommandHelper(config, self,
                                                    self.mcu_probe.query_endstop)

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -316,7 +316,10 @@ class PrinterHoming:
                     "Homing failed due to printer shutdown")
             raise
         return epos
-    def probing_move(self, mcu_probe, pos, speed):
+    def check_probe_first_home(self, gcmd):
+        return (gcmd.get_command() == 'G28'
+                and gcmd.get("HOME_ATTEMPT_NUM", None) == '1')
+    def probing_move(self, mcu_probe, pos, speed, check_movement=True):
         endstops = [(mcu_probe, "probe")]
         hmove = HomingMove(self.printer, endstops)
         try:
@@ -326,7 +329,7 @@ class PrinterHoming:
                 raise self.printer.command_error(
                     "Probing failed due to printer shutdown")
             raise
-        if hmove.check_no_movement() is not None:
+        if check_movement and hmove.check_no_movement() is not None:
             raise self.printer.command_error(
                 "Probe triggered prior to movement")
         return epos

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -185,37 +185,43 @@ class Homing:
         return thcoord
     def set_homed_position(self, pos):
         self.toolhead.set_position(self._fill_coord(pos))
+    def _set_start_position(self, forcepos):
+        homing_axes = "".join(["xyz"[axis] for axis in range(3)
+                               if forcepos[axis] is not None])
+        startpos = self._fill_coord(forcepos)
+        self.toolhead.set_position(startpos, homing_axes=homing_axes)
+    def _retract_move(self, homing_info, forcepos, movepos):
+        # Determine retract position and move to it
+        startpos = self._fill_coord(forcepos)
+        homepos = self._fill_coord(movepos)
+        axes_d = [hp - sp for hp, sp in zip(homepos, startpos)]
+        move_d = math.sqrt(sum([d*d for d in axes_d[:3]]))
+        retract_r = min(1., homing_info.retract_dist / move_d)
+        retractpos = [hp - ad * retract_r
+                      for hp, ad in zip(homepos, axes_d)]
+        self.toolhead.move(retractpos, homing_info.retract_speed)
+        # Force new kinematic position
+        startpos = [rp - ad * retract_r
+                    for rp, ad in zip(retractpos, axes_d)]
+        self.toolhead.set_position(startpos)
+        return homepos
     def home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
         # Alter kinematics class to think printer is at forcepos
-        force_axes = [axis for axis in range(3) if forcepos[axis] is not None]
-        homing_axes = "".join(["xyz"[i] for i in force_axes])
-        startpos = self._fill_coord(forcepos)
         homepos = self._fill_coord(movepos)
-        self.toolhead.set_position(startpos, homing_axes=homing_axes)
+        self._set_start_position(forcepos)
         # Perform first home
         endstops = [es for rail in rails for es in rail.get_endstops()]
-        hi = rails[0].get_homing_info()
+        homing_info = rails[0].get_homing_info()
         hmove = HomingMove(self.printer, endstops)
-        hmove.homing_move(homepos, hi.speed)
+        hmove.homing_move(homepos, homing_info.speed)
         # Perform second home
-        if hi.retract_dist:
-            # Retract
-            startpos = self._fill_coord(forcepos)
-            homepos = self._fill_coord(movepos)
-            axes_d = [hp - sp for hp, sp in zip(homepos, startpos)]
-            move_d = math.sqrt(sum([d*d for d in axes_d[:3]]))
-            retract_r = min(1., hi.retract_dist / move_d)
-            retractpos = [hp - ad * retract_r
-                          for hp, ad in zip(homepos, axes_d)]
-            self.toolhead.move(retractpos, hi.retract_speed)
+        if homing_info.retract_dist:
+            homepos = self._retract_move(homing_info, forcepos, movepos)
             # Home again
-            startpos = [rp - ad * retract_r
-                        for rp, ad in zip(retractpos, axes_d)]
-            self.toolhead.set_position(startpos)
             hmove = HomingMove(self.printer, endstops)
-            hmove.homing_move(homepos, hi.second_homing_speed)
+            hmove.homing_move(homepos, homing_info.second_homing_speed)
             if hmove.check_no_movement() is not None:
                 raise self.printer.command_error(
                     "Endstop %s still triggered after retract"

--- a/klippy/extras/homing.py
+++ b/klippy/extras/homing.py
@@ -1,6 +1,6 @@
 # Helper code for implementing homing operations
 #
-# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math
@@ -205,7 +205,7 @@ class Homing:
                     for rp, ad in zip(retractpos, axes_d)]
         self.toolhead.set_position(startpos)
         return homepos
-    def home_rails(self, rails, forcepos, movepos):
+    def _do_home_rails(self, rails, forcepos, movepos):
         # Notify of upcoming homing operation
         self.printer.send_event("homing:home_rails_begin", self, rails)
         # Alter kinematics class to think printer is at forcepos
@@ -247,6 +247,55 @@ class Homing:
                             "axis %s after homing" % "xyz"[axis])
                 homepos[axis] = newpos[axis]
             self.toolhead.set_position(homepos)
+    def _create_probe_gcmd(self, attempt_num, probe_speed):
+        gcode = self.printer.lookup_object('gcode')
+        params = {'HOME_ATTEMPT_NUM': str(attempt_num), 'SAMPLES': '1',
+                  'PROBE_SPEED': str(probe_speed)}
+        return gcode.create_gcode_command("G28", "", params)
+    def _probing_home(self, probe_session, attempt_num, probe_speed):
+        # Run probe
+        gcmd = self._create_probe_gcmd(attempt_num, probe_speed)
+        probe_session.run_probe(gcmd)
+        ppos = probe_session.pull_probed_results()[0]
+        # Update toolhead position
+        curpos = self.toolhead.get_position()
+        curpos[2] -= ppos.bed_z
+        self.toolhead.set_position(curpos)
+    def _do_home_z_via_probe(self, rails, forcepos, movepos):
+        if movepos[0] is not None or movepos[1] is not None:
+            raise self.printer.command_error(
+                "Can only home Z with probe:z_virtual_endstop")
+        endstops = [es for rail in rails for es in rail.get_endstops()]
+        homing_info = rails[0].get_homing_info()
+        # Create probe session
+        probe = self.printer.lookup_object("probe")
+        gcmd = self._create_probe_gcmd(1, homing_info.speed)
+        probe_session = probe.start_probe_session(gcmd)
+        # Alter kinematics class to think printer is at forcepos
+        self._set_start_position(forcepos)
+        # Perform first home
+        self._probing_home(probe_session, 1, homing_info.speed)
+        # Perform second home
+        if homing_info.retract_dist:
+            self._retract_move(homing_info, forcepos, movepos)
+            # Home again
+            self._probing_home(probe_session, 2,
+                               homing_info.second_homing_speed)
+        probe_session.end_probe_session()
+    def home_rails(self, rails, forcepos, movepos):
+        # Check if this is actually a Z home via probe request
+        endstops = [es for rail in rails for es in rail.get_endstops()]
+        probe_endstops = [hasattr(e[0], "get_position_endstop")
+                          for e in endstops]
+        if len(probe_endstops) == 1 and probe_endstops[0]:
+            # Perform Z home via probe
+            self._do_home_z_via_probe(rails, forcepos, movepos)
+            return
+        if any(probe_endstops):
+            raise self.printer.command_error(
+                "Can't home to mix of probe:z_virtual_endstop rails")
+        # Perform normal home to endstops
+        self._do_home_rails(rails, forcepos, movepos)
 
 class PrinterHoming:
     def __init__(self, config):

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -510,7 +510,7 @@ class LoadCellPrinterProbe:
             config_helper)
         tap_session = TapSession(config, self._tapping_move,
                                  self._probe_offsets, self._param_helper)
-        self._probe_session = probe.ProbeSessionHelper(config,
+        self._probe_session = probe.SampleAveragingHelper(config,
             self._param_helper, tap_session.start_probe_session)
         # printer integration
         LoadCellProbeCommands(config, load_cell_probing_move)

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -514,7 +514,7 @@ class LoadCellPrinterProbe:
             self._param_helper, tap_session.start_probe_session)
         # printer integration
         LoadCellProbeCommands(config, load_cell_probing_move)
-        probe.ProbeVirtualEndstopDeprecation(config)
+        probe.HomingViaProbeHelper(config, self.get_offsets()[2])
         self._printer.add_object('probe', self)
 
     def get_probe_params(self, gcmd=None):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -1,6 +1,6 @@
 # Z-Probe support
 #
-# Copyright (C) 2017-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2017-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -229,20 +229,38 @@ class HomingViaProbeHelper:
                                             self._handle_home_rails_end)
         self.printer.register_event_handler("gcode:command_error",
                                             self._handle_command_error)
+    # MCU_endstop interface
+    def get_mcu(self):
+        return self.mcu_probe.get_mcu()
+    def add_stepper(self, stepper):
+        self.mcu_probe.add_stepper(stepper)
+    def get_steppers(self):
+        return self.mcu_probe.get_steppers()
+    def home_start(self, print_time, sample_time, sample_count, rest_time,
+                   triggered=True):
+        return self.mcu_probe.home_start(print_time, sample_time, sample_count,
+                                         rest_time, triggered)
+    def home_wait(self, home_end_time):
+        return self.mcu_probe.home_wait(home_end_time)
+    def query_endstop(self, print_time):
+        return self.mcu_probe.query_endstop(print_time)
+    def get_position_endstop(self):
+        return self.mcu_probe.get_position_endstop()
+    # Printer pins module setup_pin() interface
     def _handle_homing_move_begin(self, hmove):
-        if self.mcu_probe in hmove.get_mcu_endstops():
+        if self in hmove.get_mcu_endstops():
             self.mcu_probe.probe_prepare(hmove)
     def _handle_homing_move_end(self, hmove):
-        if self.mcu_probe in hmove.get_mcu_endstops():
+        if self in hmove.get_mcu_endstops():
             self.mcu_probe.probe_finish(hmove)
     def _handle_home_rails_begin(self, homing_state, rails):
         endstops = [es for rail in rails for es, name in rail.get_endstops()]
-        if self.mcu_probe in endstops:
+        if self in endstops:
             self.mcu_probe.multi_probe_begin()
             self.multi_probe_pending = True
     def _handle_home_rails_end(self, homing_state, rails):
         endstops = [es for rail in rails for es, name in rail.get_endstops()]
-        if self.multi_probe_pending and self.mcu_probe in endstops:
+        if self.multi_probe_pending and self in endstops:
             self.multi_probe_pending = False
             self.mcu_probe.multi_probe_end()
     def _handle_command_error(self):
@@ -257,7 +275,7 @@ class HomingViaProbeHelper:
             raise pins.error("Probe virtual endstop only useful as endstop pin")
         if pin_params['invert'] or pin_params['pullup']:
             raise pins.error("Can not pullup/invert probe virtual endstop")
-        return self.mcu_probe
+        return self
     # Helper to convert probe based commands to use homing module
     def start_probe_session(self, gcmd):
         self.mcu_probe.multi_probe_begin()
@@ -269,7 +287,7 @@ class HomingViaProbeHelper:
         pos[2] = self.z_min_position
         speed = self.param_helper.get_probe_params(gcmd)['probe_speed']
         phoming = self.printer.lookup_object('homing')
-        ppos = phoming.probing_move(self.mcu_probe, pos, speed)
+        ppos = phoming.probing_move(self, pos, speed)
         offsets = self.probe_offsets.get_offsets()
         res = manual_probe.create_probe_result(ppos, offsets)
         self.results.append(res)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -207,28 +207,33 @@ class LookupZSteppers:
 
 # Support homing via probe using the probe:z_virtual_endstop pseudo-pin
 class HomingViaProbeHelper:
-    def __init__(self, config, mcu_probe):
+    def __init__(self, config, position_endstop, query_endstop_cb=None):
         self.printer = config.get_printer()
-        self.mcu_probe = mcu_probe
+        self.position_endstop = position_endstop
+        self.query_endstop_cb = query_endstop_cb
         # Register z_virtual_endstop pin
         self.printer.lookup_object('pins').register_chip('probe', self)
+    def _raise_error(self):
+        raise self.printer.command_error(
+            "Internal error. Can't home via HomingViaProbeHelper.")
     # MCU_endstop interface
     def get_mcu(self):
-        return self.mcu_probe.get_mcu()
+        self._raise_error()
     def add_stepper(self, stepper):
-        self.mcu_probe.add_stepper(stepper)
+        pass
     def get_steppers(self):
-        return self.mcu_probe.get_steppers()
+        return []
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
-        return self.mcu_probe.home_start(print_time, sample_time, sample_count,
-                                         rest_time, triggered)
+        self._raise_error()
     def home_wait(self, home_end_time):
-        return self.mcu_probe.home_wait(home_end_time)
+        self._raise_error()
     def query_endstop(self, print_time):
-        return self.mcu_probe.query_endstop(print_time)
+        if self.query_endstop_cb is None:
+            return False
+        return self.query_endstop_cb(print_time)
     def get_position_endstop(self):
-        return self.mcu_probe.get_position_endstop()
+        return self.position_endstop
     # Printer pins module setup_pin() interface
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
@@ -249,7 +254,8 @@ class DescendToEndstopHelper:
         self.z_min_position = lookup_minimum_z(config)
         self.results = []
         LookupZSteppers(config, self.mcu_probe.add_stepper)
-        HomingViaProbeHelper(config, mcu_probe)
+        HomingViaProbeHelper(config, probe_offsets.get_offsets()[2],
+                             mcu_probe.query_endstop)
     def start_probe_session(self, gcmd):
         self.mcu_probe.multi_probe_begin()
         self.results = []
@@ -563,7 +569,6 @@ def run_single_probe(probe, gcmd):
 class ProbeEndstopWrapper:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.position_endstop = config.getfloat('z_offset')
         self.stow_on_each_sample = config.getboolean(
             'deactivate_on_each_sample', True)
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
@@ -614,8 +619,6 @@ class ProbeEndstopWrapper:
     def probe_finish(self):
         if self.multi == 'OFF':
             self._raise_probe()
-    def get_position_endstop(self):
-        return self.position_endstop
 
 # Main external probe interface
 class PrinterProbe:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -317,7 +317,7 @@ class ProbeParameterHelper:
                 'samples_result': samples_result}
 
 # Helper to track multiple probe attempts in a single command
-class ProbeSessionHelper:
+class SampleAveragingHelper:
     def __init__(self, config, param_helper, start_session_cb):
         self.printer = config.get_printer()
         self.param_helper = param_helper
@@ -614,7 +614,7 @@ class PrinterProbe:
         self.param_helper = ProbeParameterHelper(config)
         self.mcu_probe = ProbeEndstopWrapper(config, self.probe_offsets,
                                              self.param_helper)
-        self.probe_session = ProbeSessionHelper(
+        self.probe_session = SampleAveragingHelper(
             config, self.param_helper, self.mcu_probe.start_probe_session)
         self.cmd_helper = ProbeCommandHelper(config, self,
                                              self.mcu_probe.query_endstop)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -239,11 +239,13 @@ class HomingViaProbeHelper:
 
 # Support for probes that trigger via mcu_endstop
 class DescendToEndstopHelper:
-    def __init__(self, config, mcu_probe, probe_offsets, param_helper):
+    def __init__(self, config, mcu_probe, probe_offsets, param_helper,
+                 always_check_movement=False):
         self.printer = config.get_printer()
         self.mcu_probe = mcu_probe
         self.probe_offsets = probe_offsets
         self.param_helper = param_helper
+        self.always_check_movement = always_check_movement
         self.z_min_position = lookup_minimum_z(config)
         self.results = []
         LookupZSteppers(config, self.mcu_probe.add_stepper)
@@ -258,9 +260,12 @@ class DescendToEndstopHelper:
         pos[2] = self.z_min_position
         speed = self.param_helper.get_probe_params(gcmd)['probe_speed']
         phoming = self.printer.lookup_object('homing')
+        check_movement = (self.always_check_movement
+                          or not phoming.check_probe_first_home(gcmd))
         self.mcu_probe.probe_prepare()
         try:
-            ppos = phoming.probing_move(self.mcu_probe, pos, speed)
+            ppos = phoming.probing_move(self.mcu_probe, pos, speed,
+                                        check_movement=check_movement)
         except self.printer.command_error as e:
             self.mcu_probe.probe_finish()
             raise

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -205,16 +205,11 @@ class LookupZSteppers:
             if stepper.is_active_axis('z'):
                 self.add_stepper_cb(stepper)
 
-# Homing via probe:z_virtual_endstop
+# Support homing via probe using the probe:z_virtual_endstop pseudo-pin
 class HomingViaProbeHelper:
-    def __init__(self, config, mcu_probe, probe_offsets, param_helper):
+    def __init__(self, config, mcu_probe):
         self.printer = config.get_printer()
         self.mcu_probe = mcu_probe
-        self.probe_offsets = probe_offsets
-        self.param_helper = param_helper
-        self.z_min_position = lookup_minimum_z(config)
-        self.results = []
-        LookupZSteppers(config, self.mcu_probe.add_stepper)
         # Register z_virtual_endstop pin
         self.printer.lookup_object('pins').register_chip('probe', self)
     # MCU_endstop interface
@@ -241,7 +236,18 @@ class HomingViaProbeHelper:
         if pin_params['invert'] or pin_params['pullup']:
             raise pins.error("Can not pullup/invert probe virtual endstop")
         return self
-    # Helper to convert probe based commands to use homing module
+
+# Support for probes that trigger via mcu_endstop
+class DescendToEndstopHelper:
+    def __init__(self, config, mcu_probe, probe_offsets, param_helper):
+        self.printer = config.get_printer()
+        self.mcu_probe = mcu_probe
+        self.probe_offsets = probe_offsets
+        self.param_helper = param_helper
+        self.z_min_position = lookup_minimum_z(config)
+        self.results = []
+        LookupZSteppers(config, self.mcu_probe.add_stepper)
+        HomingViaProbeHelper(config, mcu_probe)
     def start_probe_session(self, gcmd):
         self.mcu_probe.multi_probe_begin()
         self.results = []
@@ -615,7 +621,7 @@ class PrinterProbe:
                                              self.mcu_probe.query_endstop)
         self.probe_offsets = ProbeOffsetsHelper(config)
         self.param_helper = ProbeParameterHelper(config)
-        self.homing_helper = HomingViaProbeHelper(
+        self.homing_helper = DescendToEndstopHelper(
             config, self.mcu_probe, self.probe_offsets, self.param_helper)
         self.probe_session = ProbeSessionHelper(
             config, self.param_helper, self.homing_helper.start_probe_session)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -287,17 +287,6 @@ class DescendToEndstopHelper:
         self.results = []
         self.mcu_probe.multi_probe_end()
 
-class ProbeVirtualEndstopDeprecation:
-    def __init__(self, config):
-        self._name = config.get_name()
-        self._printer = config.get_printer()
-        # Register z_virtual_endstop pin
-        self._printer.lookup_object('pins').register_chip('probe', self)
-    def setup_pin(self, pin_type, pin_params):
-        raise self._printer.config_error(
-            "Module [%s] does not support `probe:z_virtual_endstop`"
-            ", use a pin instead." % (self._name,))
-
 # Helper to read multi-sample parameters from config
 class ProbeParameterHelper:
     def __init__(self, config):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -212,23 +212,11 @@ class HomingViaProbeHelper:
         self.mcu_probe = mcu_probe
         self.probe_offsets = probe_offsets
         self.param_helper = param_helper
-        self.multi_probe_pending = False
         self.z_min_position = lookup_minimum_z(config)
         self.results = []
         LookupZSteppers(config, self.mcu_probe.add_stepper)
         # Register z_virtual_endstop pin
         self.printer.lookup_object('pins').register_chip('probe', self)
-        # Register event handlers
-        self.printer.register_event_handler("homing:homing_move_begin",
-                                            self._handle_homing_move_begin)
-        self.printer.register_event_handler("homing:homing_move_end",
-                                            self._handle_homing_move_end)
-        self.printer.register_event_handler("homing:home_rails_begin",
-                                            self._handle_home_rails_begin)
-        self.printer.register_event_handler("homing:home_rails_end",
-                                            self._handle_home_rails_end)
-        self.printer.register_event_handler("gcode:command_error",
-                                            self._handle_command_error)
     # MCU_endstop interface
     def get_mcu(self):
         return self.mcu_probe.get_mcu()
@@ -247,29 +235,6 @@ class HomingViaProbeHelper:
     def get_position_endstop(self):
         return self.mcu_probe.get_position_endstop()
     # Printer pins module setup_pin() interface
-    def _handle_homing_move_begin(self, hmove):
-        if self in hmove.get_mcu_endstops():
-            self.mcu_probe.probe_prepare(hmove)
-    def _handle_homing_move_end(self, hmove):
-        if self in hmove.get_mcu_endstops():
-            self.mcu_probe.probe_finish(hmove)
-    def _handle_home_rails_begin(self, homing_state, rails):
-        endstops = [es for rail in rails for es, name in rail.get_endstops()]
-        if self in endstops:
-            self.mcu_probe.multi_probe_begin()
-            self.multi_probe_pending = True
-    def _handle_home_rails_end(self, homing_state, rails):
-        endstops = [es for rail in rails for es, name in rail.get_endstops()]
-        if self.multi_probe_pending and self in endstops:
-            self.multi_probe_pending = False
-            self.mcu_probe.multi_probe_end()
-    def _handle_command_error(self):
-        if self.multi_probe_pending:
-            self.multi_probe_pending = False
-            try:
-                self.mcu_probe.multi_probe_end()
-            except:
-                logging.exception("Homing multi-probe end")
     def setup_pin(self, pin_type, pin_params):
         if pin_type != 'endstop' or pin_params['pin'] != 'z_virtual_endstop':
             raise pins.error("Probe virtual endstop only useful as endstop pin")
@@ -287,7 +252,13 @@ class HomingViaProbeHelper:
         pos[2] = self.z_min_position
         speed = self.param_helper.get_probe_params(gcmd)['probe_speed']
         phoming = self.printer.lookup_object('homing')
-        ppos = phoming.probing_move(self, pos, speed)
+        self.mcu_probe.probe_prepare()
+        try:
+            ppos = phoming.probing_move(self.mcu_probe, pos, speed)
+        except self.printer.command_error as e:
+            self.mcu_probe.probe_finish()
+            raise
+        self.mcu_probe.probe_finish()
         offsets = self.probe_offsets.get_offsets()
         res = manual_probe.create_probe_result(ppos, offsets)
         self.results.append(res)
@@ -624,12 +595,12 @@ class ProbeEndstopWrapper:
             return
         self._raise_probe()
         self.multi = 'OFF'
-    def probe_prepare(self, hmove):
+    def probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self._lower_probe()
             if self.multi == 'FIRST':
                 self.multi = 'ON'
-    def probe_finish(self, hmove):
+    def probe_finish(self):
         if self.multi == 'OFF':
             self._raise_probe()
     def get_position_endstop(self):

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -402,9 +402,10 @@ class ProbeSessionHelper:
         self.printer.send_event("probe:update_results", results)
         epos = results[0]
         # Report results
-        gcode = self.printer.lookup_object('gcode')
-        gcode.respond_info("probe: at %.3f,%.3f bed will contact at z=%.6f"
-                           % (epos.bed_x, epos.bed_y, epos.bed_z))
+        if gcmd.get_command() != "G28":
+            gcode = self.printer.lookup_object('gcode')
+            gcode.respond_info("probe: at %.3f,%.3f bed will contact at z=%.6f"
+                               % (epos.bed_x, epos.bed_y, epos.bed_z))
         return epos
     def run_probe(self, gcmd):
         if self.hw_probe_session is None:

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -256,11 +256,7 @@ class DescendToEndstopHelper:
         LookupZSteppers(config, self.mcu_probe.add_stepper)
         HomingViaProbeHelper(config, probe_offsets.get_offsets()[2],
                              mcu_probe.query_endstop)
-    def start_probe_session(self, gcmd):
-        self.mcu_probe.multi_probe_begin()
-        self.results = []
-        return self
-    def run_probe(self, gcmd):
+    def descend_until_trigger(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
         pos = toolhead.get_position()
         pos[2] = self.z_min_position
@@ -268,24 +264,17 @@ class DescendToEndstopHelper:
         phoming = self.printer.lookup_object('homing')
         check_movement = (self.always_check_movement
                           or not phoming.check_probe_first_home(gcmd))
-        self.mcu_probe.probe_prepare()
-        try:
-            ppos = phoming.probing_move(self.mcu_probe, pos, speed,
-                                        check_movement=check_movement)
-        except self.printer.command_error as e:
-            self.mcu_probe.probe_finish()
-            raise
-        self.mcu_probe.probe_finish()
+        ppos = phoming.probing_move(self.mcu_probe, pos, speed,
+                                    check_movement=check_movement)
         offsets = self.probe_offsets.get_offsets()
         res = manual_probe.create_probe_result(ppos, offsets)
         self.results.append(res)
-    def pull_probed_results(self):
+    def pull_trigger_positions(self):
         res = self.results
         self.results = []
         return res
-    def end_probe_session(self):
-        self.results = []
-        self.mcu_probe.multi_probe_end()
+    def clear_trigger_positions(self):
+        self.pull_trigger_positions()
 
 # Helper to read multi-sample parameters from config
 class ProbeParameterHelper:
@@ -556,7 +545,7 @@ def run_single_probe(probe, gcmd):
 
 # Endstop wrapper that enables probe specific features
 class ProbeEndstopWrapper:
-    def __init__(self, config):
+    def __init__(self, config, probe_offsets, param_helper):
         self.printer = config.get_printer()
         self.stow_on_each_sample = config.getboolean(
             'deactivate_on_each_sample', True)
@@ -568,13 +557,10 @@ class ProbeEndstopWrapper:
         # Create an "endstop" object to handle the probe pin
         ppins = self.printer.lookup_object('pins')
         self.mcu_endstop = ppins.setup_pin('endstop', config.get('pin'))
-        # Wrappers
-        self.get_mcu = self.mcu_endstop.get_mcu
-        self.add_stepper = self.mcu_endstop.add_stepper
-        self.get_steppers = self.mcu_endstop.get_steppers
-        self.home_start = self.mcu_endstop.home_start
-        self.home_wait = self.mcu_endstop.home_wait
         self.query_endstop = self.mcu_endstop.query_endstop
+        # Probing via homing to endstop
+        self.homing_helper = DescendToEndstopHelper(
+            config, self.mcu_endstop, probe_offsets, param_helper)
         # multi probes state
         self.multi = 'OFF'
     def _raise_probe(self):
@@ -591,37 +577,47 @@ class ProbeEndstopWrapper:
         if toolhead.get_position()[:3] != start_pos[:3]:
             raise self.printer.command_error(
                 "Toolhead moved during probe activate_gcode script")
-    def multi_probe_begin(self):
-        if self.stow_on_each_sample:
-            return
-        self.multi = 'FIRST'
-    def multi_probe_end(self):
-        if self.stow_on_each_sample:
-            return
-        self._raise_probe()
-        self.multi = 'OFF'
-    def probe_prepare(self):
+    def start_probe_session(self, gcmd):
+        self.homing_helper.clear_trigger_positions()
+        if not self.stow_on_each_sample:
+            self.multi = 'FIRST'
+        return self
+    def _probe_prepare(self):
         if self.multi == 'OFF' or self.multi == 'FIRST':
             self._lower_probe()
             if self.multi == 'FIRST':
                 self.multi = 'ON'
-    def probe_finish(self):
+    def _probe_finish(self):
         if self.multi == 'OFF':
             self._raise_probe()
+    def run_probe(self, gcmd):
+        self._probe_prepare()
+        try:
+            self.homing_helper.descend_until_trigger(gcmd)
+        except self.printer.command_error as e:
+            self._probe_finish()
+            raise
+        self._probe_finish()
+    def pull_probed_results(self):
+        return self.homing_helper.pull_trigger_positions()
+    def end_probe_session(self):
+        self.homing_helper.clear_trigger_positions()
+        if not self.stow_on_each_sample:
+            self._raise_probe()
+            self.multi = 'OFF'
 
 # Main external probe interface
 class PrinterProbe:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.mcu_probe = ProbeEndstopWrapper(config)
-        self.cmd_helper = ProbeCommandHelper(config, self,
-                                             self.mcu_probe.query_endstop)
         self.probe_offsets = ProbeOffsetsHelper(config)
         self.param_helper = ProbeParameterHelper(config)
-        self.homing_helper = DescendToEndstopHelper(
-            config, self.mcu_probe, self.probe_offsets, self.param_helper)
+        self.mcu_probe = ProbeEndstopWrapper(config, self.probe_offsets,
+                                             self.param_helper)
         self.probe_session = ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
+            config, self.param_helper, self.mcu_probe.start_probe_session)
+        self.cmd_helper = ProbeCommandHelper(config, self,
+                                             self.mcu_probe.query_endstop)
     def get_probe_params(self, gcmd=None):
         return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self, gcmd=None):

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -593,7 +593,9 @@ class EddyDescend:
         speed = self._param_helper.get_probe_params(gcmd)['probe_speed']
         # Perform probing move
         phoming = self._printer.lookup_object('homing')
-        trig_pos = phoming.probing_move(self._trigger_analog, pos, speed)
+        check_movement = not phoming.check_probe_first_home(gcmd)
+        trig_pos = phoming.probing_move(self._trigger_analog, pos, speed,
+                                        check_movement=check_movement)
         # Extract samples
         start_time = self._trigger_analog.get_last_trigger_time() + 0.050
         end_time = start_time + 0.100

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -1046,25 +1046,27 @@ class PrinterEddyProbe:
         # Basic probe requests
         self.probe_offsets = EddyProbeOffsets(config)
         self.param_helper = EddyParameterHelper(config)
-        self.eddy_descend = EddyDescend(
+        eddy_descend = EddyDescend(
             config, self.sensor_helper, self.calibration, self.probe_offsets,
             self.param_helper, trig_analog)
+        self.eddy_descend_session = probe.ProbeSessionHelper(
+            config, self.param_helper, eddy_descend.start_probe_session)
         # Create wrapper to support Z homing with probe
-        mcu_probe = EddyEndstopWrapper(self.sensor_helper, self.eddy_descend)
+        mcu_probe = EddyEndstopWrapper(self.sensor_helper, eddy_descend)
         probe.HomingViaProbeHelper(config, mcu_probe,
                                    self.probe_offsets, self.param_helper)
         # Probing via "tap" interface
-        self.eddy_tap = EddyTap(config, self.sensor_helper,
-                                self.param_helper, trig_analog)
-        EddyTapCalibration(config, self.calibration, self.eddy_tap)
+        eddy_tap = EddyTap(config, self.sensor_helper,
+                           self.param_helper, trig_analog)
+        EddyTapCalibration(config, self.calibration, eddy_tap)
+        self.eddy_tap_session = probe.ProbeSessionHelper(
+            config, self.param_helper, eddy_tap.start_probe_session)
         # Probing via "scan" and "rapid_scan" requests
         self.eddy_scan = EddyScanningProbe(config, self.sensor_helper,
                                            self.calibration, self.probe_offsets)
         # Register with main probe interface
         self.cmd_helper = probe.ProbeCommandHelper(config, self,
                                                    can_set_z_offset=False)
-        self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self._start_descend_wrapper)
         self.printer.add_object('probe', self)
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)
@@ -1076,17 +1078,13 @@ class PrinterEddyProbe:
         return self.probe_offsets.get_offsets(gcmd)
     def get_status(self, eventtime):
         return self.cmd_helper.get_status(eventtime)
-    def _start_descend_wrapper(self, gcmd):
-        method = gcmd.get('METHOD', 'automatic').lower()
-        if method == "tap":
-            return self.eddy_tap.start_probe_session(gcmd)
-        return self.eddy_descend.start_probe_session(gcmd)
     def start_probe_session(self, gcmd):
         method = gcmd.get('METHOD', 'automatic').lower()
         if method in ('scan', 'rapid_scan'):
             return self.eddy_scan.start_probe_session(gcmd)
-        # For "tap" and normal, probe_session can average multiple attempts
-        return self.probe_session.start_probe_session(gcmd)
+        elif method == 'tap':
+            return self.eddy_tap_session.start_probe_session(gcmd)
+        return self.eddy_descend_session.start_probe_session(gcmd)
     def register_drift_compensation(self, comp):
         self.calibration.register_drift_compensation(comp)
 

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -572,6 +572,7 @@ class EddyDescend:
             self._descend_z = config.getfloat('descend_z', above=0.)
         self._z_min_position = probe.lookup_minimum_z(config)
         self._gather = None
+        probe.HomingViaProbeHelper(config, self._descend_z)
     def _prep_trigger_analog(self):
         sos_filter = self._trigger_analog.get_sos_filter()
         sos_filter.set_filter_design(None)
@@ -609,41 +610,6 @@ class EddyDescend:
     def end_probe_session(self):
         self._gather.finish()
         self._gather = None
-
-# Wrapper to emulate mcu_endstop for probe:z_virtual_endstop
-# Note that this does not provide accurate results
-class EddyEndstopWrapper:
-    def __init__(self, sensor_helper, eddy_descend):
-        self._sensor_helper = sensor_helper
-        self._eddy_descend = eddy_descend
-        self._hw_probe_session = None
-    # Interface for MCU_endstop
-    def get_mcu(self):
-        return self._sensor_helper.get_mcu()
-    def add_stepper(self, stepper):
-        pass
-    def get_steppers(self):
-        return self._eddy_descend._trigger_analog.get_steppers()
-    def home_start(self, print_time, sample_time, sample_count, rest_time,
-                   triggered=True):
-        return self._eddy_descend._trigger_analog.home_start(
-            print_time, sample_time, sample_count, rest_time, triggered)
-    def home_wait(self, home_end_time):
-        return self._eddy_descend._trigger_analog.home_wait(home_end_time)
-    def query_endstop(self, print_time):
-        return False # XXX
-    # Interface for HomingViaProbeHelper
-    def multi_probe_begin(self):
-        self._hw_probe_session = self._eddy_descend.start_probe_session(None)
-    def multi_probe_end(self):
-        self._hw_probe_session.end_probe_session()
-        self._hw_probe_session = None
-    def probe_prepare(self):
-        pass
-    def probe_finish(self):
-        pass
-    def get_position_endstop(self):
-        return self._eddy_descend._descend_z
 
 # Probing helper for "tap" requests
 class EddyTap:
@@ -1053,9 +1019,6 @@ class PrinterEddyProbe:
             self.param_helper, trig_analog)
         self.eddy_descend_session = probe.ProbeSessionHelper(
             config, self.param_helper, eddy_descend.start_probe_session)
-        # Create wrapper to support Z homing with probe
-        mcu_probe = EddyEndstopWrapper(self.sensor_helper, eddy_descend)
-        probe.HomingViaProbeHelper(config, mcu_probe)
         # Probing via "tap" interface
         eddy_tap = EddyTap(config, self.sensor_helper,
                            self.param_helper, trig_analog)

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -1017,13 +1017,13 @@ class PrinterEddyProbe:
         eddy_descend = EddyDescend(
             config, self.sensor_helper, self.calibration, self.probe_offsets,
             self.param_helper, trig_analog)
-        self.eddy_descend_session = probe.ProbeSessionHelper(
+        self.eddy_descend_session = probe.SampleAveragingHelper(
             config, self.param_helper, eddy_descend.start_probe_session)
         # Probing via "tap" interface
         eddy_tap = EddyTap(config, self.sensor_helper,
                            self.param_helper, trig_analog)
         EddyTapCalibration(config, self.calibration, eddy_tap)
-        self.eddy_tap_session = probe.ProbeSessionHelper(
+        self.eddy_tap_session = probe.SampleAveragingHelper(
             config, self.param_helper, eddy_tap.start_probe_session)
         # Probing via "scan" and "rapid_scan" requests
         self.eddy_scan = EddyScanningProbe(config, self.sensor_helper,

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -636,9 +636,9 @@ class EddyEndstopWrapper:
     def multi_probe_end(self):
         self._hw_probe_session.end_probe_session()
         self._hw_probe_session = None
-    def probe_prepare(self, hmove):
+    def probe_prepare(self):
         pass
-    def probe_finish(self, hmove):
+    def probe_finish(self):
         pass
     def get_position_endstop(self):
         return self._eddy_descend._descend_z

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -1053,8 +1053,7 @@ class PrinterEddyProbe:
             config, self.param_helper, eddy_descend.start_probe_session)
         # Create wrapper to support Z homing with probe
         mcu_probe = EddyEndstopWrapper(self.sensor_helper, eddy_descend)
-        probe.HomingViaProbeHelper(config, mcu_probe,
-                                   self.probe_offsets, self.param_helper)
+        probe.HomingViaProbeHelper(config, mcu_probe)
         # Probing via "tap" interface
         eddy_tap = EddyTap(config, self.sensor_helper,
                            self.param_helper, trig_analog)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -49,21 +49,15 @@ class ControlPinHelper:
         return bit_time
 
 class SmartEffectorProbe:
-    def __init__(self, config):
+    def __init__(self, config, probe_offsets, param_helper):
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
         self.probe_accel = config.getfloat('probe_accel', 0., minval=0.)
         self.recovery_time = config.getfloat('recovery_time', 0.4, minval=0.)
-        self.probe_wrapper = probe.ProbeEndstopWrapper(config)
-        # Wrappers
-        self.get_mcu = self.probe_wrapper.get_mcu
-        self.add_stepper = self.probe_wrapper.add_stepper
-        self.get_steppers = self.probe_wrapper.get_steppers
-        self.home_start = self.probe_wrapper.home_start
-        self.home_wait = self.probe_wrapper.home_wait
+        self.probe_wrapper = probe.ProbeEndstopWrapper(config, probe_offsets,
+                                                       param_helper)
         self.query_endstop = self.probe_wrapper.query_endstop
-        self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
-        self.multi_probe_end = self.probe_wrapper.multi_probe_end
+        self.probe_session = None
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:
@@ -78,9 +72,8 @@ class SmartEffectorProbe:
         self.gcode.register_command("SET_SMART_EFFECTOR",
                                     self.cmd_SET_SMART_EFFECTOR,
                                     desc=self.cmd_SET_SMART_EFFECTOR_help)
-    def probe_prepare(self):
+    def _probe_prepare(self):
         toolhead = self.printer.lookup_object('toolhead')
-        self.probe_wrapper.probe_prepare()
         if self.probe_accel:
             systime = self.printer.get_reactor().monotonic()
             toolhead_info = toolhead.get_status(systime)
@@ -89,11 +82,26 @@ class SmartEffectorProbe:
                     "M204 S%.3f" % (self.probe_accel,))
         if self.recovery_time:
             toolhead.dwell(self.recovery_time)
-    def probe_finish(self):
+    def _probe_finish(self):
         if self.probe_accel:
             self.gcode.run_script_from_command(
                     "M204 S%.3f" % (self.old_max_accel,))
-        self.probe_wrapper.probe_finish()
+    def start_probe_session(self, gcmd):
+        self.probe_session = self.probe_wrapper.start_probe_session(gcmd)
+        return self
+    def run_probe(self, gcmd):
+        self._probe_prepare()
+        try:
+            self.probe_session.run_probe(gcmd)
+        except self.printer.command_error as e:
+            self._probe_finish()
+            raise
+        self._probe_finish()
+    def pull_probed_results(self):
+        return self.probe_session.pull_probed_results()
+    def end_probe_session(self):
+        self.probe_session.end_probe_session()
+        self.probe_session = None
     def _send_command(self, buf):
         # Each byte is sent to the SmartEffector as
         # [0 0 1 0 b7 b6 b5 b4 !b4 b3 b2 b1 b0 !b0]
@@ -150,15 +158,14 @@ class SmartEffectorProbe:
 class PrinterSmartEffector:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.mcu_probe = SmartEffectorProbe(config)
-        self.cmd_helper = probe.ProbeCommandHelper(config, self,
-                                                   self.mcu_probe.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.DescendToEndstopHelper(
-            config, self.mcu_probe, self.probe_offsets, self.param_helper)
+        self.mcu_probe = SmartEffectorProbe(config, self.probe_offsets,
+                                            self.param_helper)
         self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
+            config, self.param_helper, self.mcu_probe.start_probe_session)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self,
+                                                   self.mcu_probe.query_endstop)
     def get_probe_params(self, gcmd=None):
         return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self, gcmd=None):

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -70,7 +70,7 @@ class SmartEffectorProbe:
             config, self, self.probe_wrapper.query_endstop)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.HomingViaProbeHelper(
+        self.homing_helper = probe.DescendToEndstopHelper(
             config, self, self.probe_offsets, self.param_helper)
         self.probe_session = probe.ProbeSessionHelper(
             config, self.param_helper, self.homing_helper.start_probe_session)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -162,7 +162,7 @@ class PrinterSmartEffector:
         self.param_helper = probe.ProbeParameterHelper(config)
         self.mcu_probe = SmartEffectorProbe(config, self.probe_offsets,
                                             self.param_helper)
-        self.probe_session = probe.ProbeSessionHelper(
+        self.probe_session = probe.SampleAveragingHelper(
             config, self.param_helper, self.mcu_probe.start_probe_session)
         self.cmd_helper = probe.ProbeCommandHelper(config, self,
                                                    self.mcu_probe.query_endstop)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -96,9 +96,9 @@ class SmartEffectorProbe:
         return self.cmd_helper.get_status(eventtime)
     def start_probe_session(self, gcmd):
         return self.probe_session.start_probe_session(gcmd)
-    def probe_prepare(self, hmove):
+    def probe_prepare(self):
         toolhead = self.printer.lookup_object('toolhead')
-        self.probe_wrapper.probe_prepare(hmove)
+        self.probe_wrapper.probe_prepare()
         if self.probe_accel:
             systime = self.printer.get_reactor().monotonic()
             toolhead_info = toolhead.get_status(systime)
@@ -107,11 +107,11 @@ class SmartEffectorProbe:
                     "M204 S%.3f" % (self.probe_accel,))
         if self.recovery_time:
             toolhead.dwell(self.recovery_time)
-    def probe_finish(self, hmove):
+    def probe_finish(self):
         if self.probe_accel:
             self.gcode.run_script_from_command(
                     "M204 S%.3f" % (self.old_max_accel,))
-        self.probe_wrapper.probe_finish(hmove)
+        self.probe_wrapper.probe_finish()
     def _send_command(self, buf):
         # Each byte is sent to the SmartEffector as
         # [0 0 1 0 b7 b6 b5 b4 !b4 b3 b2 b1 b0 !b0]

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -64,7 +64,6 @@ class SmartEffectorProbe:
         self.query_endstop = self.probe_wrapper.query_endstop
         self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
         self.multi_probe_end = self.probe_wrapper.multi_probe_end
-        self.get_position_endstop = self.probe_wrapper.get_position_endstop
         # Common probe implementation helpers
         self.cmd_helper = probe.ProbeCommandHelper(
             config, self, self.probe_wrapper.query_endstop)

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -64,15 +64,6 @@ class SmartEffectorProbe:
         self.query_endstop = self.probe_wrapper.query_endstop
         self.multi_probe_begin = self.probe_wrapper.multi_probe_begin
         self.multi_probe_end = self.probe_wrapper.multi_probe_end
-        # Common probe implementation helpers
-        self.cmd_helper = probe.ProbeCommandHelper(
-            config, self, self.probe_wrapper.query_endstop)
-        self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.DescendToEndstopHelper(
-            config, self, self.probe_offsets, self.param_helper)
-        self.probe_session = probe.ProbeSessionHelper(
-            config, self.param_helper, self.homing_helper.start_probe_session)
         # SmartEffector control
         control_pin = config.get('control_pin', None)
         if control_pin:
@@ -87,14 +78,6 @@ class SmartEffectorProbe:
         self.gcode.register_command("SET_SMART_EFFECTOR",
                                     self.cmd_SET_SMART_EFFECTOR,
                                     desc=self.cmd_SET_SMART_EFFECTOR_help)
-    def get_probe_params(self, gcmd=None):
-        return self.param_helper.get_probe_params(gcmd)
-    def get_offsets(self, gcmd=None):
-        return self.probe_offsets.get_offsets(gcmd)
-    def get_status(self, eventtime):
-        return self.cmd_helper.get_status(eventtime)
-    def start_probe_session(self, gcmd):
-        return self.probe_session.start_probe_session(gcmd)
     def probe_prepare(self):
         toolhead = self.printer.lookup_object('toolhead')
         self.probe_wrapper.probe_prepare()
@@ -164,7 +147,28 @@ class SmartEffectorProbe:
         self._send_command(buf)
         gcmd.respond_info('SmartEffector sensitivity was reset')
 
+class PrinterSmartEffector:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.mcu_probe = SmartEffectorProbe(config)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self,
+                                                   self.mcu_probe.query_endstop)
+        self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        self.param_helper = probe.ProbeParameterHelper(config)
+        self.homing_helper = probe.DescendToEndstopHelper(
+            config, self.mcu_probe, self.probe_offsets, self.param_helper)
+        self.probe_session = probe.ProbeSessionHelper(
+            config, self.param_helper, self.homing_helper.start_probe_session)
+    def get_probe_params(self, gcmd=None):
+        return self.param_helper.get_probe_params(gcmd)
+    def get_offsets(self, gcmd=None):
+        return self.probe_offsets.get_offsets(gcmd)
+    def get_status(self, eventtime):
+        return self.cmd_helper.get_status(eventtime)
+    def start_probe_session(self, gcmd):
+        return self.probe_session.start_probe_session(gcmd)
+
 def load_config(config):
-    smart_effector = SmartEffectorProbe(config)
+    smart_effector = PrinterSmartEffector(config)
     config.get_printer().add_object('probe', smart_effector)
     return smart_effector

--- a/test/klippy/smart_effector.cfg
+++ b/test/klippy/smart_effector.cfg
@@ -1,0 +1,77 @@
+# Test config for smart_effector
+[stepper_x]
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PE5
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_y]
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PJ1
+position_endstop: 0
+position_max: 200
+homing_speed: 50
+
+[stepper_z]
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
+microsteps: 16
+rotation_distance: 8
+endstop_pin: probe:z_virtual_endstop
+position_max: 200
+
+[extruder]
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
+microsteps: 16
+rotation_distance: 33.5
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PB4
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK5
+control: pid
+pid_Kp: 22.2
+pid_Ki: 1.08
+pid_Kd: 114
+min_temp: 0
+max_temp: 250
+
+[heater_bed]
+heater_pin: PH5
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PK6
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[smart_effector]
+pin: PC7
+control_pin: PC5
+probe_accel: 50
+z_offset: 1.15
+
+[bed_mesh]
+mesh_min: 10,10
+mesh_max: 180,180
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/smart_effector.test
+++ b/test/klippy/smart_effector.test
@@ -1,0 +1,30 @@
+# Test case for smart_effector support
+CONFIG smart_effector.cfg
+DICTIONARY atmega2560.dict
+
+# Start by homing the printer.
+G28
+G1 F6000
+
+# Z / X / Y moves
+G1 Z1
+G1 X1
+G1 Y1
+
+# Run bed_mesh_calibrate
+BED_MESH_CALIBRATE
+
+# Move again
+G1 Z5 X0 Y0
+
+# smart effector commands
+SET_SMART_EFFECTOR SENSITIVITY=99
+RESET_SMART_EFFECTOR SENSITIVITY=99
+SET_SMART_EFFECTOR SENSITIVITY=89
+
+# Do regular probe
+PROBE
+QUERY_PROBE
+
+# Move again
+G1 Z9


### PR DESCRIPTION
This PR refactors the homing/probing code and adds support for homing the Z axis using probe_eddy_current and load_cell_probe via the standard "probe:z_virtual_endstop" mechanism.

Previously, both of these probe types could not emulate an "endstop", and so they required strange hacks to home with them.  Basically, they required one to use "PROBE" followed by "SET_KINEMATIC_POSITION".

This PR changes the G28 homing code to detect the "probe:z_virtual_endstop" usage, and it will now effectively implement "PROBE" followed by "SET_KINEMATIC_POSITION" itself.  This is done for all probe types (not just eddy and loadcell).  This has the advantage of simplifying the probe code, as it reduces the amount of "endstop" emulation on all probes.

As part of this PR, I have enabled "probe:z_virtual_endstop" on load cells.  I have also updated the Probe_Eddy.md document to no longer recommend the homing correction macros.

I've tested this PR on my local printers, but I do not have loadcell, bltouch, or smart_effector hardware.  Testing feedback is appreciated.  If you do test, let me know your results (success or failure).

FYI - @nefelim4ag, @dmbutyugin , @garethky .

-Kevin