### PR TITLE
scripts: report MCU and firmware info in canbus_query

### DIFF
--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import json, optparse, select, socket, struct, sys, time, zlib
+import json, optparse, os, select, socket, struct, sys, time, zlib
 
 CANBUS_ID_ADMIN = 0x3f0
 CMD_QUERY_UNASSIGNED = 0x00
@@ -93,6 +93,16 @@ def format_mcu_name(mcu):
     if mcu.endswith("XX"):
         mcu = mcu[:-2]
     return mcu
+
+def get_canbus_iface_mcu(canbus_iface):
+    devpath = os.path.realpath("/sys/class/net/%s/device" % (canbus_iface,))
+    for path in (devpath, os.path.dirname(devpath)):
+        try:
+            with open(os.path.join(path, "product"), "r") as f:
+                return format_mcu_name(f.read().strip())
+        except OSError:
+            pass
+    return None
 
 class SocketCan:
     def __init__(self, canbus_iface, can_filter=None):
@@ -298,13 +308,10 @@ def get_firmware_info(canbus_iface, uuid, canbus_nodeid, connect_timeout):
         processor = format_mcu_name(conn.msgparser.config.get("MCU",
                                                               "Unknown"))
         firmware = conn.msgparser.version or "Unknown"
-        return {"processor": processor, "firmware": firmware}
-    finally:
-        try:
-            conn.reset()
-        except Exception:
-            pass
+        return {"processor": processor, "firmware": firmware}, conn
+    except Exception:
         conn.close()
+        raise
 
 def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout):
     bus = SocketCan(canbus_iface, CANBUS_ID_ADMIN + 1)
@@ -342,24 +349,39 @@ def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout):
     finally:
         bus.close()
 
-    for uuid, app_id, app_name in found_devices:
-        if app_id != CMD_SET_KLIPPER_NODEID:
-            output_line("Found canbus_uuid=%012x, Application: %s"
-                        % (uuid, app_name))
-            continue
-        try:
-            info = get_firmware_info(canbus_iface, uuid, canbus_nodeid,
-                                     connect_timeout)
-            output_line("Found canbus_uuid=%012x, Application: %s,"
-                        " Processor: %s,"
-                        " Firmware: %s"
-                        % (uuid, app_name, info["processor"],
-                           info["firmware"]))
-        except error as e:
-            output_line("Found canbus_uuid=%012x, Application: %s"
-                        % (uuid, app_name))
-            output_line("Unable to query firmware info: %s" % (str(e),))
-    output_line("Total %d uuids found" % (len(found_ids,)))
+    reset_conns = []
+    iface_mcu = get_canbus_iface_mcu(canbus_iface)
+    try:
+        for uuid, app_id, app_name in found_devices:
+            if app_id != CMD_SET_KLIPPER_NODEID:
+                output_line("Found canbus_uuid=%012x, Application: %s"
+                            % (uuid, app_name))
+                continue
+            try:
+                info, conn = get_firmware_info(canbus_iface, uuid,
+                                               canbus_nodeid,
+                                               connect_timeout)
+                processor = info["processor"]
+                reset_conns.append((processor == iface_mcu, conn))
+                output_line("Found canbus_uuid=%012x, Application: %s,"
+                            " Processor: %s,"
+                            " Firmware: %s"
+                            % (uuid, app_name, processor,
+                               info["firmware"]))
+            except error as e:
+                output_line("Found canbus_uuid=%012x, Application: %s"
+                            % (uuid, app_name))
+                output_line("Unable to query firmware info: %s" % (str(e),))
+        output_line("Total %d uuids found" % (len(found_ids,)))
+    finally:
+        reset_conns.sort(key=lambda item: item[0])
+        for _is_iface_mcu, conn in reset_conns:
+            try:
+                conn.reset()
+            except Exception:
+                pass
+        for _is_iface_mcu, conn in reset_conns:
+            conn.close()
 
 def main():
     usage = "%prog [options] <can interface>"

--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Tool to query CAN bus uuids
 #
 # Copyright (C) 2021  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import sys, os, optparse, time
-import can
+import json, optparse, select, socket, struct, sys, time, zlib
 
 CANBUS_ID_ADMIN = 0x3f0
 CMD_QUERY_UNASSIGNED = 0x00
