### PR TITLE
angle: Fix MT6826S debug status lookup

### DIFF
--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -595,7 +595,7 @@ class HelperMT6826S:
             gcmd.respond_info("AUTOCAL_FREQ = %i" % (val >> 4 & 0x7))
         elif reg == 0x113:
             val = self._read_reg(reg)
-            gcmd.respond_info("Status: %s" % (self.cal_status[val >> 6]))
+            gcmd.respond_info("Status: %s" % (self.status_map[val >> 6]))
         else:
             val = self._read_reg(reg)
             gcmd.respond_info("REG[0x%04x] = 0x%02x" % (reg, val))


### PR DESCRIPTION
The MT6826S `ANGLE_DEBUG_READ REG=0x113` path attempted to report the
calibration status through `self.cal_status`, but the helper stores that
mapping in `self.status_map`.

Use the existing status map so the debug command can report the register
state instead of raising an AttributeError.

Tested:
- `git diff --check`
- exercised `HelperMT6826S.cmd_ANGLE_DEBUG_READ()` with `REG=0x113` via a
  minimal stub and confirmed it reports `Status: Calibration Failed`