### PR TITLE
RFC: clocksync: weight outliners instead of discarding them

### DIFF
--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -15,18 +15,21 @@ class ClockSync:
         self.serial = None
         self.get_clock_timer = reactor.register_timer(self._get_clock_event)
         self.get_clock_cmd = self.cmd_queue = None
-        self.queries_pending = 0
         self.mcu_freq = 1.
+        # Tracking of background requests (updated in bg thread)
+        self.queries_pending = 0
+        # 32bit to 64bit clock conversions (updated in bg thread)
         self.last_clock = 0
-        self.clock_est = (0., 0., 0.)
-        # Minimum round-trip-time tracking
-        self.min_half_rtt = 999999999.9
-        self.min_rtt_time = 0.
-        # Linear regression of mcu clock and system sent_time
+        # Linear regression of mcu clock and system sent_time (bg thread)
         self.time_avg = self.time_variance = 0.
         self.clock_avg = self.clock_covariance = 0.
         self.prediction_variance = 0.
         self.last_prediction_time = 0.
+        # Minimum round-trip-time tracking (bg thread)
+        self.min_half_rtt = 999999999.9
+        self.min_rtt_time = 0.
+        # System clock to mcu clock estimation (updated in bg thread)
+        self.clock_est = (0., 0., 0.)
     def connect(self, serial):
         self.serial = serial
         self.mcu_freq = serial.msgparser.get_constant_float('CLOCK_FREQ')
@@ -62,39 +65,23 @@ class ClockSync:
         # Use an unusual time for the next event so clock messages
         # don't resonate with other periodic events.
         return eventtime + .9839
-    def _handle_clock(self, params):
-        self.queries_pending = 0
-        # Extend clock to 64bit
-        last_clock = self.last_clock
-        clock_delta = (params['clock'] - last_clock) & 0xffffffff
-        self.last_clock = clock = last_clock + clock_delta
-        # Check if this is the best round-trip-time seen so far
-        sent_time = params['#sent_time']
-        if not sent_time:
-            return
-        receive_time = params['#receive_time']
-        half_rtt = .5 * (receive_time - sent_time)
-        aged_rtt = (sent_time - self.min_rtt_time) * RTT_AGE
-        if half_rtt < self.min_half_rtt + aged_rtt:
-            self.min_half_rtt = half_rtt
-            self.min_rtt_time = sent_time
-            logging.debug("new minimum rtt %.3f: hrtt=%.6f freq=%d",
-                          sent_time, half_rtt, self.clock_est[2])
-        # Filter out samples that are extreme outliers
-        exp_clock = ((sent_time - self.time_avg) * self.clock_est[2]
-                     + self.clock_avg)
+    def _update_regression(self, sent_time, clock):
+        # Calculate expected clock using existing time/clock regression
+        old_freq = self.clock_est[2] # self.clock_covariance/self.time_variance
+        exp_clock = (sent_time - self.time_avg) * old_freq + self.clock_avg
+        # Track prediction accuracy and filter out extreme outliers
         clock_diff2 = (clock - exp_clock)**2
         if (clock_diff2 > 25. * self.prediction_variance
             and clock_diff2 > (.000500 * self.mcu_freq)**2):
             if clock > exp_clock and sent_time < self.last_prediction_time+10.:
                 logging.debug("Ignoring clock sample %.3f:"
                               " freq=%d diff=%d stddev=%.3f",
-                              sent_time, self.clock_est[2], clock - exp_clock,
+                              sent_time, old_freq, clock - exp_clock,
                               math.sqrt(self.prediction_variance))
-                return
+                return False
             logging.info("Resetting prediction variance %.3f:"
                          " freq=%d diff=%d stddev=%.3f",
-                         sent_time, self.clock_est[2], clock - exp_clock,
+                         sent_time, old_freq, clock - exp_clock,
                          math.sqrt(self.prediction_variance))
             self.prediction_variance = (.001 * self.mcu_freq)**2
         else:
