### PR TITLE
pid_calibrate: fix Ku formula

### DIFF
--- a/docs/Config_Changes.md
+++ b/docs/Config_Changes.md
@@ -8,6 +8,9 @@ All dates in this document are approximate.
 
 ## Changes
 
+20260731: The `PID_CALIBRATE` now reports PID values at half their
+previous magnitude due to a correction in the underlying PID math.
+
 20260525: The internal implementation of "probe:z_virtual_endstop" has
 changed. Most users will not observe a change in behavior. Previously
 it was technically possible to mix "probe:z_virtual_endstop" with

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -116,7 +116,8 @@ class ControlAutoTune:
         time_diff = self.peaks[pos][1] - self.peaks[pos-2][1]
         # Use Astrom-Hagglund method to estimate Ku and Tu
         amplitude = .5 * abs(temp_diff)
-        Ku = 4. * self.heater_max_power / (math.pi * amplitude)
+        power_amplitude = .5 * self.heater_max_power
+        Ku = 4. * power_amplitude / (math.pi * amplitude)
         Tu = time_diff
         # Use Ziegler-Nichols method to generate PID parameters
         Ti = 0.5 * Tu


### PR DESCRIPTION
While I was initially working with #7209, I noticed that there is hysteresis, and a relay with hysteresis should be calculated differently.
If one reduces hysteresis, it is "expected" that PID should be more precise, but instead everything was wrong.

Back then, I was unable to understand why it happened, and why with hysteresis = 1.0, I cannot calibrate anything (when it should still output something adequate).

Well, the thing is +u ~ +d input, and vice versa (for ideal relay)[^1]:
<img width="264" height="191" alt="image" src="https://github.com/user-attachments/assets/cf8647a8-a4a6-4feb-8672-8489f4edb13b" />

> Initially, the input u is increased by h. As the output y starts to increase (after a time delay D), the relay switches to
the opposite position, u) -h. [^3]


Wiki:
>  where a is the amplitude of the process variable oscillation, and b is the amplitude of the control output change which caused it. [^2]

So, the `b` or `d` term in the current implementation is an "amplitude".
For temperature, we assume that the amplitude is half of the swing.
In this case, the amplitude of power input is half of the input power.

This is another calibrator implementation, which seems to use power amplitude correctly, so +- from the "middle" point: https://sproclib.readthedocs.io/en/latest/controller/tuning/RelayTuning.html#automated-implementation

With this change, lower hysteresis seems to be still adequate  (Kd is a little too large to my taste, but regardless).
Where normal mainline PID will be halved, and it is expected.

<img width="1293" height="380" alt="image" src="https://github.com/user-attachments/assets/cb5d6144-1fdd-4bda-8874-59b4a5c2896f" />


Regards,
-Timofey

---
Testing:
```
cd ~/klipper
git fetch origin pull/7310/head
git checkout FETCH_HEAD
sudo systemctl restart klipper
```

---
[^1]: https://warwick.ac.uk/fac/cross_fac/iatl/research/reinvention/archive/volume5issue2/hornsey/
[^2]: https://en.wikipedia.org/wiki/PID_controller#Relay_(%C3%85str%C3%B6m%E2%80%93H%C3%A4gglund)_method
[^3]: https://scholars.lib.ntu.edu.tw/server/api/core/bitstreams/ec41f996-82aa-42e8-8dce-0030155f076d/content

