### PR TITLE
bed_mesh: Add Wandering Probe Points (WPP) dynamic offset

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -333,6 +333,13 @@ radius:
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 ```
 
 ### Deltesian Kinematics
@@ -681,6 +688,13 @@ radius:
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 ```
 
 ### Cable winch Kinematics
@@ -1092,6 +1106,13 @@ Visual Examples:
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 #mesh_radius:
 #   Defines the radius of the mesh to probe for round beds. Note that
 #   the radius is relative to the coordinate specified by the
@@ -1215,6 +1236,13 @@ information.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 ```
 
 ### [bed_screws]
@@ -1295,6 +1323,13 @@ information.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 #screw_thread: CW-M3
 #   The type of screw used for bed leveling, M3, M4, or M5, and the
 #   rotation direction of the knob that is used to level the bed.
@@ -1333,6 +1368,13 @@ extended [G-Code command](G-Codes.md#z_tilt) becomes available.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 #retries: 0
 #   Number of times to retry if the probed points aren't within
 #   tolerance.
@@ -1384,6 +1426,13 @@ Where x is the 0, 0 point on the bed
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 #max_adjust: 4
 #   Safety limit if an adjustment greater than this value is requested
 #   quad_gantry_level will abort.
@@ -2385,6 +2434,13 @@ for more detailed information regarding symptoms, configuration and setup.
 #horizontal_move_z: 5
 #   The height (in mm) that the head should be commanded to move to
 #   just prior to starting a probe operation. The default is 5.
+#wandering_step: 0.0
+#   The distance (in mm) to shift the mesh points in a 3x3 grid pattern
+#   on successive measurement cycles. This feature spreads probe wear
+#   across a wider area. Note that the grid will expand the probed area
+#   by up to ~1.41 * wandering_step; ensure your mesh_min, mesh_max, or
+#   mesh_radius leaves a safe margin from the physical limits to prevent
+#   "out of range" errors. Default is 0.0 (disabled).
 calibrate_start_x: 20
 #   Defines the minimum X coordinate of the calibration
 #   This should be the X coordinate that positions the nozzle at the starting

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -171,7 +171,8 @@ The following commands are available when the
 #### BED_MESH_CALIBRATE
 `BED_MESH_CALIBRATE [PROFILE=<name>] [METHOD=manual] [HORIZONTAL_MOVE_Z=<value>]
 [<probe_parameter>=<value>] [<mesh_parameter>=<value>] [ADAPTIVE=1]
-[ADAPTIVE_MARGIN=<value>]`: This command probes the bed using generated points
+[ADAPTIVE_MARGIN=<value>] [WANDERING_STEP=<value>]`: This command probes the bed
+using generated points
 specified by the parameters in the config. After probing, a mesh is generated
 and z-movement is adjusted according to the mesh.
 The mesh is immediately active after successful completion of `BED_MESH_CALIBRATE`.
@@ -185,7 +186,9 @@ while this tool is active. The optional `HORIZONTAL_MOVE_Z` value overrides the
 `horizontal_move_z` option specified in the config file. If ADAPTIVE=1 is
 specified then the objects defined by the Gcode file being printed will be used
 to define the probed area. The optional `ADAPTIVE_MARGIN` value overrides the
-`adaptive_margin` option specified in the config file.
+`adaptive_margin` option specified in the config file. The optional
+`WANDERING_STEP` value overrides the `wandering_step` option specified in
+the config file.
 
 #### BED_MESH_OUTPUT
 `BED_MESH_OUTPUT PGP=[<0:1>]`: This command outputs the current probed

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -1,8 +1,6 @@
 # Mesh Bed Leveling
 #
 # Copyright (C) 2018-2019 Eric Callahan <arksine.code@gmail.com>
-# Wandering Probe Points (WPP) Feature Concept & Implementation
-# Copyright (C) 2026 Famtory <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
@@ -627,9 +625,9 @@ class BedMeshCalibrate:
             ]
             dx, dy = grid[self.wandering_state % 9]
             if is_calibrating:
