### PR TITLE
probe_eddy_current: add query and backlash diagnostics

### DIFF
--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -455,23 +455,6 @@ steps outlined below.  If the printer to be calibrated is enclosed, it
 is strongly recommended to set the `max_validation_temp` option to a value
 between 100 and 120.
 
-Some users monitor a toolhead board temperature (for example, MCU
-temperature from a SHT36 board) and ask if that can be used for eddy drift
-compensation. It may be useful for general monitoring, but it is not a
-replacement for a probe coil temperature sensor.
-
-For example, one may monitor toolhead MCU temperature with:
-
-```
-[temperature_sensor toolhead_mcu_temp]
-sensor_type: temperature_mcu
-sensor_mcu: my_toolhead_mcu
-```
-
-This reports board MCU temperature. Thermal drift compensation in this
-section requires a `[temperature_probe]` that reports probe coil
-temperature and is linked to the same name as `[probe_eddy_current]`.
-
 Eddy probe manufacturers may offer a stock drift calibration that can be
 manually added to `drift_calibration` option of the `[probe_eddy_current]`
 section. If they do not, or if the stock calibration does not perform well on

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -455,6 +455,23 @@ steps outlined below.  If the printer to be calibrated is enclosed, it
 is strongly recommended to set the `max_validation_temp` option to a value
 between 100 and 120.
 
+Some users monitor a toolhead board temperature (for example, MCU
+temperature from a SHT36 board) and ask if that can be used for eddy drift
+compensation. It may be useful for general monitoring, but it is not a
+replacement for a probe coil temperature sensor.
+
+For example, one may monitor toolhead MCU temperature with:
+
+```
+[temperature_sensor toolhead_mcu_temp]
+sensor_type: temperature_mcu
+sensor_mcu: my_toolhead_mcu
+```
+
+This reports board MCU temperature. Thermal drift compensation in this
+section requires a `[temperature_probe]` that reports probe coil
+temperature and is linked to the same name as `[probe_eddy_current]`.
+
 Eddy probe manufacturers may offer a stock drift calibration that can be
 manually added to `drift_calibration` option of the `[probe_eddy_current]`
 section. If they do not, or if the stock calibration does not perform well on

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -267,6 +267,23 @@ hardware temperature can alter the results. Therefore, for best
 results the calibration done here and the subsequent probing that
 utilizes that calibration should be done at the same temperature.
 
+### Diagnostics commands
+
+After calibration, the following commands may be useful for live
+diagnostics:
+
+- `PROBE_EDDY_CURRENT_QUERY CHIP=<config_name>`
+  - Reports current sensor frequency and corresponding calibrated
+    height at the current toolhead position.
+- `PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=<config_name>`
+  - Runs repeated above/below approaches to the same Z target and
+    reports cycle-by-cycle backlash estimates plus aggregate
+    statistics (`avg`, `median`, `min`, `max`, `std`).
+
+For both commands, keep the nozzle inside the calibrated Z range.
+If outside that range, the command will return an out-of-range error
+with movement guidance.
+
 ### Tap calibration
 
 In order to utilize "tap" probing it is necessary to configure some

--- a/docs/Eddy_Probe.md
+++ b/docs/Eddy_Probe.md
@@ -273,16 +273,65 @@ After calibration, the following commands may be useful for live
 diagnostics:
 
 - `PROBE_EDDY_CURRENT_QUERY CHIP=<config_name>`
-  - Reports current sensor frequency and corresponding calibrated
+  - Reports the live sensor frequency median and corresponding calibrated
     height at the current toolhead position.
 - `PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=<config_name>`
   - Runs repeated above/below approaches to the same Z target and
     reports cycle-by-cycle backlash estimates plus aggregate
-    statistics (`avg`, `median`, `min`, `max`, `std`).
+    statistics (`median`, `mad`, `min`, `max`).
 
 For both commands, keep the nozzle inside the calibrated Z range.
 If outside that range, the command will return an out-of-range error
 with movement guidance.
