### PR TITLE
Reactor improvements for latency and idle checking

### DIFF
--- a/klippy/extras/error_mcu.py
+++ b/klippy/extras/error_mcu.py
@@ -93,9 +93,6 @@ class PrinterMCUError:
             self._check_mcu_shutdown(msg, details)
         else:
             self.printer.update_error_msg(msg, "%s%s" % (msg, message_shutdown))
-        # Report reactor info (no good place to do this, so done here)
-        logging.info("Reactor garbage collection: %s",
-                     self.printer.get_reactor().get_gc_stats())
     def _check_protocol_error(self, msg, details):
         host_version = self.printer.start_args['software_version']
         msg_update = []

--- a/klippy/extras/garbage_collection.py
+++ b/klippy/extras/garbage_collection.py
@@ -27,7 +27,7 @@ class GarbageCollection:
     def _handle_analyze_shutdown(self, msg, details):
         logging.info("Reactor garbage collection: %s", self._last_gc_times)
 
-    def _handle_idle(self, eventtime):
+    def _handle_idle(self, eventtime, start_busy_time):
         gi = gc.get_count()
         if gi[0] < 700:
             return False

--- a/klippy/extras/garbage_collection.py
+++ b/klippy/extras/garbage_collection.py
@@ -1,6 +1,7 @@
 # Garbage collection optimizations
 #
 # Copyright (C) 2025  Branden Cash <ammmze@gmail.com>
+# Copyright (C) 2016-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import gc
@@ -8,14 +9,37 @@ import logging
 
 class GarbageCollection:
     def __init__(self, config):
-        self.printer = config.get_printer()
+        self.printer = printer = config.get_printer()
+        # Perform gc on reactor idle
+        self._last_gc_times = [0., 0., 0.]
+        reactor = printer.get_reactor()
+        reactor.set_idle_notifier(self._handle_idle)
+        printer.register_event_handler("klippy:analyze_shutdown",
+                                       self._handle_analyze_shutdown)
+        gc.disable()
         # feature check ... freeze/unfreeze is only available in python 3.7+
         can_freeze = hasattr(gc, 'freeze') and hasattr(gc, 'unfreeze')
         if can_freeze:
-            self.printer.register_event_handler("klippy:ready",
-                                                self._handle_ready)
-            self.printer.register_event_handler("klippy:disconnect",
-                                                self._handle_disconnect)
+            printer.register_event_handler("klippy:ready", self._handle_ready)
+            printer.register_event_handler("klippy:disconnect",
+                                           self._handle_disconnect)
+
+    def _handle_analyze_shutdown(self, msg, details):
+        logging.info("Reactor garbage collection: %s", self._last_gc_times)
+
+    def _handle_idle(self, eventtime):
+        gi = gc.get_count()
+        if gi[0] < 700:
+            return False
+        # Reactor is idle and gc is due - run it
+        gc_level = 0
+        if gi[1] >= 10:
+            gc_level = 1
+            if gi[2] >= 10:
+                gc_level = 2
+        self._last_gc_times[gc_level] = eventtime
+        gc.collect(gc_level)
+        return True
 
     def _handle_ready(self):
         logging.debug("Running full garbage collection and freezing")

--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # Main code for host side printer firmware
 #
-# Copyright (C) 2016-2024  Kevin O'Connor <kevin@koconnor.net>
+# Copyright (C) 2016-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import sys, os, gc, optparse, logging, time, collections, importlib
@@ -346,7 +346,6 @@ def main():
     elif not options.debugoutput:
         logging.warning("No log file specified!"
                         " Severe timing issues may result!")
-    gc.disable()
 
     # Start Printer() class
     while 1:
@@ -354,7 +353,7 @@ def main():
             bglogger.clear_rollover_info()
             bglogger.set_rollover_info('versions', versions)
         gc.collect()