@@ -13,52 +12,369 @@ RESP_NEED_NODEID = 0x20
 CMD_SET_KLIPPER_NODEID = 0x01
 CMD_SET_CANBOOT_NODEID = 0x11
 
-def query_unassigned(canbus_iface):
-    # Open CAN socket
-    filters = [{"can_id": CANBUS_ID_ADMIN + 1, "can_mask": 0x7ff,
-                "extended": False}]
-    bus = can.interface.Bus(channel=canbus_iface, can_filters=filters,
-                            bustype='socketcan')
-    # Send query
-    msg = can.Message(arbitration_id=CANBUS_ID_ADMIN,
-                      data=[CMD_QUERY_UNASSIGNED], is_extended_id=False)
-    bus.send(msg)
-    # Read responses
-    found_ids = {}
-    start_time = curtime = time.time()
-    while 1:
-        tdiff = start_time + 2. - curtime
-        if tdiff <= 0.:
-            break
-        msg = bus.recv(tdiff)
-        curtime = time.time()
-        if (msg is None or msg.arbitration_id != CANBUS_ID_ADMIN + 1
-            or msg.dlc < 7 or msg.data[0] != RESP_NEED_NODEID):
-            continue
-        uuid = sum([v << ((5-i)*8) for i, v in enumerate(msg.data[1:7])])
-        if uuid in found_ids:
-            continue
-        found_ids[uuid] = 1
-        AppNames = {
-            CMD_SET_KLIPPER_NODEID: "Klipper",
-            CMD_SET_CANBOOT_NODEID: "CanBoot"
+MESSAGE_MIN = 5
+MESSAGE_MAX = 64
+MESSAGE_HEADER_SIZE = 2
+MESSAGE_TRAILER_SIZE = 3
+MESSAGE_SEQ_MASK = 0x0f
+MESSAGE_DEST = 0x10
+MESSAGE_SYNC = 0x7e
+
+CAN_FRAME_FMT = "=IB3x8s"
+CAN_FRAME_SIZE = struct.calcsize(CAN_FRAME_FMT)
+SOL_CAN_RAW = getattr(socket, "SOL_CAN_RAW", 101)
+CAN_RAW_FILTER = getattr(socket, "CAN_RAW_FILTER", 1)
+
+class error(Exception):
+    pass
+
+def output_line(msg):
+    sys.stdout.write("%s\n" % (msg,))
+    sys.stdout.flush()
+
+def crc16_ccitt(buf):
+    crc = 0xffff
+    for data in bytearray(buf):
+        data ^= crc & 0xff
+        data ^= (data & 0x0f) << 4
+        crc = ((data << 8) | (crc >> 8)) ^ (data >> 4) ^ (data << 3)
+    return bytearray([(crc >> 8) & 0xff, crc & 0xff])
+
+def encode_int(v):
+    out = bytearray()
+    if v >= 0xc000000 or v < -0x4000000:
+        out.append(((v >> 28) & 0x7f) | 0x80)
+    if v >= 0x180000 or v < -0x80000:
+        out.append(((v >> 21) & 0x7f) | 0x80)
+    if v >= 0x3000 or v < -0x1000:
+        out.append(((v >> 14) & 0x7f) | 0x80)
+    if v >= 0x60 or v < -0x20:
+        out.append(((v >> 7) & 0x7f) | 0x80)
+    out.append(v & 0x7f)
+    return out
+
+def parse_int(buf, pos):
+    c = buf[pos]
+    pos += 1
+    v = c & 0x7f
+    if (c & 0x60) == 0x60:
+        v |= -0x20
+    while c & 0x80:
+        c = buf[pos]
+        pos += 1
+        v = (v << 7) | (c & 0x7f)
+    return int(v & 0xffffffff), pos
+
+def parse_string(buf, pos):
+    count = buf[pos]
+    pos += 1
+    return bytes(buf[pos:pos + count]), pos + count
+
+def check_packet(buf):
+    if len(buf) < MESSAGE_MIN:
+        return 0
+    msglen = buf[0]
+    if msglen < MESSAGE_MIN or msglen > MESSAGE_MAX:
+        return -1
+    msgseq = buf[1]
+    if (msgseq & ~MESSAGE_SEQ_MASK) != MESSAGE_DEST:
+        return -1
+    if len(buf) < msglen:
+        return 0
+    if buf[msglen - 1] != MESSAGE_SYNC:
+        return -1
+    msgcrc = buf[msglen - 3:msglen - 1]
+    if msgcrc != crc16_ccitt(buf[:msglen - MESSAGE_TRAILER_SIZE]):
+        return -1
+    return msglen
+
+def format_mcu_name(mcu):
+    mcu = str(mcu).upper()
+    if mcu.endswith("XX"):
+        mcu = mcu[:-2]
+    return mcu
+
+class SocketCan:
+    def __init__(self, canbus_iface, can_filter=None):
+        self.sock = socket.socket(socket.PF_CAN, socket.SOCK_RAW,
+                                  socket.CAN_RAW)
+        if can_filter is not None:
+            packed_filter = struct.pack("=II", can_filter, 0x7ff)
+            self.sock.setsockopt(SOL_CAN_RAW, CAN_RAW_FILTER, packed_filter)
+        self.sock.bind((canbus_iface,))
+
+    def close(self):
+        self.sock.close()
+
+    def send(self, can_id, data):
+        data = bytes(bytearray(data))
+        frame = struct.pack(CAN_FRAME_FMT, can_id, len(data),
+                            data + b"\x00" * (8 - len(data)))
+        self.sock.send(frame)
+
+    def recv(self, timeout):
+        rlist, _wlist, _xlist = select.select([self.sock], [], [], timeout)
+        if not rlist:
+            return None
+        frame = self.sock.recv(CAN_FRAME_SIZE)
+        can_id, can_dlc, data = struct.unpack(CAN_FRAME_FMT, frame)
+        return can_id & 0x7ff, bytearray(data[:can_dlc])
+
+class MessageParser:
+    def __init__(self):
+        self.commands = {"identify offset=%u count=%c": 1}
+        self.responses = {"identify_response offset=%u data=%.*s": 0}
+        self.messages_by_id = {
+            0: "identify_response offset=%u data=%.*s"
         }
-        app_id = CMD_SET_KLIPPER_NODEID
-        if msg.dlc > 7:
-            app_id = msg.data[7]
-        app_name = AppNames.get(app_id, "Unknown")
-        sys.stdout.write("Found canbus_uuid=%012x, Application: %s\n"
-                         % (uuid, app_name))
-    sys.stdout.write("Total %d uuids found\n" % (len(found_ids,)))
+        self.version = ""
+        self.config = {}
+
+    def process_identify(self, data):
+        data = zlib.decompress(data)
+        if not isinstance(data, str):
+            data = data.decode()
+        dictionary = json.loads(data)
+        self.commands = dictionary.get("commands", {})
+        self.responses = dictionary.get("responses", {})
+        self.messages_by_id = dict((v, k) for k, v in self.responses.items())
+        self.version = dictionary.get("version", "")
+        self.config = dictionary.get("config", {})
+
+    def lookup_command(self, name):
+        for msgformat, msgid in self.commands.items():
+            if msgformat.split()[0] == name:
+                return msgformat, msgid
+        raise error("Unknown command: %s" % (name,))
+
+    def create_command(self, name, params=None):
+        if params is None:
+            params = {}
+        msgformat, msgid = self.lookup_command(name)
+        out = encode_int(msgid)
+        for arg in msgformat.split()[1:]:
+            argname, argtype = arg.split("=")
+            val = params[argname]
+            if argtype in ("%u", "%i", "%hu", "%hi", "%c"):
+                out += encode_int(int(val))
+            elif argtype in ("%s", "%.*s", "%*s"):
+                val = bytes(bytearray(val))
+                out.append(len(val))
+                out += val
+            else:
+                raise error("Unknown parameter type: %s" % (argtype,))
+        return out
+
+    def parse_response(self, block):
+        pos = MESSAGE_HEADER_SIZE
+        msgid, pos = parse_int(block, pos)
+        msgformat = self.messages_by_id.get(msgid)
+        if msgformat is None:
+            return None
+        params = {"#name": msgformat.split()[0]}
+        for arg in msgformat.split()[1:]:
+            argname, argtype = arg.split("=")
+            if argtype in ("%u", "%i", "%hu", "%hi", "%c"):
+                params[argname], pos = parse_int(block, pos)
+            elif argtype in ("%s", "%.*s", "%*s"):
+                params[argname], pos = parse_string(block, pos)
+            else:
+                raise error("Unknown parameter type: %s" % (argtype,))
+        return params
+
+class CanbusQueryConnection:
+    def __init__(self, canbus_iface, uuid, canbus_nodeid, connect_timeout):
+        self.canbus_iface = canbus_iface
+        self.uuid = uuid
+        self.canbus_nodeid = canbus_nodeid
+        self.connect_timeout = connect_timeout
+        self.txid = canbus_nodeid * 2 + 0x100
+        self.bus = SocketCan(canbus_iface, self.txid + 1)
+        self.msgparser = MessageParser()
+        self.send_seq = 1
+        self.input_buf = bytearray()
+
+    def close(self):
+        self.bus.close()
+
+    def _send_set_nodeid(self):
+        uuid = [(self.uuid >> (40 - i * 8)) & 0xff for i in range(6)]
+        self.bus.send(CANBUS_ID_ADMIN,
+                      [CMD_SET_KLIPPER_NODEID] + uuid + [self.canbus_nodeid])
+
+    def _send_block(self, payload):
+        msglen = MESSAGE_MIN + len(payload)
+        seq = MESSAGE_DEST | (self.send_seq & MESSAGE_SEQ_MASK)
+        block = bytearray([msglen, seq]) + bytearray(payload)
+        block += crc16_ccitt(block)
+        block.append(MESSAGE_SYNC)
+        for pos in range(0, len(block), 8):
+            self.bus.send(self.txid, block[pos:pos + 8])
+        self.send_seq += 1
+
+    def _read_block(self, deadline):
+        while time.time() < deadline:
+            msg = self.bus.recv(deadline - time.time())
+            if msg is None:
+                break
+            can_id, data = msg
+            if can_id != self.txid + 1:
+                continue
+            self.input_buf += data
+            while self.input_buf:
+                msglen = check_packet(self.input_buf)
+                if msglen == 0:
+                    break
+                if msglen < 0:
+                    sync_pos = self.input_buf.find(bytearray([MESSAGE_SYNC]))
+                    if sync_pos < 0:
+                        del self.input_buf[:]
+                    else:
+                        del self.input_buf[:sync_pos + 1]
+                    continue
+                block = self.input_buf[:msglen]
+                del self.input_buf[:msglen]
+                if msglen == MESSAGE_MIN:
+                    continue
+                return block
+        return None
+
+    def send_with_response(self, name, params, response, deadline):
+        retry_delay = .010
+        while time.time() < deadline:
+            self._send_block(self.msgparser.create_command(name, params))
+            retry_deadline = min(deadline, time.time() + retry_delay)
+            while time.time() < retry_deadline:
+                block = self._read_block(retry_deadline)
+                if block is None:
+                    break
+                msg = self.msgparser.parse_response(block)
+                if msg is not None and msg["#name"] == response:
+                    return msg
+            retry_delay = min(retry_delay * 2., .500)
+        raise error("Unable to connect")
+
+    def identify(self):
+        self._send_set_nodeid()
+        deadline = time.time() + self.connect_timeout
+        identify_data = bytearray()
+        while 1:
+            params = {
+                "offset": len(identify_data),
+                "count": 40
+            }
+            msg = self.send_with_response("identify", params,
+                                          "identify_response", deadline)
+            if msg["offset"] != len(identify_data):
+                continue
+            data = msg["data"]
+            if not data:
+                break
+            identify_data += data
+        self.msgparser.process_identify(bytes(identify_data))
+        try:
+            msg = self.send_with_response("get_canbus_id", {}, "canbus_id",
+                                          deadline)
+        except error as e:
+            if "Unknown command: get_canbus_id" not in str(e):
+                raise
+            return
+        got_uuid = sum([v << ((5 - i) * 8)
+                        for i, v in enumerate(bytearray(msg["canbus_uuid"]))])
+        if got_uuid != self.uuid:
+            raise error("Failed to match canbus_uuid")
+
+    def reset(self):
+        try:
+            self._send_block(self.msgparser.create_command("reset"))
+        except error:
+            pass
+
+def get_firmware_info(canbus_iface, uuid, canbus_nodeid, connect_timeout):
+    conn = CanbusQueryConnection(canbus_iface, uuid, canbus_nodeid,
+                                 connect_timeout)
+    try:
+        conn.identify()
+        processor = format_mcu_name(conn.msgparser.config.get("MCU",
+                                                              "Unknown"))
+        firmware = conn.msgparser.version or "Unknown"
+        return {"processor": processor, "firmware": firmware}
+    finally:
+        try:
+            conn.reset()
+        except Exception:
+            pass
+        conn.close()
+
+def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout):
+    bus = SocketCan(canbus_iface, CANBUS_ID_ADMIN + 1)
+    try:
+        bus.send(CANBUS_ID_ADMIN, [CMD_QUERY_UNASSIGNED])
+        found_ids = {}
+        found_devices = []
+        start_time = curtime = time.time()
+        while 1:
+            tdiff = start_time + 2. - curtime
+            if tdiff <= 0.:
+                break
+            msg = bus.recv(tdiff)
+            curtime = time.time()
+            if msg is None:
+                continue
+            can_id, data = msg
+            if (can_id != CANBUS_ID_ADMIN + 1 or len(data) < 7
+                or data[0] != RESP_NEED_NODEID):
+                continue
+            uuid = sum([v << ((5 - i) * 8)
+                        for i, v in enumerate(data[1:7])])
+            if uuid in found_ids:
+                continue
+            app_names = {
+                CMD_SET_KLIPPER_NODEID: "Klipper",
+                CMD_SET_CANBOOT_NODEID: "CanBoot/Katapult"
+            }
+            app_id = CMD_SET_KLIPPER_NODEID
+            if len(data) > 7:
+                app_id = data[7]
+            app_name = app_names.get(app_id, "Unknown")
+            found_ids[uuid] = 1
+            found_devices.append((uuid, app_id, app_name))
+    finally:
+        bus.close()
+
+    for uuid, app_id, app_name in found_devices:
+        if app_id != CMD_SET_KLIPPER_NODEID:
+            output_line("Found canbus_uuid=%012x, Application: %s"
+                        % (uuid, app_name))
+            continue
+        try:
+            info = get_firmware_info(canbus_iface, uuid, canbus_nodeid,
+                                     connect_timeout)
+            output_line("Found canbus_uuid=%012x, Application: %s,"
+                        " Processor: %s,"
+                        " Firmware: %s"
+                        % (uuid, app_name, info["processor"],
+                           info["firmware"]))
+        except error as e:
+            output_line("Found canbus_uuid=%012x, Application: %s"
+                        % (uuid, app_name))
+            output_line("Unable to query firmware info: %s" % (str(e),))
+    output_line("Total %d uuids found" % (len(found_ids,)))
 
 def main():
     usage = "%prog [options] <can interface>"
     opts = optparse.OptionParser(usage)
