### PR TITLE
Improve mcu transmit buffer utilization

### DIFF
--- a/scripts/buildcommands.py
+++ b/scripts/buildcommands.py
@@ -354,7 +354,9 @@ class HandleCommandGeneration:
             max_size = min(msgproto.MESSAGE_MAX,
                            (msgproto.MESSAGE_MIN + msgid_size
                             + sum([t.max_length for t in param_types])))
-            out += "    .max_size=%d," % (max_size,)
+            min_size = min(msgproto.MESSAGE_MAX,
+                           msgproto.MESSAGE_MIN + msgid_size + len(param_types))
+            out += "    .max_size=%d,\n    .min_size=%d" % (max_size, min_size)
         return out
     def generate_responses_code(self):
         encoder_defs = []

--- a/src/ar100/main.c
+++ b/src/ar100/main.c
@@ -115,7 +115,7 @@ void
 console_sendf(const struct command_encoder *ce, va_list args)
 {
     uint8_t buf[MESSAGE_MAX];
-    uint_fast8_t msglen = command_encode_and_frame(buf, ce, args);
+    uint_fast8_t msglen = command_encode_and_frame(buf, sizeof(buf), ce, args);
 
     for(int i=0; i<msglen; i++) {
         r_uart_putc(buf[i]);

--- a/src/command.c
+++ b/src/command.c
@@ -131,20 +131,23 @@ error:
 
 // Encode a message
 static uint_fast8_t
-command_encodef(uint8_t *buf, const struct command_encoder *ce, va_list args)
+command_encodef(uint8_t *buf, uint_fast8_t buf_size
+                , const struct command_encoder *ce, va_list args)
 {
     uint_fast8_t max_size = READP(ce->max_size);
     if (max_size <= MESSAGE_MIN)
         // Ack/Nak message
         return max_size;
+    if (buf_size < max_size)
+        max_size = buf_size;
     uint8_t *p = &buf[MESSAGE_HEADER_SIZE];
     uint8_t *maxend = &p[max_size - MESSAGE_MIN];
     uint_fast8_t num_params = READP(ce->num_params);
     const uint8_t *param_types = READP(ce->param_types);
     p = encode_msgid(p, READP(ce->encoded_msgid));
     while (num_params--) {
-        if (p > maxend)
-            goto error;
+        if (p + 2 > maxend)
+            goto need_space;
         uint_fast8_t t = READP(*param_types);
         param_types++;
         uint32_t v;
@@ -165,7 +168,7 @@ command_encodef(uint8_t *buf, const struct command_encoder *ce, va_list args)
             break;
         case PT_string: {
             uint8_t *s = va_arg(args, uint8_t*), *lenp = p++;
-            while (*s && p<maxend)
+            while (*s && p<=maxend)
                 *p++ = *s++;
             *lenp = p-lenp-1;
             break;
@@ -173,8 +176,8 @@ command_encodef(uint8_t *buf, const struct command_encoder *ce, va_list args)
         case PT_progmem_buffer:
         case PT_buffer: {
             v = va_arg(args, int);
-            if (v > maxend-p)
-                v = maxend-p;
+            if (v >= maxend-p)
+                goto need_space;
             *p++ = v;
             uint8_t *s = va_arg(args, uint8_t*);
             if (t == PT_progmem_buffer)
@@ -188,7 +191,11 @@ command_encodef(uint8_t *buf, const struct command_encoder *ce, va_list args)
             goto error;
         }
     }
+    if (p > maxend)
+        goto need_space;
     return p - buf + MESSAGE_TRAILER_SIZE;
+need_space:
+    return 0;
 error:
     shutdown("Message encode error");
 }
@@ -207,11 +214,12 @@ command_add_frame(uint8_t *buf, uint_fast8_t msglen)
 
 // Encode a message and then add a message block frame around it
 uint_fast8_t
-command_encode_and_frame(uint8_t *buf, const struct command_encoder *ce
-                         , va_list args)
+command_encode_and_frame(uint8_t *buf, uint_fast8_t buf_size
+                         , const struct command_encoder *ce, va_list args)
 {
-    uint_fast8_t msglen = command_encodef(buf, ce, args);
-    command_add_frame(buf, msglen);
+    uint_fast8_t msglen = command_encodef(buf, buf_size, ce, args);
+    if (msglen)
+        command_add_frame(buf, msglen);
     return msglen;
 }
 

--- a/src/command.h
+++ b/src/command.h
@@ -58,7 +58,7 @@
 
 struct command_encoder {
     uint16_t encoded_msgid;
-    uint8_t max_size, num_params;
+    uint8_t max_size, min_size, num_params;
     const uint8_t *param_types;
 };
 struct command_parser {
@@ -77,8 +77,9 @@ void *command_decode_ptr(uint32_t v);
 uint_fast16_t command_parse_msgid(uint8_t **pp);
 uint8_t *command_parsef(uint8_t *p, uint8_t *maxend
                         , const struct command_parser *cp, uint32_t *args);
-uint_fast8_t command_encode_and_frame(
-    uint8_t *buf, const struct command_encoder *ce, va_list args);
+uint_fast8_t command_encode_and_frame(uint8_t *buf, uint_fast8_t bus_size
+                                      , const struct command_encoder *ce
+                                      , va_list args);
 void command_sendf(const struct command_encoder *ce, ...);
 int_fast8_t command_find_block(uint8_t *buf, uint_fast8_t buf_len
                                , uint_fast8_t *pop_count);

--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -86,9 +86,8 @@ console_sendf(const struct command_encoder *ce, va_list args)
     uint32_t tpos = CanData.transmit_pos, tmax = CanData.transmit_max;
     if (tpos >= tmax)
         CanData.transmit_pos = CanData.transmit_max = tpos = tmax = 0;
-    uint32_t max_size = ce->max_size;
-    if (tmax + max_size > sizeof(CanData.transmit_buf)) {
-        if (tmax + max_size - tpos > sizeof(CanData.transmit_buf))
+    if (tmax + ce->max_size > sizeof(CanData.transmit_buf)) {
+        if (tmax - tpos + ce->min_size > sizeof(CanData.transmit_buf))
             // Not enough space for message
             return;
         // Move buffer
@@ -99,8 +98,11 @@ console_sendf(const struct command_encoder *ce, va_list args)
     }
 
     // Generate message
-    uint32_t msglen = command_encode_and_frame(&CanData.transmit_buf[tmax]
-                                               , ce, args);
+    uint32_t msglen = command_encode_and_frame(
+        &CanData.transmit_buf[tmax], sizeof(CanData.transmit_buf) - tmax
+        , ce, args);
+    if (!msglen)
+        return;
 
     // Start message transmit
     CanData.transmit_max = tmax + msglen;

--- a/src/generic/canserial.c
+++ b/src/generic/canserial.c
@@ -35,7 +35,7 @@ static struct canbus_data {
 
     // Transfer buffers
     struct canbus_msg admin_queue[8];
-    uint8_t transmit_buf[96];
+    uint8_t transmit_buf[192];
     uint8_t receive_buf[192];
 } CanData;
 

--- a/src/generic/serial_irq.c
+++ b/src/generic/serial_irq.c
@@ -100,9 +100,8 @@ console_sendf(const struct command_encoder *ce, va_list args)
         writeb(&transmit_max, 0);
         writeb(&transmit_pos, 0);
     }
-    uint_fast8_t max_size = READP(ce->max_size);
-    if (tmax + max_size > sizeof(transmit_buf)) {
-        if (tmax + max_size - tpos > sizeof(transmit_buf))
+    if (tmax + READP(ce->max_size) > sizeof(transmit_buf)) {
+        if (tmax - tpos + READP(ce->min_size) > sizeof(transmit_buf))
             // Not enough space for message
             return;
         // Disable TX irq and move buffer
@@ -117,7 +116,10 @@ console_sendf(const struct command_encoder *ce, va_list args)
 
     // Generate message
     uint8_t *buf = &transmit_buf[tmax];
-    uint_fast8_t msglen = command_encode_and_frame(buf, ce, args);
+    uint_fast8_t msglen = command_encode_and_frame(
+        buf, sizeof(transmit_buf) - tmax, ce, args);
+    if (!msglen)
+        return;
 
     // Start message transmit
     writeb(&transmit_max, tmax + msglen);

--- a/src/generic/usb_cdc.c
+++ b/src/generic/usb_cdc.c
@@ -68,14 +68,17 @@ void
 console_sendf(const struct command_encoder *ce, va_list args)
 {
     // Verify space for message
-    uint_fast8_t tpos = transmit_pos, max_size = READP(ce->max_size);
-    if (tpos + max_size > sizeof(transmit_buf))
+    uint_fast8_t tpos = transmit_pos;
+    if (tpos + READP(ce->min_size) > sizeof(transmit_buf))
         // Not enough space for message
         return;
 
     // Generate message
     uint8_t *buf = &transmit_buf[tpos];
-    uint_fast8_t msglen = command_encode_and_frame(buf, ce, args);
+    uint_fast8_t msglen = command_encode_and_frame(
+        buf, sizeof(transmit_buf) - tpos, ce, args);
+    if (!msglen)
+        return;
 
     // Start message transmit
     transmit_pos = tpos + msglen;

--- a/src/linux/console.c
+++ b/src/linux/console.c
@@ -170,7 +170,9 @@ console_sendf(const struct command_encoder *ce, va_list args)
 {
     // Generate message
     uint8_t buf[MESSAGE_MAX];
-    uint_fast8_t msglen = command_encode_and_frame(buf, ce, args);
+    uint_fast8_t msglen = command_encode_and_frame(buf, sizeof(buf), ce, args);
+    if (!msglen)
+        return;
 
     // Transmit message
     int ret = write(main_pfd[MP_TTY_IDX].fd, buf, msglen);

--- a/src/pru/pru0.c
+++ b/src/pru/pru0.c
@@ -97,7 +97,8 @@ check_can_send(void)
         }
         // Encode and build message
         uint8_t *data = get_transmit_ptr(&ce);
-        int msglen = command_encode_and_frame(data, &ce, (void*)local_args);
+        int msglen = command_encode_and_frame(data, ce.max_size
+                                              , &ce, (void*)local_args);
         if (readl(&SHARED_MEM->next_encoder) != rce)
             continue;
         writel(&SHARED_MEM->next_encoder, 0);
@@ -244,7 +245,7 @@ void
 console_sendf(const struct command_encoder *ce, va_list args)
 {
     uint8_t *data = get_transmit_ptr(ce);
-    int msglen = command_encode_and_frame(data, ce, args);
+    int msglen = command_encode_and_frame(data, ce->max_size, ce, args);
     finalize_transmit(msglen);
 }
 


### PR DESCRIPTION
PR #7202 changed the format of ADC response commands.  A side effect of that change is that the maximum message size of those ADC messages is 64 bytes, even though most ADC messages are far smaller than that.  (As mentioned at https://github.com/Klipper3d/klipper/pull/7202#issuecomment-4166489477 .)

That change could increase the chance of lost ADC messages during periods of high message traffic.  This PR reworks the low-level response message building to better handle low buffer situations - it'll no longer discard a message if the buffer can't fit the maximum message size - instead it'll try to build the message as long as there is enough space for the minimum message size.  This should eliminate the side effect of PR #7202 and improve buffer utilization in general.

This PR also increases the `transmit_buf` size on CANbus mcus (increase from 96 to 192 bytes).  Only ARM based MCUs currently support CANbus, and these MCUs have plenty of ram.

@nefelim4ag - fyi.

-Kevin