### PR TITLE
load_cell: Fixed error reporting, added sensor fields to status

### DIFF
--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -316,22 +316,29 @@ The following information is available for each `[led led_name]`,
 ## load_cell
 
 The following information is available for each `[load_cell name]`:
-- 'is_calibrated': True/False is the load cell calibrated
-- 'counts_per_gram': The number of raw sensor counts that equals 1 gram of force
-- 'reference_tare_counts': The reference number of raw sensor counts for 0 force
-- 'tare_counts': The current number of raw sensor counts for 0 force
-- 'force_g': The force in grams, averaged over the last polling period.
-- 'min_force_g': The minimum force in grams, over the last polling period.
-- 'max_force_g': The maximum force in grams, over the last polling period.
+- `is_calibrated`: True/False whether the load cell is calibrated.
+- `counts_per_gram`: The number of raw sensor counts that equals 1 gram of force.
+- `reference_tare_counts`: The reference number of raw sensor counts for 0 force.
+- `tare_counts`: The current number of raw sensor counts for 0 force.
+- `force_g`: The force in grams, averaged over the last polling period.
+- `min_force_g`: The minimum force in grams, over the last polling period.
+- `max_force_g`: The maximum force in grams, over the last polling period.
+- `errors`: The number of sensor errors detected since the last start
+  of measurements.
+- `overflows`: The number of data buffer overflows detected since the last
+  start of measurements.
+- `sample_rate`: The sensor's sample rate in samples per second.
 
 ## load_cell_probe
 
 The following information is available for `[load_cell_probe]`:
 - all items from [load_cell](Status_Reference.md#load_cell)
 - all items from [probe](Status_Reference.md#probe)
-- 'endstop_tare_counts': the load cell probe keeps a tare value independent of
-the load cell. This re-set at the start of each probe.
-- 'last_trigger_time': timestamp of the last homing trigger
+- `endstop_tare_counts`: The load cell probe keeps a tare value independent of
+  the load cell. This is re-set at the start of each probe.
+- `last_trigger_time`: Timestamp of the last homing trigger.
+- `last_z_result`: The Z position result of the last tap.
+- `is_last_tap_valid`: True if the last tap result is valid.
 
 ## manual_probe
 

--- a/klippy/extras/ads1220.py
+++ b/klippy/extras/ads1220.py
@@ -120,6 +120,13 @@ class ADS1220:
     def get_samples_per_second(self):
         return self.sps
 
+    def get_status(self, eventtime):
+        return {
+            'errors': self.last_error_count,
+            'overflows': self.ffreader.get_last_overflows(),
+            'sample_rate': self.get_samples_per_second(),
+        }
+
     def lookup_sensor_error(self, error_code):
         return "Unknown ads1220 error" % (error_code,)
 

--- a/klippy/extras/ads131m0x.py
+++ b/klippy/extras/ads131m0x.py
@@ -209,6 +209,13 @@ class ADS131M0X:
     def get_samples_per_second(self):
         return self.sps
 
+    def get_status(self, eventtime):
+        return {
+            'errors': self.last_error_count,
+            'overflows': self.ffreader.get_last_overflows(),
+            'sample_rate': self.get_samples_per_second(),
+        }
+
     def lookup_sensor_error(self, error_code):
         return self._sensor_errors.get(error_code,
                                        "Unknown %s error" % (self.sensor_type,))

--- a/klippy/extras/hx71x.py
+++ b/klippy/extras/hx71x.py
@@ -78,6 +78,13 @@ class HX71xBase:
     def get_samples_per_second(self):
         return self.sps
 
+    def get_status(self, eventtime):
+        return {
+            'errors': self.last_error_count,
+            'overflows': self.ffreader.get_last_overflows(),
+            'sample_rate': self.get_samples_per_second(),
+        }
+
     def lookup_sensor_error(self, error_code):
         return "Unknown hx71x error %d" % (error_code,)
 

--- a/klippy/extras/load_cell.py
+++ b/klippy/extras/load_cell.py
@@ -323,10 +323,12 @@ class LoadCellSampleCollector:
         while self.is_started:
             now = self._reactor.monotonic()
             if self._mcu.estimated_print_time(now) > timeout:
-                _, (errors, overflows) = self._finish_collecting()
+                samples, err = self._finish_collecting()
+                errors, overflows = err if err else (0, 0)
                 raise self._printer.command_error(
-                    "LoadCellSampleCollector timed out! Errors: %i,"
-                    " Overflows: %i" % (errors, overflows))
+                    "LoadCellSampleCollector timed out! Collected %i samples,"
+                    " Errors: %i, Overflows: %i" % (len(samples), errors,
+                                                    overflows))
             if self._mcu.is_fileoutput():
                 break
             self._reactor.pause(now + RETRY_DELAY)

--- a/klippy/extras/load_cell.py
+++ b/klippy/extras/load_cell.py
@@ -286,12 +286,14 @@ class LoadCellSampleCollector:
         self._samples = []
         self._errors = 0
         self._overflows = 0
+        self._start_errors = 0
+        self._start_overflows = 0
 
     def _on_samples(self, msg):
         if not self.is_started:
             return False  # already stopped, ignore
-        self._errors += msg['errors']
-        self._overflows += msg['overflows']
+        self._errors = msg['errors']
+        self._overflows = msg['overflows']
         samples = msg['data']
         for sample in samples:
             time = sample[0]
@@ -310,9 +312,9 @@ class LoadCellSampleCollector:
         self.min_count = float("inf")  # In Python 3.5 math.inf is better
         samples = self._samples
         self._samples = []
-        errors = self._errors
+        errors = max(0, self._errors - self._start_errors)
         self._errors = 0
-        overflows = self._overflows
+        overflows = max(0, self._overflows - self._start_overflows)
         self._overflows = 0
         if self._mcu.is_fileoutput():
             samples = [(0., 0., 0.)]
@@ -340,6 +342,10 @@ class LoadCellSampleCollector:
             return
         self.min_time = min_time if min_time is not None else self.min_time
         self.is_started = True
+        sensor_status = self._load_cell.sensor.get_status(
+            self._reactor.monotonic())
+        self._start_errors = sensor_status['errors']
+        self._start_overflows = sensor_status['overflows']
         self._load_cell.add_client(self._on_samples)
 
     # stop collecting immediately and return results
@@ -519,6 +525,7 @@ class LoadCell:
                        'counts_per_gram': self.counts_per_gram,
                        'reference_tare_counts': self.reference_tare_counts,
                        'tare_counts': self.tare_counts})
+        status.update(self.sensor.get_status(eventtime))
         return status
 
 


### PR DESCRIPTION
The first commit 11a8553a28d66df1e4112153743db5dc2ebfef84 addresses a potential oversight in e5394f30699ac55aadc31b8991e8d4292411b892 commit: the sensor could return insufficient/no samples without errors, which would trigger a crash. The second commit addresses a discussion from PR #7264 that load_cell currently reports incorrect number of errors and overflows detected during an operation. It also adds ADC fields to load_cell/load_cell_probe status. And I have updated the documentation to add the missing status fields, along with some minor formatting fixes.