-                self.wandering_state += 1
-                logging.info("bed_mesh: wandering step=%.2f, "
-                             "offset=(%.2f, %.2f)" % (step, dx, dy))
+                # Diagonal points are distance step * sqrt(2) (~1.41 * step)
+                logging.debug("bed_mesh: wandering step=%.2f, "
+                              "offset=(%.2f, %.2f)" % (step, dx, dy))
 
         shifted_min = (self.mesh_min[0] + dx, self.mesh_min[1] + dy)
         shifted_max = (self.mesh_max[0] + dx, self.mesh_max[1] + dy)
@@ -808,6 +806,13 @@ class BedMeshCalibrate:
             zero_ref_pos = self.probe_mgr.get_zero_ref_pos()
             z_mesh.set_zero_reference(*zero_ref_pos)
         self.bedmesh.set_mesh(z_mesh)
+        if self.wandering_step > 0.0:
+            self.wandering_state += 1
+            if self.svv is not None:
+                gcode = self.printer.lookup_object('gcode')
+                gcode.run_script(
+                    "SAVE_VARIABLE VARIABLE=bed_mesh_wandering_state VALUE=%d"
+                    % (self.wandering_state,))
         self.gcode.respond_info("Mesh Bed Leveling Complete")
         if self._profile_name is not None:
             self.bedmesh.save_profile(self._profile_name)
@@ -1748,6 +1753,13 @@ class ProfileManager:
         except BedMeshError as e:
             raise self.gcode.error(str(e))
         self.bedmesh.set_mesh(z_mesh)
+        if self.wandering_step > 0.0:
+            self.wandering_state += 1
+            if self.svv is not None:
+                gcode = self.printer.lookup_object('gcode')
+                gcode.run_script(
+                    "SAVE_VARIABLE VARIABLE=bed_mesh_wandering_state VALUE=%d"
+                    % (self.wandering_state,))
     def remove_profile(self, prof_name):
         if prof_name in self.profiles:
             configfile = self.printer.lookup_object('configfile')

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -1,7 +1,8 @@
 # Mesh Bed Leveling
 #
 # Copyright (C) 2018-2019 Eric Callahan <arksine.code@gmail.com>
-# Wandering Probe Points (WPP) Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
+# Wandering Probe Points (WPP) Feature Concept & Implementation
+# Copyright (C) 2026 Famtory <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
@@ -627,12 +628,14 @@ class BedMeshCalibrate:
             dx, dy = grid[self.wandering_state % 9]
             if is_calibrating:
                 self.wandering_state += 1
-                logging.info("bed_mesh: wandering step=%.2f, offset=(%.2f, %.2f)" % 
-                             (step, dx, dy))
-                             
+                logging.info("bed_mesh: wandering step=%.2f, "
+                             "offset=(%.2f, %.2f)" % (step, dx, dy))
+
         shifted_min = (self.mesh_min[0] + dx, self.mesh_min[1] + dy)
         shifted_max = (self.mesh_max[0] + dx, self.mesh_max[1] + dy)
-        shifted_orig = (self.origin[0] + dx, self.origin[1] + dy) if self.origin else None
+        shifted_orig = None
+        if self.origin:
+            shifted_orig = (self.origin[0] + dx, self.origin[1] + dy)
 
         if need_cfg_update:
             self._verify_algorithm(gcmd.error)

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -1,6 +1,7 @@
 # Mesh Bed Leveling
 #
 # Copyright (C) 2018-2019 Eric Callahan <arksine.code@gmail.com>
+# Wandering Probe Points (WPP) Feature Concept & Implementation Copyright (C) 2026 Famtory <famtory@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging, math, json, collections
@@ -329,6 +330,8 @@ class BedMeshCalibrate:
         self.radius = self.origin = None
         self.mesh_min = self.mesh_max = (0., 0.)
         self.adaptive_margin = config.getfloat('adaptive_margin', 0.0)