+    opts.add_option("-i", "--canbus-nodeid", "--canbus_nodeid",
+                    type="int", dest="canbus_nodeid",
+                    default=64, help="Temporary CAN nodeid to use while"
+                    " querying Klipper nodes (default 64)")
+    opts.add_option("-t", "--connect-timeout", type="float",
+                    dest="connect_timeout", default=10.,
+                    help="CAN connect timeout per Klipper node (default 10)")
     options, args = opts.parse_args()
     if len(args) != 1:
         opts.error("Incorrect number of arguments")
-    canbus_iface = args[0]
-    query_unassigned(canbus_iface)
+    query_unassigned(args[0], options.canbus_nodeid, options.connect_timeout)
 
 if __name__ == '__main__':
     main()

--- a/scripts/canbus_query.py
+++ b/scripts/canbus_query.py
@@ -94,16 +94,6 @@ def format_mcu_name(mcu):
         mcu = mcu[:-2]
     return mcu
 
-def get_canbus_iface_mcu(canbus_iface):
-    devpath = os.path.realpath("/sys/class/net/%s/device" % (canbus_iface,))
-    for path in (devpath, os.path.dirname(devpath)):
-        try:
-            with open(os.path.join(path, "product"), "r") as f:
-                return format_mcu_name(f.read().strip())
-        except OSError:
-            pass
-    return None
-
 class SocketCan:
     def __init__(self, canbus_iface, can_filter=None):
         self.sock = socket.socket(socket.PF_CAN, socket.SOCK_RAW,
@@ -308,12 +298,53 @@ def get_firmware_info(canbus_iface, uuid, canbus_nodeid, connect_timeout):
         processor = format_mcu_name(conn.msgparser.config.get("MCU",
                                                               "Unknown"))
         firmware = conn.msgparser.version or "Unknown"
-        return {"processor": processor, "firmware": firmware}, conn
-    except Exception:
+        return {"processor": processor, "firmware": firmware}
+    finally:
+        try:
+            conn.reset()
+        except Exception:
+            pass
         conn.close()
-        raise
 
-def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout):
+def wait_can_iface(canbus_iface, timeout):
+    deadline = time.time() + timeout
+    sys_path = "/sys/class/net/%s" % (canbus_iface,)
+    while time.time() < deadline:
+        if os.path.exists(sys_path):
+            try:
+                test_sock = socket.socket(socket.PF_CAN, socket.SOCK_RAW,
+                                          socket.CAN_RAW)
+                test_sock.bind((canbus_iface,))
+                test_sock.close()
+                return True
+            except OSError:
+                pass
+        time.sleep(.100)
+    return False
+
+def get_firmware_info_with_retry(canbus_iface, uuid, canbus_nodeid,
+                                 connect_timeout, iface_timeout):
+    endtime = time.time() + iface_timeout
+    last_error = None
+    try:
+        return get_firmware_info(canbus_iface, uuid, canbus_nodeid,
+                                 connect_timeout)
+    except OSError as e:
+        last_error = e
+    while time.time() < endtime:
+        remaining = endtime - time.time()
+        if not wait_can_iface(canbus_iface, remaining):
+            break
+        time.sleep(.250)
+        try:
+            return get_firmware_info(canbus_iface, uuid, canbus_nodeid,
+                                     connect_timeout)
+        except OSError as e:
+            last_error = e
+    raise last_error
+
+def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout,
+                     iface_timeout):
     bus = SocketCan(canbus_iface, CANBUS_ID_ADMIN + 1)
     try:
         bus.send(CANBUS_ID_ADMIN, [CMD_QUERY_UNASSIGNED])
