### PR TITLE
config: improve comments and add warnings for Alligator Rev.3 board

### DIFF
--- a/config/generic-alligator-r3.cfg
+++ b/config/generic-alligator-r3.cfg
@@ -1,6 +1,11 @@
 # This file contains common pin mappings for Alligator (Rev.3) board.
 # To use this config, the firmware should be compiled for the Arduino
 # Due.
+# When running "make menuconfig", please select the corresponding microcontroller (Arduino Due).
+# Notes:
+# - Microstepping options: 16, 32 (currently configured as 32)
+# - The enable pin PC28 is used for both the Y-axis and microstepping configuration;
+#   please verify that the hardware connections are correct. 
 
 # Remember flash procedure:
 # sudo /etc/init.d/alligator-manager --erase
@@ -11,10 +16,9 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [static_digital_output DRV8825_microstepping]
-pins:PC10
-pins:PC29
-pins:PC19
-pins:PC18
+# Configure the microstepping mode of the DRV8825 driver
+# Options: 16, 32 (currently configured as 32)
+pins: PC10, PC29, PC19, PC18
 
 [dac084S085 stepper_digipot]
 enable_pin: PD2
@@ -44,6 +48,9 @@ homing_speed: 50
 [stepper_y]
 step_pin: PB22
 dir_pin: !PB23
+# Note: 
+# The enable pin PC28 is shared with the DRV8825 microstepping configuration;
+# please verify that the hardware connections are correct.
 enable_pin: !PC28
 microsteps: 32
 rotation_distance: 16

--- a/config/generic-alligator-r3.cfg
+++ b/config/generic-alligator-r3.cfg
@@ -48,7 +48,7 @@ homing_speed: 50
 [stepper_y]
 step_pin: PB22
 dir_pin: !PB23
-# Note: 
+# Note:
 # The enable pin PC28 is shared with the DRV8825 microstepping configuration;
 # please verify that the hardware connections are correct.
 enable_pin: !PC28

--- a/config/generic-alligator-r3.cfg
+++ b/config/generic-alligator-r3.cfg
@@ -5,7 +5,7 @@
 # Notes:
 # - Microstepping options: 16, 32 (currently configured as 32)
 # - The enable pin PC28 is used for both the Y-axis and microstepping configuration;
-#   please verify that the hardware connections are correct. 
+#   please verify that the hardware connections are correct.
 
 # Remember flash procedure:
 # sudo /etc/init.d/alligator-manager --erase


### PR DESCRIPTION
This PR improves the Alligator Rev.3 configuration file comments:

- Added note about micro-controller selection (`Arduino Due`) during menuconfig
- Clarified microstepping optional values (16, 32)
- Added warning about shared enable pin (PC28) between Y-axis and microstepping

These changes make the config file more beginner-friendly and highlight potential hardware conflicts.