-        main_reactor = reactor.Reactor(gc_checking=True)
+        main_reactor = reactor.Reactor()
         printer = Printer(main_reactor, bglogger, start_args)
         res = printer.run()
         if res in ['exit', 'error_exit']:

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -297,7 +297,11 @@ class SelectReactor:
                 self._write_fds.remove(fd)
         elif is_writeable:
             self._write_fds.append(fd)
-    def _check_fds(self, eventtime, hdls):
+    def _check_fd_activity(self, timeout):
+        res = select.select(self._read_fds, self._write_fds, [], timeout)
+        return ([(fd, self._READ) for fd in res[0]]
+                + [(fd, self._WRITE) for fd in res[1]])
+    def _dispatch_fd_events(self, eventtime, hdls):
         g_dispatch = self._g_dispatch
         for fd, event in hdls:
             hdl = self._fds.get(fd, self._dummy_fd_hdl)
@@ -319,13 +323,11 @@ class SelectReactor:
         while self._process:
             timeout = self._check_timers(eventtime, busy)
             busy = False
-            res = select.select(self._read_fds, self._write_fds, [], timeout)
+            hdls = self._check_fd_activity(timeout)
             eventtime = self.monotonic()
-            if res[0] or res[1]:
+            if hdls:
                 busy = True
-                hdls = ([(fd, self._READ) for fd in res[0]]
-                        + [(fd, self._WRITE) for fd in res[1]])
-                eventtime = self._check_fds(eventtime, hdls)
+                eventtime = self._dispatch_fd_events(eventtime, hdls)
     def run(self):
         if self._pipe_fds is None:
             self._setup_async_callbacks()
@@ -379,18 +381,8 @@ class PollReactor(SelectReactor):
         if is_writeable:
             flags |= select.POLLOUT
         self._poll.modify(file_handler.fd, flags)
-    # Main loop
-    def _dispatch_loop(self):
-        busy = True
-        eventtime = self.monotonic()
-        while self._process:
-            timeout = self._check_timers(eventtime, busy)
-            busy = False
-            res = self._poll.poll(int(math.ceil(timeout * 1000.)))
-            eventtime = self.monotonic()
-            if res:
-                busy = True
-                eventtime = self._check_fds(eventtime, res)
+    def _check_fd_activity(self, timeout):
+        return self._poll.poll(int(math.ceil(timeout * 1000.)))
 
 class EPollReactor(SelectReactor):
     def __init__(self, gc_checking=False):
@@ -414,18 +406,8 @@ class EPollReactor(SelectReactor):
         if is_writeable:
             flags |= select.EPOLLOUT
         self._epoll.modify(file_handler.fd, flags)
-    # Main loop
-    def _dispatch_loop(self):
-        busy = True
-        eventtime = self.monotonic()
-        while self._process:
-            timeout = self._check_timers(eventtime, busy)
-            busy = False
-            res = self._epoll.poll(timeout)
-            eventtime = self.monotonic()
-            if res:
-                busy = True
-                eventtime = self._check_fds(eventtime, res)
+    def _check_fd_activity(self, timeout):
+        return self._epoll.poll(timeout)
 
 # Use the poll based reactor if it is available
 try:

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -129,6 +129,11 @@ class SelectReactor:
         self._cached_dispatch_greenlets = []
         self._all_greenlets = []
         self._prevent_pause_count = 0
+        # Tracking of high latency
+        self._latency_warning = self.NEVER
+        self._latency_callback = (lambda e, pe, rc: None)
+        self._recent_eventtime = 0.
+        self._recent_callbacks = []
     # Timers
     def update_timer(self, timer_handler, waketime):
         if timer_handler.timer_is_running:
@@ -155,6 +160,7 @@ class SelectReactor:
             if eventtime >= waketime:
                 t.waketime = self.NEVER
                 t.timer_is_running = True
+                self._recent_callbacks.append(t.callback)
                 t.waketime = waketime = t.callback(eventtime)
                 t.timer_is_running = False
                 if g_dispatch is not self._g_dispatch:
@@ -166,6 +172,7 @@ class SelectReactor:
     def set_idle_notifier(self, callback):
         self._idle_callback = callback
     def _calc_sleep_time(self, eventtime):
+        self._recent_callbacks.append(self._idle_callback)
         self._prevent_pause_count += 1
         busy = self._idle_callback(eventtime)
         self._prevent_pause_count -= 1
@@ -289,16 +296,28 @@ class SelectReactor:
         for fd, event in hdls:
             hdl = self._fds.get(fd, self._dummy_fd_hdl)
             if event & self._READ:
+                self._recent_callbacks.append(hdl.read_callback)
                 hdl.read_callback(eventtime)
                 if g_dispatch is not self._g_dispatch:
                     self._end_greenlet(g_dispatch)
                     return True
             if event & self._WRITE:
+                self._recent_callbacks.append(hdl.write_callback)
                 hdl.write_callback(eventtime)
                 if g_dispatch is not self._g_dispatch:
                     self._end_greenlet(g_dispatch)
                     return True
         return False
+    # High latency checking
+    def set_latency_notifier(self, latency, latency_callback):
+        self._latency_warning = latency
+        self._latency_callback = latency_callback
+    def _dispatch_latency_callback(self, eventtime, prev_eventtime):
+        prev_cbs = self._recent_callbacks
+        self._recent_callbacks = [self._latency_callback]
+        self._prevent_pause_count += 1
+        self._latency_callback(eventtime, prev_eventtime, prev_cbs)
+        self._prevent_pause_count -= 1
     # Main loop
     def _dispatch_loop(self):
         eventtime = 0.
@@ -312,6 +331,14 @@ class SelectReactor:
             hdls = self._check_fd_activity(timeout)
             eventtime = self.monotonic()
             busy = False
+            # Check for high latency
+            prev_etime = self._recent_eventtime
+            self._recent_eventtime = eventtime
+            if not timeout and eventtime - prev_etime >= self._latency_warning:
+                busy = True
+                self._dispatch_latency_callback(eventtime, prev_etime)
+            else:
+                del self._recent_callbacks[:]
             # Dispatch file events
             if hdls:
                 busy = True
@@ -327,6 +354,8 @@ class SelectReactor:
             self._setup_async_callbacks()
         self._process = True
         self._prevent_pause_count = 0
+        self._recent_eventtime = self.monotonic()
+        self._recent_callbacks = []
         try:
             while self._process:
                 # Create new greenlet to dispatch timers and events
@@ -337,6 +366,7 @@ class SelectReactor:
                 # Control returns here on end() request or switch from pause()
         finally:
             self._g_dispatch = None
+        self._recent_callbacks = []
     def end(self):
         self._process = False
     def finalize(self):

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -15,7 +15,7 @@ class ReactorError(Exception):
 
 class ReactorTimer:
     def __init__(self, callback, waketime):
-        self.callback = callback
+        self.callback = self.underlying_callback = callback
         self.waketime = waketime
         self.timer_is_running = False
 
@@ -45,6 +45,7 @@ class ReactorCallback:
     def __init__(self, reactor, callback, waketime):
         self.reactor = reactor
         self.timer = reactor.register_timer(self.invoke, waketime)
+        self.timer.underlying_callback = callback
         self.callback = callback
         self.completion = ReactorCompletion(reactor)
     def invoke(self, eventtime):
@@ -160,7 +161,7 @@ class SelectReactor:
             if eventtime >= waketime:
                 t.waketime = self.NEVER
                 t.timer_is_running = True
-                self._recent_callbacks.append(t.callback)
+                self._recent_callbacks.append(t.underlying_callback)
                 t.waketime = waketime = t.callback(eventtime)
                 t.timer_is_running = False
                 if g_dispatch is not self._g_dispatch:
@@ -236,6 +237,8 @@ class SelectReactor:
             return self._g_dispatch.switch(waketime)
         # Pausing the dispatch greenlet - setup timer to resume this greenlet
         g.timer = self.register_timer(g.switch, waketime)
+        if self._recent_callbacks:
+            g.timer.underlying_callback = self._recent_callbacks[-1]
         self._next_timer = self.NOW
         if self._cached_dispatch_greenlets:
             # Switch to _end_greenlet to activate cached dispatch greenlet

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016-2026  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import os, gc, select, math, time, logging, queue
+import os, select, math, time, logging, queue
 import greenlet
 import chelper, util
 
@@ -104,16 +104,15 @@ class ReactorPreventPause:
 class SelectReactor:
     NOW = _NOW
     NEVER = _NEVER
-    def __init__(self, gc_checking=False):
+    def __init__(self):
         # Main code
         self._process = False
         self.monotonic = chelper.get_ffi()[1].get_monotonic
-        # Python garbage collection
-        self._gc_checking = gc_checking
-        self._last_gc_times = [0., 0., 0.]
         # Timers
         self._timers = []
         self._next_timer = self.NEVER
+        # Idle notifier callback
+        self._idle_callback = (lambda e: False)
         # Callbacks
         self._pipe_fds = None
         self._async_queue = queue.Queue()
@@ -130,24 +129,6 @@ class SelectReactor:
         self._cached_dispatch_greenlets = []
         self._all_greenlets = []
         self._prevent_pause_count = 0
-    # Python garbage collection
-    def get_gc_stats(self):
-        return tuple(self._last_gc_times)
-    def _check_gc(self, eventtime):
-        if not self._gc_checking:
-            return False
-        gi = gc.get_count()
-        if gi[0] < 700:
-            return False
-        # Reactor looks idle and gc is due - run it
-        gc_level = 0
-        if gi[1] >= 10:
-            gc_level = 1
-            if gi[2] >= 10:
-                gc_level = 2
-        self._last_gc_times[gc_level] = eventtime
-        gc.collect(gc_level)
-        return True
     # Timers
     def update_timer(self, timer_handler, waketime):
         if timer_handler.timer_is_running:
@@ -166,14 +147,7 @@ class SelectReactor:
         timers = list(self._timers)
         timers.pop(timers.index(timer_handler))
         self._timers = timers
-    def _check_timers(self, eventtime, busy):
-        if eventtime < self._next_timer:
-            if busy:
-                return 0.
-            gc_busy = self._check_gc(eventtime)
-            if gc_busy:
-                return 0.
-            return min(1., max(.001, self._next_timer - eventtime))
+    def _check_timers(self, eventtime):
         self._next_timer = self.NEVER
         g_dispatch = self._g_dispatch
         for t in self._timers:
@@ -186,9 +160,18 @@ class SelectReactor:
                 if g_dispatch is not self._g_dispatch:
                     self._next_timer = min(self._next_timer, waketime)
                     self._end_greenlet(g_dispatch)
-                    return 0.
+                    return
             self._next_timer = min(self._next_timer, waketime)
-        return 0.
+    # Idle notifiers
+    def set_idle_notifier(self, callback):
+        self._idle_callback = callback
+    def _calc_sleep_time(self, eventtime):
+        self._prevent_pause_count += 1
+        busy = self._idle_callback(eventtime)
+        self._prevent_pause_count -= 1
+        if busy:
+            return 0.
+        return min(1., max(.001, self._next_timer - eventtime))
     # Callbacks and Completions
     def completion(self):
         return ReactorCompletion(self)
@@ -309,25 +292,36 @@ class SelectReactor:
                 hdl.read_callback(eventtime)
                 if g_dispatch is not self._g_dispatch:
                     self._end_greenlet(g_dispatch)
-                    return self.monotonic()
+                    return True
             if event & self._WRITE:
                 hdl.write_callback(eventtime)
                 if g_dispatch is not self._g_dispatch:
                     self._end_greenlet(g_dispatch)
