### PR TITLE
mathutil: Optimizations of matrix multiplications and gaussian solve

### DIFF
--- a/klippy/mathutil.py
+++ b/klippy/mathutil.py
@@ -189,8 +189,7 @@ def gaussian_solve(a, rhs, allow_underdetermined=False):
     # Perform the LU-decomposition through Gaussian elimination
     for i in range(n):
         # Find a pivot and swap the corresponding rows
-        abs_col = [abs(m[j][i]) for j in range(i, n)]
-        j = abs_col.index(max(abs_col)) + i
+        j = max(range(i, n), key=lambda jj: abs(m[jj][i]))
         if i != j:
             m[i], m[j] = m[j], m[i]
             res[i], res[j] = res[j], res[i]
@@ -202,19 +201,23 @@ def gaussian_solve(a, rhs, allow_underdetermined=False):
             recipr = 0.
         else:
             recipr = 1. / m[i][i]
-        m[i][i+1:] = [mij * recipr for mij in m[i][i+1:]]
-        res[i][:] = [rij * recipr for rij in res[i]]
-        m[i][i] = 1.
-
-        # Zero-out the i-th column after the row i
         mi = m[i]
         ri = res[i]
         for j in range(i+1, n):
+            mi[j] *= recipr
+        for j in range(len(res[i])):
+            ri[j] *= recipr
+        mi[i] = 1.
+
+        # Zero-out the i-th column after the row i
+        for j in range(i+1, n):
             mj = m[j]
             c = mj[i]
-            mj[i:] = [mjk - c * mik for mjk, mik in zip(mj[i:], mi[i:])]
+            for k in range(i, n):
+                mj[k] -= c * mi[k]
             rj = res[j]
-            rj[:] = [rjk - c * rik for rjk, rik in zip(rj, ri)]
+            for k in range(len(rj)):
+                rj[k] -= c * ri[k]
 
     # Solve the system with the upper-triangular matrix
     for i in range(n-2, -1, -1):
@@ -223,7 +226,8 @@ def gaussian_solve(a, rhs, allow_underdetermined=False):
         for j in range(i+1, n):
             c = mi[j]
             rj = res[j]
-            ri[:] = [rik - c * rjk for rik, rjk in zip(ri, rj)]
+            for k in range(len(ri)):
+                ri[k] -= c * rj[k]
     return res
 
 def pseudo_inverse(m):

--- a/klippy/mathutil.py
+++ b/klippy/mathutil.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2025-2026  Dmitry Butyugin <dmbutyugin@google.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import copy, math, logging, multiprocessing, traceback
+import math, logging, multiprocessing, traceback
 import queuelogger
 
 
@@ -154,7 +154,8 @@ def mat_mat_mul(a, b):
     cols_b = len(b[0])
     if cols_a != rows_b:
         return None
