### PR TITLE
rp2040: Add legacy clock setup option

### DIFF
--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -41,6 +41,12 @@ config CLOCK_FREQ
     default 12000000 if MACH_RP2040
     default 150000000 if MACH_RP2350
 
+config RP2040_LEGACY_CLOCK_SETUP
+    bool "Use legacy RP2040 clock setup" if LOW_LEVEL_OPTIONS && MACH_RP2040
+    help
+        Use the older 125MHz RP2040 clock setup for compatibility with
+        boards that do not reliably restart with the default clock setup.
+
 config FLASH_SIZE
     hex
     default 0x200000

--- a/src/rp2040/main.c
+++ b/src/rp2040/main.c
@@ -60,14 +60,19 @@ bootloader_request(void)
  ****************************************************************/
 
 #define FREQ_XOSC 12000000
-#define FREQ_SYS (CONFIG_MACH_RP2040 ? 200000000 : CONFIG_CLOCK_FREQ)
+#define FREQ_SYS (CONFIG_MACH_RP2040                    \
+                  ? (CONFIG_RP2040_LEGACY_CLOCK_SETUP   \
+                     ? 125000000 : 200000000)            \
+                  : CONFIG_CLOCK_FREQ)
 #define FBDIV (FREQ_SYS == 200000000 ? 100 : 125)
 #define FREQ_USB 48000000
+#define USB_PLL_FBDIV (CONFIG_MACH_RP2040 && CONFIG_RP2040_LEGACY_CLOCK_SETUP \
+                       ? 40 : 80)
 
 void set_vsel(void)
 {
     // Set internal voltage regulator output to 1.15V on rp2040
-#if CONFIG_MACH_RP2040
+#if CONFIG_MACH_RP2040 && !CONFIG_RP2040_LEGACY_CLOCK_SETUP
     uint32_t cval = vreg_and_chip_reset_hw->vreg;
     uint32_t vref = VREG_AND_CHIP_RESET_VREG_VSEL_RESET + 1;
     cval &= ~VREG_AND_CHIP_RESET_VREG_VSEL_BITS;
@@ -168,7 +173,7 @@ clock_setup(void)
 
     // Setup pll_usb
     enable_pclock(RESETS_RESET_PLL_USB_BITS);
-    pll_setup(pll_usb_hw, 80, 80*FREQ_XOSC/FREQ_USB);
+    pll_setup(pll_usb_hw, USB_PLL_FBDIV, USB_PLL_FBDIV*FREQ_XOSC/FREQ_USB);
 
     // Setup peripheral clocks
     clk_aux_setup(clk_peri, CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS);


### PR DESCRIPTION
This adds an optional low-level configuration setting for RP2040 builds to use the previous 125MHz clock setup.

Recent RP2040 builds use a 200MHz system clock and the newer USB PLL setup. On a Waveshare RP2040-Zero board with a GENERIC_03H flash chip, firmware built with the current default clock setup enumerates over USB after flashing, but fails to enumerate again after a board reset. The same board reliably restarts with older Klipper firmware using the previous 125MHz clock setup.

This change keeps the current 200MHz setup as the default, and only enables the 125MHz setup when the new low-level compatibility option is selected.

Tested on a Waveshare RP2040-Zero using:

- RP2040
- No bootloader
- GENERIC_03H with CLKDIV 4
- Legacy RP2040 clock setup enabled
- USB serial
- CAN bus, RX gpio4, TX gpio5, 1000000 bitrate

With the option enabled, the board continues to enumerate as USB CDC after reset in USB serial mode, and the same legacy clock setup also works in CAN bus mode.