-                    return self.monotonic()
-        return eventtime
+                    return True
+        return False
     # Main loop
     def _dispatch_loop(self):
+        eventtime = 0.
         busy = True
-        eventtime = self.monotonic()
         while self._process:
-            timeout = self._check_timers(eventtime, busy)
-            busy = False
+            # Check if can sleep
+            timeout = 0.
+            if not busy:
+                timeout = self._calc_sleep_time(eventtime)
+            # Check for file activity
             hdls = self._check_fd_activity(timeout)
             eventtime = self.monotonic()
+            busy = False
+            # Dispatch file events
             if hdls:
                 busy = True
-                eventtime = self._dispatch_fd_events(eventtime, hdls)
+                did_switch = self._dispatch_fd_events(eventtime, hdls)
+                if did_switch:
+                    continue
+            # Dispatch pending timers
+            if eventtime >= self._next_timer:
+                busy = True
+                self._check_timers(eventtime)
     def run(self):
         if self._pipe_fds is None:
             self._setup_async_callbacks()
@@ -360,8 +354,8 @@ class SelectReactor:
             self._pipe_fds = None
 
 class PollReactor(SelectReactor):
-    def __init__(self, gc_checking=False):
-        SelectReactor.__init__(self, gc_checking)
+    def __init__(self):
+        SelectReactor.__init__(self)
         self._poll = select.poll()
         self._READ = select.POLLIN | select.POLLHUP
         self._WRITE = select.POLLOUT
@@ -385,8 +379,8 @@ class PollReactor(SelectReactor):
         return self._poll.poll(int(math.ceil(timeout * 1000.)))
 
 class EPollReactor(SelectReactor):
-    def __init__(self, gc_checking=False):
-        SelectReactor.__init__(self, gc_checking)
+    def __init__(self):
+        SelectReactor.__init__(self)
         self._epoll = select.epoll()
         self._READ = select.EPOLLIN | select.EPOLLHUP
         self._WRITE = select.EPOLLOUT

--- a/klippy/reactor.py
+++ b/klippy/reactor.py
@@ -113,7 +113,8 @@ class SelectReactor:
         self._timers = []
         self._next_timer = self.NEVER
         # Idle notifier callback
-        self._idle_callback = (lambda e: False)
+        self._start_busy_time = 0.
+        self._idle_callback = (lambda e, sbt: False)
         # Callbacks
         self._pipe_fds = None
         self._async_queue = queue.Queue()
@@ -175,7 +176,7 @@ class SelectReactor:
     def _calc_sleep_time(self, eventtime):
         self._recent_callbacks.append(self._idle_callback)
         self._prevent_pause_count += 1
-        busy = self._idle_callback(eventtime)
+        busy = self._idle_callback(eventtime, self._start_busy_time)
         self._prevent_pause_count -= 1
         if busy:
             return 0.
@@ -333,6 +334,8 @@ class SelectReactor:
             # Check for file activity
             hdls = self._check_fd_activity(timeout)
             eventtime = self.monotonic()
+            if timeout:
+                self._start_busy_time = eventtime
             busy = False
             # Check for high latency
             prev_etime = self._recent_eventtime
@@ -357,7 +360,7 @@ class SelectReactor:
             self._setup_async_callbacks()
         self._process = True
         self._prevent_pause_count = 0
-        self._recent_eventtime = self.monotonic()
+        self._recent_eventtime = self._start_busy_time = self.monotonic()
         self._recent_callbacks = []
         try:
             while self._process:


### PR DESCRIPTION
This PR updates the core reactor module to support an idle notification callback along with a high latency callback.

This is the result of a discussion in #7170 .  The goal is to make it possible to log if the reactor struggles to keep up with real-time deadlines.

This PR doesn't actually add any logging.  It adds the low-level capabilities to the reactor module in preparation for future enhancements.

@nefelim4ag - fyi.

-Kevin