@@ -110,15 +97,42 @@ class ClockSync:
         self.clock_avg += DECAY * diff_clock
         self.clock_covariance = (1. - DECAY) * (
             self.clock_covariance + diff_sent_time * diff_clock * DECAY)
-        # Update prediction from linear regression
+        return True
+    def _update_best_rtt(self, sent_time, receive_time):
+        # Check if this is the best round-trip-time seen so far
+        half_rtt = .5 * (receive_time - sent_time)
+        aged_rtt = (sent_time - self.min_rtt_time) * RTT_AGE
+        if half_rtt < self.min_half_rtt + aged_rtt:
+            self.min_half_rtt = half_rtt
+            self.min_rtt_time = sent_time
+            logging.debug("new minimum rtt %.3f: hrtt=%.6f freq=%d",
+                          sent_time, half_rtt, self.clock_est[2])
+    def _handle_clock(self, params):
+        self.queries_pending = 0
+        # Extend clock to 64bit
+        last_clock = self.last_clock
+        clock_delta = (params['clock'] - last_clock) & 0xffffffff
+        self.last_clock = clock = last_clock + clock_delta
+        # Determine message timing
+        sent_time = params['#sent_time']
+        receive_time = params['#receive_time']
+        if not sent_time:
+            # sent_time unknown because of 'get_clock' retransmit
+            return
+        # Update sent_time to clock regression
+        ret = self._update_regression(sent_time, clock)
+        if not ret:
+            # Message is an "outlier" and should be discarded
+            return
+        # Update serialqueue message release timing
         new_freq = self.clock_covariance / self.time_variance
         pred_stddev = math.sqrt(self.prediction_variance)
         self.serial.set_clock_est(new_freq, self.time_avg + TRANSMIT_EXTRA,
                                   int(self.clock_avg - 3. * pred_stddev))
+        # Update time translation (mainly for multi-mcu synchronization)
+        self._update_best_rtt(sent_time, receive_time)
         self.clock_est = (self.time_avg + self.min_half_rtt,
                           self.clock_avg, new_freq)
-        #logging.debug("regr %.3f: freq=%.3f d=%d(%.3f)",
-        #              sent_time, new_freq, clock - exp_clock, pred_stddev)
     # clock frequency conversions
     def print_time_to_clock(self, print_time):
         return int(print_time * self.mcu_freq)

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -80,39 +80,41 @@ class ClockSync:
         # Use an unusual time for the next event so clock messages
         # don't resonate with other periodic events.
         return eventtime + .9839
-    def _update_regression(self, sent_time, clock):
+    def _update_regression(self, sent_time, rtt, clock):
         # Calculate expected clock using existing time/clock regression
         old_freq = self.clock_est[2] # self.clock_covariance/self.time_variance
-        exp_clock = (sent_time - self.time_avg) * old_freq + self.clock_avg
+        remote_time = sent_time + rtt / 2.0
+        exp_clock = (remote_time - self.time_avg) * old_freq + self.clock_avg
         # Track prediction accuracy and filter out extreme outliers
         clock_diff2 = (clock - exp_clock)**2
         if (clock_diff2 > 25. * self.prediction_variance
             and clock_diff2 > (.000500 * self.mcu_freq)**2):
-            if clock > exp_clock and sent_time < self.last_prediction_time+10.:
+            if (clock > exp_clock
+                and remote_time < self.last_prediction_time+10.):
                 logging.debug("Ignoring clock sample %.3f:"
                               " freq=%d diff=%d stddev=%.3f",
-                              sent_time, old_freq, clock - exp_clock,
+                              remote_time, old_freq, clock - exp_clock,
                               math.sqrt(self.prediction_variance))
