### PR TITLE
load_cell: Optional continuous tracking of loadcell measurements

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,11 @@ All dates in this document are approximate.
 
 ## Changes
 
+20260610: `[load_cell]` and `[load_cell_probe]` do not track the force
+data after startup by default anymore. Users can restore the previous
+behavior via `track_force: True` configuration option, or by running
+`LOAD_CELL_TRACK_FORCE` G-Code command during runtime.
+
 20260525: The internal implementation of "probe:z_virtual_endstop" has
 changed. Most users will not observe a change in behavior. Previously
 it was technically possible to mix "probe:z_virtual_endstop" with

--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -5172,6 +5172,10 @@ sensor_type:
 #   Change the sensor's orientation. Can be either 'normal' or 'inverted'.
 #   The default is 'normal'. Use 'inverted' if the sensor reports a
 #   decreasing force value when placed under load.
+#track_force:
+#   Whether the load cell should be tracking the force after startup.
+#   Force tracking can be enabled or disabled at runtime using the
+#   LOAD_CELL_TRACK_FORCE command. The default is False.
 ```
 
 #### HX711

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -931,6 +931,14 @@ This command takes a reading from the load cell. The response is the percentage
 of the sensors range that was read and the raw value in counts. If the load cell
 is calibrated a force in grams is also reported.
 
+### LOAD_CELL_TRACK_FORCE
+`LOAD_CELL_TRACK_FORCE [LOAD_CELL=<config_name>] [TRACKING=START|STOP]`:
+This command enables (with `TRACKING=START`, which is the default) or disables
+continuous tracking of the force by the load cell. The tracking results are
+exported in the load_cell [status](./Status_Reference.md#load_cell) and can be
+used by the user macros. Note that this does not affect the regular load cell
+functionality, such as probing (see `[load_cell_probe]` below), etc.
+
 ### [load_cell_probe]
 
 The commands below are enabled if a

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -320,14 +320,17 @@ The following information is available for each `[load_cell name]`:
 - `counts_per_gram`: The number of raw sensor counts that equals 1 gram of force.
 - `reference_tare_counts`: The reference number of raw sensor counts for 0 force.
 - `tare_counts`: The current number of raw sensor counts for 0 force.
-- `force_g`: The force in grams, averaged over the last polling period.
-- `min_force_g`: The minimum force in grams, over the last polling period.
-- `max_force_g`: The maximum force in grams, over the last polling period.
+- `is_active`: Returns True if the sensor is currently active.
 - `errors`: The number of sensor errors detected since the last start
   of measurements.
 - `overflows`: The number of data buffer overflows detected since the last
   start of measurements.
 - `sample_rate`: The sensor's sample rate in samples per second.
+
+The following information is available if tracking of force is enabled:
+- `force_g`: The force in grams, averaged over the last polling period.
+- `min_force_g`: The minimum force in grams, over the last polling period.
+- `max_force_g`: The maximum force in grams, over the last polling period.
 
 ## load_cell_probe
 

--- a/klippy/extras/load_cell.py
+++ b/klippy/extras/load_cell.py
@@ -25,10 +25,11 @@ def avg(data):
 
 # Helper for event driven webhooks and subscription based API clients
 class ApiClientHelper(object):
-    def __init__(self, printer):
+    def __init__(self, printer, start_cb=None):
         self.printer = printer
         self.client_cbs = []
         self.webhooks_start_resp = {}
+        self.start_cb = start_cb
 
     # send data to clients
     def send(self, msg):
@@ -37,10 +38,19 @@ class ApiClientHelper(object):
             if not res:
                 # This client no longer needs updates - unregister it
                 self.client_cbs.remove(client_cb)
+        return self.is_active()
 
     # Add a client that gets data callbacks
     def add_client(self, client_cb):
+        was_active = self.is_active()
         self.client_cbs.append(client_cb)
+        if not was_active:
+            # No clients previously - sensor data collection was stopped
+            self.start_cb()
+
+    # Check whether there are active measurements running
+    def is_active(self):
+        return not not self.client_cbs
 
     # Add Webhooks client and send header
     def _add_webhooks_client(self, web_request):
@@ -80,6 +90,9 @@ class LoadCellCommandHelper:
         gcode.register_mux_command("LOAD_CELL_DIAGNOSTIC", "LOAD_CELL", name,
                                    self.cmd_LOAD_CELL_DIAGNOSTIC,
                                    desc=self.cmd_LOAD_CELL_DIAGNOSTIC_help)
+        gcode.register_mux_command("LOAD_CELL_TRACK_FORCE", "LOAD_CELL", name,
+                                   self.cmd_LOAD_CELL_TRACK_FORCE,
+                                   desc=self.cmd_LOAD_CELL_TRACK_FORCE_help)
 
     cmd_LOAD_CELL_TARE_help = "Set the Zero point of the load cell"
     def cmd_LOAD_CELL_TARE(self, gcmd):
@@ -144,6 +157,19 @@ class LoadCellCommandHelper:
                           % (min_pct, max_pct))
         gcmd.respond_info("Sample range / sensor capacity: %.5f%%"
                           % ((max_pct - min_pct) / 2.))
+
+    cmd_LOAD_CELL_TRACK_FORCE_help = "Start/stop continuous force tracking"
+    def cmd_LOAD_CELL_TRACK_FORCE(self, gcmd):
+        tracking = gcmd.get("TRACKING", "START").upper()
+        if tracking not in ("START", "STOP"):
+            raise gcmd.error("TRACKING must be START or STOP")
+        if tracking == "START":
+            self.load_cell._start_tracking()
+            gcmd.respond_info("Load cell force tracking started")
+        else:
+            self.load_cell._stop_tracking()
+            gcmd.respond_info("Load cell force tracking stopped")
+
 
 # Class to guide the user through calibrating a load cell
 class LoadCellGuidedCalibrationHelper:
@@ -389,16 +415,18 @@ class LoadCell:
                         {'normal': 1., 'inverted': -1.}, default="normal")
         LoadCellCommandHelper(config, self)
         # Client support:
-        self.clients = ApiClientHelper(printer)
+        self.clients = ApiClientHelper(printer,
+                                       start_cb=self._start_sensor_data)
         header = {"header": ["time", "force (g)", "counts", "tare_counts"]}
         self.clients.add_mux_endpoint("load_cell/dump_force",
                                       "load_cell", self.name, header)
-        # startup, when klippy is ready, start capturing data
+        # startup, when klippy is ready, start capturing data if requested
+        self._is_tracking = config.getboolean("track_force", False)
         printer.register_event_handler("klippy:ready", self._handle_ready)
 
     def _handle_do_ready(self, eventtime):
-        self.sensor.add_client(self._sensor_data_event)
-        self.add_client(self._track_force)
+        if self._is_tracking:
+            self.add_client(self._track_force)
         # announce calibration status on ready
         if self.is_calibrated():
             self.printer.send_event("load_cell:calibrate", self)
@@ -406,6 +434,8 @@ class LoadCell:
             self.printer.send_event("load_cell:tare", self)
     def _handle_ready(self):
         self.printer.get_reactor().register_callback(self._handle_do_ready)
+    def _start_sensor_data(self):
+        self.sensor.add_client(self._sensor_data_event)
 
     # convert raw counts to grams and broadcast to clients
     def _sensor_data_event(self, msg):
@@ -420,8 +450,7 @@ class LoadCell:
             samples.append([row[0], self.counts_to_grams(row[1]), row[1],
                             self.tare_counts])
         msg = {'data': samples, 'errors': errors, 'overflows': overflows}
-        self.clients.send(msg)
-        return True
+        return self.clients.send(msg)
 
     # get internal events of force data
     def add_client(self, callback):
@@ -481,6 +510,8 @@ class LoadCell:
 
     # Provide ongoing force tracking/averaging for status updates
     def _track_force(self, msg):
+        if not self._is_tracking:
+            return False
         if not (self.is_calibrated() and self.is_tared()):
             return True
         samples = msg['data']
@@ -488,6 +519,16 @@ class LoadCell:
         for sample in samples:
             self._force_buffer.append(sample[1])
         return True
+
+    def _start_tracking(self):
+        if self._is_tracking:
+            return
+        self._is_tracking = True
+        self.add_client(self._track_force)
+
+    def _stop_tracking(self):
+        self._is_tracking = False
+        self._force_buffer.clear()
 
     def _force_g(self):
         if (self.is_calibrated() and self.is_tared()
@@ -524,7 +565,8 @@ class LoadCell:
         status.update({'is_calibrated': self.is_calibrated(),
                        'counts_per_gram': self.counts_per_gram,
                        'reference_tare_counts': self.reference_tare_counts,
-                       'tare_counts': self.tare_counts})
+                       'tare_counts': self.tare_counts,
+                       'is_active': self.clients.is_active()})
         status.update(self.sensor.get_status(eventtime))
         return status
 


### PR DESCRIPTION
This PR changes the default behavior of `load_cell` and `load_cell_probe`  to not start tracking force after Klipper startup. This can be changed back via a configuration option, or enabled and disabled at runtime on-demand via a command. This can be particularly useful for fast-sampling loadcells as continuous sampling when not needed creates unnecessary load on the MCU and the host. And FWIW, this is an initial proposal and I'm open to suggestions on the command and configuration option names and such.

@garethky FYI