### PR TITLE
Temperature sensing support for the gd32f303* MCUs

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3133,7 +3133,7 @@ sensor_type: LM75
 
 ### Builtin micro-controller temperature sensor
 
-The atsam, atsamd, stm32 and rp2040 micro-controllers contain an internal
+The atsam, atsamd, stm32, gd32 and rp2040 micro-controllers contain an internal
 temperature sensor. One can use the "temperature_mcu" sensor to
 monitor these temperatures.
 
@@ -3163,6 +3163,18 @@ sensor_type: temperature_mcu
 #   default is to use the factory calibration data on the
 #   micro-controller (if applicable) or the nominal values from the
 #   micro-controller specification.
+#smooth_time:
+#   A time value (in seconds) over which temperature measurements will
+#   be smoothed to reduce the impact of measurement noise.
+#   This could be necessary because we do not always have control over
+#   the design of proprietary boards.
+#   The default is 0.01, which effectively disables the feature.
+#ignore_spike_size:
+#   Use this to ignore large random spikes that cannot be smoothed out
+#   without introducing too much lag.
+#   Unit of measure is degrees Celsius relative to the last measurement.
+#   Default is 2.0, minimum is 2.0.  This should be sufficient for the
+#   slow heating and cooling rate of MCUs.
 ```
 
 ### Host temperature sensor

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -82,6 +82,7 @@ class PrinterTemperatureMCU:
             ('stm32l4', self.config_stm32g0),
             ('stm32h723', self.config_stm32h723),
             ('stm32h7', self.config_stm32h7),
+            ('gd32f303xe', self.config_gd32f303xe),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -166,6 +167,9 @@ class PrinterTemperatureMCU:
         cal_adc_110 = self.read16(0x1FF1E840) / 65535.
         self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
+    def config_gd32f303xe(self):
+        self.slope = 3.3 / -.004100
+        self.base_temperature = self.calc_base(25., 1.45 / 3.3)
     def read16(self, addr):
         params = self.debug_read_cmd.send([1, addr])
         return params['val']

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -31,7 +31,8 @@ class PrinterTemperatureMCU:
                 self.adc2 = config.getfloat('sensor_adc2', minval=0., maxval=1.)
         self.smooth_time = config.getfloat('smooth_time', 0.01, above=0.)
         self.inv_smooth_time = 1. / self.smooth_time
-        self.ignore_spike_size = config.getfloat('ignore_spike_size', 2., minval=2.)
+        self.ignore_spike_size = config.getfloat('ignore_spike_size',
+                                                  2., minval=2.)
         # Setup ADC port
         ppins = config.get_printer().lookup_object('pins')
         self.mcu_adc = ppins.setup_pin('adc',
@@ -61,8 +62,9 @@ class PrinterTemperatureMCU:
         temp = self.base_temperature + (read_value * self.slope)
         temp_diff = temp - self.last_temp
 
-        # Ignore spikes caused by bad PCB layout of the board. Of which we dont have control over.
-        # Also disregard the startup reading of 0 which will cause a "spike" to the actual temp.
+        # Ignore spikes caused by bad PCB layout of the board. Of which we
+        # dont have control over. Also disregard the startup reading of 0
+        # which will cause a "spike" to the actual temp.
         if ( abs(temp_diff) > self.ignore_spike_size ) and (self.last_temp):
             self.last_temp_time = read_time
         else:
@@ -73,7 +75,8 @@ class PrinterTemperatureMCU:
             self.smoothed_temp += temp_diff * adj_time
             self.last_temp = self.smoothed_temp
         # Pass on to temperature_sensor and/or temperature_fan etc..
-        self.temperature_callback(read_time + (SAMPLE_COUNT * SAMPLE_TIME), self.last_temp)
+        self.temperature_callback(read_time + (SAMPLE_COUNT * SAMPLE_TIME),
+                                   self.last_temp)
 
     def calc_temp(self, adc):
         return self.base_temperature + adc * self.slope

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -19,6 +19,8 @@ class PrinterTemperatureMCU:
         self.temp1 = self.adc1 = self.temp2 = self.adc2 = None
         self.min_temp = self.max_temp = 0.
         self.debug_read_cmd = None
+        self.smoothed_temp = self.last_temp = 0.
+        self.last_temp_time = 0.
         # Read config
         mcu_name = config.get('sensor_mcu', 'mcu')
         self.temp1 = config.getfloat('sensor_temperature1', None)
@@ -27,6 +29,9 @@ class PrinterTemperatureMCU:
             self.temp2 = config.getfloat('sensor_temperature2', None)
             if self.temp2 is not None:
                 self.adc2 = config.getfloat('sensor_adc2', minval=0., maxval=1.)
+        self.smooth_time = config.getfloat('smooth_time', 0.01, above=0.)
+        self.inv_smooth_time = 1. / self.smooth_time
+        self.ignore_spike_size = config.getfloat('ignore_spike_size', 2., minval=2.)
         # Setup ADC port
         ppins = config.get_printer().lookup_object('pins')
         self.mcu_adc = ppins.setup_pin('adc',
@@ -51,9 +56,25 @@ class PrinterTemperatureMCU:
         self.max_temp = max_temp
     # Internal code
     def adc_callback(self, samples):
+
         read_time, read_value = samples[-1]
-        temp = self.base_temperature + read_value * self.slope
-        self.temperature_callback(read_time + SAMPLE_COUNT * SAMPLE_TIME, temp)
+        temp = self.base_temperature + (read_value * self.slope)
+        temp_diff = temp - self.last_temp
+
+        # Ignore spikes caused by bad PCB layout of the board. Of which we dont have control over.
+        # Also disregard the startup reading of 0 which will cause a "spike" to the actual temp.
+        if ( abs(temp_diff) > self.ignore_spike_size ) and (self.last_temp):
+            self.last_temp_time = read_time
+        else:
+            # Smooth as required.
+            time_diff = read_time - self.last_temp_time
+            self.last_temp_time = read_time
+            adj_time = min(time_diff * self.inv_smooth_time, 1.)
+            self.smoothed_temp += temp_diff * adj_time
+            self.last_temp = self.smoothed_temp
+        # Pass on to temperature_sensor and/or temperature_fan etc..
+        self.temperature_callback(read_time + (SAMPLE_COUNT * SAMPLE_TIME), self.last_temp)
+
     def calc_temp(self, adc):
         return self.base_temperature + adc * self.slope
     def calc_adc(self, temp):
@@ -82,7 +103,7 @@ class PrinterTemperatureMCU:
             ('stm32l4', self.config_stm32g0),
             ('stm32h723', self.config_stm32h723),
             ('stm32h7', self.config_stm32h7),
-            ('gd32f303xe', self.config_gd32f303xe),
+            ('gd32f303', self.config_gd32f303),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -167,7 +188,7 @@ class PrinterTemperatureMCU:
         cal_adc_110 = self.read16(0x1FF1E840) / 65535.
         self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
-    def config_gd32f303xe(self):
+    def config_gd32f303(self):
         self.slope = 3.3 / -.004100
         self.base_temperature = self.calc_base(25., 1.45 / 3.3)
     def read16(self, addr):


### PR DESCRIPTION
This PR aims to add temperature sensing support for the gd32f303* MCUs which are found on many Creality printers.

I also implemented basic smoothing since the users do not have control over the design of the
boards.  The MCU on my CR10-SE Mainboard is very noisy.

The configuration accepts 2 new parameters:
`smooth_time:`
This was copied form heaters.py
Default is 0.01, which effectively disables it - to match the current behavior.
Must be above 0.0 (to avoid division by 0). Unit of measure is seconds.

`ignore_spike_size:`
Positive and negative spikes larger than this are ignored.
Default is 2.0, minimum is 2.0. _(The minimum can be discussed)._
Unit of measure is degrees Celsius.
I found this more effective since it does not introduce a slowed response like 'smooth_time" does.
On the Creality main board the spikes are huge, so they required a long smooth time to get them flat.
Welcome for suggestions on a better name for `ignore_spike_size` :face_with_diagonal_mouth:  
I've considered `max_delta` as well, but it is less intuitive.

I tested this on my CR10-SE and it works fine using this config:
```
[temperature_sensor Nozzle_MCU]
sensor_type: temperature_mcu
min_temp: 0
max_temp: 70
# temperature_mcu's parameters:
sensor_mcu: nozzle_mcu
sensor_temperature1: 17.4 # As measured by Extruder & Bed at startup.
sensor_adc1: 0.441422
# smooth_time:       # It seems to be stable so default of 0.01 is fine.
# ignore_spike_size: # The MCU heats at +/- 0.4C/s and cools slowly, so default of 2.0 is high enough.

[temperature_fan Mainboard_MCU]
pin: mcu:PB1
sensor_type: temperature_mcu
min_temp: 0
max_temp: 60
control: watermark
max_delta: 3.0
target_temp: 35.0
# temperature_mcu's parameters:
sensor_mcu: mcu
sensor_temperature1: 15 # As measured by Extruder & Bed at startup.
sensor_adc1: 0.440781
smooth_time: 3.0 # Default is 0.01.
ignore_spike_size: 2.0 # Default is 2. The MCU heats and cools very slowly, so 2 is high enough.
```

Note that the pin config in the factory supplied printer.cfg wrongly is inverted `!PB1` !

This is during bed mesh and nozzle heating:
Before:
<img width="898" height="363" alt="Screenshot from 2026-07-07 19-25-18" src="https://github.com/user-attachments/assets/b6bc87d9-6731-49ec-9e71-a5693133f6fb" />

After:
<img width="898" height="363" alt="Screenshot from 2026-07-07 19-35-38" src="https://github.com/user-attachments/assets/3f5456c2-39e5-420a-9bfb-def388cd6a58" />

Signed-off-by: Henri van der Riet <henrivdr@gmail.com>