+
+In practice, these commands are most useful when they are run at a
+repeatable reference position and compared against a known baseline.
+They are intended to answer questions such as:
+
+- Is the sensor output currently stable?
+- Has repeatability changed after a config or hardware change?
+- Is Z backlash (or directional hysteresis) getting worse?
+
+Suggested practical workflow:
+
+1. Prepare a repeatable test position.
+   - Home XY (and Z if appropriate for your setup), move to a fixed XY
+     point near bed center, then move to a known Z (for example, near
+     1-3mm above bed).
+   - Reuse this same position for all future checks.
+
+2. Capture a baseline query result.
+   - Run `PROBE_EDDY_CURRENT_QUERY CHIP=<config_name>` several times
+     (for example, 3-5 runs).
+   - Record `freq_median` and `height` values and keep them with the
+     printer's current temperature conditions.
+   - Use this as your "known good" reference after calibration.
+
+3. Measure directional repeatability.
+   - Run `PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=<config_name>`.
+   - Record `estimate_median` and `estimate_mad`.
+   - Repeat this test after mechanical changes, speed changes, lead
+     screw service, or if first-layer consistency regresses.
+
+4. Compare against your own baseline over time.
+   - If query values at the same XY/Z drift significantly across
+     similar temperatures, suspect thermal effects or stale
+     calibration.
+   - If backlash `estimate_median` grows or `estimate_mad` becomes
+     erratic, suspect mechanical hysteresis, looseness, or motion
+     profile effects.
+
+What to do with results:
+
+- Stable query + stable backlash: keep current settings.
+- Stable query + rising backlash: inspect Z mechanics and approach
+  strategy (motion speed/accel/path), then re-test.
+- Query drift at same position/temperature: warm up to consistent
+  conditions, re-check, then consider re-running
+  `PROBE_EDDY_CURRENT_CALIBRATE`.
+- Frequent out-of-range in diagnostics: keep test positions within
+  calibration range and verify calibration was performed with the
+  current frequency/clock settings.
 
 ### Tap calibration
 

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1275,6 +1275,24 @@ starts a tool that can calibrate the probe's "tap_threshold"
 parameter. See the
 [eddy probe documentation](Eddy_Probe.md#tap-calibration) for details.
 
+#### PROBE_EDDY_CURRENT_QUERY
+`PROBE_EDDY_CURRENT_QUERY CHIP=<config_name> [SAMPLES=<count>]`
+`[SAMPLE_TIME=<seconds>]`: Report the current eddy frequency and
+corresponding calibrated height at the current toolhead position.
+`SAMPLES` defaults to 40 and `SAMPLE_TIME` defaults to 0.100 seconds.
+If the measured point is outside the calibrated range, the command
+returns an error with a hint on how to move back into range.
+
+#### PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH
+`PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=<config_name>`
+`[TARGET_Z=<mm>] [TRAVEL=<mm>] [SPEED=<mm/s>] [CYCLES=<count>]`
+`[SAMPLES=<count>] [SAMPLE_TIME=<seconds>]`: Estimate Z backlash by
+repeatedly approaching the same target Z from above and below. The
+command prints one line per cycle and then an aggregate summary with
+`avg`, `median`, `min`, `max`, and `std` statistics. Defaults are:
+`TRAVEL=0.500`, `SPEED=10.0`, `CYCLES=5`, `SAMPLES=20`, and
+`SAMPLE_TIME=0.100`.
+
 #### LDC_CALIBRATE_DRIVE_CURRENT
 `LDC_CALIBRATE_DRIVE_CURRENT CHIP=<config_name>` This tool will
 calibrate the ldc1612 DRIVE_CURRENT0 register. Prior to using this

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1279,9 +1279,11 @@ parameter. See the
 `PROBE_EDDY_CURRENT_QUERY CHIP=<config_name> [SAMPLES=<count>]`
 `[SAMPLE_TIME=<seconds>]`: Report the current eddy frequency and
 corresponding calibrated height at the current toolhead position.
-`SAMPLES` defaults to 40 and `SAMPLE_TIME` defaults to 0.100 seconds.
-If the measured point is outside the calibrated range, the command
-returns an error with a hint on how to move back into range.
+The command uses the live eddy sensor stream and reports the median
+frequency from the requested sample window. `SAMPLES` defaults to 40
+and `SAMPLE_TIME` defaults to 0.100 seconds. If the measured point is
+outside the calibrated range, the command returns an error with a
+hint on how to move back into range.
 
 #### PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH
 `PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=<config_name>`
@@ -1289,7 +1291,7 @@ returns an error with a hint on how to move back into range.
 `[SAMPLES=<count>] [SAMPLE_TIME=<seconds>]`: Estimate Z backlash by
 repeatedly approaching the same target Z from above and below. The
 command prints one line per cycle and then an aggregate summary with
-`avg`, `median`, `min`, `max`, and `std` statistics. Defaults are:
+`median`, `mad`, `min`, and `max` statistics. Defaults are:
 `TRAVEL=0.500`, `SPEED=10.0`, `CYCLES=5`, `SAMPLES=20`, and
 `SAMPLE_TIME=0.100`.
 

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -565,7 +565,8 @@ class EddyDiagnosticsHelper:
                                    self.cmd_EDDY_ESTIMATE_BACKLASH,
                                    desc=self.cmd_EDDY_ESTIMATE_BACKLASH_help)
 
