### PR TITLE
Adding a watercooling_fan

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3374,6 +3374,10 @@ temperature threshold, or whenever one of its associated stepper
 drivers is active. The fan may continue to run at an idle speed for a
 short time after those conditions are no longer met.
 
+The fan status is also exposed as "controller_fan <name>" so that
+clients can display it as an automatically controlled fan. A
+watercooling_fan and controller_fan may not use the same name.
+
 ```
 [watercooling_fan my_watercooling_fan]
 #pin:

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3364,6 +3364,60 @@ watched component.
 #   default stepper is all of them.
 ```
 
+### [watercooling_fan]
+
+Watercooling fan (one may define any number of sections with a
+"watercooling_fan" prefix). A "watercooling fan" is a fan that will be
+enabled whenever one of its associated heaters has a non-zero target,
+whenever one of its associated heaters remains above a configured
+temperature threshold, or whenever one of its associated stepper
+drivers is active. The fan may continue to run at an idle speed for a
+short time after those conditions are no longer met.
+
+```
+[watercooling_fan my_watercooling_fan]
+#pin:
+#max_power:
+#shutdown_speed:
+#cycle_time:
+#hardware_pwm:
+#kick_start_time:
+#off_below:
+#tachometer_pin:
+#tachometer_ppr:
+#tachometer_poll_interval:
+#enable_pin:
+#   See the "fan" section for a description of the above parameters.
+#fan_speed: 1.0
+#   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
+#   will be set to when a selected heater or stepper driver is active,
+#   or when a selected heater remains above `heater_temp`. The default
+#   is 1.0
+#idle_timeout:
+#   The amount of time (in seconds) after a watched stepper driver or
+#   heater was active that the fan should be kept running. The default
+#   is 30 seconds.
+#idle_speed: 0.0
+#   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
+#   will be set to after activity stops and before the idle_timeout is
+#   reached. The default is 0.0.
+#heater: extruder
+#   Name of the config section defining the heater that this fan is
+#   associated with. If a comma separated list of heater names is
+#   provided here, then the fan will react when any of the given
+#   heaters are active or remain above `heater_temp`. The default is
+#   "extruder".
+#heater_temp: 50.0
+#   A temperature (in Celsius) that a watched heater must drop below
+#   before heat alone stops keeping the fan active. The default is 50
+#   Celsius.
+#stepper:
+#   The names of the stepper drivers this fan is associated with. If
+#   no stepper names are provided, then the fan will be associated
+#   with all of the stepper drivers in the config. The default
+#   is to associate with all of the stepper drivers.
+```
+
 ### [temperature_fan]
 
 Temperature-triggered cooling fans (one may define any number of

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3390,9 +3390,14 @@ short time after those conditions are no longer met.
 #   See the "fan" section for a description of the above parameters.
 #fan_speed: 1.0
 #   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
-#   will be set to when a selected heater or stepper driver is active,
-#   or when a selected heater remains above `heater_temp`. The default
-#   is 1.0
+#   will be set to when both a selected heater and a selected stepper
+#   driver are active, or when one is active and
+#   `single_active_speed` is left at its default. The default is 1.0.
+#single_active_speed:
+#   The fan speed (expressed as a value from 0.0 to 1.0) that the fan
+#   will be set to when only selected heaters are active, only selected
+#   stepper drivers are active, or only heat above `heater_temp`
+#   remains. The default is `fan_speed`.
 #idle_timeout:
 #   The amount of time (in seconds) after a watched stepper driver or
 #   heater was active that the fan should be kept running. The default

--- a/klippy/extras/watercooling_fan.py
+++ b/klippy/extras/watercooling_fan.py
@@ -25,6 +25,9 @@ class WatercoolingFan:
         self.fan = fan.Fan(config, default_shutdown_speed=1.)
         self.fan_speed = config.getfloat('fan_speed', default=1.,
                                          minval=0., maxval=1.)
+        self.single_active_speed = config.getfloat(
+            'single_active_speed', default=self.fan_speed,
+            minval=0., maxval=1.)
         self.idle_speed = config.getfloat(
             'idle_speed', default=0., minval=0., maxval=1.)
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
@@ -54,16 +57,21 @@ class WatercoolingFan:
 
     def callback(self, eventtime):
         speed = 0.
-        active = False
+        stepper_active = False
+        heater_active = False
         for name in self.stepper_names:
-            active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()
+            stepper_active |= self.stepper_enable.lookup_enable(
+                name).is_motor_enabled()
         for heater in self.heaters:
             current_temp, target_temp = heater.get_temp(eventtime)
             if target_temp or current_temp > self.heater_temp:
-                active = True
-        if active:
+                heater_active = True
+        if stepper_active and heater_active:
             self.last_on = 0
             speed = self.fan_speed
+        elif stepper_active or heater_active:
+            self.last_on = 0
+            speed = self.single_active_speed
         elif self.last_on < self.idle_timeout:
             speed = self.idle_speed
             self.last_on += 1

--- a/klippy/extras/watercooling_fan.py
+++ b/klippy/extras/watercooling_fan.py
@@ -1,0 +1,76 @@
+# Support fans for watercooling loops that should run when selected
+# steppers are active, a heater has a target temperature, or a heater
+# remains above a configured threshold.
+#
+# Copyright (C) 2026
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from . import fan
+
+PIN_MIN_TIME = 0.100
+
+
+class WatercoolingFan:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.printer.register_event_handler("klippy:ready", self.handle_ready)
+        self.printer.register_event_handler("klippy:connect",
+                                            self.handle_connect)
+        self.stepper_names = config.getlist("stepper", None)
+        self.stepper_enable = self.printer.load_object(config, 'stepper_enable')
+        self.printer.load_object(config, 'heaters')
+        self.heaters = []
+        self.heater_names = config.getlist("heater", ("extruder",))
+        self.heater_temp = config.getfloat("heater_temp", 50.0)
+        self.fan = fan.Fan(config, default_shutdown_speed=1.)
+        self.fan_speed = config.getfloat('fan_speed', default=1.,
+                                         minval=0., maxval=1.)
+        self.idle_speed = config.getfloat(
+            'idle_speed', default=0., minval=0., maxval=1.)
+        self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
+        self.last_on = self.idle_timeout
+        self.last_speed = 0.
+
+    def handle_connect(self):
+        pheaters = self.printer.lookup_object('heaters')
+        self.heaters = [pheaters.lookup_heater(n) for n in self.heater_names]
+        all_steppers = self.stepper_enable.get_steppers()
+        if self.stepper_names is None:
+            self.stepper_names = all_steppers
+            return
+        if not all(x in all_steppers for x in self.stepper_names):
+            raise self.printer.config_error(
+                "One or more of these steppers are unknown: "
+                "%s (valid steppers are: %s)"
+                % (self.stepper_names, ", ".join(all_steppers)))
+
+    def handle_ready(self):
+        reactor = self.printer.get_reactor()
+        reactor.register_timer(self.callback, reactor.monotonic() + PIN_MIN_TIME)
+
+    def get_status(self, eventtime):
+        return self.fan.get_status(eventtime)
+
+    def callback(self, eventtime):
+        speed = 0.
+        active = False
+        for name in self.stepper_names:
+            active |= self.stepper_enable.lookup_enable(name).is_motor_enabled()
+        for heater in self.heaters:
+            current_temp, target_temp = heater.get_temp(eventtime)
+            if target_temp or current_temp > self.heater_temp:
+                active = True
+        if active:
+            self.last_on = 0
+            speed = self.fan_speed
+        elif self.last_on < self.idle_timeout:
+            speed = self.idle_speed
+            self.last_on += 1
+        if speed != self.last_speed:
+            self.last_speed = speed
+            self.fan.set_speed(speed)
+        return eventtime + 1.
+
+
+def load_config_prefix(config):
+    return WatercoolingFan(config)

--- a/klippy/extras/watercooling_fan.py
+++ b/klippy/extras/watercooling_fan.py
@@ -2,7 +2,7 @@
 # steppers are active, a heater has a target temperature, or a heater
 # remains above a configured threshold.
 #
-# Copyright (C) 2026
+# Copyright (C) 2026 Steven Kretzschmar <privat.06.steven@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import fan

--- a/klippy/extras/watercooling_fan.py
+++ b/klippy/extras/watercooling_fan.py
@@ -33,6 +33,13 @@ class WatercoolingFan:
         self.idle_timeout = config.getint("idle_timeout", default=30, minval=0)
         self.last_on = self.idle_timeout
         self.last_speed = 0.
+        fan_name = config.get_name().split()[-1]
+        status_name = "controller_fan " + fan_name
+        if (config.has_section(status_name)
+                or self.printer.lookup_object(status_name, None) is not None):
+            raise config.error("Printer object '%s' already created"
+                               % (status_name,))
+        self.printer.add_object(status_name, self)
 
     def handle_connect(self):
         pheaters = self.printer.lookup_object('heaters')

--- a/klippy/extras/watercooling_fan.py
+++ b/klippy/extras/watercooling_fan.py
@@ -46,7 +46,8 @@ class WatercoolingFan:
 
     def handle_ready(self):
         reactor = self.printer.get_reactor()
-        reactor.register_timer(self.callback, reactor.monotonic() + PIN_MIN_TIME)
+        reactor.register_timer(
+            self.callback, reactor.monotonic() + PIN_MIN_TIME)
 
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)


### PR DESCRIPTION
I implemented this feature to be able to control a Watercooling system with the temperatur of a heater and an active stepper.

This combines the heater_fan and controller_fan.

I used to have both in the config controlling the same pin, but sometimes the fans wouldn't spin when they were supposed to.

I also updated the docs.