-                return False
+                return (clock - exp_clock) / old_freq, False
             logging.info("Resetting prediction variance %.3f:"
                          " freq=%d diff=%d stddev=%.3f",
-                         sent_time, old_freq, clock - exp_clock,
+                         remote_time, old_freq, clock - exp_clock,
                          math.sqrt(self.prediction_variance))
             self.prediction_variance = (.001 * self.mcu_freq)**2
         else:
-            self.last_prediction_time = sent_time
+            self.last_prediction_time = remote_time
             self.prediction_variance = (
                 (1. - DECAY) * (self.prediction_variance + clock_diff2 * DECAY))
-        # Add clock and sent_time to linear regression
-        diff_sent_time = sent_time - self.time_avg
-        self.time_avg += DECAY * diff_sent_time
+        # Add remote clock and time to linear regression
+        diff_remote_time = remote_time - self.time_avg
+        self.time_avg += DECAY * diff_remote_time
         self.time_variance = (1. - DECAY) * (
-            self.time_variance + diff_sent_time**2 * DECAY)
+            self.time_variance + diff_remote_time**2 * DECAY)
         diff_clock = clock - self.clock_avg
         self.clock_avg += DECAY * diff_clock
         self.clock_covariance = (1. - DECAY) * (
-            self.clock_covariance + diff_sent_time * diff_clock * DECAY)
-        return True
+            self.clock_covariance + diff_remote_time * diff_clock * DECAY)
+        return (clock - exp_clock) / old_freq, True
     def _update_best_rtt(self, sent_time, receive_time):
         # Check if this is the best round-trip-time seen so far
         half_rtt = .5 * (receive_time - sent_time)
@@ -140,7 +142,7 @@ class ClockSync:
         if rtt > threshold and sent_time - self.last_prediction_time < 10.:
             return
         # Update sent_time to clock regression
-        ret = self._update_regression(sent_time, clock)
+        offset, ret = self._update_regression(sent_time, rtt, clock)
         if not ret:
             # Message is an "outlier" and should be discarded
             return
@@ -151,7 +153,7 @@ class ClockSync:
                                   int(self.clock_avg - 3. * pred_stddev))
         # Update time translation (mainly for multi-mcu synchronization)
         self._update_best_rtt(sent_time, receive_time)
