### PR TITLE
Improve untracked files

### DIFF
--- a/klippy/klippy.py
+++ b/klippy/klippy.py
@@ -309,8 +309,11 @@ def main():
     logging.info("Starting Klippy...")
     git_info = util.get_git_version()
     git_vers = git_info["version"]
+    repo = os.path.join(os.path.dirname(__file__), '..')
     extra_files = [fname for code, fname in git_info["file_status"]
-                   if (code in ('??', '!!') and fname.endswith('.py')
+                   if (code in ('??', '!!')
+                       and (fname.endswith('.py')
+                            or os.path.islink(os.path.join(repo, fname)))
                        and (fname.startswith('klippy/kinematics/')
                             or fname.startswith('klippy/extras/')))]
     modified_files = [fname for code, fname in git_info["file_status"]

--- a/klippy/util.py
+++ b/klippy/util.py
@@ -206,7 +206,8 @@ def get_git_version(from_file=True):
     gitdir = os.path.join(klippy_src, '..')
     prog_desc = ('git', '-C', gitdir, 'describe', '--always',
                  '--tags', '--long', '--dirty')
-    prog_status = ('git', '-C', gitdir, 'status', '--porcelain', '--ignored')
+    prog_status = ('git', '-C', gitdir, 'status', '--porcelain', '--ignored',
+                   '--untracked-files=all')
     try:
         process = subprocess.Popen(prog_desc, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)


### PR DESCRIPTION
This basically covers some missing spots in the "dirty" tracking that I've encountered over the past 2 years.

To be specific:
```
mkdir -p klippy/extras/custom/
touch klippy/extras/custom/test.py
# and
ln -svr /tmp klippy/extras/symlink
```

Thanks,
-Timofey