+        self.wandering_step = config.getfloat('wandering_step', 0.0)
+        self.wandering_state = 0
         self.bedmesh = bedmesh
         self.mesh_config = collections.OrderedDict()
         self._init_mesh_config(config)
@@ -560,7 +563,7 @@ class BedMeshCalibrate:
             self.mesh_config["y_count"] = new_y_probe_count
         self._profile_name = None
         return True
-    def update_config(self, gcmd):
+    def update_config(self, gcmd, is_calibrating=False):
         # reset default configuration
         self.radius = self.orig_config['radius']
         self.origin = self.orig_config['origin']
@@ -612,19 +615,38 @@ class BedMeshCalibrate:
         need_cfg_update |= self.set_adaptive_mesh(gcmd)
         probe_method = gcmd.get("METHOD", "automatic")
 
+        # Wandering Probe offset calculation
+        step = gcmd.get_float("WANDERING_STEP", self.wandering_step)
+        dx = dy = 0.0
+        if step > 0.0:
+            grid = [
+                (0.0, 0.0), (step, 0.0), (step, step), (0.0, step),
+                (-step, step), (-step, 0.0), (-step, -step),
+                (0.0, -step), (step, -step)
+            ]
+            dx, dy = grid[self.wandering_state % 9]
+            if is_calibrating:
+                self.wandering_state += 1
+                logging.info("bed_mesh: wandering step=%.2f, offset=(%.2f, %.2f)" % 
+                             (step, dx, dy))
+                             
+        shifted_min = (self.mesh_min[0] + dx, self.mesh_min[1] + dy)
+        shifted_max = (self.mesh_max[0] + dx, self.mesh_max[1] + dy)
+        shifted_orig = (self.origin[0] + dx, self.origin[1] + dy) if self.origin else None
+
         if need_cfg_update:
             self._verify_algorithm(gcmd.error)
             self.probe_mgr.generate_points(
-                self.mesh_config, self.mesh_min, self.mesh_max,
-                self.radius, self.origin, probe_method
+                self.mesh_config, shifted_min, shifted_max,
+                self.radius, shifted_orig, probe_method
             )
             msg = "\n".join(["%s: %s" % (k, v)
                              for k, v in self.mesh_config.items()])
             logging.info("Updated Mesh Configuration:\n" + msg)
         else:
             self.probe_mgr.generate_points(
-                self.mesh_config, self.mesh_min, self.mesh_max,
-                self.radius, self.origin, probe_method
+                self.mesh_config, shifted_min, shifted_max,
+                self.radius, shifted_orig, probe_method
             )
     def dump_calibration(self, gcmd=None):
         if gcmd is not None and gcmd.get_command_parameters():
@@ -647,7 +669,7 @@ class BedMeshCalibrate:
             raise gcmd.error("Value for parameter 'PROFILE' must be specified")
         self.bedmesh.set_mesh(None)
         try:
-            self.update_config(gcmd)
+            self.update_config(gcmd, is_calibrating=True)
         except BedMeshError as e:
             raise gcmd.error(str(e))
         self.probe_mgr.start_probe(gcmd)


### PR DESCRIPTION
### What does this PR do?
This PR introduces the "Wandering Probe Points (WPP)" feature to `bed_mesh.py`. 
Currently, traditional bed probing systems hit the exact same coordinates on the PEI surface repeatedly. Over time, this repetitive probing causes physical wear, leaves filament oozing/divots, and ultimately degrades bed leveling accuracy.

WPP solves this by applying a dynamic, persistent translational offset to the entire probing grid matrix across successive probes. This distributes the nozzle impact evenly across the bed without altering the underlying mesh math.

### Key Changes
- Added `wandering_step` parameter to dynamically shift `dx, dy` offsets for each probe cycle.
- Prevents localized PEI degradation and reduces errors from accumulated oozing.
- Stamped with the Famtory Conceptual Designer attribution.

Signed-off-by: Hwang Younsang <famtory@gmail.com>