-    cmd_EDDY_QUERY_help = "Report current probe_eddy_current frequency and height"
+    cmd_EDDY_QUERY_help = (
+        "Report current probe_eddy_current frequency and height")
     cmd_EDDY_ESTIMATE_BACKLASH_help = (
         "Estimate Z backlash using repeated opposite-direction approaches")
 
@@ -626,14 +627,16 @@ class EddyDiagnosticsHelper:
         freq_avg, sensor_z, min_z, max_z = self._collect_height(
             sample_count, sample_time)
         gcmd.respond_info(
-            "%s: freq=%.3fHz height=%.6fmm samples=%d range=%.6f..%.6fmm status=ok"
+            "%s: freq=%.3fHz height=%.6fmm samples=%d "
+            "range=%.6f..%.6fmm status=ok"
             % (self.name, freq_avg, sensor_z, sample_count, min_z, max_z))
 
     def cmd_EDDY_ESTIMATE_BACKLASH(self, gcmd):
         self.calibration.verify_calibrated()
         reactor = self.printer.get_reactor()
         toolhead = self.printer.lookup_object('toolhead')
-        homed_axes = toolhead.get_status(reactor.monotonic()).get('homed_axes', '')
+        homed_axes = toolhead.get_status(
+            reactor.monotonic()).get('homed_axes', '')
         if 'z' not in homed_axes:
             raise self.printer.command_error("Must home axis first")
 
@@ -700,7 +703,8 @@ class EddyDiagnosticsHelper:
             "%s backlash: target_z=%.6fmm cycles=%d from_above_avg=%.6fmm "
             "from_below_avg=%.6fmm estimate_avg=%.6fmm estimate_median=%.6fmm "
             "estimate_min=%.6fmm estimate_max=%.6fmm estimate_std=%.6fmm "
-            "travel=%.3fmm speed=%.1fmm/s samples=%d range=%.6f..%.6fmm status=ok"
+                "travel=%.3fmm speed=%.1fmm/s samples=%d "
+                "range=%.6f..%.6fmm status=ok"
             % (self.name, target_z, cycles,
                avg_from_above, avg_from_below,
                avg_backlash, median_backlash,

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -596,8 +596,9 @@ class EddyDiagnosticsHelper:
                 "Unable to obtain probe_eddy_current sensor readings")
 
         samples = samples[:sample_count]
-        freq_avg = sum([freq for eventtime, freq in samples]) / len(samples)
-        sensor_z = self.calibration.freq_to_height(freq_avg)
+        sample_freqs = [freq for eventtime, freq in samples]
+        freq_median = self._calc_median(sample_freqs)
+        sensor_z = self.calibration.freq_to_height(freq_median)
         dummy_freqs, cal_zpos = self.calibration.get_calibration()
         min_z = min(cal_zpos)
         max_z = max(cal_zpos)