@@ -349,39 +380,26 @@ def query_unassigned(canbus_iface, canbus_nodeid, connect_timeout):
     finally:
         bus.close()
 
-    reset_conns = []
-    iface_mcu = get_canbus_iface_mcu(canbus_iface)
-    try:
-        for uuid, app_id, app_name in found_devices:
-            if app_id != CMD_SET_KLIPPER_NODEID:
-                output_line("Found canbus_uuid=%012x, Application: %s"
-                            % (uuid, app_name))
-                continue
-            try:
-                info, conn = get_firmware_info(canbus_iface, uuid,
-                                               canbus_nodeid,
-                                               connect_timeout)
-                processor = info["processor"]
-                reset_conns.append((processor == iface_mcu, conn))
-                output_line("Found canbus_uuid=%012x, Application: %s,"
-                            " Processor: %s,"
-                            " Firmware: %s"
-                            % (uuid, app_name, processor,
-                               info["firmware"]))
-            except error as e:
-                output_line("Found canbus_uuid=%012x, Application: %s"
-                            % (uuid, app_name))
-                output_line("Unable to query firmware info: %s" % (str(e),))
-        output_line("Total %d uuids found" % (len(found_ids,)))
-    finally:
-        reset_conns.sort(key=lambda item: item[0])
-        for _is_iface_mcu, conn in reset_conns:
-            try:
-                conn.reset()
-            except Exception:
-                pass
-        for _is_iface_mcu, conn in reset_conns:
-            conn.close()
+    for uuid, app_id, app_name in found_devices:
+        if app_id != CMD_SET_KLIPPER_NODEID:
+            output_line("Found canbus_uuid=%012x, Application: %s"
+                        % (uuid, app_name))
+            continue
+        try:
+            info = get_firmware_info_with_retry(canbus_iface, uuid,
+                                                canbus_nodeid,
+                                                connect_timeout,
+                                                iface_timeout)
+            output_line("Found canbus_uuid=%012x, Application: %s,"
+                        " Processor: %s,"
+                        " Firmware: %s"
+                        % (uuid, app_name, info["processor"],
+                           info["firmware"]))
+        except (error, OSError) as e:
+            output_line("Found canbus_uuid=%012x, Application: %s"
+                        % (uuid, app_name))
+            output_line("Unable to query firmware info: %s" % (str(e),))
+    output_line("Total %d uuids found" % (len(found_ids,)))
 
 def main():
     usage = "%prog [options] <can interface>"
