### PR TITLE
Add a new "action" item

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ Welcome to the Klipper project!
 
 [![Klipper](docs/img/klipper-logo-small.png)](https://www.klipper3d.org/)
 
+## Describe
+
+This warehouse was modified to match the requirements of klipperscreen-pop. The "action" category was added to accommodate the new entries in klipperscreen. To trigger the newly added entries in klipperscreen, the main body of the project is: https://github.com/sun-yi-geng/klipperscreen-pop.git
+
+此仓库是为了配合klipperscreen-pop所做的修改，增加了action的条目，为了触发klipperscreen新增的条目，项目主体：https://github.com/sun-yi-geng/klipperscreen-pop.git
+
 https://www.klipper3d.org/
 
 The Klipper firmware controls 3d-Printers. It combines the power of a

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -43,6 +43,8 @@ class RunoutHelper:
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
     def _runout_event_handler(self, eventtime):
+        # Notify clients (KlipperScreen) that pause is due to filament runout
+        self.gcode.respond_info("action:filament_runout")
         # Pausing from inside an event requires that the pause portion
         # of pause_resume execute immediately.
         pause_prefix = ""


### PR DESCRIPTION
Added a new message to be sent to klipperscreen

Just one modification, and there won't be any running errors in Klipper. The purpose is: After triggering the filament_switch_sensor, send a message to the KlipperScreen and pop up a panel on the touchscreen. The user can click "Confirm" to cancel the panel.

The modifications to klipperscreen are being finalized and a pull request will be submitted shortly. The changes have been successfully tested on a real printer.