@@ -609,8 +610,8 @@ class EddyDiagnosticsHelper:
             raise self.printer.command_error(
                 "probe_eddy_current sensor not in valid range: "
                 "freq=%.3fHz height=%.6fmm calibrated=%.6f..%.6fmm hint=%s"
-                % (freq_avg, sensor_z, min_z, max_z, hint))
-        return freq_avg, sensor_z, min_z, max_z
+                % (freq_median, sensor_z, min_z, max_z, hint))
+        return freq_median, sensor_z, min_z, max_z
 
     def _calc_median(self, values):
         sorted_values = sorted(values)
@@ -624,12 +625,12 @@ class EddyDiagnosticsHelper:
         sample_count = gcmd.get_int("SAMPLES", 40, minval=1, maxval=400)
         sample_time = gcmd.get_float("SAMPLE_TIME", 0.100,
                                      minval=0.020, maxval=2.000)
-        freq_avg, sensor_z, min_z, max_z = self._collect_height(
+        freq_median, sensor_z, min_z, max_z = self._collect_height(
             sample_count, sample_time)
         gcmd.respond_info(
-            "%s: freq=%.3fHz height=%.6fmm samples=%d "
+            "%s: freq_median=%.3fHz height=%.6fmm samples=%d "
             "range=%.6f..%.6fmm status=ok"
-            % (self.name, freq_avg, sensor_z, sample_count, min_z, max_z))
+            % (self.name, freq_median, sensor_z, sample_count, min_z, max_z))
 
     def cmd_EDDY_ESTIMATE_BACKLASH(self, gcmd):
         self.calibration.verify_calibrated()
@@ -653,8 +654,6 @@ class EddyDiagnosticsHelper:
         toolhead.manual_move(pos, speed)
 
         cycle_backlash = []
-        cycle_from_above = []
-        cycle_from_below = []
         min_z = max_z = 0.
         for i in range(cycles):
             pos[2] = target_z + travel
@@ -673,8 +672,6 @@ class EddyDiagnosticsHelper:
             freq_from_below, z_from_below, min_z, max_z = self._collect_height(
                 sample_count, sample_time)
 
-            cycle_from_above.append(z_from_above)
-            cycle_from_below.append(z_from_below)
             cycle_backlash.append(abs(z_from_above - z_from_below))
             gcmd.respond_info(
                 "%s backlash cycle %d/%d: "
@@ -684,31 +681,23 @@ class EddyDiagnosticsHelper:
                    freq_from_below, z_from_below,
                    cycle_backlash[-1]))
 
-        avg_backlash = sum(cycle_backlash) / len(cycle_backlash)
         min_backlash = min(cycle_backlash)
         max_backlash = max(cycle_backlash)
-        std_backlash = 0.
-        if len(cycle_backlash) > 1:
-            variance = sum([(b - avg_backlash) ** 2
-                            for b in cycle_backlash]) / len(cycle_backlash)
-            std_backlash = math.sqrt(variance)
         median_backlash = self._calc_median(cycle_backlash)
-        avg_from_above = sum(cycle_from_above) / len(cycle_from_above)
-        avg_from_below = sum(cycle_from_below) / len(cycle_from_below)
+        backlash_mad = self._calc_median(
+            [abs(b - median_backlash) for b in cycle_backlash])
         estimates_text = ','.join(['%.6f' % (b,) for b in cycle_backlash])
         gcmd.respond_info(
             "%s backlash detail: estimates_mm=[%s]"
             % (self.name, estimates_text))
         gcmd.respond_info(
-            "%s backlash: target_z=%.6fmm cycles=%d from_above_avg=%.6fmm "
-            "from_below_avg=%.6fmm estimate_avg=%.6fmm estimate_median=%.6fmm "
-            "estimate_min=%.6fmm estimate_max=%.6fmm estimate_std=%.6fmm "
+            "%s backlash: target_z=%.6fmm cycles=%d estimate_median=%.6fmm "
+            "estimate_mad=%.6fmm estimate_min=%.6fmm estimate_max=%.6fmm "
                 "travel=%.3fmm speed=%.1fmm/s samples=%d "
                 "range=%.6f..%.6fmm status=ok"
             % (self.name, target_z, cycles,
-               avg_from_above, avg_from_below,
-               avg_backlash, median_backlash,
-               min_backlash, max_backlash, std_backlash,
+               median_backlash, backlash_mad,
+               min_backlash, max_backlash,
                travel, speed, sample_count, min_z, max_z))
 
 

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -548,6 +548,166 @@ def probe_results_from_avg(measures, toolhead_pos, calibration, offsets):
                                             (offsets[0], offsets[1], sensor_z))
 
 
