### PR TITLE
sht3x: Fix CRC computation when high byte is zero

### DIFF
--- a/klippy/extras/sht3x.py
+++ b/klippy/extras/sht3x.py
@@ -155,18 +155,11 @@ class SHT3X:
         self._callback(print_time, self.temp)
         return measured_time + self.report_time
 
-    def _split_bytes(self, data):
-        bytes = []
-        for i in range((data.bit_length() + 7) // 8):
-            bytes.append((data >> i*8) & 0xFF)
-        bytes.reverse()
-        return bytes
-
     def _crc8(self, data):
         #crc8 polynomial for 16bit value, CRC8 -> x^8 + x^5 + x^4 + 1
         SHT3X_CRC8_POLYNOMINAL= 0x31
         crc = 0xFF
-        data_bytes = self._split_bytes(data)
+        data_bytes = [data >> 8 & 0xFF, data & 0xFF]
         for byte in data_bytes:
             crc ^= byte
             for _ in range(8):


### PR DESCRIPTION
### What this does

The SHT3x driver's CRC helper (`_crc8`) takes a 16-bit integer and
splits it into bytes via `_split_bytes()`, which derives the byte count
from `data.bit_length()`. When the high byte of a value is zero — a
common case for in-range temperature/humidity readings and for the
status word — `bit_length()` reports 8 bits or fewer, so `_split_bytes()`
returns a **single** byte. The CRC is then computed over one byte
instead of the two the sensor checksums, the computed CRC mismatches the
sensor's, and the reading is discarded with a logged "checksum error".

This passes the two response bytes directly to `_crc8()` so the checksum
is always computed over the full two-byte value, per the SHT3x
datasheet, and removes the now-unused `_split_bytes()` helper.

### Why it matters

On real hardware this silently drops otherwise-valid readings whenever a
sample happens to have a zero high byte. Because it's data-dependent it
looks like intermittent sensor flakiness rather than a code bug.

### Testing

- Verified the CRC now matches the SHT3x datasheet's worked example
  (0xBEEF -> 0x92) and known-good sensor responses with zero high bytes.
- Confirmed no remaining references to the removed `_split_bytes` helper.

Signed-off-by: Kevin Blackburn-Matzen <kmatzen@gmail.com>