@@ -393,10 +411,14 @@ def main():
     opts.add_option("-t", "--connect-timeout", type="float",
                     dest="connect_timeout", default=10.,
                     help="CAN connect timeout per Klipper node (default 10)")
+    opts.add_option("--iface-timeout", type="float", dest="iface_timeout",
+                    default=5., help="CAN interface recovery timeout after"
+                    " reset (default 5)")
     options, args = opts.parse_args()
     if len(args) != 1:
         opts.error("Incorrect number of arguments")
-    query_unassigned(args[0], options.canbus_nodeid, options.connect_timeout)
+    query_unassigned(args[0], options.canbus_nodeid, options.connect_timeout,
+                     options.iface_timeout)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary

This PR extends `canbus_query.py` to report MCU and firmware information for unassigned Klipper CAN nodes.

When a Klipper CAN node is found, the script temporarily assigns it a CAN node id, queries the Klipper identify dictionary, and prints the MCU type and firmware version alongside the existing UUID and application information.

Non-Klipper nodes, such as CanBoot/Katapult, are still reported without attempting a Klipper protocol query.

## Motivation

On CAN setups with multiple devices, it is often difficult to know which UUID belongs to which physical board. Reporting the MCU type directly makes it easier to distinguish between mainboards, toolhead boards, USB-to-CAN bridges, and other Klipper CAN devices.

