### PR TITLE
Add CAN support for LPC176x

### DIFF
--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -90,6 +90,46 @@ choice
     config LPC_SERIAL_UART3_P429_P428
         bool "Serial (on UART3 P4.29/P4.28)" if LOW_LEVEL_OPTIONS
         select SERIAL
+    config LPC_MMENU_CANBUS_P0_0_P0_1
+        bool "CAN bus (CAN1 on P0.0/P0.1)"
+        select CANSERIAL
+    config LPC_MMENU_CANBUS_P0_21_P0_22
+        bool "CAN bus (CAN1 on P0.21/P0.22)" if LOW_LEVEL_OPTIONS
+        select CANSERIAL
+    config LPC_MMENU_CANBUS_P0_4_P0_5
+        bool "CAN bus (CAN2 on P0.4/P0.5)" if LOW_LEVEL_OPTIONS
+        select CANSERIAL
+    config LPC_MMENU_CANBUS_P2_7_P2_8
+        bool "CAN bus (CAN2 on P2.7/P2.8)" if LOW_LEVEL_OPTIONS
+        select CANSERIAL
+    config LPC_USBCANBUS
+        bool "USB to CAN bus bridge" if LOW_LEVEL_OPTIONS
+        select USBCANBUS
 endchoice
+
+choice
+    prompt "CAN bus interface" if USBCANBUS
+    config LPC_CMENU_CANBUS_P0_0_P0_1
+        bool "CAN bus (CAN1 on P0.0/P0.1)"
+    config LPC_CMENU_CANBUS_P0_21_P0_22
+        bool "CAN bus (CAN1 on P0.21/P0.22)"
+    config LPC_CMENU_CANBUS_P0_4_P0_5
+        bool "CAN bus (CAN2 on P0.4/P0.5)"
+    config LPC_CMENU_CANBUS_P2_7_P2_8
+        bool "CAN bus (CAN2 on P2.7/P2.8)"
+endchoice
+
+config LPC_CANBUS_P0_0_P0_1
+    bool
+    default y if LPC_MMENU_CANBUS_P0_0_P0_1 || LPC_CMENU_CANBUS_P0_0_P0_1
+config LPC_CANBUS_P0_21_P0_22
+    bool
+    default y if LPC_MMENU_CANBUS_P0_21_P0_22 || LPC_CMENU_CANBUS_P0_21_P0_22
+config LPC_CANBUS_P0_4_P0_5
+    bool
+    default y if LPC_MMENU_CANBUS_P0_4_P0_5 || LPC_CMENU_CANBUS_P0_4_P0_5
+config LPC_CANBUS_P2_7_P2_8
+    bool
+    default y if LPC_MMENU_CANBUS_P2_7_P2_8 || LPC_CMENU_CANBUS_P2_7_P2_8
 
 endif

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -4,8 +4,11 @@
 CROSS_PREFIX=arm-none-eabi-
 
 dirs-y += src/lpc176x src/generic lib/lpc176x/device
-
-CFLAGS += -mthumb -mcpu=cortex-m3 -Ilib/lpc176x/device -Ilib/cmsis-core
+dirs-$(CONFIG_CANSERIAL) += lib/fast-hash
+dirs-$(CONFIG_USBCANBUS) += lib/fast-hash
+CFLAGS-$(CONFIG_CANBUS) += -Ilib/fast-hash
+CFLAGS += $(CFLAGS-y) -mthumb -mcpu=cortex-m3
+CFLAGS += -Ilib/lpc176x/device -Ilib/cmsis-core
 
 CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
@@ -22,6 +25,11 @@ src-$(CONFIG_WANT_I2C) += lpc176x/i2c.c
 src-$(CONFIG_USBSERIAL) += lpc176x/usbserial.c lpc176x/chipid.c
 src-$(CONFIG_USBSERIAL) += generic/usb_cdc.c
 src-$(CONFIG_SERIAL) += lpc176x/serial.c generic/serial_irq.c
+canbus-src-y := lpc176x/can.c lpc176x/chipid.c generic/canserial.c
+canbus-src-y += ../lib/fast-hash/fasthash.c
+src-$(CONFIG_CANSERIAL) += $(canbus-src-y) generic/canbus.c
+src-$(CONFIG_USBCANBUS) += $(canbus-src-y) lpc176x/usbserial.c
+src-$(CONFIG_USBCANBUS) += generic/usb_canbus.c
 src-$(CONFIG_WANT_HARD_PWM) += lpc176x/hard_pwm.c
 
 # Build the additional bin output file

