### PR TITLE
ads131m0x: Optimized timer scheduling to attain higher sampling rates

### DIFF
--- a/src/sensor_ads131m0x.c
+++ b/src/sensor_ads131m0x.c
@@ -6,6 +6,7 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <stdint.h>
+#include <string.h> // memset
 #include "basecmd.h" // oid_alloc
 #include "board/gpio.h" // gpio_in_setup
 #include "board/irq.h" // irq_disable
@@ -21,10 +22,20 @@ struct ads131m0x_adc {
     uint32_t rest_ticks;
     struct gpio_in data_ready;
     struct spidev_s *spi;
-    uint8_t pending_flag, data_count, was_reset;
+    uint8_t frame_size, data_offset;
+    uint8_t flags, continuous_reads;
     uint8_t channel, num_channels;
     struct sensor_bulk sb;
     struct trigger_analog *ta;
+};
+
+enum {
+    RESCHEDULE_TIMER = 1
+};
+
+enum {
+    FLAG_PENDING = 1<<0,
+    FLAG_RESET = 1<<1
 };
 
 // Internal errors transmitted to trigger_analog
@@ -71,14 +82,13 @@ ads131m0x_is_data_ready(struct ads131m0x_adc *ads131m0x) {
 
 // CCITT CRC-16 calculation (polynomial 0x1021, init 0xFFFF, optimized version)
 static uint16_t
-ads131m0x_crc16_ccitt(const uint8_t *data, uint8_t len)
+ads131m0x_crc16_ccitt(const uint8_t *data, uint_fast8_t len)
 {
     uint16_t crc = 0xFFFF;
     while (len--) {
-        uint8_t x = (crc >> 8) ^ *data++;
+        uint16_t x = (crc >> 8) ^ *data++;
         x ^= x >> 4;
-        crc = (crc << 8) ^ ((uint16_t)x << 12) ^ ((uint16_t)x << 5)
-            ^ (uint16_t)x;
+        crc = (crc << 8) ^ (x << 12) ^ (x << 5) ^ x;
     }
     return crc;
 }
@@ -92,6 +102,20 @@ ads131m0x_has_crc_error(uint8_t *msg, uint8_t frame_size)
     return calc_crc != frame_crc;
 }
 
+// Helper code to reschedule the ads131m0x_event() timer
+static void
+ads131m0x_reschedule_timer(struct ads131m0x_adc *ads131m0x)
+{
+    // The event handler will check the data availability
+    ads131m0x->flags &= ~FLAG_PENDING;
+    irq_disable();
+    uint32_t waketime = timer_read_time() + ads131m0x->rest_ticks;
+    if (timer_is_before(ads131m0x->timer.waketime, waketime))
+        ads131m0x->timer.waketime = waketime;
+    sched_add_timer(&ads131m0x->timer);
+    irq_enable();
+}
+
 // Event handler that periodically wakes the capture task
 static uint_fast8_t
 ads131m0x_event(struct timer *timer)
@@ -99,13 +123,11 @@ ads131m0x_event(struct timer *timer)
     struct ads131m0x_adc *ads131m0x = container_of(
             timer, struct ads131m0x_adc, timer);
     uint32_t rest_ticks = ads131m0x->rest_ticks;
