### PR TITLE
i2c_software: support SCL clock stretching

### DIFF
--- a/src/i2c_software.c
+++ b/src/i2c_software.c
@@ -21,6 +21,8 @@ struct i2c_software {
     uint32_t ticks;
 };
 
+#define I2C_SW_STRETCH_TIMEOUT_US 5000
+
 void
 command_i2c_set_sw_bus(uint32_t *args)
 {
@@ -46,34 +48,52 @@ i2c_delay(uint32_t ticks)
         ;
 }
 
-static void
-i2c_software_send_ack(struct i2c_software *is, const uint8_t ack)
+static int
+scl_release_wait(struct gpio_in g, uint32_t timeout)
+{
+    gpio_in_reset(g, 1);
+    int is_high = gpio_in_read(g);
+    while (timer_is_before(timer_read_time(), timeout) && !is_high)
+        is_high = gpio_in_read(g);
+    return is_high ? I2C_BUS_SUCCESS : I2C_BUS_TIMEOUT;
+}
+
+static int
+i2c_software_send_ack(struct i2c_software *is, const uint8_t ack
+                      , uint32_t timeout)
 {
     if (!ack) {
         gpio_out_reset(is->sda_out, 0);
     }
     i2c_delay(is->ticks);
-    gpio_in_reset(is->scl_in, 1);
+    int ret = scl_release_wait(is->scl_in, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
     i2c_delay(is->ticks);
     gpio_out_reset(is->scl_out, 0);
+    return I2C_BUS_SUCCESS;
 }
 
-static uint8_t
-i2c_software_read_ack(struct i2c_software *is, uint_fast8_t state)
+static int
+i2c_software_read_ack(struct i2c_software *is, uint_fast8_t state
+                      , uint32_t timeout)
 {
     uint8_t nack = 0;
     if (state == 0)
         gpio_in_reset(is->sda_in, 1);
     i2c_delay(is->ticks);
-    gpio_in_reset(is->scl_in, 1);
+    int ret = scl_release_wait(is->scl_in, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
     nack = gpio_in_read(is->sda_in);
     i2c_delay(is->ticks);
     gpio_out_reset(is->scl_out, 0);
-    return nack;
+    return nack ? I2C_BUS_NACK : I2C_BUS_SUCCESS;
 }
 
 static int
-i2c_software_send_byte(struct i2c_software *is, uint8_t b)
+i2c_software_send_byte(struct i2c_software *is, uint8_t b
+                       , uint32_t timeout)
 {
     uint_fast8_t state = 2;
     for (uint_fast8_t i = 0; i < 8; i++) {
@@ -88,59 +108,65 @@ i2c_software_send_byte(struct i2c_software *is, uint8_t b)
         }
         b <<= 1;
         i2c_delay(is->ticks);
-        gpio_in_reset(is->scl_in, 1);
+        int ret = scl_release_wait(is->scl_in, timeout);
+        if (ret != I2C_BUS_SUCCESS)
+            return ret;
         i2c_delay(is->ticks);
         gpio_out_reset(is->scl_out, 0);
     }
 
-    if (i2c_software_read_ack(is, state)) {
-        return I2C_BUS_NACK;
-    }
-
-    return I2C_BUS_SUCCESS;
+    return i2c_software_read_ack(is, state, timeout);
 }
 
-static uint8_t
-i2c_software_read_byte(struct i2c_software *is, uint8_t remaining)
+static int
+i2c_software_read_byte(struct i2c_software *is, uint8_t remaining, uint8_t *out
+                       , uint32_t timeout)
 {
     uint8_t b = 0;
     gpio_in_reset(is->sda_in, 1);
     for (uint_fast8_t i = 0; i < 8; i++) {
         i2c_delay(is->ticks);
-        gpio_in_reset(is->scl_in, 1);
+        int ret = scl_release_wait(is->scl_in, timeout);
+        if (ret != I2C_BUS_SUCCESS)
+            return ret;
         i2c_delay(is->ticks);
         b <<= 1;
         b |= gpio_in_read(is->sda_in);
         gpio_out_reset(is->scl_out, 0);
     }
-    i2c_software_send_ack(is, remaining == 0);
-    return b;
+    int ret = i2c_software_send_ack(is, remaining == 0, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
+    *out = b;
+    return I2C_BUS_SUCCESS;
 }
 
 static int
-i2c_software_start(struct i2c_software *is, uint8_t addr)
+i2c_software_start(struct i2c_software *is, uint8_t addr, uint32_t timeout)
 {
     int ret;
     i2c_delay(is->ticks);
     gpio_in_reset(is->sda_in, 1);
-    gpio_in_reset(is->scl_in, 1);
+    ret = scl_release_wait(is->scl_in, timeout);
+    if (ret != I2C_BUS_SUCCESS)
+        return ret;
     i2c_delay(is->ticks);
     gpio_out_reset(is->sda_out, 0);
     i2c_delay(is->ticks);
     gpio_out_reset(is->scl_out, 0);
 
-    ret = i2c_software_send_byte(is, addr);
+    ret = i2c_software_send_byte(is, addr, timeout);
     if (ret == I2C_BUS_NACK)
         return I2C_BUS_START_NACK;
     return ret;
 }
 
 static void
-i2c_software_stop(struct i2c_software *is)
+i2c_software_stop(struct i2c_software *is, uint32_t timeout)
 {
     gpio_out_reset(is->sda_out, 0);
     i2c_delay(is->ticks);
-    gpio_in_reset(is->scl_in, 1);
+    scl_release_wait(is->scl_in, timeout);
     i2c_delay(is->ticks);
     gpio_in_reset(is->sda_in, 1);
 }
@@ -148,18 +174,20 @@ i2c_software_stop(struct i2c_software *is)
 int
 i2c_software_write(struct i2c_software *is, uint8_t write_len, uint8_t *write)
 {
-    int ret = i2c_software_start(is, is->addr);
+    uint32_t timeout = timer_read_time()
+        + timer_from_us(I2C_SW_STRETCH_TIMEOUT_US);
+    int ret = i2c_software_start(is, is->addr, timeout);
     if (ret != I2C_BUS_SUCCESS)
         goto out;
 
     while (write_len--) {
-        ret = i2c_software_send_byte(is, *write++);
+        ret = i2c_software_send_byte(is, *write++, timeout);
         if (ret != I2C_BUS_SUCCESS)
             break;
     }
 
 out:
-    i2c_software_stop(is);
+    i2c_software_stop(is, timeout);
     return ret;
 }
 
@@ -168,29 +196,33 @@ i2c_software_read(struct i2c_software *is, uint8_t reg_len, uint8_t *reg
                   , uint8_t read_len, uint8_t *read)
 {
     int ret;
+    uint32_t timeout = timer_read_time()
+        + timer_from_us(I2C_SW_STRETCH_TIMEOUT_US);
     if (reg_len) {
         // write the register
-        ret = i2c_software_start(is, is->addr);
+        ret = i2c_software_start(is, is->addr, timeout);
         if (ret != I2C_BUS_SUCCESS)
             goto out;
         while(reg_len--) {
-            ret = i2c_software_send_byte(is, *reg++);
+            ret = i2c_software_send_byte(is, *reg++, timeout);
             if (ret != I2C_BUS_SUCCESS)
                 goto out;
         }
 
     }
     // start/re-start and read data
-    ret = i2c_software_start(is, is->addr | 0x01);
+    ret = i2c_software_start(is, is->addr | 0x01, timeout);
     if (ret != I2C_BUS_SUCCESS) {
         ret = I2C_BUS_START_READ_NACK;
         goto out;
     }
     while(read_len--) {
-        *read = i2c_software_read_byte(is, read_len);
+        ret = i2c_software_read_byte(is, read_len, read, timeout);
+        if (ret != I2C_BUS_SUCCESS)
+            goto out;
         read++;
     }
 out:
-    i2c_software_stop(is);
+    i2c_software_stop(is, timeout);
     return ret;
 }


### PR DESCRIPTION
This change updates the software I2C implementation to wait until the SCL line is actually high after releasing it.

Previously, the software I2C code released SCL, waited for the fixed half-cycle delay, and then immediately continued. That works for devices that do not stretch the clock, but it can fail with devices that hold SCL low while processing a byte or ACK. In that case, the host may sample SDA or continue the transaction before the bus is actually ready.

This patch adds a helper that checks the real SCL input level after releasing SCL. If the line is still low, it polls briefly until SCL becomes high or a timeout is reached. The helper is used in the bit write path, ACK read/write path, byte read path, and START/STOP handling.

This is needed for devices such as the PN532 NFC controller. In testing, PN532 software I2C initialization required more than 200 us of SCL stretching. With a 1000 us timeout, the PN532 initializes and works correctly over software I2C.

Devices that do not use clock stretching should be unaffected, because the helper returns immediately when SCL is already high.

Testing:
- Tested with a PN532 NFC controller over Klipper software I2C on STM32G0.
- Confirmed that the previous software I2C implementation failed during PN532 initialization.
- Confirmed that a 200 us SCL wait timeout was not sufficient.
- Confirmed that a 1000 us timeout allows PN532 initialization to complete successfully.
- Confirmed that the PN532 can detect and read an NTAG tag over software I2C.
- Confirmed that a PN7160 NFC controller and AHT20/BME280, which does not require this clock stretching behavior, still works over software I2C.