### PR TITLE
Use newer greenlet for compatibility with Python 3.14

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -5,7 +5,7 @@
 
 # greenlet is used by the reactor.py code
 greenlet==2.0.2 ; python_version < '3.12'
-greenlet==3.1.1 ; python_version >= '3.12'
+greenlet==3.3.2 ; python_version >= '3.12'
 # cffi is used by "chelper" code and by greenlet
 cffi==1.14.6 ; python_version < '3.12'
 cffi==1.17.1 ; python_version >= '3.12'


### PR DESCRIPTION
Similarly to #6910, installation fails with build errors when using python 3.14.
According to https://github.com/python-greenlet/greenlet/issues/493 and greenlet changelog, minimal version of greenlet for python 3.14 is `3.3.x`.

*I've not yet tested if everything works with the new version (currently trying to set up klipper for the first time), but at least it builds without errors now.