-    return [[sum([a[i][k] * b[k][j] for k in range(rows_b)])
+    bt = mat_transp(b)
+    return [[sum([aik * bkj for aik, bkj in zip(a[i], bt[j])])
              for j in range(cols_b)]
             for i in range(rows_a)]
 
@@ -166,18 +167,24 @@ def mat_transp_mul(a, b):
     cols_b = len(b[0])
     if cols_at != rows_b:
         return None
+    at = mat_transp(a)
+    bt = mat_transp(b) if a is not b else at
     res = [[0.] * cols_b for i in range(rows_at)]
     for i in range(rows_at):
-        for j in range(cols_b):
-            if a is b and j < i:
-                res[i][j] = res[j][i]
-                continue
-            res[i][j] = sum([a[k][i] * b[k][j] for k in range(rows_b)])
+        if a is b:
+            res[i][:i] = [r[i] for r in res[:i]]
+            j_start = i
+        else:
+            j_start = 0
+        axi = at[i]
+        for j in range(j_start, cols_b):
+            bxj = bt[j]
+            res[i][j] = sum([aki * bkj for aki, bkj in zip(axi, bxj)])
     return res
 
 def gaussian_solve(a, rhs, allow_underdetermined=False):
-    res = copy.deepcopy(rhs)
-    m = copy.deepcopy(a)
+    res = [row[:] for row in rhs]
+    m = [row[:] for row in a]
     n = len(m)
     # Perform the LU-decomposition through Gaussian elimination
     for i in range(n):
@@ -195,25 +202,28 @@ def gaussian_solve(a, rhs, allow_underdetermined=False):
             recipr = 0.
         else:
             recipr = 1. / m[i][i]
-        for j in range(i+1, n):
-            m[i][j] *= recipr
-        for j in range(len(res[i])):
-            res[i][j] *= recipr
+        m[i][i+1:] = [mij * recipr for mij in m[i][i+1:]]
+        res[i][:] = [rij * recipr for rij in res[i]]
         m[i][i] = 1.
 
         # Zero-out the i-th column after the row i
+        mi = m[i]
+        ri = res[i]
         for j in range(i+1, n):
-            c = m[j][i]
-            for k in range(i, n):
-                m[j][k] -= c * m[i][k]
-            for k in range(len(res[j])):
-                res[j][k] -= c * res[i][k]
+            mj = m[j]
+            c = mj[i]
+            mj[i:] = [mjk - c * mik for mjk, mik in zip(mj[i:], mi[i:])]
+            rj = res[j]
+            rj[:] = [rjk - c * rik for rjk, rik in zip(rj, ri)]
 
     # Solve the system with the upper-triangular matrix
     for i in range(n-2, -1, -1):
+        mi = m[i]
+        ri = res[i]
         for j in range(i+1, n):
-            for k in range(len(res[j])):
-                res[i][k] -= m[i][j] * res[j][k]
+            c = mi[j]
+            rj = res[j]
+            ri[:] = [rik - c * rjk for rik, rjk in zip(ri, rj)]
     return res
 
 def pseudo_inverse(m):


### PR DESCRIPTION
Notable optimizations include:

- transposing appropriate matrices in matrix-matrix multiplications to ensure optimal lists traversals
- use list comprehensions to improve performance of per-row operations

I ran some tests on my RPi4. Baseline:

|       Case |      A^T A |      A^T b |     GSolve |      Total | A^T A% | A^T b% | GSolve%|
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
|    64x64   |    0.0455s |    0.0017s |    0.0394s |    0.0866s |  52.5% |   2.0% |  45.5% |
|  128x128  |    0.3328s |    0.0054s |    0.3332s |    0.6714s |  49.6% |   0.8% |  49.6% |
|  256x256  |    2.9712s |    0.0252s |    2.0338s |    5.0303s |  59.1% |   0.5% |  40.4% |
|   400x64   |    0.2692s |    0.0086s |    0.0392s |    0.3170s |  84.9% |   2.7% |  12.4% |

And this optimized version:
|       Case |      A^T A |      A^T b |     GSolve |      Total | A^T A% | A^T b% | GSolve%|
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
|    64x64   |    0.0269s |    0.0016s |    0.0330s |    0.0615s |  43.8% |   2.6% |  53.6% |
|   128x128  |    0.1992s |    0.0059s |    0.2050s |    0.4101s |  48.6% |   1.4% |  50.0% |
|   256x256  |    1.7634s |    0.0257s |    1.5958s |    3.3849s |  52.1% |   0.8% |  47.1% |
|   400x64   |    0.1707s |    0.0092s |    0.0329s |    0.2129s |  80.2% |   4.3% |  15.5% |

So, the total runtime has reduced by 30-35%, and the **A^T A** performance was improved by ~40%, while gaussian_solve was improved by 15-20%. It was also called out in #7266 that it was not feasible to convert `angle.py` to use this solver instead of the one from `numpy` due to low performance, but perhaps now this becomes a bit more feasible.