### PR TITLE
rp2040: Fix i2c bus bounds check

### DIFF
--- a/src/rp2040/i2c.c
+++ b/src/rp2040/i2c.c
@@ -71,7 +71,7 @@ static const struct i2c_info i2c_bus[] = {
 struct i2c_config
 i2c_setup(uint32_t bus, uint32_t rate, uint8_t addr)
 {
-    if (bus > ARRAY_SIZE(i2c_bus))
+    if (bus >= ARRAY_SIZE(i2c_bus))
         shutdown("Invalid i2c bus");
 
     const struct i2c_info *info = &i2c_bus[bus];


### PR DESCRIPTION
## Summary

Fix an off-by-one bounds check in the RP2040 I2C bus setup path.

The RP2040 `i2c_bus` table has 15 entries, so valid indexes are `0..14`. The current guard rejects values greater than `ARRAY_SIZE(i2c_bus)`, but allows `bus == ARRAY_SIZE(i2c_bus)` through to `i2c_bus[bus]`.

This changes the check to `>=`, matching the RP2040 SPI implementation and other MCU I2C implementations in the tree.

## Testing

- `git diff --check HEAD~1..HEAD`
- `python scripts/check_whitespace.py src/rp2040/i2c.c`
- Confirmed `src/rp2040/i2c.c` remains LF-only after editing on Windows
- GitHub Actions `Build test` passed

I did not run the full MCU build locally because this Windows environment does not have `make` or the RP2040 cross toolchain installed.