### PR TITLE
[RFC] Feature: Implement Region-Aware Filament Runout Pause

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5040,6 +5040,17 @@ more information.
 #   switch gcode. The switch must he held in a single state for at least
 #   this long to activate. If the switch is toggled on/off during this delay,
 #   the event is ignored. Default is 0.
+#extruder: extruder
+#   The name of the extruder or extruder_stepper section this sensor
+#   is associated with. This parameter is used to track the extrusion
+#   distance when using the runout_distance feature. The default is
+#   'extruder'.
+#runout_distance: 0.0
+#   The amount of filament (in mm) extruded after a runout is detected
+#   before a pause is enforced. When combined with SET_PRINT_FEATURE,
+#   this allows the pause to be deferred until the toolhead is in an
+#   infill area, protecting the cosmetic quality of the outer wall.
+#   A value of 0.0 disables this safety margin. Default is 0.0.
 #switch_pin:
 #   The pin on which the switch is connected. This parameter must be
 #   provided.
@@ -5069,6 +5080,7 @@ switch_pin:
 #insert_gcode:
 #event_delay:
 #pause_delay:
+#runout_distance:
 #   See the "filament_switch_sensor" section for a description of the
 #   above parameters.
 ```

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -536,6 +536,13 @@ depend on the sensor type defined in the configuration.
 filament sensor on/off. If ENABLE is set to 0, the filament sensor
 will be disabled, if set to 1 it is enabled.
 
+#### SET_PRINT_FEATURE
+`SET_PRINT_FEATURE FEATURE=<feature_code>`: Notifies the runout sensor of
+the current printing feature when combined with `runout_distance`. This
+allows pausing to be safely deferred until the toolhead reaches an
+infill area. `<feature_code>` must be `1` (Outer Wall), `2` (Infill), or
+`0` (Other). This command is typically injected by the slicer on role changes.
+
 ### [firmware_retraction]
 
 The following standard G-Code commands are available when the

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -540,8 +540,9 @@ will be disabled, if set to 1 it is enabled.
 `SET_PRINT_FEATURE FEATURE=<feature_code>`: Notifies the runout sensor of
 the current printing feature when combined with `runout_distance`. This
 allows pausing to be safely deferred until the toolhead reaches an
-infill area. `<feature_code>` must be `1` (Outer Wall), `2` (Infill), or
-`0` (Other). This command is typically injected by the slicer on role changes.
+infill area. `<feature_code>` must be `1` (Outer Wall), `2` (Infill),
+`3` (Bridge), or `0` (Other). This command is typically injected by the
+slicer on role changes.
 
 ### [firmware_retraction]
 

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,7 +1,11 @@
 # Generic Filament Sensor Module
 #
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+<<<<<<< Updated upstream
 # Copyright (C) 2026  Hwang Younsang <famtory@gmail.com>
+=======
+# Region-Aware Filament Runout Pause Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
+>>>>>>> Stashed changes
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,19 +1,13 @@
 # Generic Filament Sensor Module
 #
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
-# Region-Aware Filament Runout Pause Feature Concept & Implementation
-# Copyright (C) 2026 Famtory <famtory@gmail.com>
+# Copyright (C) 2026  Hwang Younsang <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 
 
 class RunoutHelper:
-    FEATURE_OTHER = 0
-    FEATURE_OUTER_WALL = 1
-    FEATURE_INFILL = 2
-    POLL_INTERVAL = 0.100
-
     def __init__(self, config):
         self.name = config.get_name().split()[-1]
         self.printer = config.get_printer()
@@ -34,29 +28,25 @@ class RunoutHelper:
         self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
         self.event_delay = config.getfloat('event_delay', 3., minval=.0)
         # Distance configuration
-        self.runout_distance = config.getfloat(
-            'runout_distance', 0., minval=0.)
+        self.runout_distance = config.getfloat('runout_distance', 0., minval=0.)
         self.extruder_name = config.get('extruder', 'extruder')
-        self.feature_history = [(0., self.FEATURE_OTHER)]
+        self.feature_history = [(0., 0)]
         self.deferred_runout = False
-        self.runout_trigger_pos = 0.
         self.runout_check_timer = None
         # Internal state
         self.min_event_systime = self.reactor.NEVER
         self.filament_present = False
         self.sensor_enabled = True
         # Register commands and event handlers
-        self.printer.register_event_handler(
-            "klippy:ready", self._handle_ready)
+        self.printer.register_event_handler("klippy:ready", self._handle_ready)
         self.printer.register_event_handler("filament_sensor:set_feature",
                                             self._handle_set_feature)
         try:
             self.gcode.register_command(
                 "SET_PRINT_FEATURE", self.cmd_SET_PRINT_FEATURE,
                 desc="Set current print feature for runout sensors")
-        except self.printer.config_error as e:
-            if "already registered" not in str(e):
-                raise
+        except self.printer.config_error:
+            pass
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_QUERY_FILAMENT_SENSOR,
@@ -70,11 +60,10 @@ class RunoutHelper:
         self.extruder = self.printer.lookup_object(self.extruder_name)
         self.estimated_print_time = (
             self.printer.lookup_object('mcu').estimated_print_time)
-        # Reset state on restart
-        self.feature_history = [(0., self.FEATURE_OTHER)]
+        self.feature_history = [(0., 0)]
         self.deferred_runout = False
     def cmd_SET_PRINT_FEATURE(self, gcmd):
-        feature = gcmd.get_int('FEATURE', self.FEATURE_OTHER)
+        feature = gcmd.get_int('FEATURE', 0)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_lookahead_callback(
             lambda pt: self.printer.send_event(
@@ -84,7 +73,7 @@ class RunoutHelper:
         if len(self.feature_history) > 100:
             self.feature_history.pop(0)
     def _get_feature_at_time(self, print_time):
-        current_feature = self.FEATURE_OTHER
+        current_feature = 0
         for pt, feature in self.feature_history:
             if pt <= print_time:
                 current_feature = feature
@@ -96,9 +85,10 @@ class RunoutHelper:
             return self.reactor.NEVER
         print_time = self.estimated_print_time(eventtime)
         current_feature = self._get_feature_at_time(print_time)
-        if current_feature == self.FEATURE_INFILL:
-            logging.info("Filament Sensor %s: Deferred runout pausing "
-                         "now on infill" % (self.name,))
+        if current_feature == 2:
+            logging.info(
+                "Filament Sensor %s: Deferred runout pausing "
+                "now on infill" % (self.name,))
             self.deferred_runout = False
             self.reactor.register_callback(self._runout_event_handler)
             return self.reactor.NEVER
@@ -106,13 +96,13 @@ class RunoutHelper:
         diff = current_pos - self.runout_trigger_pos
         if diff >= self.runout_distance:
             logging.info(
-                "Filament Sensor %s: runout distance limit reached "
-                "(%.2f / %.2f). Pausing now." %
+                "Filament Sensor %s: runout distance limit "
+                "reached (%.2f / %.2f). Pausing now." %
                 (self.name, diff, self.runout_distance))
             self.deferred_runout = False
             self.reactor.register_callback(self._runout_event_handler)
             return self.reactor.NEVER
-        return eventtime + self.POLL_INTERVAL
+        return eventtime + 0.100
     def _runout_event_handler(self, eventtime):
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.
@@ -136,13 +126,6 @@ class RunoutHelper:
             return
         self.filament_present = is_filament_present
 
-        if is_filament_present and self.deferred_runout:
-            self.deferred_runout = False
-            logging.info(
-                "Filament Sensor %s: filament reinserted, "
-                "clearing deferred runout" % (self.name,))
-            return
-
         if eventtime < self.min_event_systime or not self.sensor_enabled:
             # do not process during the initialization time, duplicates,
             # during the event delay time, while an event is running, or
@@ -154,6 +137,11 @@ class RunoutHelper:
         is_printing = idle_timeout.get_status(now)["state"] == "Printing"
         # Perform filament action associated with status change (if any)
         if is_filament_present:
+            if self.deferred_runout:
+                self.deferred_runout = False
+                logging.info(
+                    "Filament Sensor %s: filament reinserted, "
+                    "clearing deferred runout" % (self.name,))
             if not is_printing and self.insert_gcode is not None:
                 # insert detected
                 self.min_event_systime = self.reactor.NEVER
@@ -170,7 +158,7 @@ class RunoutHelper:
             # Check if we should defer (current feature is 1 - Outer Wall)
             print_time = self.estimated_print_time(now)
             current_feature = self._get_feature_at_time(print_time)
-            if current_feature == self.FEATURE_OUTER_WALL and self.runout_distance > 0.:
+            if current_feature == 1 and self.runout_distance > 0.:
                 self.deferred_runout = True
                 self.runout_trigger_pos = (
                     self.extruder.find_past_position(print_time))
@@ -181,8 +169,8 @@ class RunoutHelper:
                 if self.runout_check_timer is None:
                     self.runout_check_timer = self.reactor.register_timer(
                         self._runout_distance_check_event)
-                self.reactor.update_timer(self.runout_check_timer,
-                                          self.reactor.NOW)
+                self.reactor.update_timer(
+                    self.runout_check_timer, self.reactor.NOW)
             else:
                 self.reactor.register_callback(self._runout_event_handler)
     def get_status(self, eventtime):

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -9,6 +9,11 @@ import logging
 
 
 class RunoutHelper:
+    FEATURE_OTHER = 0
+    FEATURE_OUTER_WALL = 1
+    FEATURE_INFILL = 2
+    POLL_INTERVAL = 0.100
+
     def __init__(self, config):
         self.name = config.get_name().split()[-1]
         self.printer = config.get_printer()
@@ -32,8 +37,9 @@ class RunoutHelper:
         self.runout_distance = config.getfloat(
             'runout_distance', 0., minval=0.)
         self.extruder_name = config.get('extruder', 'extruder')
-        self.feature_history = [(0., 0)]
+        self.feature_history = [(0., self.FEATURE_OTHER)]
         self.deferred_runout = False
+        self.runout_trigger_pos = 0.
         self.runout_check_timer = None
         # Internal state
         self.min_event_systime = self.reactor.NEVER
@@ -48,8 +54,9 @@ class RunoutHelper:
             self.gcode.register_command(
                 "SET_PRINT_FEATURE", self.cmd_SET_PRINT_FEATURE,
                 desc="Set current print feature for runout sensors")
-        except self.printer.config_error:
-            pass
+        except self.printer.config_error as e:
+            if "already registered" not in str(e):
+                raise
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_QUERY_FILAMENT_SENSOR,
@@ -63,10 +70,11 @@ class RunoutHelper:
         self.extruder = self.printer.lookup_object(self.extruder_name)
         self.estimated_print_time = (
             self.printer.lookup_object('mcu').estimated_print_time)
-        self.feature_history = [(0., 0)]
+        # Reset state on restart
+        self.feature_history = [(0., self.FEATURE_OTHER)]
         self.deferred_runout = False
     def cmd_SET_PRINT_FEATURE(self, gcmd):
-        feature = gcmd.get_int('FEATURE', 0)
+        feature = gcmd.get_int('FEATURE', self.FEATURE_OTHER)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_lookahead_callback(
             lambda pt: self.printer.send_event(
@@ -76,7 +84,7 @@ class RunoutHelper:
         if len(self.feature_history) > 100:
             self.feature_history.pop(0)
     def _get_feature_at_time(self, print_time):
-        current_feature = 0
+        current_feature = self.FEATURE_OTHER
         for pt, feature in self.feature_history:
             if pt <= print_time:
                 current_feature = feature
@@ -88,7 +96,7 @@ class RunoutHelper:
             return self.reactor.NEVER
         print_time = self.estimated_print_time(eventtime)
         current_feature = self._get_feature_at_time(print_time)
-        if current_feature == 2:
+        if current_feature == self.FEATURE_INFILL:
             logging.info("Filament Sensor %s: Deferred runout pausing "
                          "now on infill" % (self.name,))
             self.deferred_runout = False
@@ -104,7 +112,7 @@ class RunoutHelper:
             self.deferred_runout = False
             self.reactor.register_callback(self._runout_event_handler)
             return self.reactor.NEVER
-        return eventtime + 0.100
+        return eventtime + self.POLL_INTERVAL
     def _runout_event_handler(self, eventtime):
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.
@@ -128,6 +136,13 @@ class RunoutHelper:
             return
         self.filament_present = is_filament_present
 
+        if is_filament_present and self.deferred_runout:
+            self.deferred_runout = False
+            logging.info(
+                "Filament Sensor %s: filament reinserted, "
+                "clearing deferred runout" % (self.name,))
+            return
+
         if eventtime < self.min_event_systime or not self.sensor_enabled:
             # do not process during the initialization time, duplicates,
             # during the event delay time, while an event is running, or
@@ -139,11 +154,6 @@ class RunoutHelper:
         is_printing = idle_timeout.get_status(now)["state"] == "Printing"
         # Perform filament action associated with status change (if any)
         if is_filament_present:
-            if self.deferred_runout:
-                self.deferred_runout = False
-                logging.info(
-                    "Filament Sensor %s: filament reinserted, "
-                    "clearing deferred runout" % (self.name,))
             if not is_printing and self.insert_gcode is not None:
                 # insert detected
                 self.min_event_systime = self.reactor.NEVER
@@ -160,7 +170,7 @@ class RunoutHelper:
             # Check if we should defer (current feature is 1 - Outer Wall)
             print_time = self.estimated_print_time(now)
             current_feature = self._get_feature_at_time(print_time)
-            if current_feature == 1 and self.runout_distance > 0.:
+            if current_feature == self.FEATURE_OUTER_WALL and self.runout_distance > 0.:
                 self.deferred_runout = True
                 self.runout_trigger_pos = (
                     self.extruder.find_past_position(print_time))

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,6 +1,7 @@
 # Generic Filament Sensor Module
 #
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
+# Copyright (C) 2026  Hwang Younsang <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
@@ -26,12 +27,26 @@ class RunoutHelper:
                 config, 'insert_gcode')
         self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
         self.event_delay = config.getfloat('event_delay', 3., minval=.0)
+        # Distance configuration
+        self.runout_distance = config.getfloat('runout_distance', 0., minval=0.)
+        self.extruder_name = config.get('extruder', 'extruder')
+        self.feature_history = [(0., 0)]
+        self.deferred_runout = False
+        self.runout_check_timer = None
         # Internal state
         self.min_event_systime = self.reactor.NEVER
         self.filament_present = False
         self.sensor_enabled = True
         # Register commands and event handlers
         self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.printer.register_event_handler("filament_sensor:set_feature",
+                                            self._handle_set_feature)
+        try:
+            self.gcode.register_command(
+                "SET_PRINT_FEATURE", self.cmd_SET_PRINT_FEATURE,
+                desc="Set current print feature for runout sensors")
+        except self.printer.config_error:
+            pass
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_QUERY_FILAMENT_SENSOR,
@@ -42,6 +57,48 @@ class RunoutHelper:
             desc=self.cmd_SET_FILAMENT_SENSOR_help)
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
+        self.extruder = self.printer.lookup_object(self.extruder_name)
+        self.estimated_print_time = (
+            self.printer.lookup_object('mcu').estimated_print_time)
+        self.feature_history = [(0., 0)]
+        self.deferred_runout = False
+    def cmd_SET_PRINT_FEATURE(self, gcmd):
+        feature = gcmd.get_int('FEATURE', 0)
+        toolhead = self.printer.lookup_object('toolhead')
+        toolhead.register_lookahead_callback(
+            lambda pt: self.printer.send_event("filament_sensor:set_feature", pt, feature))
+    def _handle_set_feature(self, pt, feature):
+        self.feature_history.append((pt, feature))
+        if len(self.feature_history) > 100:
+            self.feature_history.pop(0)
+    def _get_feature_at_time(self, print_time):
+        current_feature = 0
+        for pt, feature in self.feature_history:
+            if pt <= print_time:
+                current_feature = feature
+            else:
+                break
+        return current_feature
+    def _runout_distance_check_event(self, eventtime):
+        if not self.deferred_runout:
+            return self.reactor.NEVER
+        print_time = self.estimated_print_time(eventtime)
+        current_feature = self._get_feature_at_time(print_time)
+        if current_feature == 2:
+            logging.info("Filament Sensor %s: Deferred runout pausing now on infill" % (self.name,))
+            self.deferred_runout = False
+            self.reactor.register_callback(self._runout_event_handler)
+            return self.reactor.NEVER
+        current_pos = self.extruder.find_past_position(print_time)
+        diff = current_pos - self.runout_trigger_pos
+        if diff >= self.runout_distance:
+            logging.info(
+                "Filament Sensor %s: runout distance limit reached (%.2f / %.2f). Pausing now." %
+                (self.name, diff, self.runout_distance))
+            self.deferred_runout = False
+            self.reactor.register_callback(self._runout_event_handler)
+            return self.reactor.NEVER
+        return eventtime + 0.100
     def _runout_event_handler(self, eventtime):
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.
@@ -76,6 +133,10 @@ class RunoutHelper:
         is_printing = idle_timeout.get_status(now)["state"] == "Printing"
         # Perform filament action associated with status change (if any)
         if is_filament_present:
+            if self.deferred_runout:
+                self.deferred_runout = False
+                logging.info(
+                    "Filament Sensor %s: filament reinserted, clearing deferred runout" % (self.name,))
             if not is_printing and self.insert_gcode is not None:
                 # insert detected
                 self.min_event_systime = self.reactor.NEVER
@@ -89,7 +150,21 @@ class RunoutHelper:
             logging.info(
                 "Filament Sensor %s: runout event detected, Time %.2f" %
                 (self.name, now))
-            self.reactor.register_callback(self._runout_event_handler)
+            # Check if we should defer (current feature is 1 - Outer Wall)
+            print_time = self.estimated_print_time(now)
+            current_feature = self._get_feature_at_time(print_time)
+            if current_feature == 1 and self.runout_distance > 0.:
+                self.deferred_runout = True
+                self.runout_trigger_pos = self.extruder.find_past_position(print_time)
+                logging.info(
+                    "Filament Sensor %s: outer wall detected, deferring runout. Start position: %.2f" %
+                    (self.name, self.runout_trigger_pos))
+                if self.runout_check_timer is None:
+                    self.runout_check_timer = self.reactor.register_timer(
+                        self._runout_distance_check_event)
+                self.reactor.update_timer(self.runout_check_timer, self.reactor.NOW)
+            else:
+                self.reactor.register_callback(self._runout_event_handler)
     def get_status(self, eventtime):
         return {
             "filament_detected": bool(self.filament_present),

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -28,7 +28,8 @@ class RunoutHelper:
         self.pause_delay = config.getfloat('pause_delay', .5, above=.0)
         self.event_delay = config.getfloat('event_delay', 3., minval=.0)
         # Distance configuration
-        self.runout_distance = config.getfloat('runout_distance', 0., minval=0.)
+        self.runout_distance = config.getfloat(
+            'runout_distance', 0., minval=0.)
         self.extruder_name = config.get('extruder', 'extruder')
         self.feature_history = [(0., 0)]
         self.deferred_runout = False
@@ -38,7 +39,8 @@ class RunoutHelper:
         self.filament_present = False
         self.sensor_enabled = True
         # Register commands and event handlers
-        self.printer.register_event_handler("klippy:ready", self._handle_ready)
+        self.printer.register_event_handler(
+            "klippy:ready", self._handle_ready)
         self.printer.register_event_handler("filament_sensor:set_feature",
                                             self._handle_set_feature)
         try:
@@ -66,7 +68,8 @@ class RunoutHelper:
         feature = gcmd.get_int('FEATURE', 0)
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.register_lookahead_callback(
-            lambda pt: self.printer.send_event("filament_sensor:set_feature", pt, feature))
+            lambda pt: self.printer.send_event(
+                "filament_sensor:set_feature", pt, feature))
     def _handle_set_feature(self, pt, feature):
         self.feature_history.append((pt, feature))
         if len(self.feature_history) > 100:
@@ -85,7 +88,8 @@ class RunoutHelper:
         print_time = self.estimated_print_time(eventtime)
         current_feature = self._get_feature_at_time(print_time)
         if current_feature == 2:
-            logging.info("Filament Sensor %s: Deferred runout pausing now on infill" % (self.name,))
+            logging.info("Filament Sensor %s: Deferred runout pausing "
+                         "now on infill" % (self.name,))
             self.deferred_runout = False
             self.reactor.register_callback(self._runout_event_handler)
             return self.reactor.NEVER
@@ -93,7 +97,8 @@ class RunoutHelper:
         diff = current_pos - self.runout_trigger_pos
         if diff >= self.runout_distance:
             logging.info(
-                "Filament Sensor %s: runout distance limit reached (%.2f / %.2f). Pausing now." %
+                "Filament Sensor %s: runout distance limit reached "
+                "(%.2f / %.2f). Pausing now." %
                 (self.name, diff, self.runout_distance))
             self.deferred_runout = False
             self.reactor.register_callback(self._runout_event_handler)
@@ -136,7 +141,8 @@ class RunoutHelper:
             if self.deferred_runout:
                 self.deferred_runout = False
                 logging.info(
-                    "Filament Sensor %s: filament reinserted, clearing deferred runout" % (self.name,))
+                    "Filament Sensor %s: filament reinserted, "
+                    "clearing deferred runout" % (self.name,))
             if not is_printing and self.insert_gcode is not None:
                 # insert detected
                 self.min_event_systime = self.reactor.NEVER
@@ -155,14 +161,17 @@ class RunoutHelper:
             current_feature = self._get_feature_at_time(print_time)
             if current_feature == 1 and self.runout_distance > 0.:
                 self.deferred_runout = True
-                self.runout_trigger_pos = self.extruder.find_past_position(print_time)
+                self.runout_trigger_pos = (
+                    self.extruder.find_past_position(print_time))
                 logging.info(
-                    "Filament Sensor %s: outer wall detected, deferring runout. Start position: %.2f" %
+                    "Filament Sensor %s: outer wall detected, deferring "
+                    "runout. Start position: %.2f" %
                     (self.name, self.runout_trigger_pos))
                 if self.runout_check_timer is None:
                     self.runout_check_timer = self.reactor.register_timer(
                         self._runout_distance_check_event)
-                self.reactor.update_timer(self.runout_check_timer, self.reactor.NOW)
+                self.reactor.update_timer(self.runout_check_timer,
+                                          self.reactor.NOW)
             else:
                 self.reactor.register_callback(self._runout_event_handler)
     def get_status(self, eventtime):

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -8,6 +8,11 @@ import logging
 
 
 class RunoutHelper:
+    FEATURE_UNKNOWN = 0
+    FEATURE_OUTER_WALL = 1
+    FEATURE_INFILL = 2
+    FEATURE_BRIDGE = 3
+
     def __init__(self, config):
         self.name = config.get_name().split()[-1]
         self.printer = config.get_printer()
@@ -85,7 +90,7 @@ class RunoutHelper:
             return self.reactor.NEVER
         print_time = self.estimated_print_time(eventtime)
         current_feature = self._get_feature_at_time(print_time)
-        if current_feature == 2:
+        if current_feature == self.FEATURE_INFILL:
             logging.info(
                 "Filament Sensor %s: Deferred runout pausing "
                 "now on infill" % (self.name,))
@@ -158,13 +163,15 @@ class RunoutHelper:
             # Check if we should defer (current feature is 1 - Outer Wall)
             print_time = self.estimated_print_time(now)
             current_feature = self._get_feature_at_time(print_time)
-            if current_feature == 1 and self.runout_distance > 0.:
+            if current_feature in (self.FEATURE_OUTER_WALL,
+                                   self.FEATURE_BRIDGE) \
+                    and self.runout_distance > 0.:
                 self.deferred_runout = True
                 self.runout_trigger_pos = (
                     self.extruder.find_past_position(print_time))
                 logging.info(
-                    "Filament Sensor %s: outer wall detected, deferring "
-                    "runout. Start position: %.2f" %
+                    "Filament Sensor %s: critical feature detected, "
+                    "deferring runout. Start position: %.2f" %
                     (self.name, self.runout_trigger_pos))
                 if self.runout_check_timer is None:
                     self.runout_check_timer = self.reactor.register_timer(

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,11 +1,7 @@
 # Generic Filament Sensor Module
 #
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
-<<<<<<< Updated upstream
-# Copyright (C) 2026  Hwang Younsang <famtory@gmail.com>
-=======
 # Region-Aware Filament Runout Pause Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
->>>>>>> Stashed changes
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -1,7 +1,8 @@
 # Generic Filament Sensor Module
 #
 # Copyright (C) 2019  Eric Callahan <arksine.code@gmail.com>
-# Region-Aware Filament Runout Pause Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
+# Region-Aware Filament Runout Pause Feature Concept & Implementation
+# Copyright (C) 2026 Famtory <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging


### PR DESCRIPTION
I would like to propose a region-aware filament runout pause mechanism for `filament_switch_sensor` / `filament_motion_sensor` (`RunoutHelper`).

**Why this feature is needed:**
Pausing immediately upon filament runout often leaves an ugly scar on the outer wall of the print. By delaying the pause until the toolhead reaches an infill area (where defects are hidden inside), we can protect the cosmetic print quality.

**How it works:**
1. The slicer emits `SET_PRINT_FEATURE FEATURE=<N>` (1: Outer Wall, 2: Infill, 3: Other) on role changes.
2. `RunoutHelper` registers the `SET_PRINT_FEATURE` command and uses `toolhead.register_lookahead_callback` to synchronize the active feature state with the lookahead queue.
3. If a runout is detected while printing the outer wall, the helper defers the pause event and starts a periodic timer checking the physical print head position.
4. The pause is triggered as soon as the print head moves to an infill area, or if the printed distance since the runout triggers exceeds `runout_distance` (safety margin, user-configurable).

**Current Status:**
I have implemented a working draft in `klippy/extras/filament_switch_sensor.py` where `runout_distance` defaults to `0.0` (disabled by default, requiring explicit user configuration to activate).

I would love to get the community's feedback on this approach and any suggestions regarding naming or architecture before moving forward.

Signed-off-by: Hwang Younsang <famtory@gmail.com>