+# Implement diagnostics commands for probe_eddy_current
+class EddyDiagnosticsHelper:
+    def __init__(self, config, sensor_helper, calibration):
+        self.printer = config.get_printer()
+        self.name = config.get_name()
+        self.sensor_helper = sensor_helper
+        self.calibration = calibration
+        cname = self.name.split()[-1]
+        gcode = self.printer.lookup_object('gcode')
+        gcode.register_mux_command("PROBE_EDDY_CURRENT_QUERY", "CHIP",
+                                   cname, self.cmd_EDDY_QUERY,
+                                   desc=self.cmd_EDDY_QUERY_help)
+        gcode.register_mux_command("PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH",
+                                   "CHIP", cname,
+                                   self.cmd_EDDY_ESTIMATE_BACKLASH,
+                                   desc=self.cmd_EDDY_ESTIMATE_BACKLASH_help)
+
+    cmd_EDDY_QUERY_help = "Report current probe_eddy_current frequency and height"
+    cmd_EDDY_ESTIMATE_BACKLASH_help = (
+        "Estimate Z backlash using repeated opposite-direction approaches")
+
+    def _collect_height(self, sample_count, sample_time):
+        samples = []
+        is_querying = True
+
+        def handle_batch(msg):
+            if not is_querying:
+                return False
+            for eventtime, freq, dummy_z in msg.get('data', []):
+                samples.append((eventtime, freq))
+            return len(samples) < sample_count
+
+        self.sensor_helper.add_client(handle_batch)
+        toolhead = self.printer.lookup_object('toolhead')
+        samples_per_second = self.sensor_helper.get_samples_per_second()
+        min_dwell = float(sample_count) / samples_per_second + 0.100
+        dwell_time = max(sample_time, min_dwell)
+        toolhead.dwell(dwell_time)
+        toolhead.wait_moves()
+        is_querying = False
+        toolhead.dwell(0.110)
+        toolhead.wait_moves()
+        if not samples:
+            raise self.printer.command_error(
+                "Unable to obtain probe_eddy_current sensor readings")
+
+        samples = samples[:sample_count]
+        freq_avg = sum([freq for eventtime, freq in samples]) / len(samples)
+        sensor_z = self.calibration.freq_to_height(freq_avg)
+        dummy_freqs, cal_zpos = self.calibration.get_calibration()
+        min_z = min(cal_zpos)
+        max_z = max(cal_zpos)
+        if sensor_z <= -OUT_OF_RANGE or sensor_z >= OUT_OF_RANGE:
+            if sensor_z >= OUT_OF_RANGE:
+                hint = "move nozzle closer to bed (decrease Z)"
+            else:
+                hint = "move nozzle away from bed (increase Z)"
+            raise self.printer.command_error(
+                "probe_eddy_current sensor not in valid range: "
+                "freq=%.3fHz height=%.6fmm calibrated=%.6f..%.6fmm hint=%s"
+                % (freq_avg, sensor_z, min_z, max_z, hint))
+        return freq_avg, sensor_z, min_z, max_z
+
+    def _calc_median(self, values):
+        sorted_values = sorted(values)
+        center = len(sorted_values) // 2
+        if len(sorted_values) % 2:
+            return sorted_values[center]
+        return 0.5 * (sorted_values[center - 1] + sorted_values[center])
+
+    def cmd_EDDY_QUERY(self, gcmd):
+        self.calibration.verify_calibrated()
+        sample_count = gcmd.get_int("SAMPLES", 40, minval=1, maxval=400)
+        sample_time = gcmd.get_float("SAMPLE_TIME", 0.100,
+                                     minval=0.020, maxval=2.000)
+        freq_avg, sensor_z, min_z, max_z = self._collect_height(
+            sample_count, sample_time)
+        gcmd.respond_info(
+            "%s: freq=%.3fHz height=%.6fmm samples=%d range=%.6f..%.6fmm status=ok"
+            % (self.name, freq_avg, sensor_z, sample_count, min_z, max_z))
+
+    def cmd_EDDY_ESTIMATE_BACKLASH(self, gcmd):
+        self.calibration.verify_calibrated()
+        reactor = self.printer.get_reactor()
+        toolhead = self.printer.lookup_object('toolhead')
+        homed_axes = toolhead.get_status(reactor.monotonic()).get('homed_axes', '')
+        if 'z' not in homed_axes:
+            raise self.printer.command_error("Must home axis first")
+
+        travel = gcmd.get_float("TRAVEL", 0.500, minval=0.050, maxval=5.000)
+        speed = gcmd.get_float("SPEED", 10.0, minval=1.0, maxval=80.0)
+        cycles = gcmd.get_int("CYCLES", 5, minval=1, maxval=20)
+        sample_count = gcmd.get_int("SAMPLES", 20, minval=1, maxval=400)
+        sample_time = gcmd.get_float("SAMPLE_TIME", 0.100,
+                                     minval=0.020, maxval=2.000)
+
+        pos = list(toolhead.get_position())
+        target_z = gcmd.get_float("TARGET_Z", pos[2])
+        pos[2] = target_z
+        toolhead.manual_move(pos, speed)
+
+        cycle_backlash = []
+        cycle_from_above = []
+        cycle_from_below = []
+        min_z = max_z = 0.
+        for i in range(cycles):
+            pos[2] = target_z + travel
+            toolhead.manual_move(pos, speed)
+            pos[2] = target_z
+            toolhead.manual_move(pos, speed)
+            toolhead.wait_moves()
+            freq_from_above, z_from_above, min_z, max_z = self._collect_height(
+                sample_count, sample_time)
+
+            pos[2] = target_z - travel
+            toolhead.manual_move(pos, speed)
+            pos[2] = target_z
+            toolhead.manual_move(pos, speed)
+            toolhead.wait_moves()
+            freq_from_below, z_from_below, min_z, max_z = self._collect_height(
+                sample_count, sample_time)
+
+            cycle_from_above.append(z_from_above)
+            cycle_from_below.append(z_from_below)
+            cycle_backlash.append(abs(z_from_above - z_from_below))
+            gcmd.respond_info(
+                "%s backlash cycle %d/%d: "
+                "above=%.3fHz/%.6fmm below=%.3fHz/%.6fmm estimate=%.6fmm"
+                % (self.name, i + 1, cycles,
+                   freq_from_above, z_from_above,
+                   freq_from_below, z_from_below,
+                   cycle_backlash[-1]))
+
+        avg_backlash = sum(cycle_backlash) / len(cycle_backlash)
+        min_backlash = min(cycle_backlash)
+        max_backlash = max(cycle_backlash)
+        std_backlash = 0.
+        if len(cycle_backlash) > 1:
+            variance = sum([(b - avg_backlash) ** 2
+                            for b in cycle_backlash]) / len(cycle_backlash)
+            std_backlash = math.sqrt(variance)
+        median_backlash = self._calc_median(cycle_backlash)
+        avg_from_above = sum(cycle_from_above) / len(cycle_from_above)
+        avg_from_below = sum(cycle_from_below) / len(cycle_from_below)
+        estimates_text = ','.join(['%.6f' % (b,) for b in cycle_backlash])
+        gcmd.respond_info(
+            "%s backlash detail: estimates_mm=[%s]"
+            % (self.name, estimates_text))
+        gcmd.respond_info(
+            "%s backlash: target_z=%.6fmm cycles=%d from_above_avg=%.6fmm "
+            "from_below_avg=%.6fmm estimate_avg=%.6fmm estimate_median=%.6fmm "
+            "estimate_min=%.6fmm estimate_max=%.6fmm estimate_std=%.6fmm "
+            "travel=%.3fmm speed=%.1fmm/s samples=%d range=%.6f..%.6fmm status=ok"
+            % (self.name, target_z, cycles,
+               avg_from_above, avg_from_below,
+               avg_backlash, median_backlash,
+               min_backlash, max_backlash, std_backlash,
+               travel, speed, sample_count, min_z, max_z))
+
+
 ######################################################################
 # Data fitting for "tap"
 ######################################################################
