### PR TITLE
docs: Update DCO real name requirement to reflect official CNCF guidance

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -295,8 +295,13 @@ context for the commit comments.
 It is important to have a "Signed-off-by" line on each commit - it
 certifies that you agree to the
 [developer certificate of origin](developer-certificate-of-origin). It
-must contain your real name (sorry, no pseudonyms or anonymous
-contributions) and contain a current email address.
+must contain a real name and a current email address. A real name does
+not need to be a legal name, birth name, or any name appearing on an
+official ID; it is the name by which people in the community can
+identify and reach you if a question about your contribution were ever
+to arise. Anonymous IDs or false names that misrepresent who you are
+are not acceptable. See the [CNCF DCO guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/dco-guidelines.md#dco-and-real-names)
+for further detail.
 
 ## Contributing to Klipper Translations
 


### PR DESCRIPTION
The existing text states contributors must use their real name, with a parenthetical explicitly banning pseudonyms. This language was inherited from the Linux kernel's submitting-patches documentation, but it does not reflect the current official policy for CNCF projects.
The CNCF Foundation formally addressed this in ([cncf/foundation#379](https://github.com/cncf/foundation/issues/379), [cncf/foundation#383](https://github.com/cncf/foundation/issues/383), and linux kernal commit [d4563201f33a022fc0353033d9dfeb1606a88330](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/Documentation/process/submitting-patches.rst?id=d4563201f33a022fc0353033d9dfeb1606a88330)). The outcome, authored with input from Linux Foundation legal counsel, revised [DCO Guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/dco-guidelines.md#dco-and-real-names), which state:

A real name does not require a legal name, nor a birth name, nor any name that appears on an official ID (e.g. a passport). Your real name is the name you convey to people in the community for them to use to identify you as you. The key concern is that your identification is sufficient enough to contact you if an issue were to arise in the future about your contribution.

The requirement is identifiability and reachability, not disclosure of legal identity. The prohibition on pseudonyms is explicitly _not_ part of DCO policy.
This PR updates the contributing guide to match what the governing bodies actually require, replacing the inaccurate parenthetical with a plain-language summary of the official guidelines.

Signed-off-by: Robert Samples <rsamples@smith.edu>