-    if (ads131m0x->pending_flag) {
-        ads131m0x->sb.possible_overflows++;
-        rest_ticks *= 4;
-    } else if (ads131m0x_is_data_ready(ads131m0x)) {
-        ads131m0x->pending_flag = 1;
+    if (ads131m0x_is_data_ready(ads131m0x)) {
+        ads131m0x->flags |= FLAG_PENDING;
         sched_wake_task(&wake_ads131m0x);
-        rest_ticks *= 8;
+        ads131m0x->timer.waketime += rest_ticks << 3;
+        return SF_DONE;
     }
     ads131m0x->timer.waketime += rest_ticks;
     return SF_RESCHEDULE;
@@ -131,36 +153,34 @@ ads131m0x_publish_error(struct ads131m0x_adc *ads131m0x, uint8_t oid
 }
 
 // Send a NULL command frame and read conversion data from all channels.
-// Returns sample from the configured channel.
-static void
+// Appends a sample from the configured channel to the buffer.
+// Returns RESCHEDULE_TIMER if a new timer even task should be rescheduled.
+static uint_fast8_t
 ads131m0x_read_adc(struct ads131m0x_adc *ads131m0x, uint8_t oid)
 {
-    uint8_t frame_size = (ADS131M0X_STATUS_WORDS + ads131m0x->num_channels
-                          + ADS131M0X_CRC_WORDS) * ADS131M0X_WORD_SIZE;
-    uint8_t msg[ADS131M0X_MAX_FRAME_SIZE] = {0};
+    uint8_t frame_size = ads131m0x->frame_size;
+    // Frame layout: status(3), channel[0](3), channel[1](3), ..., crc(3)
+    // Data is 24-bit two's complement, MSB first
+    uint8_t msg[frame_size];
+    memset(msg, 0, frame_size);
     spidev_transfer(ads131m0x->spi, 1, frame_size, msg);
-    ads131m0x->pending_flag = 0;
-    barrier();
 
     // Validate CRC
     if (ads131m0x_has_crc_error(msg, frame_size)) {
         ads131m0x_publish_error(ads131m0x, oid, SE_ERROR_CRC);
-        return;
+        return RESCHEDULE_TIMER;
     }
 
     // Check for unexpected sensor reset
     if (msg[0] & STATUS_RESET_BIT) {
-        ads131m0x->was_reset = 1;
+        ads131m0x->flags |= FLAG_RESET;
     }
-    if (ads131m0x->was_reset) {
+    if (ads131m0x->flags & FLAG_RESET) {
         ads131m0x_publish_error(ads131m0x, oid, SE_ERROR_RESET);
-        return;
+        return RESCHEDULE_TIMER;
     }
 
-    // Frame layout: status(3), channel[0](3), channel[1](3), ..., crc(3)
-    // Data is 24-bit two's complement, MSB first
-    uint8_t data_offset = ADS131M0X_STATUS_WORDS * ADS131M0X_WORD_SIZE
-        + ads131m0x->channel * ADS131M0X_WORD_SIZE;
+    uint_fast8_t data_offset = ads131m0x->data_offset;
     uint32_t raw = ((uint32_t)msg[data_offset] << 16)
         | ((uint32_t)msg[data_offset + 1] << 8)
         | ((uint32_t)msg[data_offset + 2]);
@@ -172,6 +192,21 @@ ads131m0x_read_adc(struct ads131m0x_adc *ads131m0x, uint8_t oid)
     trigger_analog_update(ads131m0x->ta, raw);
     buffer_append_int32(&ads131m0x->sb, raw);
     ads131m0x_flush_buffer(ads131m0x, oid);
+    if (unlikely(!ads131m0x_is_data_ready(ads131m0x))) {
+        ads131m0x->continuous_reads = 0;
+        return RESCHEDULE_TIMER;
+    }
+    if (unlikely(ads131m0x->continuous_reads >= 2)) {
+        // ADS131M0x FIFO can hold two readings
+        ads131m0x->sb.possible_overflows++;
+    } else {
+        ads131m0x->continuous_reads++;
+    }
+    // Delay the next timer event even further
+    ads131m0x->timer.waketime += ads131m0x->rest_ticks << 3;
+    // More data is available, wake up immediately
+    sched_wake_task(&wake_ads131m0x);
+    return 0;
 }
 
 // Create an ads131m0x sensor
@@ -181,7 +216,7 @@ command_config_ads131m0x(uint32_t *args)
     struct ads131m0x_adc *ads131m0x = oid_alloc(args[0]
             , command_config_ads131m0x, sizeof(*ads131m0x));
     ads131m0x->timer.func = ads131m0x_event;
-    ads131m0x->pending_flag = 0;
+    ads131m0x->flags = 0;
     ads131m0x->spi = spidev_oid_lookup(args[1]);
     ads131m0x->channel = (uint8_t)(args[2] & 0xFF);
     ads131m0x->num_channels = (uint8_t)(args[3] & 0xFF);
@@ -190,6 +225,10 @@ command_config_ads131m0x(uint32_t *args)
             ads131m0x->channel >= ads131m0x->num_channels)
         shutdown("Invalid ads131m0x channels configuration");
     ads131m0x->data_ready = gpio_in_setup(args[4], 0);
+    ads131m0x->frame_size = (ADS131M0X_STATUS_WORDS + ads131m0x->num_channels
+                             + ADS131M0X_CRC_WORDS) * ADS131M0X_WORD_SIZE;
+    ads131m0x->data_offset =
+        (ADS131M0X_STATUS_WORDS + ads131m0x->channel) * ADS131M0X_WORD_SIZE;
 }
 DECL_COMMAND(command_config_ads131m0x, "config_ads131m0x oid=%c"
     " spi_oid=%c channel=%c num_channels=%c data_ready_pin=%u");
@@ -212,14 +251,14 @@ command_query_ads131m0x(uint32_t *args)
     uint8_t oid = args[0];
     struct ads131m0x_adc *ads131m0x = oid_lookup(oid, command_config_ads131m0x);
     sched_del_timer(&ads131m0x->timer);
-    ads131m0x->pending_flag = 0;
+    ads131m0x->flags = 0;
     ads131m0x->rest_ticks = args[1];
     if (!ads131m0x->rest_ticks) {
         // End measurements
         return;
     }
     // Start new measurements
