### PR TITLE
rp2040: Add GENERIC_03H CLKDIV 8 option

### DIFF
--- a/src/rp2040/Kconfig
+++ b/src/rp2040/Kconfig
@@ -98,15 +98,19 @@ choice
         bool "W25Q080 with CLKDIV 2"
     config RP2040_FLASH_GENERIC_03
         bool "GENERIC_03H with CLKDIV 4"
+    config RP2040_FLASH_GENERIC_03_CLKDIV8
+        bool "GENERIC_03H with CLKDIV 8"
 endchoice
 
 config RP2040_STAGE2_FILE
     string
     default "boot2_generic_03h.S" if RP2040_FLASH_GENERIC_03
+    default "boot2_generic_03h.S" if RP2040_FLASH_GENERIC_03_CLKDIV8
     default "boot2_w25q080.S"
 
 config RP2040_STAGE2_CLKDIV
     int
+    default 8 if RP2040_FLASH_GENERIC_03_CLKDIV8
     default 4 if RP2040_FLASH_GENERIC_03
     default 2
 


### PR DESCRIPTION
This adds an additional RP2040 flash chip menu option for GENERIC_03H using CLKDIV 8.

The existing GENERIC_03H option remains unchanged at CLKDIV 4, so current configurations keep their existing behavior. The new option provides a slower stage2 flash clock for boards that are unstable with the existing GENERIC_03H divider after reset.

This keeps the change limited to the stage2 flash clock divider and does not change the RP2040 system clock setup.

Tested on a Waveshare RP2040-Zero with current Klipper master and the current 200MHz RP2040 clock setup:

- GENERIC_03H with CLKDIV 4: enumerates after flashing, but does not enumerate again after reset
- GENERIC_03H with CLKDIV 8: enumerates after flashing and after reset