-        self.clock_est = (self.time_avg + self.min_half_rtt,
+        self.clock_est = (self.time_avg,
                           self.clock_avg, new_freq)
     # clock frequency conversions
     def print_time_to_clock(self, print_time):

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -3,7 +3,20 @@
 # Copyright (C) 2016-2018  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging, math
+import logging, math, heapq
+
+class PercentileFilter:
+    def __init__(self, size):
+        self._size = size
+        self._samples = [999999999.9] * size
+        self._next_free = 0
+    def insert(self, sample):
+        self._samples[self._next_free % self._size] = sample
+        self._next_free += 1
+    def get_threshold_for_ratio(self, ratio):
+        threshold_pos = self._size - int(self._size * ratio) + 1
+        threshold = heapq.nlargest(threshold_pos, self._samples)[-1]
+        return threshold
 
 RTT_AGE = .000010 / (60. * 60.)
 DECAY = 1. / 30.
@@ -30,6 +43,8 @@ class ClockSync:
         self.min_rtt_time = 0.
         # System clock to mcu clock estimation (updated in bg thread)
         self.clock_est = (0., 0., 0.)
+        # Input filtering
+        self.rtt_filter = PercentileFilter(30)
     def connect(self, serial):
         self.serial = serial
         self.mcu_freq = serial.msgparser.get_constant_float('CLOCK_FREQ')
@@ -118,6 +133,11 @@ class ClockSync:
         receive_time = params['#receive_time']
         if not sent_time:
             # sent_time unknown because of 'get_clock' retransmit
+            return
+        threshold = self.rtt_filter.get_threshold_for_ratio(0.9)
+        rtt = receive_time - sent_time
+        self.rtt_filter.insert(rtt)
+        if rtt > threshold and sent_time - self.last_prediction_time < 10.:
             return
         # Update sent_time to clock regression
         ret = self._update_regression(sent_time, clock)

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -18,6 +18,72 @@ class PercentileFilter:
         threshold = heapq.nlargest(threshold_pos, self._samples)[-1]
         return threshold
 
+class BestOfNFilter:
+    def __init__(self, size):
+        self._size = size
+        self._samples = [(.1, .1)] * size
+        self._next_free = 0
+        self._last_min_place = 0
+        self._last_max_place = 0
+    def insert(self, half_rtt, offset):
+        sample = (half_rtt, offset)
+        self._samples[self._next_free % self._size] = sample
+        if self._samples[self._last_min_place % self._size][0] > sample[0]:
+            self._last_min_place = self._next_free
+        if self._samples[self._last_max_place % self._size][0] < sample[0]:
+            self._last_max_place = self._next_free
+        self._next_free += 1
+        if self._next_free - self._last_min_place > self._size:
+            next_min = self._last_min_place + 1
+            for i in range(next_min, self._next_free):
+                ii = i % self._size
+                nb = next_min % self._size
+                if self._samples[ii][0] < self._samples[nb][0]:
+                    next_min = i
+            self._last_min_place = next_min
+        if self._next_free - self._last_max_place > self._size:
+            next_max = self._last_max_place + 1
+            for i in range(next_max, self._next_free):
+                ii = i % self._size
+                nb = next_max % self._size
+                if self._samples[ii][0] > self._samples[nb][0]:
+                    next_max = i
+            self._last_max_place = next_max
+    def get_min(self):
+        return self._samples[self._last_min_place % self._size]
+    def get_max(self):
+        return self._samples[self._last_max_place % self._size]
+
+class RTTRatio:
+    def __init__(self, decay):
+        self.decay = decay
+        self.bon_filter = BestOfNFilter(10)
+        self.min_x = 0.0001
+        self.min_y = 0.0
+        self.max_x = 0.0005
+        self.max_y = 0.0
+        self.last_min = ()
+        self.last_max = ()
+        self._ratio = 1.0
+    def insert(self, half_rtt, offset):
+        self.bon_filter.insert(half_rtt, offset)
+        min_sample = self.bon_filter.get_min()
+        if min_sample != self.last_min:
+            self.last_min = min_sample
+            half_rtt, offset = min_sample
+            self.min_x = (1 - self.decay) * self.min_x + self.decay * half_rtt
+            self.min_y = (1 - self.decay) * self.min_y + self.decay * offset
+        max_sample = self.bon_filter.get_max()
+        if max_sample != self.last_max:
+            self.last_max = max_sample
+            half_rtt, offset = max_sample
+            self.max_x = (1 - self.decay) * self.max_x + self.decay * half_rtt
+            self.max_y = (1 - self.decay) * self.max_y + self.decay * offset
+    def get_ratio(self):
+        # Vector (y - y0) / (x - x0)
+        divisor = (self.max_x - self.min_x)
+        return (self.max_y - self.min_y) / divisor + 1
+
 RTT_AGE = .000010 / (60. * 60.)
 DECAY = 1. / 30.
 TRANSMIT_EXTRA = .001
@@ -45,6 +111,8 @@ class ClockSync:
         self.clock_est = (0., 0., 0.)
         # Input filtering
         self.rtt_filter = PercentileFilter(30)
+        # Center the RTT compensation
+        self.rtt_tracker = RTTRatio(1/180)
     def connect(self, serial):
         self.serial = serial
         self.mcu_freq = serial.msgparser.get_constant_float('CLOCK_FREQ')
@@ -83,7 +151,7 @@ class ClockSync:
     def _update_regression(self, sent_time, rtt, clock):
         # Calculate expected clock using existing time/clock regression
         old_freq = self.clock_est[2] # self.clock_covariance/self.time_variance
-        remote_time = sent_time + rtt / 2.0
+        remote_time = sent_time + self.rtt_tracker.get_ratio() * rtt / 2.0
         exp_clock = (remote_time - self.time_avg) * old_freq + self.clock_avg
         # Track prediction accuracy and filter out extreme outliers
         clock_diff2 = (clock - exp_clock)**2
@@ -143,6 +211,7 @@ class ClockSync:
             return
         # Update sent_time to clock regression
         offset, ret = self._update_regression(sent_time, rtt, clock)
+        self.rtt_tracker.insert(rtt / 2.0, offset)
         if not ret:
             # Message is an "outlier" and should be discarded
             return


### PR DESCRIPTION
I did another round on a clock sync & Timer too close during homing: https://klipper.discourse.group/t/intermittant-timer-too-close-fault-during-eddy-home-tap/25871/23

I've reformulated the problem as "what/how to do with outliners".
I had an idea that they can slowly update prediction_variance, and so, the filter will pass the new "high" latency values eventually, and maybe that eventually would happen <10s.

Then, I thought that, as they still provide some measurements, they can be extracted, and probably linear regression can be replaced with something? (which can be slightly more robust to outliers) Kalman filter? Idk.
But still, there should be some mechanism to estimate the quality of samples.

Then, I realized that basically, we have one - RTT: https://manpages.debian.org/testing/chrony/chrony.conf.5.en.html
And the worse the RTT is, the worse the data quality.

> For small variations in the round-trip delay, chronyd uses a weighting scheme when processing the measurements. Beyond a certain level of delay, however, the measurements are likely to be so corrupted as to be useless. (This is particularly so on wireless networks and other slow links, where a long delay probably indicates a highly asymmetric delay caused by the response waiting behind a lot of packets related to a download of some sort).

Sooo, then, the weight is the difference between min_rtt (max quality) and rtt.
That should allow us to always progress in regression, update last_clock & etc.

This is a small debug output:
<details>
  <summary>Code</summary>
  
```DIFF
diff --git a/klippy/clocksync.py b/klippy/clocksync.py
index eebf70cbf..ce9804012 100644
--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -105,6 +105,8 @@ class ClockSync:
                                   int(self.clock_avg - 3. * pred_stddev), clock)
         self.clock_est = (self.time_avg + self.min_half_rtt,
                           self.clock_avg, new_freq)
+        logging.info("%.3f| diff: %.6f, decay: 1/%.1f, est %s" % (
+            self.reactor.monotonic(), (clock - exp_clock)/new_freq, 1 / decay, self.clock_est))
         #logging.debug("regr %.3f: freq=%.3f d=%d(%.3f)",
         #              sent_time, new_freq, clock - exp_clock, pred_stddev)
     # clock frequency conversions
```
</details>

SBC -> USB -> H723 (520MHz)
SBC -> USB -> STM32G0 (96MHz) -> CAN STM32F042 (48MHz)

Master:
```
573.789| diff: -0.000002, decay: 1/30.0, est (3556.5336420627655, 12462257276956.418, 47998661.48893246)
3574.246| diff: 0.000074, decay: 1/30.0, est (3556.991087931111, 24925466795302.734, 96000891.30091943)
3574.253| diff: -0.000362, decay: 1/30.0, est (3556.5883272242136, 135018723727292.94, 520025029.1838946)

3574.773| diff: 0.000004, decay: 1/30.0, est (3557.14161321834, 12462286458764.805, 47998662.6268494)
3575.231| diff: -0.000012, decay: 1/30.0, est (3557.5990738975406, 24925525162458.176, 96000884.63130176)
3575.237| diff: -0.000315, decay: 1/30.0, est (3557.209955211423, 135019046983952.08, 520024152.4753663)

3575.757| diff: -0.000001, decay: 1/30.0, est (3557.762119057595, 12462316242212.844, 47998662.23985328)
3576.216| diff: -0.000016, decay: 1/30.0, est (3558.219625650856, 24925584735923.504, 96000876.2410543)
3576.222| diff: 0.000113, decay: 1/30.0, est (3557.843680725592, 135019376538485.38, 520024452.5410524)

3576.742| diff: 0.000003, decay: 1/30.0, est (3558.394758989842, 12462346608088.482, 47998663.04106459)
3577.200| diff: -0.000011, decay: 1/30.0, est (3558.852296027828, 24925645472799.72, 96000870.96003336)
3577.206| diff: 0.000023, decay: 1/30.0, est (3558.489085723222, 135019712165257.1, 520024509.68683696)

3577.726| diff: -0.000001, decay: 1/30.0, est (3559.0391140391475, 12462377536267.766, 47998662.80541758)
3578.185| diff: -0.000019, decay: 1/30.0, est (3559.4967069150334, 24925707336745.996, 96000862.13555531)
3578.191| diff: 0.000230, decay: 1/30.0, est (3559.145805210398, 135020053679471.95, 520025066.3642938)
```

Patched:
```
4093.321| diff: -0.000007, decay: 1/32.0, est (4070.8866331106265, 24974801186254.062, 96000848.59225443)
4093.838| diff: -0.000004, decay: 1/33.3, est (4071.5588037149564, 12486977793460.312, 47998682.67624803)
4094.297| diff: 0.000061, decay: 1/30.9, est (4063.1611842308357, 135282155530829.64, 520019454.1419183)

4094.306| diff: -0.000014, decay: 1/30.7, est (4071.650012452412, 24974874471274.97, 96000843.6721773)
4094.822| diff: -0.000014, decay: 1/30.9, est (4072.312162024833, 12487013953645.47, 47998680.355986565)
4095.281| diff: 0.000359, decay: 1/126.8, est (4063.414569066289, 135282287297345.45, 520019738.0337636)

4095.290| diff: -0.000010, decay: 1/31.3, est (4072.4041208430217, 24974946866284.91, 96000840.24291386)
4095.807| diff: 0.000035, decay: 1/38.7, est (4072.918672428116, 12487043065388.105, 47998684.99946961)
4096.266| diff: 0.000402, decay: 1/142.8, est (4063.644656065944, 135282406948591.61, 520020016.5356514)

4096.274| diff: -0.000010, decay: 1/33.1, est (4073.125864434187, 24975016154247.168, 96000837.23105885)
4096.792| diff: -0.000013, decay: 1/31.9, est (4073.66678875629, 12487078973968.26, 47998682.96858281)
4097.250| diff: 0.000051, decay: 1/32.2, est (4064.688451648248, 135282949744005.48, 520020149.5380992)

4097.259| diff: -0.000003, decay: 1/32.8, est (4073.8607410568884, 24975086703010.11, 96000836.41681017)
4097.776| diff: -0.000015, decay: 1/33.5, est (4074.385749799426, 12487113483130.582, 47998680.90028314)
4098.235| diff: 0.000539, decay: 1/193.4, est (4064.8619179053503, 135283039951404.22, 520020385.5606817)
```

So:
- (from full log) It seems to me that the master has a tighter prediction but slightly higher jitter for the expected clock
- It seems to me that a long RTT delay is correlated with high variance (and so uncertainty, I think).
- It seems to me that patched has a longer lead time to "synchronization" a little. 

Where 500us for USB serial seems to be expected, and is caused by thread wakeup latency[^1].

Even if it seems to work for me, I can miss something, so it is RFC.

Thanks,
-Timofey

---
UPD:
From converged `self.prediction_variance`, both variants seem to perform the same on my hardware.
I've tried to apply backpressure based on variance (higher variance, more frequent requests), and even this converges to the same values. I guess this is because any error is already accounted for within the per-sample diff in linear regression, so my additional accounting basically only increases sample frequency.

[^1]: 500us usb serial delay seems to be expected from my previous debugging, the more traffic, the better the latency is: https://klipper.discourse.group/t/serialqueue-profiling/24877