### PR TITLE
Separate last_clock tracking from clock estimate tracking

### DIFF
--- a/klippy/chelper/__init__.py
+++ b/klippy/chelper/__init__.py
@@ -204,7 +204,7 @@ defs_serialqueue = """
     void serialqueue_set_receive_window(struct serialqueue *sq
         , int receive_window);
     void serialqueue_set_clock_est(struct serialqueue *sq, double est_freq
-        , double conv_time, uint64_t conv_clock, uint64_t last_clock);
+        , double conv_time, uint64_t conv_clock);
     void serialqueue_get_stats(struct serialqueue *sq, char *buf, int len);
     int serialqueue_extract_old(struct serialqueue *sq, int sentq
         , struct pull_queue_message *q, int max);

--- a/klippy/chelper/msgblock.c
+++ b/klippy/chelper/msgblock.c
@@ -184,15 +184,20 @@ message_queue_free(struct list_head *root)
 
 
 /****************************************************************
- * Clock estimation
+ * Clock conversion from 32bit to 64bit
  ****************************************************************/
 
 // Extend a 32bit clock value to its full 64bit value
 uint64_t
-clock_from_clock32(struct clock_estimate *ce, uint32_t clock32)
+clock_from_clock32(uint64_t last_clock, uint32_t clock32)
 {
-    return ce->last_clock + (int32_t)(clock32 - ce->last_clock);
+    return last_clock + (int32_t)(clock32 - last_clock);
 }
+
+
+/****************************************************************
+ * Clock estimation
+ ****************************************************************/
 
 // Convert a clock to its estimated time
 double
@@ -211,10 +216,9 @@ clock_from_time(struct clock_estimate *ce, double time)
 // Fill the fields of a 'struct clock_estimate'
 void
 clock_fill(struct clock_estimate *ce, double est_freq, double conv_time
-           , uint64_t conv_clock, uint64_t last_clock)
+           , uint64_t conv_clock)
 {
     ce->est_freq = est_freq;
     ce->conv_time = conv_time;
     ce->conv_clock = conv_clock;
-    ce->last_clock = last_clock;
 }

--- a/klippy/chelper/msgblock.h
+++ b/klippy/chelper/msgblock.h
@@ -35,7 +35,7 @@ struct queue_message {
 };
 
 struct clock_estimate {
-    uint64_t last_clock, conv_clock;
+    uint64_t conv_clock;
     double conv_time, est_freq;
 };
 
@@ -47,10 +47,10 @@ struct queue_message *message_fill(uint8_t *data, int len);
 struct queue_message *message_alloc_and_encode(uint32_t *data, int len);
 void message_free(struct queue_message *qm);
 void message_queue_free(struct list_head *root);
-uint64_t clock_from_clock32(struct clock_estimate *ce, uint32_t clock32);
+uint64_t clock_from_clock32(uint64_t last_clock, uint32_t clock32);
 double clock_to_time(struct clock_estimate *ce, uint64_t clock);
 uint64_t clock_from_time(struct clock_estimate *ce, double time);
 void clock_fill(struct clock_estimate *ce, double est_freq, double conv_time
-                , uint64_t conv_clock, uint64_t last_clock);
+                , uint64_t conv_clock);
 
 #endif // msgblock.h

--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -316,7 +316,7 @@ handle_message(struct serialqueue *sq, double eventtime, int len)
         // Release main lock and invoke callback
         pthread_mutex_lock(&sq->fast_reader_dispatch_lock);
         pthread_mutex_unlock(&sq->lock);
-        fr->func(fr, sq->input_buf, len);
+        fr->func(fr, eventtime, sq->input_buf, len);
         pthread_mutex_unlock(&sq->fast_reader_dispatch_lock);
         return;
     }
@@ -1008,11 +1008,10 @@ serialqueue_set_receive_window(struct serialqueue *sq, int receive_window)
 // serial port
 void __visible
 serialqueue_set_clock_est(struct serialqueue *sq, double est_freq
-                          , double conv_time, uint64_t conv_clock
-                          , uint64_t last_clock)
+                          , double conv_time, uint64_t conv_clock)
 {
     pthread_mutex_lock(&sq->lock);
-    clock_fill(&sq->ce, est_freq, conv_time, conv_clock, last_clock);
+    clock_fill(&sq->ce, est_freq, conv_time, conv_clock);
     pthread_mutex_unlock(&sq->lock);
 }
 

--- a/klippy/chelper/serialqueue.h
+++ b/klippy/chelper/serialqueue.h
@@ -9,7 +9,8 @@
 #define BACKGROUND_PRIORITY_CLOCK 0x7fffffff00000000LL
 
 struct fastreader;
-typedef void (*fastreader_cb)(struct fastreader *fr, uint8_t *data, int len);
+typedef void (*fastreader_cb)(struct fastreader *fr, double eventtime
+                              , uint8_t *data, int len);
 
 struct fastreader {
     struct list_node node;
@@ -45,8 +46,7 @@ void serialqueue_pull(struct serialqueue *sq, struct pull_queue_message *pqm);
 void serialqueue_set_wire_frequency(struct serialqueue *sq, double frequency);
 void serialqueue_set_receive_window(struct serialqueue *sq, int receive_window);
 void serialqueue_set_clock_est(struct serialqueue *sq, double est_freq
-                               , double conv_time, uint64_t conv_clock
-                               , uint64_t last_clock);
+                               , double conv_time, uint64_t conv_clock);
 void serialqueue_get_clock_est(struct serialqueue *sq
                                , struct clock_estimate *ce);
 void serialqueue_get_stats(struct serialqueue *sq, char *buf, int len);

--- a/klippy/chelper/steppersync.c
+++ b/klippy/chelper/steppersync.c
@@ -262,7 +262,7 @@ void __visible
 steppersync_set_time(struct steppersync *ss, double time_offset
                      , double mcu_freq)
 {
-    clock_fill(&ss->ce, mcu_freq, time_offset, 0, 0);
+    clock_fill(&ss->ce, mcu_freq, time_offset, 0);
     struct syncemitter *se;
     list_for_each_entry(se, &ss->se_list, ss_node) {
         if (se->sc)

--- a/klippy/chelper/trdispatch.c
+++ b/klippy/chelper/trdispatch.c
@@ -60,7 +60,8 @@ send_trsync_set_timeout(struct trdispatch_mcu *tdm)
 
 // Handle a trsync_state message (callback from serialqueue fastreader)
 static void
-handle_trsync_state(struct fastreader *fr, uint8_t *data, int len)
+handle_trsync_state(struct fastreader *fr, double eventtime
+                    , uint8_t *data, int len)
 {
     struct trdispatch_mcu *tdm = container_of(fr, struct trdispatch_mcu, fr);
 
@@ -89,7 +90,8 @@ handle_trsync_state(struct fastreader *fr, uint8_t *data, int len)
 
     // mcu is still working okay - update last_status_clock
     serialqueue_get_clock_est(tdm->sq, &tdm->ce);
-    tdm->last_status_clock = clock_from_clock32(&tdm->ce, clock);
+    uint64_t est_msg_clock = clock_from_time(&tdm->ce, eventtime);
+    tdm->last_status_clock = clock_from_clock32(est_msg_clock, clock);
 
     // Determine minimum acknowledged time among all mcus
     double min_time = PR_NEVER, next_min_time = PR_NEVER;

--- a/klippy/clocksync.py
+++ b/klippy/clocksync.py
@@ -54,7 +54,7 @@ class ClockSync:
         freq = 1000000000000.
         if pace:
             freq = self.mcu_freq
-        serial.set_clock_est(freq, self.reactor.monotonic(), 0, 0)
+        serial.set_clock_est(freq, self.reactor.monotonic(), 0)
     # MCU clock querying (_handle_clock is invoked from background thread)
     def _get_clock_event(self, eventtime):
         self.serial.raw_send(self.get_clock_cmd, 0, 0, self.cmd_queue)
@@ -114,7 +114,7 @@ class ClockSync:
         new_freq = self.clock_covariance / self.time_variance
         pred_stddev = math.sqrt(self.prediction_variance)
         self.serial.set_clock_est(new_freq, self.time_avg + TRANSMIT_EXTRA,
-                                  int(self.clock_avg - 3. * pred_stddev), clock)
+                                  int(self.clock_avg - 3. * pred_stddev))
         self.clock_est = (self.time_avg + self.min_half_rtt,
                           self.clock_avg, new_freq)
         #logging.debug("regr %.3f: freq=%.3f d=%d(%.3f)",

--- a/klippy/serialhdl.py
+++ b/klippy/serialhdl.py
@@ -211,9 +211,9 @@ class SerialReader:
             self.ffi_lib.serialqueue_alloc(self.serial_dev.fileno(), b'f', 0,
                                            self.sq_name),
             self.ffi_lib.serialqueue_free)
-    def set_clock_est(self, freq, conv_time, conv_clock, last_clock):
+    def set_clock_est(self, freq, conv_time, conv_clock):
         self.ffi_lib.serialqueue_set_clock_est(
-            self.serialqueue, freq, conv_time, conv_clock, last_clock)
+            self.serialqueue, freq, conv_time, conv_clock)
     def disconnect(self):
         if self.serialqueue is not None:
             self.ffi_lib.serialqueue_exit(self.serialqueue)


### PR DESCRIPTION
The clock 32bit conversion code is distinct from the clock to time conversion code.  Separate the code to make that distinction more clear.

Make sure to update the low-level C code with each get_clock response, even if the response is not used by the clock estimation code.  This reduces the chance of a failure during clock 32bit conversion.

This is intended to address the recent stm32h7 failures reported at https://klipper.discourse.group/t/intermittant-timer-too-close-fault-during-eddy-home-tap/25871/23 .

@nefelim4ag - fyi.

-Kevin