--- a/src/lpc176x/can.c
+++ b/src/lpc176x/can.c
@@ -1,0 +1,300 @@
+// Serial over CAN emulation for LPC176x boards.
+//
+// Copyright (C) 2026  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_CANBUS_FREQUENCY
+#include "board/armcm_boot.h" // armcm_enable_irq
+#include "board/irq.h" // irq_save
+#include "command.h" // DECL_CONSTANT_STR
+#include "compiler.h" // DIV_ROUND_CLOSEST
+#include "generic/canbus.h" // canbus_notify_tx
+#include "internal.h" // enable_pclock
+#include "sched.h" // DECL_INIT
+
+#if CONFIG_LPC_CANBUS_P0_0_P0_1
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "P0.0,P0.1");
+ #define LPC_CANx LPC_CAN1
+ #define PCLK_CANx PCLK_CAN1
+ #define GPIO_Rx GPIO(0, 0)
+ #define GPIO_Tx GPIO(0, 1)
+ #define CAN_FUNCTION_Rx 1
+ #define CAN_FUNCTION_Tx 1
+#elif CONFIG_LPC_CANBUS_P0_21_P0_22
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "P0.21,P0.22");
+ #define LPC_CANx LPC_CAN1
+ #define PCLK_CANx PCLK_CAN1
+ #define GPIO_Rx GPIO(0, 21)
+ #define GPIO_Tx GPIO(0, 22)
+ #define CAN_FUNCTION_Rx 2
+ #define CAN_FUNCTION_Tx 2
+#elif CONFIG_LPC_CANBUS_P0_4_P0_5
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "P0.4,P0.5");
+ #define LPC_CANx LPC_CAN2
+ #define PCLK_CANx PCLK_CAN2
+ #define GPIO_Rx GPIO(0, 4)
+ #define GPIO_Tx GPIO(0, 5)
+ #define CAN_FUNCTION_Rx 2
+ #define CAN_FUNCTION_Tx 2
+#elif CONFIG_LPC_CANBUS_P2_7_P2_8
+ DECL_CONSTANT_STR("RESERVE_PINS_CAN", "P2.7,P2.8");
+ #define LPC_CANx LPC_CAN2
+ #define PCLK_CANx PCLK_CAN2
+ #define GPIO_Rx GPIO(2, 7)
+ #define GPIO_Tx GPIO(2, 8)
+ #define CAN_FUNCTION_Rx 1
+ #define CAN_FUNCTION_Tx 1
+#else
+ #error No known CAN pins configured for LPC176x
+#endif
+
+#define CAN_MOD_RM             (1<<0)
+
+#define CAN_CMR_TR             (1<<0)
+#define CAN_CMR_RRB            (1<<2)
+#define CAN_CMR_CDO            (1<<3)
+#define CAN_CMR_STB1           (1<<5)
+
+#define CAN_GSR_ES             (1<<6)
+#define CAN_GSR_BS             (1<<7)
+#define CAN_GSR_RXERR_Pos      16
+#define CAN_GSR_TXERR_Pos      24
+
+#define CAN_IER_RIE            (1<<0)
+#define CAN_IER_TIE1           (1<<1)
+#define CAN_IER_EIE            (1<<2)
+#define CAN_IER_DOIE           (1<<3)
+#define CAN_IER_EPIE           (1<<5)
+#define CAN_IER_BEIE           (1<<7)
+
+#define CAN_ICR_RI             (1<<0)
+#define CAN_ICR_TI1            (1<<1)
+#define CAN_ICR_EI             (1<<2)
+#define CAN_ICR_DOI            (1<<3)
+#define CAN_ICR_EPI            (1<<5)
+#define CAN_ICR_BEI            (1<<7)
+#define CAN_ICR_ERRDIR_RECEIVE (1<<21)
+
+#define CAN_SR_RBS             (1<<0)
+#define CAN_SR_TBS1            (1<<2)
+
+#define CAN_TFI_DLC_Pos        16
+#define CAN_TFI_RTR            (1u<<30)
+#define CAN_TFI_FF             (1u<<31)
+
+#define CAN_RFS_DLC_Pos        16
+#define CAN_RFS_RTR            (1u<<30)
+#define CAN_RFS_FF             (1u<<31)
+
+#define CAN_BTR_SJW_Pos        14
+#define CAN_BTR_TSEG1_Pos      16
+#define CAN_BTR_TSEG2_Pos      20
+
+#define CANAF_AFMR_ACCBP       (1<<1)
+
+#define CAN_ERROR_PASSIVE_LIMIT 128
+#define CAN_ERROR_WARNING_LIMIT 96
+
+static struct {
+    uint32_t rx_error, tx_error;
+} CAN_Errors;
+
+static uint32_t
+make_btr(uint32_t sjw, uint32_t time_seg1, uint32_t time_seg2, uint32_t brp)
+{
+    return (((brp - 1) & 0x3ff)
+            | ((sjw - 1) << CAN_BTR_SJW_Pos)
+            | ((time_seg1 - 1) << CAN_BTR_TSEG1_Pos)
+            | ((time_seg2 - 1) << CAN_BTR_TSEG2_Pos));
+}
+
+static uint32_t
+compute_btr(uint32_t pclock, uint32_t bitrate)
+{
+    uint32_t bit_clocks = pclock / bitrate;
+    uint32_t best_sample_error = ~0, best_brp = bit_clocks / 10;
+    uint32_t time_seg1 = 7, time_seg2 = 2;
+    int qs;
+    for (qs = 25; qs >= 8; qs--) {
+        if (bit_clocks % qs)
+            continue;
+        uint32_t brp = bit_clocks / qs;
+        if (!brp || brp > 1024)
+            continue;
+
+        uint32_t cur_time_seg2 = DIV_ROUND_CLOSEST(qs, 8);
+        if (cur_time_seg2 < 2)
+            cur_time_seg2 = 2;
+        if (cur_time_seg2 > 8)
+            cur_time_seg2 = 8;
+
+        uint32_t cur_time_seg1 = qs - (1 + cur_time_seg2);
+        if (cur_time_seg1 > 16) {
+            cur_time_seg1 = 16;
+            cur_time_seg2 = qs - (1 + cur_time_seg1);
+        }
+        if (!cur_time_seg1 || cur_time_seg2 < 2 || cur_time_seg2 > 8)
+            continue;
+
+        uint32_t sample_point = DIV_ROUND_CLOSEST(
+            (1 + cur_time_seg1) * 1000, qs);
+        uint32_t sample_error = sample_point > 875
+                                ? sample_point - 875 : 875 - sample_point;
+        if (sample_error < best_sample_error) {
+            best_sample_error = sample_error;
+            best_brp = brp;
+            time_seg1 = cur_time_seg1;
+            time_seg2 = cur_time_seg2;
+        }
+    }
+
+    return make_btr(2, time_seg1, time_seg2, best_brp);
+}
+
+// Transmit a packet
+int
+canhw_send(struct canbus_msg *msg)
+{
+    if (!(LPC_CANx->SR & CAN_SR_TBS1)) {
+        irqstatus_t flag = irq_save();
+        LPC_CANx->IER |= CAN_IER_TIE1;
+        if (LPC_CANx->SR & CAN_SR_TBS1) {
+            LPC_CANx->IER &= ~CAN_IER_TIE1;
+            irq_restore(flag);
+            canbus_notify_tx();
+        } else {
+            irq_restore(flag);
+        }
+        return -1;
+    }
+
+    uint32_t tfi = (CANMSG_DATA_LEN(msg) << CAN_TFI_DLC_Pos);
+    if (msg->id & CANMSG_ID_EFF)
+        tfi |= CAN_TFI_FF;
+    if (msg->id & CANMSG_ID_RTR)
+        tfi |= CAN_TFI_RTR;
+
+    LPC_CANx->TFI1 = tfi;
+    LPC_CANx->TID1 = msg->id & (msg->id & CANMSG_ID_EFF ? 0x1fffffff : 0x7ff);
+    LPC_CANx->TDA1 = msg->data32[0];
+    LPC_CANx->TDB1 = msg->data32[1];
+    LPC_CANx->CMR = CAN_CMR_STB1 | CAN_CMR_TR;
+    return CANMSG_DATA_LEN(msg);
+}
+
+// Setup the receive packet filter
+void
+canhw_set_filter(uint32_t id)
+{
+    // Keep the LPC acceptance filter in bypass mode; canserial filters in
+    // software and this avoids a fragile AF LUT rewrite while the bus is live.
+}
+
+// Report interface status
+void
+canhw_get_status(struct canbus_status *status)
+{
+    irqstatus_t flag = irq_save();
+    uint32_t gsr = LPC_CANx->GSR;
+    uint32_t rx_error = CAN_Errors.rx_error, tx_error = CAN_Errors.tx_error;
+    irq_restore(flag);
+
+    uint32_t rx_count = (gsr >> CAN_GSR_RXERR_Pos) & 0xff;
+    uint32_t tx_count = (gsr >> CAN_GSR_TXERR_Pos) & 0xff;
+    status->rx_error = rx_error;
+    status->tx_error = tx_error;
+    if (gsr & CAN_GSR_BS)
+        status->bus_state = CANBUS_STATE_OFF;
+    else if (rx_count >= CAN_ERROR_PASSIVE_LIMIT
+             || tx_count >= CAN_ERROR_PASSIVE_LIMIT)
+        status->bus_state = CANBUS_STATE_PASSIVE;
+    else if (gsr & CAN_GSR_ES)
+        status->bus_state = CANBUS_STATE_WARN;
+    else
+        status->bus_state = CANBUS_STATE_ACTIVE;
+}
+
+static void
+can_process_rx(void)
+{
+    while (LPC_CANx->SR & CAN_SR_RBS) {
+        uint32_t rfs = LPC_CANx->RFS;
+        struct canbus_msg msg;
+        if (rfs & CAN_RFS_FF)
+            msg.id = (LPC_CANx->RID & 0x1fffffff) | CANMSG_ID_EFF;
+        else
+            msg.id = LPC_CANx->RID & 0x7ff;
+        msg.id |= rfs & CAN_RFS_RTR ? CANMSG_ID_RTR : 0;
+        msg.dlc = (rfs >> CAN_RFS_DLC_Pos) & 0x0f;
+        msg.data32[0] = LPC_CANx->RDA;
+        msg.data32[1] = LPC_CANx->RDB;
+        LPC_CANx->CMR = CAN_CMR_RRB;
+
+        canbus_process_data(&msg);
+    }
+}
+
+// This function handles CAN global interrupts
+void
+CAN_IRQHandler(void)
+{
+    uint32_t icr = LPC_CANx->ICR;
+
+    if (icr & (CAN_ICR_RI | CAN_ICR_DOI))
+        can_process_rx();
+
+    if (icr & CAN_ICR_DOI) {
+        CAN_Errors.rx_error += 1;
+        LPC_CANx->CMR = CAN_CMR_CDO;
+    }
+
+    if (icr & CAN_ICR_TI1) {
+        LPC_CANx->IER &= ~CAN_IER_TIE1;
+        canbus_notify_tx();
+    }
+
+    if (icr & CAN_ICR_BEI) {
+        if (icr & CAN_ICR_ERRDIR_RECEIVE)
+            CAN_Errors.rx_error += 1;
+        else
+            CAN_Errors.tx_error += 1;
+    }
+
+    if (icr & (CAN_ICR_EI | CAN_ICR_EPI)) {
+        uint32_t gsr = LPC_CANx->GSR;
+        if (((gsr >> CAN_GSR_RXERR_Pos) & 0xff)
+            >= CAN_ERROR_WARNING_LIMIT)
+            CAN_Errors.rx_error += 1;
+        if (((gsr >> CAN_GSR_TXERR_Pos) & 0xff)
+            >= CAN_ERROR_WARNING_LIMIT)
+            CAN_Errors.tx_error += 1;
+    }
+}
+
+void
+can_init(void)
+{
+    // Enable clock and hold the CAN controller in reset while configuring it.
+    enable_pclock(PCLK_CANx);
+    LPC_CANx->MOD = CAN_MOD_RM;
+    LPC_CANx->IER = 0;
+
+    gpio_peripheral(GPIO_Rx, CAN_FUNCTION_Rx, 1);
+    gpio_peripheral(GPIO_Tx, CAN_FUNCTION_Tx, 0);
+
+    LPC_CANAF->AFMR = CANAF_AFMR_ACCBP;
+    LPC_CANx->BTR = compute_btr(get_pclock_frequency(PCLK_CANx)
+                                , CONFIG_CANBUS_FREQUENCY);
+    LPC_CANx->EWL = CAN_ERROR_WARNING_LIMIT;
+
+    // Clear any stale interrupt state and enter normal operating mode.
+    uint32_t icr = LPC_CANx->ICR;
+    (void)icr;
+    LPC_CANx->MOD = 0;
+
+    armcm_enable_irq(CAN_IRQHandler, CAN_IRQn, 0);
+    LPC_CANx->IER = CAN_IER_RIE | CAN_IER_EIE | CAN_IER_DOIE
+                    | CAN_IER_EPIE | CAN_IER_BEIE;
+}
+DECL_INIT(can_init);

