### PR TITLE
serialqueue: Close pipes FDs on free

### DIFF
--- a/klippy/chelper/serialqueue.c
+++ b/klippy/chelper/serialqueue.c
@@ -828,6 +828,8 @@ serialqueue_free(struct serialqueue *sq)
     pthread_mutex_unlock(&sq->transmit_requests.lock);
     pthread_mutex_unlock(&sq->lock);
     pollreactor_free(sq->pr);
+    close(sq->transmit_requests.pipe_fds[0]);
+    close(sq->transmit_requests.pipe_fds[1]);
     free(sq);
 }
 


### PR DESCRIPTION
During the investigation (#7230) of how Python handles the virtual_sdcard file during emergency stop/restart, I've noticed that the number of opened PIPEs grows with every restart.

An easy check looks like this: `sudo lsof -p <klippy PID> | wc -l`, after each `FIRMWARE RESTART`, the count grows.

-Timofey