### PR TITLE
Delay exiting from batch mode when virtual_sdcard is busy

### DIFF
--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -48,6 +48,8 @@ class VirtualSD:
             desc=self.cmd_SDCARD_PRINT_FILE_help)
         self.printer.register_event_handler("klippy:analyze_shutdown",
                                             self._handle_analyze_shutdown)
+        self.printer.register_event_handler("gcode:debuginput_exit",
+                                            self._handle_debuginput_exit)
     def _handle_analyze_shutdown(self, msg, details):
         if self.work_timer is None:
             return
@@ -67,6 +69,9 @@ class VirtualSD:
                          readpos, repr(data[:readcount]),
                          file_position, repr(data[readcount:]))
         self.reactor.register_callback(log_debug_data)
+    def _handle_debuginput_exit(self):
+        # When in batch debugging mode, wait until sdcard idle before exiting
+        return self.work_timer is None
     def stats(self, eventtime):
         if self.work_timer is None:
             return False, ""

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -429,6 +429,10 @@ class GCodeIO:
         self.is_printer_ready = False
         if self.is_fileinput:
             self.printer.request_exit('error_exit')
+    def _do_debuginput_exit(self):
+        while not all(self.printer.send_event('gcode:debuginput_exit')):
+            self.reactor.pause(self.reactor.monotonic() + 0.010)
+        self.gcode.request_restart('exit')
     m112_r = re.compile(r'^(?:[nN][0-9]+)?\s*[mM]112(?:\s|$)')
     def _process_data(self, eventtime):
         # Read input, separate by newline, and add to pending_commands
@@ -447,11 +451,11 @@ class GCodeIO:
         self.pipe_is_active = True
         # Special handling for debug file input EOF
         if not data and self.is_fileinput:
+            self.reactor.unregister_fd(self.fd_handle)
+            self.fd_handle = None
             if not self.is_processing_data:
-                self.reactor.unregister_fd(self.fd_handle)
-                self.fd_handle = None
-                self.gcode.request_restart('exit')
-            pending_commands.append("")
+                self._do_debuginput_exit()
+            return
         # Handle case where multiple commands pending
         if len(pending_commands) < 20:
             # Check for M112 out-of-order


### PR DESCRIPTION
When performing batch mode debugging it is possible for the input file to complete before all background work has completed.  Add a new 'gcode:debuginput_exit' event so that other modules can signal when they have finished.

Add code to virtual_sdcard module to catch this event and use it to wait for any sdcard processing to complete.  This fixes the sdcard_loop.test regression test case.

@nefelim4ag - fyi.

-Kevin