--- a/src/lpc176x/chipid.c
+++ b/src/lpc176x/chipid.c
@@ -6,6 +6,7 @@
 
 #include "autoconf.h" // CONFIG_USB_SERIAL_NUMBER_CHIPID
 #include "generic/irq.h" // irq_disable
+#include "generic/canserial.h" // canserial_set_uuid
 #include "generic/usb_cdc.h" // usb_fill_serial
 #include "generic/usbstd.h" // usb_string_descriptor
 #include "sched.h" // DECL_INIT
@@ -30,7 +31,7 @@ usbserial_get_serialid(void)
 void
 chipid_init(void)
 {
-    if (!CONFIG_USB_SERIAL_NUMBER_CHIPID)
+    if (!CONFIG_USB_SERIAL_NUMBER_CHIPID && !CONFIG_CANBUS)
         return;
 
     uint32_t iap_cmd_uid[5] = {IAP_CMD_READ_UID, 0, 0, 0, 0};
@@ -40,7 +41,11 @@ chipid_init(void)
     iap_entry(iap_cmd_uid, iap_resp);
     irq_enable();
 
-    usb_fill_serial(&cdc_chipid.desc, ARRAY_SIZE(cdc_chipid.data)
-                    , &iap_resp[1]);
+    if (CONFIG_USB_SERIAL_NUMBER_CHIPID)
+        usb_fill_serial(&cdc_chipid.desc, ARRAY_SIZE(cdc_chipid.data)
+                        , &iap_resp[1]);
+
+    if (CONFIG_CANBUS)
+        canserial_set_uuid((void*)&iap_resp[1], IAP_UID_LEN);
 }
 DECL_INIT(chipid_init);