## Changes

- Query Klipper identify data from unassigned CAN nodes.
- Report MCU type and firmware version.
- Preserve the existing `Found canbus_uuid=...` output format.
- Add `--canbus-nodeid` for selecting the temporary CAN node id.
- Add `--iface-timeout` to handle CAN interface recovery after reset.
- Retry after `OSError` when a USB-to-CAN bridge reset temporarily drops the SocketCAN interface.
- Skip firmware queries for CanBoot/Katapult nodes.

## Testing

Tested on real CAN hardware. The script successfully reported:

<img width="853" height="88" alt="image" src="https://github.com/user-attachments/assets/20ee609a-c41e-4b05-9eaa-7c3ba16f4f8b" />


Also implementation for Moonraker/Fluidd:

<img width="416" height="438" alt="image" src="https://github.com/user-attachments/assets/dd4a735e-a942-43f5-8095-e266a64e0286" />


## Development notes

During development, I tested several approaches for querying additional information from unassigned CAN nodes.

The first working implementation temporarily assigned a CAN node id to a discovered Klipper node, queried the identify dictionary, printed the MCU and firmware information, and then immediately reset the node back to the unassigned state.

While testing on real hardware, I found an edge case where the queried MCU was also acting as a USB-to-CAN bridge. In that case, sending `reset` to that MCU could temporarily drop the SocketCAN interface, causing `can0` to disappear or go down. As a result, the script could fail before it finished processing the remaining discovered nodes.

To work around that, I initially tried delaying all resets until the end of the query. This allowed the script to collect information from multiple nodes before resetting them. However, that approach introduced another problem: if the USB-to-CAN bridge MCU was reset before the other queried MCUs, the CAN interface could drop before the remaining reset commands were sent. In that situation, some MCUs could remain with a temporarily assigned node id instead of returning to the unassigned state.

Because of that, I reverted to the safer sequential approach:

1. Query one Klipper node.
2. Print its MCU and firmware information.
3. Reset that node immediately.
4. Continue with the next discovered node.

To make this reliable for USB-to-CAN bridge cases, the script was made tolerant of SocketCAN reconnects. If an `OSError` occurs after a reset, the script waits for the CAN interface to become available again and retries the query. This keeps the temporary node id usage simple and avoids leaving multiple devices assigned at the same time, while still allowing the script to recover when resetting a bridge temporarily drops `can0`.

This final approach keeps the behavior closer to the original implementation while making it more robust for CAN setups where one of the discovered nodes may also be the USB-to-CAN bridge.

### If this approach and implementation look acceptable for merging, I will mark this PR as ready for review. Thanks!