### PR TITLE
aio_executor: Run calls inline when the executor is stopped

### DIFF
--- a/klippy/extras/aio_executor.py
+++ b/klippy/extras/aio_executor.py
@@ -48,6 +48,8 @@ class Executor:
             except Exception as e:
                 self.reactor.async_complete(completion, (None, e))
     def submit(self, fn, *args, **kwargs):
+        if not self._wait_for_work:
+            return fn(*args, **kwargs)
         completion = self.reactor.completion()
         self._queue.put_nowait((completion, fn, args, kwargs))
         result, exc = completion.wait()


### PR DESCRIPTION
Follow up to #7230

The executor is stopped from a "klippy:disconnect" handler, which runs after reactor.run() has returned.  Any submit() after that point waits on a completion that nobody can complete - reactor.pause() falls back to a system sleep until NEVER and raises an OverflowError. virtual_sdcard leaves current_file open when a shutdown interrupts an SD print.  On the next RESTART the object graph is released while no reactor is running, and the file finalizers call the proxied close():
```
  Exception ignored in: <_io.TextIOWrapper name='.../test_aio.gcode'>
    File "klippy/extras/aio_executor.py", line 22, in proxy
    File "klippy/extras/aio_executor.py", line 53, in submit
    File "klippy/reactor.py", line 233, in _sys_pause
  OverflowError: timestamp out of range for platform time_t
```

To reproduce: print a file from the virtual sdcard that contains M112 in
the middle.