-    ads131m0x->was_reset = 0;
+    ads131m0x->continuous_reads = 0;
     sensor_bulk_reset(&ads131m0x->sb);
     irq_disable();
     ads131m0x->timer.waketime = timer_read_time() + ads131m0x->rest_ticks;
@@ -251,8 +290,10 @@ ads131m0x_capture_task(void)
     uint8_t oid;
     struct ads131m0x_adc *ads131m0x;
     foreach_oid(oid, ads131m0x, command_config_ads131m0x) {
-        if (ads131m0x->pending_flag)
-            ads131m0x_read_adc(ads131m0x, oid);
+        uint_fast8_t flags = ads131m0x->flags;
+        if (flags & FLAG_PENDING)
+            if (ads131m0x_read_adc(ads131m0x, oid) == RESCHEDULE_TIMER)
+                ads131m0x_reschedule_timer(ads131m0x);
     }
 }
 DECL_TASK(ads131m0x_capture_task);


### PR DESCRIPTION
The current scheduling appears to be suboptimal in that it may miss or report FIFO overruns when the MCU resources still allow to attain the corresponding sampling rate. For example, with Mellow ALPS board
```
[load_cell_probe]
sensor_type: ads131m02
cs_pin: fly_alps:PA15
spi_bus: spi1_PB4_PB5_PB3
spi_speed: 4000000
data_ready_pin: fly_alps:PB6
gain: 128
pwm_clock: static_pwm_clock fly_alps_clk
sample_rate: 8000
adc_channel: 0
counts_per_gram: 67.726962
reference_tare_counts: 797253
sensor_orientation: inverted
speed: 5
lift_speed: 15
trigger_force: 100.0
tare_time: 0.1
z_offset: 0.0
samples: 5
sample_retract_dist: 5.0
samples_result: average
samples_tolerance_retries: 10
samples_tolerance: 0.04

[static_pwm_clock fly_alps_clk]
pin: fly_alps:PA3
frequency: 8000000
```
the current code reports FIFO overflows, while the MCU waketime is still below 60% (see the charts below for waketime):
```
Sensor reported errors: 0 errors, 15 overflows
Samples Collected: 77916
Measured samples per second: 7812.9, configured: 7812.5
Good samples: 77916, Saturated samples: 0, Unique values: 14549
Sample range: [9.61% to 10.02%]
Sample range / sensor capacity: 0.20522%
```

The updated code can maintain that ~8 kSPS without issues. The new code follows the conventions for scheduling used by accelerometers, e.g. ADXL345 or MPU9250, but it retains the same wakeup times from the other loadcells to ensure quick reading of the new data once it becomes available.

Here's the comparison of the MCU wake times and load for the old and the new code:
| sample_rate | base | test |
|:--:|:--:|:--:|
| 500 | <img width="800" height="600" alt="klippy-base-500" src="https://github.com/user-attachments/assets/45e487e2-0744-4607-a07f-d831a738c465" /> |  <img width="800" height="600" alt="klippy-test-500" src="https://github.com/user-attachments/assets/535d8c74-b4c2-413c-ade3-f7b649cb8598" /> |
| 1000 |  <img width="800" height="600" alt="klippy-base-1000" src="https://github.com/user-attachments/assets/86155dde-df80-4af3-b63c-6d791e149880" /> |  <img width="800" height="600" alt="klippy-test-1000" src="https://github.com/user-attachments/assets/9fb01138-ab08-4e7f-a76d-47049abe17a8" /> |
| 2000 |  <img width="800" height="600" alt="klippy-base-2000" src="https://github.com/user-attachments/assets/2654969f-8c6c-479a-8f16-53bea2d094d2" /> |  <img width="800" height="600" alt="klippy-test-2000" src="https://github.com/user-attachments/assets/db43111e-9eba-49e8-9bf6-e0d7111041e4" /> |
| 4000 |  <img width="800" height="600" alt="klippy-base-4000" src="https://github.com/user-attachments/assets/4a3242ff-db83-472f-82b1-f84e6246ed33" /> |  <img width="800" height="600" alt="klippy-test-4000" src="https://github.com/user-attachments/assets/e55b39c6-e27f-4c31-9046-5514329b53b5" /> |
| 8000 | <img width="800" height="600" alt="klippy-base-8000" src="https://github.com/user-attachments/assets/4696884d-cf8b-4700-8b19-c591e4912def" /> | <img width="800" height="600" alt="klippy-test-8000" src="https://github.com/user-attachments/assets/8a087534-1974-470d-8f35-aa1d4be7719a" /> |

So, as one can see, the test code results in a slightly higher MCU waketime, but the increase is not very large. And while one can argue that being able to get 8 kSPS is not useful, the changes also mean that less capable MCUs will be able to attain higher sampling rates quite below 8 kSPS.