### PR TITLE
Add support for building against picolibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ dirs-y = src
 cc-option=$(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`" \
     ; then echo "$(2)"; else echo "$(3)"; fi ;)
 
+# Newlib provides "libc_nano".
+# Other libraries such as picolibc only provide the standard "libc".
+# Prefer newlib when it is available.
+check-libc-nano=$(shell if test "`$(1) -print-file-name=libc_nano.a`" != "libc_nano.a" \
+    ; then echo "-lc_nano"; else echo "-lc"; fi ;)
+LIBC_LDFLAG = $(call check-libc-nano,$(CC))
+
 CFLAGS := -iquote $(OUT) -iquote src -iquote $(OUT)board-generic/ \
 		-std=gnu11 -O2 -MD -Wall \
 		-Wold-style-definition $(call cc-option,$(CC),-Wtype-limits,) \

--- a/src/atsam/Makefile
+++ b/src/atsam/Makefile
@@ -22,7 +22,7 @@ CFLAGS += $(CFLAGS-y) -D__$(MCU)__ -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
 samlink-y := $(OUT)src/generic/armcm_link.ld
 samlink-$(CONFIG_MACH_SAME70) := $(OUT)src/atsam/same70_link.ld
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano -T $(samlink-y)
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG) -T $(samlink-y)
 $(OUT)klipper.elf: $(samlink-y)
 
 # Add source files

--- a/src/atsamd/Makefile
+++ b/src/atsamd/Makefile
@@ -15,7 +15,7 @@ CFLAGS-$(CONFIG_MACH_SAME51) += -Ilib/same51/include
 CFLAGS-$(CONFIG_MACH_SAMX5) += -mcpu=cortex-m4 -Ilib/same54/include
 CFLAGS += $(CFLAGS-y) -D__$(MCU)__ -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG)
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -12,7 +12,9 @@
 #define __always_inline inline __attribute__((always_inline))
 #endif
 #define __visible __attribute__((externally_visible))
+#ifndef __noreturn
 #define __noreturn __attribute__((noreturn))
+#endif
 
 #define PACKED __attribute__((packed))
 #ifndef __aligned

--- a/src/hc32f460/Makefile
+++ b/src/hc32f460/Makefile
@@ -7,7 +7,7 @@ dirs-y += src/hc32f460 src/generic lib/hc32f460/driver/src lib/hc32f460/mcu/comm
 
 CFLAGS += -mthumb -mcpu=cortex-m4 -Isrc/hc32f460 -Ilib/hc32f460/driver/inc -Ilib/hc32f460/mcu/common -Ilib/cmsis-core -DHC32F460
 
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG)
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -10,7 +10,7 @@ CFLAGS-$(CONFIG_CANBUS) += -Ilib/fast-hash
 CFLAGS += $(CFLAGS-y) -mthumb -mcpu=cortex-m3
 CFLAGS += -Ilib/lpc176x/device -Ilib/cmsis-core
 
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG)
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 

--- a/src/rp2040/Makefile
+++ b/src/rp2040/Makefile
@@ -63,7 +63,7 @@ rptarget-$(CONFIG_RPXXXX_HAVE_BOOTLOADER) := $(OUT)klipper.bin
 
 # Set klipper.elf linker rules
 target-y += $(rptarget-y)
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG)
 CFLAGS_klipper.elf += -T $(OUT)src/rp2040/rpxxxx_link.ld
 OBJS_klipper.elf += $(stage2-y)
 $(OUT)klipper.elf: $(stage2-y) $(OUT)src/rp2040/rpxxxx_link.ld

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -32,7 +32,7 @@ CFLAGS-$(CONFIG_MACH_STM32H7) += -mcpu=cortex-m7 -Ilib/stm32h7/include
 CFLAGS-$(CONFIG_MACH_STM32L4) += -mcpu=cortex-m4 -Ilib/stm32l4/include
 CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
-CFLAGS_klipper.elf += -nostdlib -lgcc -lc_nano
+CFLAGS_klipper.elf += -nostdlib -lgcc $(LIBC_LDFLAG)
 CFLAGS_klipper.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)klipper.elf: $(OUT)src/generic/armcm_link.ld
 


### PR DESCRIPTION
Debian testing stopped shipping newlib. This PR adds support for building against picolibc.

Commit 163c738 conditionally links against libc if libc_nano is not fount.
Commit ef83965 prevents redefining __noreturn if it is already defined, as is the case in picolibc's sys/cdefs.h

This was tested on a system running Debian Testing Forky and an SKR MINI E3 v2.
The build for my SKR MINI E3 v2 was 42620 B with picolibc compared to 42452 B for newlib-nano.
Talking with Timofey on Discord yesterday confirmed that the only expected areas of impact would be in rare uses of mem* functions.

As my understanding of ELF formats & associated tooling is mostly inexistent, I did use Copilot CLI to verify where those were used and if the binary was properly linked. It confirmed only memcpy, memmove, memset, memchr and __aeabi_mem* were linked. It identified 10 functions using them, 7 of which could be exercised successfully from my setup (command_sendf, command_tmcuart_send,  run_tasks, alloc_chunk, command_allocate_oids, command_config_trsync, command_neopixel_update), the other 3 being command_config_spi_shutdown, command_i2c_set_sw_bus, command_spi_set_sw_bus.

I have yet to run a print on this build but have verified stepper buzzing, homing and neopixel worked properly. Idle stats also match runs on the previous 13.0.0 build.

I also confirmed builds passed on 38 out of 40 test configs. The remaining 2 being ar100 and pru which my environment did not have toolchains for - and these should not be impacted by these changes anyways.

A nice side benefit of moving from newlib to picolibc is 1.7GB of installed package size savings.

As this is my first time contributing here, please do let me know if I missed out on some PR requirements or if additional information would be useful.
Note I explicitly did not touch install scripts for now as I felt that would be best served in follow-up PRs if and when relevant for various distros.
