### PR TITLE
trigger_analog: Fix int32 fixed point bounds

### DIFF
--- a/klippy/extras/trigger_analog.py
+++ b/klippy/extras/trigger_analog.py
@@ -11,8 +11,8 @@ import mcu
 # SOS filters (Second Order Sectional)
 ######################################################################
 
-MAX_INT32 = (2 ** 31)
-MIN_INT32 = -(2 ** 31) - 1
+MAX_INT32 = (2 ** 31) - 1
+MIN_INT32 = -(2 ** 31)
 def assert_is_int32(value, frac_bits):
     if value > MAX_INT32 or value < MIN_INT32:
         raise OverflowError("Fixed point Q%d.%d overflow"
@@ -34,7 +34,7 @@ def calc_frac_bits(values):
     if frac_bits <= 0:
         return 0
     try:
-        validate = [to_fixed_32(v) for v in values]
+        validate = [to_fixed_32(v, frac_bits) for v in values]
     except OverflowError as e:
         # Handle rare case where rounding causes an overflow
         return frac_bits - 1


### PR DESCRIPTION
The fixed point conversion helper allowed one value beyond each side of
the signed int32 range. It also validated `calc_frac_bits()` candidates
without passing the candidate fractional bit count, so rounding overflow
at the selected scale could be missed.

Use the real int32 limits and validate candidates with the calculated
`frac_bits` before returning it.

Tested:
- `git diff --check`
- verified `to_fixed_32(2**31)` and `to_fixed_32(-(2**31)-1)` raise
  `OverflowError`
- verified valid int32 endpoints still pass
- verified `calc_frac_bits([1.9999999999])` backs off to avoid a rounded
  int32 overflow