@@ -1027,6 +1187,7 @@ class PrinterEddyProbe:
         sensors = { "ldc1612": ldc1612.LDC1612 }
         sensor_type = config.getchoice('sensor_type', {s: s for s in sensors})
         self.sensor_helper = sensors[sensor_type](config, self.calibration)
+        EddyDiagnosticsHelper(config, self.sensor_helper, self.calibration)
         # Create trigger_analog interface
         trig_analog = trigger_analog.MCU_trigger_analog(self.sensor_helper)
         probe.LookupZSteppers(config, trig_analog.get_dispatch().add_stepper)


### PR DESCRIPTION
## Summary
- add PROBE_EDDY_CURRENT_QUERY CHIP=config_name for live frequency/height diagnostics
- add PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH CHIP=config_name with cycle-by-cycle output and aggregate stats
- document both commands in G-Code and Eddy probe docs

## Example output
- PROBE_EDDY_CURRENT_QUERY
  - probe_eddy_current fly_eddy: freq_median=4371699.542Hz height=2.996046mm samples=40 range=0.050000..4.050000mm status=ok

- PROBE_EDDY_CURRENT_ESTIMATE_BACKLASH
  - probe_eddy_current fly_eddy backlash cycle 1/5: above=4371543.229Hz/3.004274mm below=4371652.454Hz/2.998525mm estimate=0.005749mm
  - probe_eddy_current fly_eddy backlash cycle 2/5: above=4371518.046Hz/3.005600mm below=4371632.189Hz/2.999591mm estimate=0.006009mm
  - probe_eddy_current fly_eddy backlash cycle 3/5: above=4371497.780Hz/3.006667mm below=4371632.189Hz/2.999591mm estimate=0.007076mm
  - probe_eddy_current fly_eddy backlash cycle 4/5: above=4371499.419Hz/3.006580mm below=4371630.549Hz/2.999678mm estimate=0.006902mm
  - probe_eddy_current fly_eddy backlash cycle 5/5: above=4371499.419Hz/3.006580mm below=4371630.549Hz/2.999678mm estimate=0.006902mm
  - probe_eddy_current fly_eddy backlash detail: estimates_mm=[0.005749,0.006009,0.007076,0.006902,0.006902]
  - probe_eddy_current fly_eddy backlash: target_z=3.000000mm cycles=5 estimate_median=0.006902mm estimate_mad=0.000174mm estimate_min=0.005749mm estimate_max=0.007076mm travel=0.500mm speed=10.0mm/s samples=20 range=0.050000..4.050000mm status=ok

## Details
- query command supports SAMPLES and SAMPLE_TIME
- backlash command supports TARGET_Z, TRAVEL, SPEED, CYCLES, SAMPLES, and SAMPLE_TIME
- backlash output includes per-cycle lines plus final median/mad/min/max and raw estimate list

## Validation
- python3 -m py_compile klippy/extras/probe_eddy_current.py
- reviewed docs updates for command syntax and behavior
- tested on Fly Eddy after recalibration with frequency: 40000000

## Notes
- defaults chosen for practical runtime: CYCLES=5, SAMPLES=20