--- a/src/lpc176x/internal.h
+++ b/src/lpc176x/internal.h
@@ -14,6 +14,8 @@
 #define PCLK_I2C0 7
 #define PCLK_SSP1 10
 #define PCLK_ADC 12
+#define PCLK_CAN1 13
+#define PCLK_CAN2 14
 #define PCLK_I2C1 19
 #define PCLK_SSP0 21
 #define PCLK_UART3 25


### PR DESCRIPTION
## Summary

Add CAN bus support for LPC176x MCUs, including both direct CAN serial and USB-to-CAN bridge modes. The new LPC176x CAN implementation supports selectable CAN1/CAN2 pin mappings through menuconfig and reports a CAN UUID from the LPC IAP chip ID.

Supported pin selections:

- CAN1 on P0.0/P0.1
- CAN1 on P0.21/P0.22
- CAN2 on P0.4/P0.5
- CAN2 on P2.7/P2.8

## Hardware Note

LPC176x chips provide a CAN controller, but common printer boards such as the SKR V1.4 do not include a CAN transceiver on these pins. An external CAN transceiver is required between the selected LPC CAN TX/RX pins and the physical CANH/CANL bus.

## Testing

- Built LPC1768 USB-to-CAN bridge firmware.
- Built LPC1768 CAN serial firmware for the supported LPC CAN pin selections.
- Verified USB-to-CAN bridge enumeration as gs_usb.
- Verified the LPC1768 bridge can be used as the local Klipper MCU over CAN.
- Verified communication with an external CAN device after enabling CAN mode on that device.
