### PR TITLE
gcode: expose command/mux_command parameter schemas via the status API

### DIFF
--- a/klippy/extras/adxl345.py
+++ b/klippy/extras/adxl345.py
@@ -133,17 +133,27 @@ class AccelCommandHelper:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("ACCELEROMETER_MEASURE", "CHIP", name,
                                    self.cmd_ACCELEROMETER_MEASURE,
-                                   desc=self.cmd_ACCELEROMETER_MEASURE_help)
+                                   desc=self.cmd_ACCELEROMETER_MEASURE_help,
+                                   params=self.cmd_ACCELEROMETER_MEASURE_params)
         gcode.register_mux_command("ACCELEROMETER_QUERY", "CHIP", name,
                                    self.cmd_ACCELEROMETER_QUERY,
-                                   desc=self.cmd_ACCELEROMETER_QUERY_help)
-        gcode.register_mux_command("ACCELEROMETER_DEBUG_READ", "CHIP", name,
-                                   self.cmd_ACCELEROMETER_DEBUG_READ,
-                                   desc=self.cmd_ACCELEROMETER_DEBUG_READ_help)
-        gcode.register_mux_command("ACCELEROMETER_DEBUG_WRITE", "CHIP", name,
-                                   self.cmd_ACCELEROMETER_DEBUG_WRITE,
-                                   desc=self.cmd_ACCELEROMETER_DEBUG_WRITE_help)
+                                   desc=self.cmd_ACCELEROMETER_QUERY_help,
+                                   params=self.cmd_ACCELEROMETER_QUERY_params)
+        gcode.register_mux_command(
+            "ACCELEROMETER_DEBUG_READ", "CHIP", name,
+            self.cmd_ACCELEROMETER_DEBUG_READ,
+            desc=self.cmd_ACCELEROMETER_DEBUG_READ_help,
+            params=self.cmd_ACCELEROMETER_DEBUG_READ_params)
+        gcode.register_mux_command(
+            "ACCELEROMETER_DEBUG_WRITE", "CHIP", name,
+            self.cmd_ACCELEROMETER_DEBUG_WRITE,
+            desc=self.cmd_ACCELEROMETER_DEBUG_WRITE_help,
+            params=self.cmd_ACCELEROMETER_DEBUG_WRITE_params)
     cmd_ACCELEROMETER_MEASURE_help = "Start/stop accelerometer"
+    cmd_ACCELEROMETER_MEASURE_params = {
+        "CHIP": {"type": "string", "required": True},
+        "NAME": {"type": "string", "required": False},
+    }
     def cmd_ACCELEROMETER_MEASURE(self, gcmd):
         if self.bg_client is None:
             # Start measurements
@@ -166,6 +176,9 @@ class AccelCommandHelper:
         gcmd.respond_info("Writing raw accelerometer data to %s file"
                           % (filename,))
     cmd_ACCELEROMETER_QUERY_help = "Query accelerometer for the current values"
+    cmd_ACCELEROMETER_QUERY_params = {
+        "CHIP": {"type": "string", "required": True},
+    }
     def cmd_ACCELEROMETER_QUERY(self, gcmd):
         aclient = self.chip.start_internal_client()
         self.printer.lookup_object('toolhead').dwell(1.)
@@ -177,11 +190,20 @@ class AccelCommandHelper:
         gcmd.respond_info("accelerometer values (x, y, z): %.6f, %.6f, %.6f"
                           % (accel_x, accel_y, accel_z))
     cmd_ACCELEROMETER_DEBUG_READ_help = "Query register (for debugging)"
+    cmd_ACCELEROMETER_DEBUG_READ_params = {
+        "CHIP": {"type": "string", "required": True},
+        "REG": {"type": "int", "required": True},
+    }
     def cmd_ACCELEROMETER_DEBUG_READ(self, gcmd):
         reg = gcmd.get("REG", minval=0, maxval=127, parser=lambda x: int(x, 0))
         val = self.chip.read_reg(reg)
         gcmd.respond_info("Accelerometer REG[0x%x] = 0x%x" % (reg, val))
     cmd_ACCELEROMETER_DEBUG_WRITE_help = "Set register (for debugging)"
+    cmd_ACCELEROMETER_DEBUG_WRITE_params = {
+        "CHIP": {"type": "string", "required": True},
+        "REG": {"type": "int", "required": True},
+        "VAL": {"type": "int", "required": True},
+    }
     def cmd_ACCELEROMETER_DEBUG_WRITE(self, gcmd):
         reg = gcmd.get("REG", minval=0, maxval=127, parser=lambda x: int(x, 0))
         val = gcmd.get("VAL", minval=0, maxval=255, parser=lambda x: int(x, 0))

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -48,7 +48,8 @@ class AngleCalibration:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("ANGLE_CALIBRATE", "CHIP",
                                    cname, self.cmd_ANGLE_CALIBRATE,
-                                   desc=self.cmd_ANGLE_CALIBRATE_help)
+                                   desc=self.cmd_ANGLE_CALIBRATE_help,
+                                   params=self.cmd_ANGLE_CALIBRATE_params)
     def handle_sync_mcu_pos(self, mcu_stepper):
         if mcu_stepper.get_name() == self.stepper_name:
             self.mcu_pos_offset = None
@@ -224,6 +225,9 @@ class AngleCalibration:
             total_variance += sum([(d - angle_avg)**2 for d in data])
         return angles, math.sqrt(total_variance / total_count), total_count
     cmd_ANGLE_CALIBRATE_help = "Calibrate angle sensor to stepper motor"
+    cmd_ANGLE_CALIBRATE_params = {
+        "CHIP": {"type": "string", "required": True},
+    }
     def cmd_ANGLE_CALIBRATE(self, gcmd):
         # Perform calibration movement and capture
         old_calibration = self.calibration
@@ -310,10 +314,12 @@ class HelperTLE5012B:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("ANGLE_DEBUG_READ", "CHIP", name,
                                    self.cmd_ANGLE_DEBUG_READ,
-                                   desc=self.cmd_ANGLE_DEBUG_READ_help)
+                                   desc=self.cmd_ANGLE_DEBUG_READ_help,
+                                   params=self.cmd_ANGLE_DEBUG_READ_params)
         gcode.register_mux_command("ANGLE_DEBUG_WRITE", "CHIP", name,
                                    self.cmd_ANGLE_DEBUG_WRITE,
-                                   desc=self.cmd_ANGLE_DEBUG_WRITE_help)
+                                   desc=self.cmd_ANGLE_DEBUG_WRITE_help,
+                                   params=self.cmd_ANGLE_DEBUG_WRITE_params)
     def _build_config(self):
         cmdqueue = self.spi.get_command_queue()
         self.spi_angle_transfer_cmd = self.mcu.lookup_query_command(
@@ -400,11 +406,20 @@ class HelperTLE5012B:
         self.chip_freq = float(1<<5) / self.mcu.seconds_to_clock(1. / 750000.)
         self.update_clock()
     cmd_ANGLE_DEBUG_READ_help = "Query low-level angle sensor register"
+    cmd_ANGLE_DEBUG_READ_params = {
+        "CHIP": {"type": "string", "required": True},
+        "REG": {"type": "int", "required": True},
+    }
     def cmd_ANGLE_DEBUG_READ(self, gcmd):
         reg = gcmd.get("REG", minval=0, maxval=0x30, parser=lambda x: int(x, 0))
         val = self._read_reg(reg)
         gcmd.respond_info("ANGLE REG[0x%02x] = 0x%04x" % (reg, val))
     cmd_ANGLE_DEBUG_WRITE_help = "Set low-level angle sensor register"
+    cmd_ANGLE_DEBUG_WRITE_params = {
+        "CHIP": {"type": "string", "required": True},
+        "REG": {"type": "int", "required": True},
+        "VAL": {"type": "int", "required": True},
+    }
     def cmd_ANGLE_DEBUG_WRITE(self, gcmd):
         reg = gcmd.get("REG", minval=0, maxval=0x30, parser=lambda x: int(x, 0))
         val = gcmd.get("VAL", minval=0, maxval=0xffff,
@@ -427,7 +442,8 @@ class HelperMT6816:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("ANGLE_DEBUG_READ", "CHIP", name,
                                    self.cmd_ANGLE_DEBUG_READ,
-                                   desc=self.cmd_ANGLE_DEBUG_READ_help)
+                                   desc=self.cmd_ANGLE_DEBUG_READ_help,
+                                   params=self.cmd_ANGLE_DEBUG_READ_params)
     def _build_config(self):
         cmdqueue = self.spi.get_command_queue()
         self.spi_angle_transfer_cmd = self.mcu.lookup_query_command(
@@ -447,6 +463,9 @@ class HelperMT6816:
     def start(self):
         pass
     cmd_ANGLE_DEBUG_READ_help = "Query low-level angle sensor register"
+    cmd_ANGLE_DEBUG_READ_params = {
+        "CHIP": {"type": "string", "required": True},
+    }
     def cmd_ANGLE_DEBUG_READ(self, gcmd):
         reg = 0x83
         val = self._read_reg(reg)
@@ -474,10 +493,12 @@ class HelperMT6826S:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("ANGLE_DEBUG_READ", "CHIP", name,
                                    self.cmd_ANGLE_DEBUG_READ,
-                                   desc=self.cmd_ANGLE_DEBUG_READ_help)
+                                   desc=self.cmd_ANGLE_DEBUG_READ_help,
+                                   params=self.cmd_ANGLE_DEBUG_READ_params)
         gcode.register_mux_command("ANGLE_CHIP_CALIBRATE", "CHIP", name,
                                    self.cmd_ANGLE_CHIP_CALIBRATE,
-                                   desc=self.cmd_ANGLE_CHIP_CALIBRATE_help)
+                                   desc=self.cmd_ANGLE_CHIP_CALIBRATE_help,
+                                   params=self.cmd_ANGLE_CHIP_CALIBRATE_params)
         self.status_map = {
             0: "No Calibration",
             1: "Running Calibration",
@@ -539,6 +560,9 @@ class HelperMT6826S:
         full_steps = stconfig['full_steps_per_rotation']
         return microsteps, full_steps
     cmd_ANGLE_CHIP_CALIBRATE_help = "Run MT6826s calibration sequence"
+    cmd_ANGLE_CHIP_CALIBRATE_params = {
+        "CHIP": {"type": "string", "required": True},
+    }
     def cmd_ANGLE_CHIP_CALIBRATE(self, gcmd):
         fmove = self.printer.lookup_object('force_move')
         mcu_stepper = fmove.lookup_stepper(self.stepper_name)
@@ -575,6 +599,10 @@ class HelperMT6826S:
         if code == 3:
             gcmd.respond_info("Calibration success, please poweroff sensor")
     cmd_ANGLE_DEBUG_READ_help = "Query low-level angle sensor register"
+    cmd_ANGLE_DEBUG_READ_params = {
+        "CHIP": {"type": "string", "required": True},
+        "REG": {"type": "int", "required": True},
+    }
     def cmd_ANGLE_DEBUG_READ(self, gcmd):
         reg = gcmd.get("REG", minval=0, maxval=0x155,
                        parser=lambda x: int(x, 0))

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -142,13 +142,18 @@ class Calibrater:
         self.gcode.register_command(
             'AXIS_TWIST_COMPENSATION_CALIBRATE',
             self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE,
-            desc=self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_help)
+            desc=self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_help,
+            params=self.cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_params)
 
     cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_help = """
     Performs the x twist calibration wizard
     Measure z probe offset at n points along the x axis,
     and calculate x twist compensation
     """
+    cmd_AXIS_TWIST_COMPENSATION_CALIBRATE_params = {
+        "SAMPLE_COUNT": {"type": "int", "required": False},
+        "AXIS": {"type": "string", "default": "X"},
+    }
 
     def cmd_AXIS_TWIST_COMPENSATION_CALIBRATE(self, gcmd):
         self.gcmd = gcmd

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -652,22 +652,20 @@ class BedMeshCalibrate:
             "rapid_path": list(self.probe_mgr.iter_rapid_path())
         }
     cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
-    cmd_BED_MESH_CALIBRATE_params = {
-        "PROFILE": {"type": "string", "default": "default"},
-        "MESH_RADIUS": {"type": "float", "required": False},
-        "MESH_ORIGIN": {"type": "string", "required": False},
-        "ROUND_PROBE_COUNT": {"type": "int", "required": False},
-        "MESH_MIN": {"type": "string", "required": False},
-        "MESH_MAX": {"type": "string", "required": False},
-        "PROBE_COUNT": {"type": "string", "required": False},
-        "MESH_PPS": {"type": "string", "required": False},
-        "ALGORITHM": {"type": "string", "required": False},
-        "ADAPTIVE": {"type": "int", "default": 0},
-        "ADAPTIVE_MARGIN": {"type": "float", "required": False},
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-        "SCAN_SPEED": {"type": "float", "required": False},
-    }
+    cmd_BED_MESH_CALIBRATE_params = dict(
+        probe.PROBE_POINTS_HELPER_PARAMS,
+        PROFILE={"type": "string", "default": "default"},
+        MESH_RADIUS={"type": "float", "required": False},
+        MESH_ORIGIN={"type": "string", "required": False},
+        ROUND_PROBE_COUNT={"type": "int", "required": False},
+        MESH_MIN={"type": "string", "required": False},
+        MESH_MAX={"type": "string", "required": False},
+        PROBE_COUNT={"type": "string", "required": False},
+        MESH_PPS={"type": "string", "required": False},
+        ALGORITHM={"type": "string", "required": False},
+        ADAPTIVE={"type": "int", "default": 0},
+        ADAPTIVE_MARGIN={"type": "float", "required": False},
+        SCAN_SPEED={"type": "float", "required": False})
     def cmd_BED_MESH_CALIBRATE(self, gcmd):
         self._profile_name = gcmd.get('PROFILE', "default")
         if not self._profile_name.strip():

--- a/klippy/extras/bed_mesh.py
+++ b/klippy/extras/bed_mesh.py
@@ -111,7 +111,8 @@ class BedMesh:
         # register gcodes
         self.gcode.register_command(
             'BED_MESH_OUTPUT', self.cmd_BED_MESH_OUTPUT,
-            desc=self.cmd_BED_MESH_OUTPUT_help)
+            desc=self.cmd_BED_MESH_OUTPUT_help,
+            params=self.cmd_BED_MESH_OUTPUT_params)
         self.gcode.register_command(
             'BED_MESH_MAP', self.cmd_BED_MESH_MAP,
             desc=self.cmd_BED_MESH_MAP_help)
@@ -120,7 +121,8 @@ class BedMesh:
             desc=self.cmd_BED_MESH_CLEAR_help)
         self.gcode.register_command(
             'BED_MESH_OFFSET', self.cmd_BED_MESH_OFFSET,
-            desc=self.cmd_BED_MESH_OFFSET_help)
+            desc=self.cmd_BED_MESH_OFFSET_help,
+            params=self.cmd_BED_MESH_OFFSET_params)
         # Register dump webhooks
         webhooks = self.printer.lookup_object('webhooks')
         webhooks.register_endpoint(
@@ -251,6 +253,9 @@ class BedMesh:
     def get_mesh(self):
         return self.z_mesh
     cmd_BED_MESH_OUTPUT_help = "Retrieve interpolated grid of probed z-points"
+    cmd_BED_MESH_OUTPUT_params = {
+        "PGP": {"type": "int", "default": 0},
+    }
     def cmd_BED_MESH_OUTPUT(self, gcmd):
         if gcmd.get_int('PGP', 0):
             # Print Generated Points instead of mesh
@@ -275,6 +280,11 @@ class BedMesh:
     def cmd_BED_MESH_CLEAR(self, gcmd):
         self.set_mesh(None)
     cmd_BED_MESH_OFFSET_help = "Add X/Y offsets to the mesh lookup"
+    cmd_BED_MESH_OFFSET_params = {
+        "X": {"type": "float", "required": False},
+        "Y": {"type": "float", "required": False},
+        "ZFADE": {"type": "float", "required": False},
+    }
     def cmd_BED_MESH_OFFSET(self, gcmd):
         if self.z_mesh is not None:
             offsets = [None, None]
@@ -346,7 +356,8 @@ class BedMeshCalibrate:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'BED_MESH_CALIBRATE', self.cmd_BED_MESH_CALIBRATE,
-            desc=self.cmd_BED_MESH_CALIBRATE_help)
+            desc=self.cmd_BED_MESH_CALIBRATE_help,
+            params=self.cmd_BED_MESH_CALIBRATE_params)
     def print_generated_points(self, print_func, truncate=False):
         x_offset = y_offset = 0.
         probe = self.printer.lookup_object('probe', None)
@@ -641,6 +652,22 @@ class BedMeshCalibrate:
             "rapid_path": list(self.probe_mgr.iter_rapid_path())
         }
     cmd_BED_MESH_CALIBRATE_help = "Perform Mesh Bed Leveling"
+    cmd_BED_MESH_CALIBRATE_params = {
+        "PROFILE": {"type": "string", "default": "default"},
+        "MESH_RADIUS": {"type": "float", "required": False},
+        "MESH_ORIGIN": {"type": "string", "required": False},
+        "ROUND_PROBE_COUNT": {"type": "int", "required": False},
+        "MESH_MIN": {"type": "string", "required": False},
+        "MESH_MAX": {"type": "string", "required": False},
+        "PROBE_COUNT": {"type": "string", "required": False},
+        "MESH_PPS": {"type": "string", "required": False},
+        "ALGORITHM": {"type": "string", "required": False},
+        "ADAPTIVE": {"type": "int", "default": 0},
+        "ADAPTIVE_MARGIN": {"type": "float", "required": False},
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+        "SCAN_SPEED": {"type": "float", "required": False},
+    }
     def cmd_BED_MESH_CALIBRATE(self, gcmd):
         self._profile_name = gcmd.get('PROFILE', "default")
         if not self._profile_name.strip():
@@ -1661,7 +1688,8 @@ class ProfileManager:
         # Register GCode
         self.gcode.register_command(
             'BED_MESH_PROFILE', self.cmd_BED_MESH_PROFILE,
-            desc=self.cmd_BED_MESH_PROFILE_help)
+            desc=self.cmd_BED_MESH_PROFILE_help,
+            params=self.cmd_BED_MESH_PROFILE_params)
     def get_profiles(self):
         return self.profiles
     def _check_incompatible_profiles(self):
@@ -1739,6 +1767,11 @@ class ProfileManager:
             self.gcode.respond_info(
                 "No profile named [%s] to remove" % (prof_name))
     cmd_BED_MESH_PROFILE_help = "Bed Mesh Persistent Storage management"
+    cmd_BED_MESH_PROFILE_params = {
+        "LOAD": {"type": "string", "required": False},
+        "SAVE": {"type": "string", "required": False},
+        "REMOVE": {"type": "string", "required": False},
+    }
     def cmd_BED_MESH_PROFILE(self, gcmd):
         options = collections.OrderedDict({
             'LOAD': self.load_profile,

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -54,8 +54,13 @@ class BedTiltCalibrate:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'BED_TILT_CALIBRATE', self.cmd_BED_TILT_CALIBRATE,
-            desc=self.cmd_BED_TILT_CALIBRATE_help)
+            desc=self.cmd_BED_TILT_CALIBRATE_help,
+            params=self.cmd_BED_TILT_CALIBRATE_params)
     cmd_BED_TILT_CALIBRATE_help = "Bed tilt calibration script"
+    cmd_BED_TILT_CALIBRATE_params = {
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+    }
     def cmd_BED_TILT_CALIBRATE(self, gcmd):
         self.probe_helper.start_probe(gcmd)
     def probe_finalize(self, positions):

--- a/klippy/extras/bed_tilt.py
+++ b/klippy/extras/bed_tilt.py
@@ -57,10 +57,7 @@ class BedTiltCalibrate:
             desc=self.cmd_BED_TILT_CALIBRATE_help,
             params=self.cmd_BED_TILT_CALIBRATE_params)
     cmd_BED_TILT_CALIBRATE_help = "Bed tilt calibration script"
-    cmd_BED_TILT_CALIBRATE_params = {
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-    }
+    cmd_BED_TILT_CALIBRATE_params = dict(probe.PROBE_POINTS_HELPER_PARAMS)
     def cmd_BED_TILT_CALIBRATE(self, gcmd):
         self.probe_helper.start_probe(gcmd)
     def probe_finalize(self, positions):

--- a/klippy/extras/bltouch.py
+++ b/klippy/extras/bltouch.py
@@ -66,9 +66,11 @@ class BLTouchProbe:
         # Register BLTOUCH_DEBUG command
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("BLTOUCH_DEBUG", self.cmd_BLTOUCH_DEBUG,
-                                    desc=self.cmd_BLTOUCH_DEBUG_help)
+                                    desc=self.cmd_BLTOUCH_DEBUG_help,
+                                    params=self.cmd_BLTOUCH_DEBUG_params)
         self.gcode.register_command("BLTOUCH_STORE", self.cmd_BLTOUCH_STORE,
-                                    desc=self.cmd_BLTOUCH_STORE_help)
+                                    desc=self.cmd_BLTOUCH_STORE_help,
+                                    params=self.cmd_BLTOUCH_STORE_params)
         # Register events
         self.printer.register_event_handler("klippy:connect",
                                             self._handle_connect)
@@ -256,6 +258,9 @@ class BLTouchProbe:
             self._send_cmd('set_OD_output_mode')
         self._send_cmd('pin_up')
     cmd_BLTOUCH_DEBUG_help = "Send a command to the bltouch for debugging"
+    cmd_BLTOUCH_DEBUG_params = {
+        "COMMAND": {"type": "string", "required": False},
+    }
     def cmd_BLTOUCH_DEBUG(self, gcmd):
         cmd = gcmd.get('COMMAND', None)
         if cmd is None or cmd not in Commands:
@@ -267,6 +272,9 @@ class BLTouchProbe:
         self._send_cmd(cmd, duration=self.pin_move_time)
         self._sync_print_time()
     cmd_BLTOUCH_STORE_help = "Store an output mode in the BLTouch EEPROM"
+    cmd_BLTOUCH_STORE_params = {
+        "MODE": {"type": "string", "required": False},
+    }
     def cmd_BLTOUCH_STORE(self, gcmd):
         cmd = gcmd.get('MODE', None)
         if cmd is None or cmd not in ['5V', 'OD']:

--- a/klippy/extras/delayed_gcode.py
+++ b/klippy/extras/delayed_gcode.py
@@ -21,7 +21,8 @@ class DelayedGcode:
         self.gcode.register_mux_command(
             "UPDATE_DELAYED_GCODE", "ID", self.name,
             self.cmd_UPDATE_DELAYED_GCODE,
-            desc=self.cmd_UPDATE_DELAYED_GCODE_help)
+            desc=self.cmd_UPDATE_DELAYED_GCODE_help,
+            params=self.cmd_UPDATE_DELAYED_GCODE_params)
     def _handle_ready(self):
         waketime = self.reactor.NEVER
         if self.duration:
@@ -40,6 +41,10 @@ class DelayedGcode:
         self.inside_timer = self.repeat = False
         return nextwake
     cmd_UPDATE_DELAYED_GCODE_help = "Update the duration of a delayed_gcode"
+    cmd_UPDATE_DELAYED_GCODE_params = {
+        "ID": {"type": "string", "required": True},
+        "DURATION": {"type": "float", "required": True},
+    }
     def cmd_UPDATE_DELAYED_GCODE(self, gcmd):
         self.duration = gcmd.get_float('DURATION', minval=0.)
         if self.inside_timer:

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -221,10 +221,7 @@ class DeltaCalibrate:
             "The SAVE_CONFIG command will update the printer config file\n"
             "with these parameters and restart the printer.")
     cmd_DELTA_CALIBRATE_help = "Delta calibration script"
-    cmd_DELTA_CALIBRATE_params = {
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-    }
+    cmd_DELTA_CALIBRATE_params = dict(probe.PROBE_POINTS_HELPER_PARAMS)
     def cmd_DELTA_CALIBRATE(self, gcmd):
         self.probe_helper.start_probe(gcmd)
     def add_manual_height(self, height):

--- a/klippy/extras/delta_calibrate.py
+++ b/klippy/extras/delta_calibrate.py
@@ -121,9 +121,11 @@ class DeltaCalibrate:
         # Register gcode commands
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command('DELTA_CALIBRATE', self.cmd_DELTA_CALIBRATE,
-                                    desc=self.cmd_DELTA_CALIBRATE_help)
+                                    desc=self.cmd_DELTA_CALIBRATE_help,
+                                    params=self.cmd_DELTA_CALIBRATE_params)
         self.gcode.register_command('DELTA_ANALYZE', self.cmd_DELTA_ANALYZE,
-                                    desc=self.cmd_DELTA_ANALYZE_help)
+                                    desc=self.cmd_DELTA_ANALYZE_help,
+                                    params=self.cmd_DELTA_ANALYZE_params)
     def handle_connect(self):
         kin = self.printer.lookup_object('toolhead').get_kinematics()
         if not hasattr(kin, "get_calibration"):
@@ -219,6 +221,10 @@ class DeltaCalibrate:
             "The SAVE_CONFIG command will update the printer config file\n"
             "with these parameters and restart the printer.")
     cmd_DELTA_CALIBRATE_help = "Delta calibration script"
+    cmd_DELTA_CALIBRATE_params = {
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+    }
     def cmd_DELTA_CALIBRATE(self, gcmd):
         self.probe_helper.start_probe(gcmd)
     def add_manual_height(self, height):
@@ -254,6 +260,15 @@ class DeltaCalibrate:
         # Perform analysis
         self.calculate_params(self.last_probe_positions, distances)
     cmd_DELTA_ANALYZE_help = "Extended delta calibration tool"
+    cmd_DELTA_ANALYZE_params = {
+        "MANUAL_HEIGHT": {"type": "float", "required": False},
+        "CENTER_DISTS": {"type": "string", "required": False},
+        "CENTER_PILLAR_WIDTHS": {"type": "string", "required": False},
+        "OUTER_DISTS": {"type": "string", "required": False},
+        "OUTER_PILLAR_WIDTHS": {"type": "string", "required": False},
+        "SCALE": {"type": "string", "required": False},
+        "CALIBRATE": {"type": "string", "required": False},
+    }
     def cmd_DELTA_ANALYZE(self, gcmd):
         # Check for manual height entry
         mheight = gcmd.get_float('MANUAL_HEIGHT', None)

--- a/klippy/extras/display/display.py
+++ b/klippy/extras/display/display.py
@@ -208,7 +208,8 @@ class PrinterLCD:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command('SET_DISPLAY_GROUP', 'DISPLAY', name,
                                    self.cmd_SET_DISPLAY_GROUP,
-                                   desc=self.cmd_SET_DISPLAY_GROUP_help)
+                                   desc=self.cmd_SET_DISPLAY_GROUP_help,
+                                   params=self.cmd_SET_DISPLAY_GROUP_params)
         if name == 'display':
             gcode.register_mux_command('SET_DISPLAY_GROUP', 'DISPLAY', None,
                                        self.cmd_SET_DISPLAY_GROUP)
@@ -263,6 +264,10 @@ class PrinterLCD:
             self.lcd_chip.write_graphics(col + width - 1 - i, row, data)
         return ""
     cmd_SET_DISPLAY_GROUP_help = "Set the active display group"
+    cmd_SET_DISPLAY_GROUP_params = {
+        "DISPLAY": {"type": "string", "required": True},
+        "GROUP": {"type": "string", "required": True},
+    }
     def cmd_SET_DISPLAY_GROUP(self, gcmd):
         group = gcmd.get('GROUP')
         new_dg = self.display_data_groups.get(group)

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -18,7 +18,8 @@ class DisplayStatus:
         gcode.register_command('M117', self.cmd_M117)
         gcode.register_command(
             'SET_DISPLAY_TEXT', self.cmd_SET_DISPLAY_TEXT,
-            desc=self.cmd_SET_DISPLAY_TEXT_help)
+            desc=self.cmd_SET_DISPLAY_TEXT_help,
+            params=self.cmd_SET_DISPLAY_TEXT_params)
     def get_status(self, eventtime):
         progress = self.progress
         if progress is not None and eventtime > self.expire_progress:
@@ -43,6 +44,9 @@ class DisplayStatus:
         msg = gcmd.get_raw_command_parameters() or None
         self.message = msg
     cmd_SET_DISPLAY_TEXT_help = "Set or clear the display message"
+    cmd_SET_DISPLAY_TEXT_params = {
+        "MSG": {"type": "string", "required": False},
+    }
     def cmd_SET_DISPLAY_TEXT(self, gcmd):
         self.message = gcmd.get("MSG", None)
 

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -135,9 +135,10 @@ class EndstopPhases:
         self.printer.register_event_handler("homing:home_rails_end",
                                             self.handle_home_rails_end)
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command("ENDSTOP_PHASE_CALIBRATE",
-                                    self.cmd_ENDSTOP_PHASE_CALIBRATE,
-                                    desc=self.cmd_ENDSTOP_PHASE_CALIBRATE_help)
+        self.gcode.register_command(
+            "ENDSTOP_PHASE_CALIBRATE", self.cmd_ENDSTOP_PHASE_CALIBRATE,
+            desc=self.cmd_ENDSTOP_PHASE_CALIBRATE_help,
+            params=self.cmd_ENDSTOP_PHASE_CALIBRATE_params)
     def update_stepper(self, stepper, trig_mcu_pos, is_primary):
         stepper_name = stepper.get_name()
         phase_calc = self.tracking.get(stepper_name)
@@ -168,6 +169,9 @@ class EndstopPhases:
                 self.update_stepper(stepper, trig_mcu_pos, is_primary)
                 is_primary = False
     cmd_ENDSTOP_PHASE_CALIBRATE_help = "Calibrate stepper phase"
+    cmd_ENDSTOP_PHASE_CALIBRATE_params = {
+        "STEPPER": {"type": "string", "required": False},
+    }
     def cmd_ENDSTOP_PHASE_CALIBRATE(self, gcmd):
         stepper_name = gcmd.get('STEPPER', None)
         if stepper_name is None:

--- a/klippy/extras/exclude_object.py
+++ b/klippy/extras/exclude_object.py
@@ -24,13 +24,16 @@ class ExcludeObject:
         self._reset_state()
         self.gcode.register_command(
             'EXCLUDE_OBJECT_START', self.cmd_EXCLUDE_OBJECT_START,
-            desc=self.cmd_EXCLUDE_OBJECT_START_help)
+            desc=self.cmd_EXCLUDE_OBJECT_START_help,
+            params=self.cmd_EXCLUDE_OBJECT_START_params)
         self.gcode.register_command(
             'EXCLUDE_OBJECT_END', self.cmd_EXCLUDE_OBJECT_END,
-            desc=self.cmd_EXCLUDE_OBJECT_END_help)
+            desc=self.cmd_EXCLUDE_OBJECT_END_help,
+            params=self.cmd_EXCLUDE_OBJECT_END_params)
         self.gcode.register_command(
             'EXCLUDE_OBJECT', self.cmd_EXCLUDE_OBJECT,
-            desc=self.cmd_EXCLUDE_OBJECT_help)
+            desc=self.cmd_EXCLUDE_OBJECT_help,
+            params=self.cmd_EXCLUDE_OBJECT_params)
         self.gcode.register_command(
             'EXCLUDE_OBJECT_DEFINE', self.cmd_EXCLUDE_OBJECT_DEFINE,
             desc=self.cmd_EXCLUDE_OBJECT_DEFINE_help)
@@ -196,6 +199,9 @@ class ExcludeObject:
 
     cmd_EXCLUDE_OBJECT_START_help = "Marks the beginning the current object" \
                                     " as labeled"
+    cmd_EXCLUDE_OBJECT_START_params = {
+        "NAME": {"type": "string", "required": True},
+    }
     def cmd_EXCLUDE_OBJECT_START(self, gcmd):
         name = gcmd.get('NAME').upper()
         if not any(obj["name"] == name for obj in self.objects):
@@ -204,6 +210,9 @@ class ExcludeObject:
         self.was_excluded_at_start = self._test_in_excluded_region()
 
     cmd_EXCLUDE_OBJECT_END_help = "Marks the end the current object"
+    cmd_EXCLUDE_OBJECT_END_params = {
+        "NAME": {"type": "string", "required": False},
+    }
     def cmd_EXCLUDE_OBJECT_END(self, gcmd):
         if self.current_object == None and self.next_transform:
             gcmd.respond_info("EXCLUDE_OBJECT_END called, but no object is"
@@ -218,6 +227,11 @@ class ExcludeObject:
         self.current_object = None
 
     cmd_EXCLUDE_OBJECT_help = "Cancel moves inside a specified objects"
+    cmd_EXCLUDE_OBJECT_params = {
+        "RESET": {"type": "string", "required": False},
+        "CURRENT": {"type": "string", "required": False},
+        "NAME": {"type": "string", "default": ""},
+    }
     def cmd_EXCLUDE_OBJECT(self, gcmd):
         reset = gcmd.get('RESET', None)
         current = gcmd.get('CURRENT', None)

--- a/klippy/extras/fan_generic.py
+++ b/klippy/extras/fan_generic.py
@@ -8,6 +8,11 @@ from . import fan, output_pin
 
 class PrinterFanGeneric:
     cmd_SET_FAN_SPEED_help = "Sets the speed of a fan"
+    cmd_SET_FAN_SPEED_params = {
+        "FAN": {"type": "string", "required": True},
+        "SPEED": {"type": "float", "required": False},
+        "TEMPLATE": {"type": "string", "required": False},
+    }
     def __init__(self, config):
         self.printer = config.get_printer()
         self.fan = fan.Fan(config, default_shutdown_speed=0.)
@@ -20,7 +25,8 @@ class PrinterFanGeneric:
         gcode.register_mux_command("SET_FAN_SPEED", "FAN",
                                    self.fan_name,
                                    self.cmd_SET_FAN_SPEED,
-                                   desc=self.cmd_SET_FAN_SPEED_help)
+                                   desc=self.cmd_SET_FAN_SPEED_help,
+                                   params=self.cmd_SET_FAN_SPEED_params)
 
     def get_status(self, eventtime):
         return self.fan.get_status(eventtime)

--- a/klippy/extras/filament_switch_sensor.py
+++ b/klippy/extras/filament_switch_sensor.py
@@ -35,11 +35,13 @@ class RunoutHelper:
         self.gcode.register_mux_command(
             "QUERY_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_QUERY_FILAMENT_SENSOR,
-            desc=self.cmd_QUERY_FILAMENT_SENSOR_help)
+            desc=self.cmd_QUERY_FILAMENT_SENSOR_help,
+            params=self.cmd_QUERY_FILAMENT_SENSOR_params)
         self.gcode.register_mux_command(
             "SET_FILAMENT_SENSOR", "SENSOR", self.name,
             self.cmd_SET_FILAMENT_SENSOR,
-            desc=self.cmd_SET_FILAMENT_SENSOR_help)
+            desc=self.cmd_SET_FILAMENT_SENSOR_help,
+            params=self.cmd_SET_FILAMENT_SENSOR_params)
     def _handle_ready(self):
         self.min_event_systime = self.reactor.monotonic() + 2.
     def _runout_event_handler(self, eventtime):
@@ -95,6 +97,9 @@ class RunoutHelper:
             "filament_detected": bool(self.filament_present),
             "enabled": bool(self.sensor_enabled)}
     cmd_QUERY_FILAMENT_SENSOR_help = "Query the status of the Filament Sensor"
+    cmd_QUERY_FILAMENT_SENSOR_params = {
+        "SENSOR": {"type": "string", "required": True},
+    }
     def cmd_QUERY_FILAMENT_SENSOR(self, gcmd):
         if self.filament_present:
             msg = "Filament Sensor %s: filament detected" % (self.name)
@@ -102,6 +107,10 @@ class RunoutHelper:
             msg = "Filament Sensor %s: filament not detected" % (self.name)
         gcmd.respond_info(msg)
     cmd_SET_FILAMENT_SENSOR_help = "Sets the filament sensor on/off"
+    cmd_SET_FILAMENT_SENSOR_params = {
+        "SENSOR": {"type": "string", "required": True},
+        "ENABLE": {"type": "int", "default": 1},
+    }
     def cmd_SET_FILAMENT_SENSOR(self, gcmd):
         self.sensor_enabled = gcmd.get_int("ENABLE", 1)
 

--- a/klippy/extras/firmware_retraction.py
+++ b/klippy/extras/firmware_retraction.py
@@ -17,7 +17,8 @@ class FirmwareRetraction:
         self.is_retracted = False
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command('SET_RETRACTION', self.cmd_SET_RETRACTION,
-                                    desc=self.cmd_SET_RETRACTION_help)
+                                    desc=self.cmd_SET_RETRACTION_help,
+                                    params=self.cmd_SET_RETRACTION_params)
         self.gcode.register_command('GET_RETRACTION', self.cmd_GET_RETRACTION,
                                     desc=self.cmd_GET_RETRACTION_help)
         self.gcode.register_command('G10', self.cmd_G10)
@@ -31,6 +32,12 @@ class FirmwareRetraction:
             "unretract_speed": self.unretract_speed,
         }
     cmd_SET_RETRACTION_help = ("Set firmware retraction parameters")
+    cmd_SET_RETRACTION_params = {
+        "RETRACT_LENGTH": {"type": "float", "required": False},
+        "RETRACT_SPEED": {"type": "float", "required": False},
+        "UNRETRACT_EXTRA_LENGTH": {"type": "float", "required": False},
+        "UNRETRACT_SPEED": {"type": "float", "required": False},
+    }
     def cmd_SET_RETRACTION(self, gcmd):
         self.retract_length = gcmd.get_float('RETRACT_LENGTH',
                                              self.retract_length, minval=0.)

--- a/klippy/extras/force_move.py
+++ b/klippy/extras/force_move.py
@@ -42,9 +42,10 @@ class ForceMove:
         self._enable_force_move = config.getboolean("enable_force_move", False)
         if self._enable_force_move:
             gcode = self.printer.lookup_object('gcode')
-            gcode.register_command('SET_KINEMATIC_POSITION',
-                                   self.cmd_SET_KINEMATIC_POSITION,
-                                   desc=self.cmd_SET_KINEMATIC_POSITION_help)
+            gcode.register_command(
+                'SET_KINEMATIC_POSITION', self.cmd_SET_KINEMATIC_POSITION,
+                desc=self.cmd_SET_KINEMATIC_POSITION_help,
+                params=self.cmd_SET_KINEMATIC_POSITION_params)
     def register_stepper(self, config, mcu_stepper):
         name = mcu_stepper.get_name()
         self.steppers[name] = mcu_stepper
@@ -52,11 +53,13 @@ class ForceMove:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command('STEPPER_BUZZ', "STEPPER", name,
                                    self.cmd_STEPPER_BUZZ,
-                                   desc=self.cmd_STEPPER_BUZZ_help)
+                                   desc=self.cmd_STEPPER_BUZZ_help,
+                                   params=self.cmd_STEPPER_BUZZ_params)
         if self._enable_force_move:
             gcode.register_mux_command('FORCE_MOVE', "STEPPER", name,
                                         self.cmd_FORCE_MOVE,
-                                        desc=self.cmd_FORCE_MOVE_help)
+                                        desc=self.cmd_FORCE_MOVE_help,
+                                        params=self.cmd_FORCE_MOVE_params)
     def lookup_stepper(self, name):
         if name not in self.steppers:
             raise self.printer.config_error("Unknown stepper %s" % (name,))
@@ -90,6 +93,9 @@ class ForceMove:
         stepper.set_stepper_kinematics(prev_sk)
         self.motion_queuing.wipe_trapq(self.trapq)
     cmd_STEPPER_BUZZ_help = "Oscillate a given stepper to help id it"
+    cmd_STEPPER_BUZZ_params = {
+        "STEPPER": {"type": "string", "required": True},
+    }
     def cmd_STEPPER_BUZZ(self, gcmd):
         stepper = self.lookup_stepper(gcmd.get('STEPPER'))
         logging.info("Stepper buzz %s", stepper.get_name())
@@ -105,6 +111,12 @@ class ForceMove:
             toolhead.dwell(.450)
         self._restore_enable(stepper, did_enable)
     cmd_FORCE_MOVE_help = "Manually move a stepper; invalidates kinematics"
+    cmd_FORCE_MOVE_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "DISTANCE": {"type": "float", "required": True},
+        "VELOCITY": {"type": "float", "required": True},
+        "ACCEL": {"type": "float", "default": 0.},
+    }
     def cmd_FORCE_MOVE(self, gcmd):
         stepper = self.lookup_stepper(gcmd.get('STEPPER'))
         distance = gcmd.get_float('DISTANCE')
@@ -115,6 +127,14 @@ class ForceMove:
         self._force_enable(stepper)
         self.manual_move(stepper, distance, speed, accel)
     cmd_SET_KINEMATIC_POSITION_help = "Force a low-level kinematic position"
+    cmd_SET_KINEMATIC_POSITION_params = {
+        "X": {"type": "float", "required": False},
+        "Y": {"type": "float", "required": False},
+        "Z": {"type": "float", "required": False},
+        "SET_HOMED": {"type": "string", "default": "xyz"},
+        "CLEAR_HOMED": {"type": "string", "required": False},
+        "CLEAR": {"type": "string", "default": ""},
+    }
     def cmd_SET_KINEMATIC_POSITION(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.get_last_move_time()

--- a/klippy/extras/gcode_button.py
+++ b/klippy/extras/gcode_button.py
@@ -28,9 +28,13 @@ class GCodeButton:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_mux_command("QUERY_BUTTON", "BUTTON", self.name,
                                         self.cmd_QUERY_BUTTON,
-                                        desc=self.cmd_QUERY_BUTTON_help)
+                                        desc=self.cmd_QUERY_BUTTON_help,
+                                        params=self.cmd_QUERY_BUTTON_params)
 
     cmd_QUERY_BUTTON_help = "Report on the state of a button"
+    cmd_QUERY_BUTTON_params = {
+        "BUTTON": {"type": "string", "required": True},
+    }
     def cmd_QUERY_BUTTON(self, gcmd):
         gcmd.respond_info(self.name + ": " + self.get_status()['state'])
 

--- a/klippy/extras/gcode_macro.py
+++ b/klippy/extras/gcode_macro.py
@@ -145,9 +145,10 @@ class GCodeMacro:
         else:
             self.gcode.register_command(self.alias, self.cmd,
                                         desc=self.cmd_desc)
-        self.gcode.register_mux_command("SET_GCODE_VARIABLE", "MACRO",
-                                        name, self.cmd_SET_GCODE_VARIABLE,
-                                        desc=self.cmd_SET_GCODE_VARIABLE_help)
+        self.gcode.register_mux_command(
+            "SET_GCODE_VARIABLE", "MACRO", name, self.cmd_SET_GCODE_VARIABLE,
+            desc=self.cmd_SET_GCODE_VARIABLE_help,
+            params=self.cmd_SET_GCODE_VARIABLE_params)
         self.in_script = False
         self.variables = {}
         prefix = 'variable_'
@@ -172,6 +173,11 @@ class GCodeMacro:
     def get_status(self, eventtime):
         return self.variables
     cmd_SET_GCODE_VARIABLE_help = "Set the value of a G-Code macro variable"
+    cmd_SET_GCODE_VARIABLE_params = {
+        "MACRO": {"type": "string", "required": True},
+        "VARIABLE": {"type": "string", "required": True},
+        "VALUE": {"type": "string", "required": True},
+    }
     def cmd_SET_GCODE_VARIABLE(self, gcmd):
         variable = gcmd.get('VARIABLE')
         value = gcmd.get('VALUE')

--- a/klippy/extras/gcode_move.py
+++ b/klippy/extras/gcode_move.py
@@ -19,7 +19,8 @@ class GCodeMove:
         for cmd in handlers:
             func = getattr(self, 'cmd_' + cmd)
             desc = getattr(self, 'cmd_' + cmd + '_help', None)
-            gcode.register_command(cmd, func, False, desc)
+            params = getattr(self, 'cmd_' + cmd + '_params', None)
+            gcode.register_command(cmd, func, False, desc, params=params)
         gcode.register_command('G0', self.cmd_G1)
         gcode.register_command('M114', self.cmd_M114, True)
         gcode.register_command('GET_POSITION', self.cmd_GET_POSITION, True,
@@ -205,6 +206,18 @@ class GCodeMove:
         self.base_position[3] = last_e_pos - e_value * new_extrude_factor
         self.extrude_factor = new_extrude_factor
     cmd_SET_GCODE_OFFSET_help = "Set a virtual offset to g-code positions"
+    cmd_SET_GCODE_OFFSET_params = {
+        "X": {"type": "float", "required": False},
+        "Y": {"type": "float", "required": False},
+        "Z": {"type": "float", "required": False},
+        "E": {"type": "float", "required": False},
+        "X_ADJUST": {"type": "float", "required": False},
+        "Y_ADJUST": {"type": "float", "required": False},
+        "Z_ADJUST": {"type": "float", "required": False},
+        "E_ADJUST": {"type": "float", "required": False},
+        "MOVE": {"type": "int", "default": 0},
+        "MOVE_SPEED": {"type": "float", "required": False},
+    }
     def cmd_SET_GCODE_OFFSET(self, gcmd):
         move_delta = [0., 0., 0., 0.]
         for pos, axis in enumerate('XYZE'):
@@ -225,6 +238,9 @@ class GCodeMove:
                 self.last_position[pos] += delta
             self.move_with_transform(self.last_position, speed)
     cmd_SAVE_GCODE_STATE_help = "Save G-Code coordinate state"
+    cmd_SAVE_GCODE_STATE_params = {
+        "NAME": {"type": "string", "default": "default"},
+    }
     def cmd_SAVE_GCODE_STATE(self, gcmd):
         state_name = gcmd.get('NAME', 'default')
         self.saved_states[state_name] = {
@@ -237,6 +253,11 @@ class GCodeMove:
             'extrude_factor': self.extrude_factor,
         }
     cmd_RESTORE_GCODE_STATE_help = "Restore a previously saved G-Code state"
+    cmd_RESTORE_GCODE_STATE_params = {
+        "NAME": {"type": "string", "default": "default"},
+        "MOVE": {"type": "int", "default": 0},
+        "MOVE_SPEED": {"type": "float", "required": False},
+    }
     def cmd_RESTORE_GCODE_STATE(self, gcmd):
         state_name = gcmd.get('NAME', 'default')
         state = self.saved_states.get(state_name)

--- a/klippy/extras/hall_filament_width_sensor.py
+++ b/klippy/extras/hall_filament_width_sensor.py
@@ -86,7 +86,8 @@ class HallFilamentWidthSensor:
             desc=self.cmd_DISABLE_FILAMENT_WIDTH_SENSOR_help)
         self.gcode.register_command('ENABLE_FILAMENT_WIDTH_SENSOR',
             self.cmd_M405,
-            desc=self.cmd_ENABLE_FILAMENT_WIDTH_SENSOR_help)
+            desc=self.cmd_ENABLE_FILAMENT_WIDTH_SENSOR_help,
+            params=self.cmd_M405_params)
         self.gcode.register_command('QUERY_RAW_FILAMENT_WIDTH',
             self.cmd_Get_Raw_Values,
             desc=self.cmd_QUERY_RAW_FILAMENT_WIDTH_help)
@@ -242,6 +243,9 @@ class HallFilamentWidthSensor:
     cmd_ENABLE_FILAMENT_WIDTH_SENSOR_help = (
         "Enable the filament width sensor and enable or disable flow "
         + "compensation")
+    cmd_M405_params = {
+        "FLOW_COMPENSATION": {"type": "int", "required": False},
+    }
     def cmd_M405(self, gcmd):
         flow_comp = gcmd.get_int("FLOW_COMPENSATION", None, minval=0, maxval=1)
         if flow_comp is not None:

--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -64,9 +64,11 @@ class Heater:
         self.printer.load_object(config, "verify_heater %s" % (short_name,))
         self.printer.load_object(config, "pid_calibrate")
         gcode = self.printer.lookup_object("gcode")
-        gcode.register_mux_command("SET_HEATER_TEMPERATURE", "HEATER",
-                                   short_name, self.cmd_SET_HEATER_TEMPERATURE,
-                                   desc=self.cmd_SET_HEATER_TEMPERATURE_help)
+        gcode.register_mux_command(
+            "SET_HEATER_TEMPERATURE", "HEATER", short_name,
+            self.cmd_SET_HEATER_TEMPERATURE,
+            desc=self.cmd_SET_HEATER_TEMPERATURE_help,
+            params=self.cmd_SET_HEATER_TEMPERATURE_params)
         self.printer.register_event_handler("klippy:shutdown",
                                             self._handle_shutdown)
     def set_pwm(self, read_time, value):
@@ -153,6 +155,10 @@ class Heater:
         return {'temperature': round(smoothed_temp, 2), 'target': target_temp,
                 'power': last_pwm_value}
     cmd_SET_HEATER_TEMPERATURE_help = "Sets a heater temperature"
+    cmd_SET_HEATER_TEMPERATURE_params = {
+        "HEATER": {"type": "string", "required": True},
+        "TARGET": {"type": "float", "default": 0.},
+    }
     def cmd_SET_HEATER_TEMPERATURE(self, gcmd):
         temp = gcmd.get_float('TARGET', 0.)
         pheaters = self.printer.lookup_object('heaters')
@@ -304,7 +310,8 @@ class PrinterHeaters:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command('TEMPERATURE_WAIT', "SENSOR", sensor_name,
                                    self.cmd_TEMPERATURE_WAIT,
-                                   desc=self.cmd_TEMPERATURE_WAIT_help)
+                                   desc=self.cmd_TEMPERATURE_WAIT_help,
+                                   params=self.cmd_TEMPERATURE_WAIT_params)
         if gcode_id is None:
             gcode_id = config.get('gcode_id', None)
             if gcode_id is None:
@@ -364,6 +371,11 @@ class PrinterHeaters:
         if wait and temp:
             self._wait_for_temperature(heater)
     cmd_TEMPERATURE_WAIT_help = "Wait for a temperature on a sensor"
+    cmd_TEMPERATURE_WAIT_params = {
+        "SENSOR": {"type": "string", "required": True},
+        "MINIMUM": {"type": "float", "required": False},
+        "MAXIMUM": {"type": "float", "required": False},
+    }
     def cmd_TEMPERATURE_WAIT(self, gcmd):
         sensor_name = gcmd.get('SENSOR')
         min_temp = gcmd.get_float('MINIMUM', float('-inf'))

--- a/klippy/extras/idle_timeout.py
+++ b/klippy/extras/idle_timeout.py
@@ -28,7 +28,8 @@ class IdleTimeout:
                                                     DEFAULT_IDLE_GCODE)
         self.gcode.register_command('SET_IDLE_TIMEOUT',
                                     self.cmd_SET_IDLE_TIMEOUT,
-                                    desc=self.cmd_SET_IDLE_TIMEOUT_help)
+                                    desc=self.cmd_SET_IDLE_TIMEOUT_help,
+                                    params=self.cmd_SET_IDLE_TIMEOUT_params)
         self.state = "Idle"
         self.last_print_start_systime = 0.
     def get_status(self, eventtime):
@@ -106,6 +107,9 @@ class IdleTimeout:
         self.printer.send_event("idle_timeout:printing",
                                 est_print_time + PIN_MIN_TIME)
     cmd_SET_IDLE_TIMEOUT_help = "Set the idle timeout in seconds"
+    cmd_SET_IDLE_TIMEOUT_params = {
+        "TIMEOUT": {"type": "float", "required": False},
+    }
     def cmd_SET_IDLE_TIMEOUT(self, gcmd):
         timeout = gcmd.get_float('TIMEOUT', self.idle_timeout, above=0.)
         self.idle_timeout = timeout

--- a/klippy/extras/input_shaper.py
+++ b/klippy/extras/input_shaper.py
@@ -118,7 +118,8 @@ class InputShaper:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("SET_INPUT_SHAPER",
                                self.cmd_SET_INPUT_SHAPER,
-                               desc=self.cmd_SET_INPUT_SHAPER_help)
+                               desc=self.cmd_SET_INPUT_SHAPER_help,
+                               params=self.cmd_SET_INPUT_SHAPER_params)
     def get_shapers(self):
         return self.shapers
     def connect(self):
@@ -197,6 +198,18 @@ class InputShaper:
             shaper.enable_shaping()
         self._update_input_shaping()
     cmd_SET_INPUT_SHAPER_help = "Set cartesian parameters for input shaper"
+    cmd_SET_INPUT_SHAPER_params = {
+        "SHAPER_TYPE": {"type": "string", "required": False},
+        "SHAPER_TYPE_X": {"type": "string", "required": False},
+        "SHAPER_TYPE_Y": {"type": "string", "required": False},
+        "SHAPER_TYPE_Z": {"type": "string", "required": False},
+        "DAMPING_RATIO_X": {"type": "float", "required": False},
+        "DAMPING_RATIO_Y": {"type": "float", "required": False},
+        "DAMPING_RATIO_Z": {"type": "float", "required": False},
+        "SHAPER_FREQ_X": {"type": "float", "required": False},
+        "SHAPER_FREQ_Y": {"type": "float", "required": False},
+        "SHAPER_FREQ_Z": {"type": "float", "required": False},
+    }
     def cmd_SET_INPUT_SHAPER(self, gcmd):
         if gcmd.get_command_parameters():
             for shaper in self.shapers:

--- a/klippy/extras/ldc1612.py
+++ b/klippy/extras/ldc1612.py
@@ -43,10 +43,14 @@ class DriveCurrentCalibrate:
         gcode.register_mux_command("LDC_CALIBRATE_DRIVE_CURRENT",
                                    "CHIP", self.name.split()[-1],
                                    self.cmd_LDC_CALIBRATE,
-                                   desc=self.cmd_LDC_CALIBRATE_help)
+                                   desc=self.cmd_LDC_CALIBRATE_help,
+                                   params=self.cmd_LDC_CALIBRATE_params)
     def get_drive_current(self):
         return self.drive_cur
     cmd_LDC_CALIBRATE_help = "Calibrate LDC1612 DRIVE_CURRENT register"
+    cmd_LDC_CALIBRATE_params = {
+        "CHIP": {"type": "string", "required": True},
+    }
     def cmd_LDC_CALIBRATE(self, gcmd):
         is_in_progress = True
         def handle_batch(msg):

--- a/klippy/extras/led.py
+++ b/klippy/extras/led.py
@@ -29,10 +29,12 @@ class LEDHelper:
         name = config.get_name().split()[-1]
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_LED", "LED", name, self.cmd_SET_LED,
-                                   desc=self.cmd_SET_LED_help)
+                                   desc=self.cmd_SET_LED_help,
+                                   params=self.cmd_SET_LED_params)
         gcode.register_mux_command("SET_LED_TEMPLATE", "LED", name,
                                    self.cmd_SET_LED_TEMPLATE,
-                                   desc=self.cmd_SET_LED_TEMPLATE_help)
+                                   desc=self.cmd_SET_LED_TEMPLATE_help,
+                                   params=self.cmd_SET_LED_TEMPLATE_params)
     def get_status(self, eventtime=None):
         return {'color_data': self.led_state}
     def _set_color(self, index, color):
@@ -71,6 +73,16 @@ class LEDHelper:
                 logging.exception("led update transmit error")
         self.printer.get_reactor().register_callback(reactor_cb)
     cmd_SET_LED_help = "Set the color of an LED"
+    cmd_SET_LED_params = {
+        "LED": {"type": "string", "required": True},
+        "RED": {"type": "float", "default": 0.},
+        "GREEN": {"type": "float", "default": 0.},
+        "BLUE": {"type": "float", "default": 0.},
+        "WHITE": {"type": "float", "default": 0.},
+        "INDEX": {"type": "int", "required": False},
+        "TRANSMIT": {"type": "int", "default": 1},
+        "SYNC": {"type": "int", "default": 1},
+    }
     def cmd_SET_LED(self, gcmd):
         # Parse parameters
         red = gcmd.get_float('RED', 0., minval=0., maxval=1.)
@@ -94,6 +106,10 @@ class LEDHelper:
             #Send update now (so as not to wake toolhead and reset idle_timeout)
             lookahead_bgfunc(None)
     cmd_SET_LED_TEMPLATE_help = "Assign a display_template to an LED"
+    cmd_SET_LED_TEMPLATE_params = {
+        "LED": {"type": "string", "required": True},
+        "INDEX": {"type": "int", "required": False},
+    }
     def cmd_SET_LED_TEMPLATE(self, gcmd):
         index = gcmd.get_int("INDEX", None, minval=1, maxval=self.led_count)
         set_template = self.template_eval.set_template

--- a/klippy/extras/load_cell.py
+++ b/klippy/extras/load_cell.py
@@ -70,18 +70,25 @@ class LoadCellCommandHelper:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("LOAD_CELL_TARE", "LOAD_CELL", name,
                                    self.cmd_LOAD_CELL_TARE,
-                                   desc=self.cmd_LOAD_CELL_TARE_help)
+                                   desc=self.cmd_LOAD_CELL_TARE_help,
+                                   params=self.cmd_LOAD_CELL_TARE_params)
         gcode.register_mux_command("LOAD_CELL_CALIBRATE", "LOAD_CELL", name,
                                    self.cmd_LOAD_CELL_CALIBRATE,
-                                   desc=self.cmd_CALIBRATE_LOAD_CELL_help)
+                                   desc=self.cmd_CALIBRATE_LOAD_CELL_help,
+                                   params=self.cmd_LOAD_CELL_CALIBRATE_params)
         gcode.register_mux_command("LOAD_CELL_READ", "LOAD_CELL", name,
                                    self.cmd_LOAD_CELL_READ,
-                                   desc=self.cmd_LOAD_CELL_READ_help)
+                                   desc=self.cmd_LOAD_CELL_READ_help,
+                                   params=self.cmd_LOAD_CELL_READ_params)
         gcode.register_mux_command("LOAD_CELL_DIAGNOSTIC", "LOAD_CELL", name,
                                    self.cmd_LOAD_CELL_DIAGNOSTIC,
-                                   desc=self.cmd_LOAD_CELL_DIAGNOSTIC_help)
+                                   desc=self.cmd_LOAD_CELL_DIAGNOSTIC_help,
+                                   params=self.cmd_LOAD_CELL_DIAGNOSTIC_params)
 
     cmd_LOAD_CELL_TARE_help = "Set the Zero point of the load cell"
+    cmd_LOAD_CELL_TARE_params = {
+        "LOAD_CELL": {"type": "string", "required": True},
+    }
     def cmd_LOAD_CELL_TARE(self, gcmd):
         tare_counts = self.load_cell.avg_counts()
         self.load_cell.tare(tare_counts)
@@ -90,10 +97,16 @@ class LoadCellCommandHelper:
                           % (tare_percent, tare_counts))
 
     cmd_CALIBRATE_LOAD_CELL_help = "Start interactive calibration tool"
+    cmd_LOAD_CELL_CALIBRATE_params = {
+        "LOAD_CELL": {"type": "string", "required": True},
+    }
     def cmd_LOAD_CELL_CALIBRATE(self, gcmd):
         LoadCellGuidedCalibrationHelper(self.printer, self.load_cell)
 
     cmd_LOAD_CELL_READ_help = "Take a reading from the load cell"
+    cmd_LOAD_CELL_READ_params = {
+        "LOAD_CELL": {"type": "string", "required": True},
+    }
     def cmd_LOAD_CELL_READ(self, gcmd):
         counts = self.load_cell.avg_counts()
         percent = self.load_cell.counts_to_percent(counts)
@@ -106,6 +119,9 @@ class LoadCellCommandHelper:
             gcmd.respond_info("%.1fg (%.2f%%)" % (force, percent))
 
     cmd_LOAD_CELL_DIAGNOSTIC_help = "Check the health of the load cell"
+    cmd_LOAD_CELL_DIAGNOSTIC_params = {
+        "LOAD_CELL": {"type": "string", "required": True},
+    }
     def cmd_LOAD_CELL_DIAGNOSTIC(self, gcmd):
         gcmd.respond_info("Collecting load cell data for 10 seconds...")
         collector = self.load_cell.get_collector()
@@ -176,7 +192,8 @@ class LoadCellGuidedCalibrationHelper:
         register_command("ACCEPT", self.cmd_ACCEPT, desc=self.cmd_ACCEPT_help)
         register_command("TARE", self.cmd_TARE, desc=self.cmd_TARE_help)
         register_command("CALIBRATE", self.cmd_CALIBRATE,
-                         desc=self.cmd_CALIBRATE_help)
+                         desc=self.cmd_CALIBRATE_help,
+                         params=self.cmd_CALIBRATE_params)
 
     # convert the delta of counts to a counts/gram metric
     def counts_per_gram(self, grams, cal_counts):
@@ -231,6 +248,9 @@ class LoadCellGuidedCalibrationHelper:
                          the force value with:\n CALIBRATE GRAMS=nnn")
 
     cmd_CALIBRATE_help = "Enter the load cell value in grams"
+    cmd_CALIBRATE_params = {
+        "GRAMS": {"type": "float", "required": True},
+    }
     def cmd_CALIBRATE(self, gcmd):
         if self._tare_counts is None:
             gcmd.respond_info("You must use TARE first.")

--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -453,9 +453,14 @@ class LoadCellProbeCommands:
         # Register commands
         gcode = self._printer.lookup_object('gcode')
         gcode.register_command("LOAD_CELL_TEST_TAP",
-            self.cmd_LOAD_CELL_TEST_TAP, desc=self.cmd_LOAD_CELL_TEST_TAP_help)
+            self.cmd_LOAD_CELL_TEST_TAP, desc=self.cmd_LOAD_CELL_TEST_TAP_help,
+            params=self.cmd_LOAD_CELL_TEST_TAP_params)
 
     cmd_LOAD_CELL_TEST_TAP_help = "Tap the load cell probe to verify operation"
+    cmd_LOAD_CELL_TEST_TAP_params = {
+        "TAPS": {"type": "int", "default": 3},
+        "TIMEOUT": {"type": "float", "default": 30.},
+    }
 
     def cmd_LOAD_CELL_TEST_TAP(self, gcmd):
         taps = gcmd.get_int("TAPS", 3, minval=1, maxval=10)

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -39,7 +39,8 @@ class ManualProbe:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode_move = self.printer.load_object(config, "gcode_move")
         self.gcode.register_command('MANUAL_PROBE', self.cmd_MANUAL_PROBE,
-                                    desc=self.cmd_MANUAL_PROBE_help)
+                                    desc=self.cmd_MANUAL_PROBE_help,
+                                    params=self.cmd_MANUAL_PROBE_params)
         # Endstop value for cartesian printers with separate Z axis
         zconfig = lookup_z_endstop_config(config)
         if zconfig is not None:
@@ -66,7 +67,8 @@ class ManualProbe:
         if self.z_position_endstop is not None:
             self.gcode.register_command(
                 'Z_ENDSTOP_CALIBRATE', self.cmd_Z_ENDSTOP_CALIBRATE,
-                desc=self.cmd_Z_ENDSTOP_CALIBRATE_help)
+                desc=self.cmd_Z_ENDSTOP_CALIBRATE_help,
+                params=self.cmd_Z_ENDSTOP_CALIBRATE_params)
             self.gcode.register_command(
                 'Z_OFFSET_APPLY_ENDSTOP',
                 self.cmd_Z_OFFSET_APPLY_ENDSTOP,
@@ -91,6 +93,9 @@ class ManualProbe:
     def get_status(self, eventtime):
         return self.status
     cmd_MANUAL_PROBE_help = "Start manual probe helper script"
+    cmd_MANUAL_PROBE_params = {
+        "SPEED": {"type": "float", "default": 5.0},
+    }
     def cmd_MANUAL_PROBE(self, gcmd):
         ManualProbeHelper(self.printer, gcmd, self.manual_probe_finalize)
     def z_endstop_finalize(self, mpresult):
@@ -106,6 +111,9 @@ class ManualProbe:
         configfile.set(self.z_endstop_config_name, 'position_endstop',
                        "%.3f" % (z_pos,))
     cmd_Z_ENDSTOP_CALIBRATE_help = "Calibrate a Z endstop"
+    cmd_Z_ENDSTOP_CALIBRATE_params = {
+        "SPEED": {"type": "float", "default": 5.0},
+    }
     def cmd_Z_ENDSTOP_CALIBRATE(self, gcmd):
         ManualProbeHelper(self.printer, gcmd, self.z_endstop_finalize)
     def cmd_Z_OFFSET_APPLY_ENDSTOP(self,gcmd):
@@ -179,7 +187,8 @@ class ManualProbeHelper:
         self.gcode.register_command('ABORT', self.cmd_ABORT,
                                     desc=self.cmd_ABORT_help)
         self.gcode.register_command('TESTZ', self.cmd_TESTZ,
-                                    desc=self.cmd_TESTZ_help)
+                                    desc=self.cmd_TESTZ_help,
+                                    params=self.cmd_TESTZ_params)
         self.gcode.respond_info(
             "Starting manual Z probe. Use TESTZ to adjust position.\n"
             "Finish with ACCEPT or ABORT command.")
@@ -252,6 +261,9 @@ class ManualProbeHelper:
     def cmd_ABORT(self, gcmd):
         self.finalize(False)
     cmd_TESTZ_help = "Move to new Z height"
+    cmd_TESTZ_params = {
+        "Z": {"type": "string", "required": True},
+    }
     def cmd_TESTZ(self, gcmd):
         # Store current position for later reference
         kin_pos = self.get_kinematics_pos()

--- a/klippy/extras/manual_stepper.py
+++ b/klippy/extras/manual_stepper.py
@@ -41,7 +41,8 @@ class ManualStepper:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command('MANUAL_STEPPER', "STEPPER",
                                    stepper_name, self.cmd_MANUAL_STEPPER,
-                                   desc=self.cmd_MANUAL_STEPPER_help)
+                                   desc=self.cmd_MANUAL_STEPPER_help,
+                                   params=self.cmd_MANUAL_STEPPER_params)
     def get_name(self):
         return self.name
     def sync_print_time(self):
@@ -91,6 +92,20 @@ class ManualStepper:
                             probe_pos, triggered, check_trigger)
         self.sync_print_time()
     cmd_MANUAL_STEPPER_help = "Command a manually configured stepper"
+    cmd_MANUAL_STEPPER_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "GCODE_AXIS": {"type": "string", "required": False},
+        "ENABLE": {"type": "int", "required": False},
+        "SET_POSITION": {"type": "float", "required": False},
+        "SPEED": {"type": "float", "required": False},
+        "ACCEL": {"type": "float", "required": False},
+        "STOP_ON_ENDSTOP": {"type": "string", "required": False},
+        "MOVE": {"type": "float", "required": False},
+        "SYNC": {"type": "int", "required": False},
+        "INSTANTANEOUS_CORNER_VELOCITY": {"type": "float", "default": 1.},
+        "LIMIT_VELOCITY": {"type": "float", "default": 999999.9},
+        "LIMIT_ACCEL": {"type": "float", "default": 999999.9},
+    }
     def cmd_MANUAL_STEPPER(self, gcmd):
         if gcmd.get('GCODE_AXIS', None) is not None:
             return self.command_with_gcode_axis(gcmd)

--- a/klippy/extras/mcp4018.py
+++ b/klippy/extras/mcp4018.py
@@ -19,13 +19,18 @@ class mcp4018:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_DIGIPOT", "DIGIPOT", self.name,
                                    self.cmd_SET_DIGIPOT,
-                                   desc=self.cmd_SET_DIGIPOT_help)
+                                   desc=self.cmd_SET_DIGIPOT_help,
+                                   params=self.cmd_SET_DIGIPOT_params)
     def handle_connect(self):
         self.set_dac(self.start_value)
     def set_dac(self, value):
         val = int(value * 127. / self.scale + .5)
         self.i2c.i2c_write([val])
     cmd_SET_DIGIPOT_help = "Set digipot value"
+    cmd_SET_DIGIPOT_params = {
+        "DIGIPOT": {"type": "string", "required": True},
+        "WIPER": {"type": "float", "required": True},
+    }
     def cmd_SET_DIGIPOT(self, gcmd):
         wiper = gcmd.get_float('WIPER', minval=0., maxval=self.scale)
         if wiper is not None:

--- a/klippy/extras/output_pin.py
+++ b/klippy/extras/output_pin.py
@@ -231,7 +231,8 @@ class PrinterOutputPin:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_PIN", "PIN", pin_name,
                                    self.cmd_SET_PIN,
-                                   desc=self.cmd_SET_PIN_help)
+                                   desc=self.cmd_SET_PIN_help,
+                                   params=self.cmd_SET_PIN_params)
     def get_status(self, eventtime):
         return {'value': self.last_value}
     def _set_pin(self, print_time, value):
@@ -250,6 +251,11 @@ class PrinterOutputPin:
             value = 0.
         self.gcrq.send_async_request(value)
     cmd_SET_PIN_help = "Set the value of an output pin"
+    cmd_SET_PIN_params = {
+        "PIN": {"type": "string", "required": True},
+        "VALUE": {"type": "float", "required": False},
+        "TEMPLATE": {"type": "string", "required": False},
+    }
     def cmd_SET_PIN(self, gcmd):
         value = gcmd.get_float('VALUE', None, minval=0., maxval=self.scale)
         template = gcmd.get('TEMPLATE', None)

--- a/klippy/extras/pause_resume.py
+++ b/klippy/extras/pause_resume.py
@@ -18,7 +18,8 @@ class PauseResume:
         self.gcode.register_command("PAUSE", self.cmd_PAUSE,
                                     desc=self.cmd_PAUSE_help)
         self.gcode.register_command("RESUME", self.cmd_RESUME,
-                                    desc=self.cmd_RESUME_help)
+                                    desc=self.cmd_RESUME_help,
+                                    params=self.cmd_RESUME_params)
         self.gcode.register_command("CLEAR_PAUSE", self.cmd_CLEAR_PAUSE,
                                     desc=self.cmd_CLEAR_PAUSE_help)
         self.gcode.register_command("CANCEL_PRINT", self.cmd_CANCEL_PRINT,
@@ -74,6 +75,9 @@ class PauseResume:
             self.gcode.respond_info("action:resumed")
         self.pause_command_sent = False
     cmd_RESUME_help = ("Resumes the print from a pause")
+    cmd_RESUME_params = {
+        "VELOCITY": {"type": "float", "required": False},
+    }
     def cmd_RESUME(self, gcmd):
         if not self.is_paused:
             gcmd.respond_info("Print is not paused, resume aborted")

--- a/klippy/extras/pid_calibrate.py
+++ b/klippy/extras/pid_calibrate.py
@@ -11,8 +11,14 @@ class PIDCalibrate:
         self.printer = config.get_printer()
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('PID_CALIBRATE', self.cmd_PID_CALIBRATE,
-                               desc=self.cmd_PID_CALIBRATE_help)
+                               desc=self.cmd_PID_CALIBRATE_help,
+                               params=self.cmd_PID_CALIBRATE_params)
     cmd_PID_CALIBRATE_help = "Run PID calibration test"
+    cmd_PID_CALIBRATE_params = {
+        "HEATER": {"type": "string", "required": True},
+        "TARGET": {"type": "float", "required": True},
+        "WRITE_FILE": {"type": "int", "default": 0},
+    }
     def cmd_PID_CALIBRATE(self, gcmd):
         heater_name = gcmd.get('HEATER')
         target = gcmd.get_float('TARGET')

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -14,7 +14,8 @@ class PrintStats:
         self.gcode = printer.lookup_object('gcode')
         self.gcode.register_command(
             "SET_PRINT_STATS_INFO", self.cmd_SET_PRINT_STATS_INFO,
-            desc=self.cmd_SET_PRINT_STATS_INFO_help)
+            desc=self.cmd_SET_PRINT_STATS_INFO_help,
+            params=self.cmd_SET_PRINT_STATS_INFO_params)
         printer.register_event_handler("extruder:activate_extruder",
                                        self._handle_activate_extruder)
     def _handle_activate_extruder(self):
@@ -71,6 +72,10 @@ class PrintStats:
         self.print_start_time = None
     cmd_SET_PRINT_STATS_INFO_help = "Pass slicer info like layer act and " \
                                     "total to klipper"
+    cmd_SET_PRINT_STATS_INFO_params = {
+        "TOTAL_LAYER": {"type": "int", "required": False},
+        "CURRENT_LAYER": {"type": "int", "required": False},
+    }
     def cmd_SET_PRINT_STATS_INFO(self, gcmd):
         total_layer = gcmd.get_int("TOTAL_LAYER", self.info_total_layer, \
                                    minval=0)

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -35,6 +35,25 @@ def calc_probe_z_average(positions, method='average'):
 # Probe device implementation helpers
 ######################################################################
 
+# Params read by ProbeParameterHelper.get_probe_params() - merge into a
+# command's own cmd_XXX_params instead of duplicating.
+PROBE_PARAMS = {
+    "PROBE_SPEED": {"type": "float", "required": False},
+    "LIFT_SPEED": {"type": "float", "required": False},
+    "SAMPLES": {"type": "int", "required": False},
+    "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
+    "SAMPLES_TOLERANCE": {"type": "float", "required": False},
+    "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
+    "SAMPLES_RESULT": {"type": "string", "required": False},
+}
+
+# Params additionally read by ProbePointsHelper.start_probe()
+PROBE_POINTS_HELPER_PARAMS = dict(
+    PROBE_PARAMS,
+    METHOD={"type": "string", "default": "automatic"},
+    HORIZONTAL_MOVE_Z={"type": "float", "required": False},
+)
+
 # Helper to implement common probing commands
 class ProbeCommandHelper:
     def __init__(self, config, probe, query_endstop=None,
@@ -85,15 +104,7 @@ class ProbeCommandHelper:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_help = "Probe Z-height at current XY position"
-    cmd_PROBE_params = {
-        "PROBE_SPEED": {"type": "float", "required": False},
-        "LIFT_SPEED": {"type": "float", "required": False},
-        "SAMPLES": {"type": "int", "required": False},
-        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
-        "SAMPLES_RESULT": {"type": "string", "required": False},
-    }
+    cmd_PROBE_params = dict(PROBE_PARAMS)
     def cmd_PROBE(self, gcmd):
         pos = run_single_probe(self.probe, gcmd)
         gcmd.respond_info("Result: at %.3f,%.3f estimate contact at z=%.6f"
@@ -116,16 +127,8 @@ class ProbeCommandHelper:
         configfile = self.printer.lookup_object('configfile')
         configfile.set(self.name, 'z_offset', "%.3f" % (z_offset,))
     cmd_PROBE_CALIBRATE_help = "Calibrate the probe's z_offset"
-    cmd_PROBE_CALIBRATE_params = {
-        "PROBE_SPEED": {"type": "float", "required": False},
-        "LIFT_SPEED": {"type": "float", "required": False},
-        "SAMPLES": {"type": "int", "required": False},
-        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
-        "SAMPLES_RESULT": {"type": "string", "required": False},
-        "SPEED": {"type": "float", "default": 5.0},
-    }
+    cmd_PROBE_CALIBRATE_params = dict(
+        PROBE_PARAMS, SPEED={"type": "float", "default": 5.0})
     def cmd_PROBE_CALIBRATE(self, gcmd):
         manual_probe.verify_no_manual_probe(self.printer)
         params = self.probe.get_probe_params(gcmd)
@@ -144,15 +147,8 @@ class ProbeCommandHelper:
         manual_probe.ManualProbeHelper(self.printer, gcmd,
                                        self.probe_calibrate_finalize)
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
-    cmd_PROBE_ACCURACY_params = {
-        "SAMPLES": {"type": "int", "default": 10},
-        "PROBE_SPEED": {"type": "float", "required": False},
-        "LIFT_SPEED": {"type": "float", "required": False},
-        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
-        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
-        "SAMPLES_RESULT": {"type": "string", "required": False},
-    }
+    cmd_PROBE_ACCURACY_params = dict(
+        PROBE_PARAMS, SAMPLES={"type": "int", "default": 10})
     def cmd_PROBE_ACCURACY(self, gcmd):
         params = self.probe.get_probe_params(gcmd)
         sample_count = gcmd.get_int("SAMPLES", 10, minval=1)
@@ -450,19 +446,6 @@ class ProbeOffsetsHelper:
 ######################################################################
 # Tools for utilizing the probe
 ######################################################################
-
-# Parameters read directly by ProbePointsHelper.start_probe() below.
-# Shared by every command that delegates its probing to start_probe()
-# (Z_TILT_ADJUST, QUAD_GANTRY_LEVEL, SCREWS_TILT_CALCULATE,
-# BED_TILT_CALIBRATE, DELTA_CALIBRATE, and so on) - those commands each
-# list these same entries in their own cmd_XXX_params (a dict-unpacking
-# merge here would defeat the static literal-dict check in
-# scripts/check_gcode_params.py, so it is spelled out at each call site
-# instead).
-PROBE_POINTS_HELPER_PARAMS = {
-    "METHOD": {"type": "string", "default": "automatic"},
-    "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-}
 
 # Helper code that can probe a series of points and report the
 # position at each point.

--- a/klippy/extras/probe.py
+++ b/klippy/extras/probe.py
@@ -52,15 +52,18 @@ class ProbeCommandHelper:
         self.last_probe_position = gcode.Coord((0., 0., 0.))
         self.last_z_result = 0.
         gcode.register_command('PROBE', self.cmd_PROBE,
-                               desc=self.cmd_PROBE_help)
+                               desc=self.cmd_PROBE_help,
+                               params=self.cmd_PROBE_params)
         # PROBE_CALIBRATE command
         self.probe_calibrate_info = None
         if can_set_z_offset:
             gcode.register_command('PROBE_CALIBRATE', self.cmd_PROBE_CALIBRATE,
-                                   desc=self.cmd_PROBE_CALIBRATE_help)
+                                   desc=self.cmd_PROBE_CALIBRATE_help,
+                                   params=self.cmd_PROBE_CALIBRATE_params)
         # Other commands
         gcode.register_command('PROBE_ACCURACY', self.cmd_PROBE_ACCURACY,
-                               desc=self.cmd_PROBE_ACCURACY_help)
+                               desc=self.cmd_PROBE_ACCURACY_help,
+                               params=self.cmd_PROBE_ACCURACY_params)
         if can_set_z_offset:
             gcode.register_command('Z_OFFSET_APPLY_PROBE',
                                    self.cmd_Z_OFFSET_APPLY_PROBE,
@@ -82,6 +85,15 @@ class ProbeCommandHelper:
         self.last_state = res
         gcmd.respond_info("probe: %s" % (["open", "TRIGGERED"][not not res],))
     cmd_PROBE_help = "Probe Z-height at current XY position"
+    cmd_PROBE_params = {
+        "PROBE_SPEED": {"type": "float", "required": False},
+        "LIFT_SPEED": {"type": "float", "required": False},
+        "SAMPLES": {"type": "int", "required": False},
+        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
+        "SAMPLES_RESULT": {"type": "string", "required": False},
+    }
     def cmd_PROBE(self, gcmd):
         pos = run_single_probe(self.probe, gcmd)
         gcmd.respond_info("Result: at %.3f,%.3f estimate contact at z=%.6f"
@@ -104,6 +116,16 @@ class ProbeCommandHelper:
         configfile = self.printer.lookup_object('configfile')
         configfile.set(self.name, 'z_offset', "%.3f" % (z_offset,))
     cmd_PROBE_CALIBRATE_help = "Calibrate the probe's z_offset"
+    cmd_PROBE_CALIBRATE_params = {
+        "PROBE_SPEED": {"type": "float", "required": False},
+        "LIFT_SPEED": {"type": "float", "required": False},
+        "SAMPLES": {"type": "int", "required": False},
+        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
+        "SAMPLES_RESULT": {"type": "string", "required": False},
+        "SPEED": {"type": "float", "default": 5.0},
+    }
     def cmd_PROBE_CALIBRATE(self, gcmd):
         manual_probe.verify_no_manual_probe(self.printer)
         params = self.probe.get_probe_params(gcmd)
@@ -122,6 +144,15 @@ class ProbeCommandHelper:
         manual_probe.ManualProbeHelper(self.printer, gcmd,
                                        self.probe_calibrate_finalize)
     cmd_PROBE_ACCURACY_help = "Probe Z-height accuracy at current XY position"
+    cmd_PROBE_ACCURACY_params = {
+        "SAMPLES": {"type": "int", "default": 10},
+        "PROBE_SPEED": {"type": "float", "required": False},
+        "LIFT_SPEED": {"type": "float", "required": False},
+        "SAMPLE_RETRACT_DIST": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE": {"type": "float", "required": False},
+        "SAMPLES_TOLERANCE_RETRIES": {"type": "int", "required": False},
+        "SAMPLES_RESULT": {"type": "string", "required": False},
+    }
     def cmd_PROBE_ACCURACY(self, gcmd):
         params = self.probe.get_probe_params(gcmd)
         sample_count = gcmd.get_int("SAMPLES", 10, minval=1)
@@ -419,6 +450,19 @@ class ProbeOffsetsHelper:
 ######################################################################
 # Tools for utilizing the probe
 ######################################################################
+
+# Parameters read directly by ProbePointsHelper.start_probe() below.
+# Shared by every command that delegates its probing to start_probe()
+# (Z_TILT_ADJUST, QUAD_GANTRY_LEVEL, SCREWS_TILT_CALCULATE,
+# BED_TILT_CALIBRATE, DELTA_CALIBRATE, and so on) - those commands each
+# list these same entries in their own cmd_XXX_params (a dict-unpacking
+# merge here would defeat the static literal-dict check in
+# scripts/check_gcode_params.py, so it is spelled out at each call site
+# instead).
+PROBE_POINTS_HELPER_PARAMS = {
+    "METHOD": {"type": "string", "default": "automatic"},
+    "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+}
 
 # Helper code that can probe a series of points and report the
 # position at each point.

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -111,10 +111,12 @@ class EddyCalibrationTool:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("PROBE_EDDY_CURRENT_CALIBRATE", "CHIP",
                                    cname, self.cmd_EDDY_CALIBRATE,
-                                   desc=self.cmd_EDDY_CALIBRATE_help)
+                                   desc=self.cmd_EDDY_CALIBRATE_help,
+                                   params=self.cmd_EDDY_CALIBRATE_params)
         gcode.register_command('Z_OFFSET_APPLY_PROBE',
                                self.cmd_Z_OFFSET_APPLY_PROBE,
-                               desc=self.cmd_Z_OFFSET_APPLY_PROBE_help)
+                               desc=self.cmd_Z_OFFSET_APPLY_PROBE_help,
+                               params=self.cmd_Z_OFFSET_APPLY_PROBE_params)
     def _save_calibration(self, z_freq_pairs):
         gcode = self.printer.lookup_object("gcode")
         gcode.respond_info(
@@ -293,6 +295,10 @@ class EddyCalibrationTool:
         z_freq_pairs = [(pos, freq) for pos, freq, _, _ in filtered]
         self._save_calibration(z_freq_pairs)
     cmd_EDDY_CALIBRATE_help = "Calibrate eddy current probe"
+    cmd_EDDY_CALIBRATE_params = {
+        "CHIP": {"type": "string", "required": True},
+        "PROBE_SPEED": {"type": "float", "default": 5.0},
+    }
     def cmd_EDDY_CALIBRATE(self, gcmd):
         self.probe_speed = gcmd.get_float("PROBE_SPEED", 5., above=0.)
         # Start manual probe
@@ -313,6 +319,9 @@ class EddyCalibrationTool:
             % (self.name, new_calibrate))
         configfile.set(self.name, 'tap_z_offset', "%.3f" % (new_calibrate,))
     cmd_Z_OFFSET_APPLY_PROBE_help = "Adjust the probe's z_offset"
+    cmd_Z_OFFSET_APPLY_PROBE_params = {
+        "METHOD": {"type": "string", "default": ""},
+    }
     def cmd_Z_OFFSET_APPLY_PROBE(self, gcmd):
         gcode_move = self.printer.lookup_object("gcode_move")
         offset = gcode_move.get_status()['homing_origin'].z
@@ -339,7 +348,8 @@ class EddyTapCalibration:
         gcode = self._printer.lookup_object("gcode")
         gcode.register_command("PROBE_EDDY_CURRENT_TAP_CALIBRATE",
                                self.cmd_TAP_CALIBRATE,
-                               desc=self.cmd_TAP_CALIBRATE_help)
+                               desc=self.cmd_TAP_CALIBRATE_help,
+                               params=self.cmd_TAP_CALIBRATE_params)
     def _analyze_main_calibration(self):
         freqs, zpos = self._calibration.get_calibration()
         if len(freqs) < 2:
@@ -399,6 +409,9 @@ class EddyTapCalibration:
             % (self._name, tap_threshold))
         configfile.set(self._name, 'tap_threshold', "%.3f" % (tap_threshold,))
     cmd_TAP_CALIBRATE_help = "Calibrate tap_threshold for 'tap' probing"
+    cmd_TAP_CALIBRATE_params = {
+        "TAP": {"type": "string", "required": False},
+    }
     def cmd_TAP_CALIBRATE(self, gcmd):
         mc_coeffs = self._analyze_main_calibration()
         last_tap = self._eddy_tap.get_last_tap_info()

--- a/klippy/extras/pwm_cycle_time.py
+++ b/klippy/extras/pwm_cycle_time.py
@@ -96,7 +96,8 @@ class PrinterOutputPWMCycle:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_PIN", "PIN", pin_name,
                                    self.cmd_SET_PIN,
-                                   desc=self.cmd_SET_PIN_help)
+                                   desc=self.cmd_SET_PIN_help,
+                                   params=self.cmd_SET_PIN_params)
     def get_status(self, eventtime):
         return {'value': self.last_value}
     def _set_pin(self, print_time, value, cycle_time):
@@ -109,6 +110,11 @@ class PrinterOutputPWMCycle:
         self.last_cycle_time = cycle_time
         self.last_print_time = print_time
     cmd_SET_PIN_help = "Set the value of an output pin"
+    cmd_SET_PIN_params = {
+        "PIN": {"type": "string", "required": True},
+        "VALUE": {"type": "float", "required": True},
+        "CYCLE_TIME": {"type": "float", "required": False},
+    }
     def cmd_SET_PIN(self, gcmd):
         # Read requested value
         value = gcmd.get_float('VALUE', minval=0., maxval=self.scale)

--- a/klippy/extras/pwm_tool.py
+++ b/klippy/extras/pwm_tool.py
@@ -163,7 +163,8 @@ class PrinterOutputPin:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_PIN", "PIN", pin_name,
                                    self.cmd_SET_PIN,
-                                   desc=self.cmd_SET_PIN_help)
+                                   desc=self.cmd_SET_PIN_help,
+                                   params=self.cmd_SET_PIN_params)
     def get_status(self, eventtime):
         return {'value': self.last_value}
     def _set_pin(self, print_time, value):
@@ -174,6 +175,10 @@ class PrinterOutputPin:
         self.last_value = value
         self.last_print_time = print_time
     cmd_SET_PIN_help = "Set the value of an output pin"
+    cmd_SET_PIN_params = {
+        "PIN": {"type": "string", "required": True},
+        "VALUE": {"type": "float", "required": True},
+    }
     def cmd_SET_PIN(self, gcmd):
         # Read requested value
         value = gcmd.get_float('VALUE', minval=0., maxval=self.scale)

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -44,9 +44,16 @@ class QuadGantryLevel:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command(
             'QUAD_GANTRY_LEVEL', self.cmd_QUAD_GANTRY_LEVEL,
-            desc=self.cmd_QUAD_GANTRY_LEVEL_help)
+            desc=self.cmd_QUAD_GANTRY_LEVEL_help,
+            params=self.cmd_QUAD_GANTRY_LEVEL_params)
     cmd_QUAD_GANTRY_LEVEL_help = (
         "Conform a moving, twistable gantry to the shape of a stationary bed")
+    cmd_QUAD_GANTRY_LEVEL_params = {
+        "RETRIES": {"type": "int", "required": False},
+        "RETRY_TOLERANCE": {"type": "float", "required": False},
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+    }
     def cmd_QUAD_GANTRY_LEVEL(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)

--- a/klippy/extras/quad_gantry_level.py
+++ b/klippy/extras/quad_gantry_level.py
@@ -48,12 +48,8 @@ class QuadGantryLevel:
             params=self.cmd_QUAD_GANTRY_LEVEL_params)
     cmd_QUAD_GANTRY_LEVEL_help = (
         "Conform a moving, twistable gantry to the shape of a stationary bed")
-    cmd_QUAD_GANTRY_LEVEL_params = {
-        "RETRIES": {"type": "int", "required": False},
-        "RETRY_TOLERANCE": {"type": "float", "required": False},
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-    }
+    cmd_QUAD_GANTRY_LEVEL_params = dict(
+        probe.PROBE_POINTS_HELPER_PARAMS, **z_tilt.RETRY_HELPER_PARAMS)
     def cmd_QUAD_GANTRY_LEVEL(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)

--- a/klippy/extras/query_adc.py
+++ b/klippy/extras/query_adc.py
@@ -10,10 +10,15 @@ class QueryADC:
         self.adc = {}
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("QUERY_ADC", self.cmd_QUERY_ADC,
-                               desc=self.cmd_QUERY_ADC_help)
+                               desc=self.cmd_QUERY_ADC_help,
+                               params=self.cmd_QUERY_ADC_params)
     def register_adc(self, name, mcu_adc):
         self.adc[name] = mcu_adc
     cmd_QUERY_ADC_help = "Report the last value of an analog pin"
+    cmd_QUERY_ADC_params = {
+        "NAME": {"type": "string", "required": False},
+        "PULLUP": {"type": "float", "required": False},
+    }
     def cmd_QUERY_ADC(self, gcmd):
         name = gcmd.get('NAME', None)
         if name not in self.adc:

--- a/klippy/extras/resonance_tester.py
+++ b/klippy/extras/resonance_tester.py
@@ -288,13 +288,16 @@ class ResonanceTester:
         self.gcode = self.printer.lookup_object('gcode')
         self.gcode.register_command("MEASURE_AXES_NOISE",
                                     self.cmd_MEASURE_AXES_NOISE,
-                                    desc=self.cmd_MEASURE_AXES_NOISE_help)
+                                    desc=self.cmd_MEASURE_AXES_NOISE_help,
+                                    params=self.cmd_MEASURE_AXES_NOISE_params)
         self.gcode.register_command("TEST_RESONANCES",
                                     self.cmd_TEST_RESONANCES,
-                                    desc=self.cmd_TEST_RESONANCES_help)
+                                    desc=self.cmd_TEST_RESONANCES_help,
+                                    params=self.cmd_TEST_RESONANCES_params)
         self.gcode.register_command("SHAPER_CALIBRATE",
                                     self.cmd_SHAPER_CALIBRATE,
-                                    desc=self.cmd_SHAPER_CALIBRATE_help)
+                                    desc=self.cmd_SHAPER_CALIBRATE_help,
+                                    params=self.cmd_SHAPER_CALIBRATE_params)
         self.printer.register_event_handler("klippy:connect", self.connect)
 
     def connect(self):
@@ -394,6 +397,19 @@ class ResonanceTester:
     def _get_max_calibration_freq(self):
         return 1.5 * self.generator.get_max_freq()
     cmd_TEST_RESONANCES_help = ("Runs the resonance test for a specified axis")
+    cmd_TEST_RESONANCES_params = {
+        "AXIS": {"type": "string", "required": True},
+        "CHIPS": {"type": "string", "required": False},
+        "POINT": {"type": "string", "required": False},
+        "OUTPUT": {"type": "string", "default": "resonances"},
+        "NAME": {"type": "string", "required": False},
+        "FREQ_START": {"type": "float", "required": False},
+        "FREQ_END": {"type": "float", "required": False},
+        "ACCEL_PER_HZ": {"type": "float", "required": False},
+        "HZ_PER_SEC": {"type": "float", "required": False},
+        "SWEEPING_ACCEL": {"type": "float", "required": False},
+        "SWEEPING_PERIOD": {"type": "float", "required": False},
+    }
     def cmd_TEST_RESONANCES(self, gcmd):
         # Parse parameters
         axis = _parse_axis(gcmd, gcmd.get("AXIS").lower())
@@ -444,6 +460,18 @@ class ResonanceTester:
                     "Resonances data written to %s file" % (csv_name,))
     cmd_SHAPER_CALIBRATE_help = (
         "Similar to TEST_RESONANCES but suggest input shaper config")
+    cmd_SHAPER_CALIBRATE_params = {
+        "AXIS": {"type": "string", "required": False},
+        "CHIPS": {"type": "string", "required": False},
+        "MAX_SMOOTHING": {"type": "float", "required": False},
+        "NAME": {"type": "string", "required": False},
+        "FREQ_START": {"type": "float", "required": False},
+        "FREQ_END": {"type": "float", "required": False},
+        "ACCEL_PER_HZ": {"type": "float", "required": False},
+        "HZ_PER_SEC": {"type": "float", "required": False},
+        "SWEEPING_ACCEL": {"type": "float", "required": False},
+        "SWEEPING_PERIOD": {"type": "float", "required": False},
+    }
     def cmd_SHAPER_CALIBRATE(self, gcmd):
         # Parse parameters
         axis = gcmd.get("AXIS", None)
@@ -505,6 +533,9 @@ class ResonanceTester:
             "with these parameters and restart the printer.")
     cmd_MEASURE_AXES_NOISE_help = (
         "Measures noise of all enabled accelerometer chips")
+    cmd_MEASURE_AXES_NOISE_params = {
+        "MEAS_TIME": {"type": "float", "default": 2.},
+    }
     def cmd_MEASURE_AXES_NOISE(self, gcmd):
         meas_time = gcmd.get_float("MEAS_TIME", 2., above=0.)
         raw_values = [(chip_axis, chip.start_internal_client())

--- a/klippy/extras/respond.py
+++ b/klippy/extras/respond.py
@@ -24,11 +24,17 @@ class HostResponder:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('M118', self.cmd_M118, True)
         gcode.register_command('RESPOND', self.cmd_RESPOND, True,
-                               desc=self.cmd_RESPOND_help)
+                               desc=self.cmd_RESPOND_help,
+                               params=self.cmd_RESPOND_params)
     def cmd_M118(self, gcmd):
         msg = gcmd.get_raw_command_parameters()
         gcmd.respond_raw("%s %s" % (self.default_prefix, msg))
     cmd_RESPOND_help = ("Echo the message prepended with a prefix")
+    cmd_RESPOND_params = {
+        "TYPE": {"type": "string", "required": False},
+        "PREFIX": {"type": "string", "required": False},
+        "MSG": {"type": "string", "default": ""},
+    }
     def cmd_RESPOND(self, gcmd):
         no_space = False
         respond_type = gcmd.get('TYPE', None)

--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -21,7 +21,8 @@ class SaveVariables:
             raise config.error(str(e))
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('SAVE_VARIABLE', self.cmd_SAVE_VARIABLE,
-                               desc=self.cmd_SAVE_VARIABLE_help)
+                               desc=self.cmd_SAVE_VARIABLE_help,
+                               params=self.cmd_SAVE_VARIABLE_params)
     def loadVariables(self):
         allvars = {}
         varfile = configparser.ConfigParser()
@@ -36,6 +37,10 @@ class SaveVariables:
             raise self.printer.command_error(msg)
         self.allVariables = allvars
     cmd_SAVE_VARIABLE_help = "Save arbitrary variables to disk"
+    cmd_SAVE_VARIABLE_params = {
+        "VARIABLE": {"type": "string", "required": True},
+        "VALUE": {"type": "string", "required": True},
+    }
     def cmd_SAVE_VARIABLE(self, gcmd):
         varname = gcmd.get('VARIABLE')
         if (varname.lower() != varname):

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -45,12 +45,10 @@ class ScrewsTiltAdjust:
     cmd_SCREWS_TILT_CALCULATE_help = "Tool to help adjust bed leveling " \
                                      "screws by calculating the number " \
                                      "of turns to level it."
-    cmd_SCREWS_TILT_CALCULATE_params = {
-        "MAX_DEVIATION": {"type": "float", "required": False},
-        "DIRECTION": {"type": "string", "required": False},
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-    }
+    cmd_SCREWS_TILT_CALCULATE_params = dict(
+        probe.PROBE_POINTS_HELPER_PARAMS,
+        MAX_DEVIATION={"type": "float", "required": False},
+        DIRECTION={"type": "string", "required": False})
 
     def cmd_SCREWS_TILT_CALCULATE(self, gcmd):
         self.max_diff = gcmd.get_float("MAX_DEVIATION", None)

--- a/klippy/extras/screws_tilt_adjust.py
+++ b/klippy/extras/screws_tilt_adjust.py
@@ -38,12 +38,19 @@ class ScrewsTiltAdjust:
         self.probe_helper.minimum_points(3)
         # Register command
         self.gcode = self.printer.lookup_object('gcode')
-        self.gcode.register_command("SCREWS_TILT_CALCULATE",
-                                    self.cmd_SCREWS_TILT_CALCULATE,
-                                    desc=self.cmd_SCREWS_TILT_CALCULATE_help)
+        self.gcode.register_command(
+            "SCREWS_TILT_CALCULATE", self.cmd_SCREWS_TILT_CALCULATE,
+            desc=self.cmd_SCREWS_TILT_CALCULATE_help,
+            params=self.cmd_SCREWS_TILT_CALCULATE_params)
     cmd_SCREWS_TILT_CALCULATE_help = "Tool to help adjust bed leveling " \
                                      "screws by calculating the number " \
                                      "of turns to level it."
+    cmd_SCREWS_TILT_CALCULATE_params = {
+        "MAX_DEVIATION": {"type": "float", "required": False},
+        "DIRECTION": {"type": "string", "required": False},
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+    }
 
     def cmd_SCREWS_TILT_CALCULATE(self, gcmd):
         self.max_diff = gcmd.get_float("MAX_DEVIATION", None)

--- a/klippy/extras/sdcard_loop.py
+++ b/klippy/extras/sdcard_loop.py
@@ -13,7 +13,8 @@ class SDCardLoop:
         self.gcode = printer.lookup_object('gcode')
         self.gcode.register_command(
             "SDCARD_LOOP_BEGIN", self.cmd_SDCARD_LOOP_BEGIN,
-            desc=self.cmd_SDCARD_LOOP_BEGIN_help)
+            desc=self.cmd_SDCARD_LOOP_BEGIN_help,
+            params=self.cmd_SDCARD_LOOP_BEGIN_params)
         self.gcode.register_command(
             "SDCARD_LOOP_END", self.cmd_SDCARD_LOOP_END,
             desc=self.cmd_SDCARD_LOOP_END_help)
@@ -22,6 +23,9 @@ class SDCardLoop:
             desc=self.cmd_SDCARD_LOOP_DESIST_help)
         self.loop_stack = []
     cmd_SDCARD_LOOP_BEGIN_help = "Begins a looped section in the SD file."
+    cmd_SDCARD_LOOP_BEGIN_params = {
+        "COUNT": {"type": "int", "required": True},
+    }
     def cmd_SDCARD_LOOP_BEGIN(self, gcmd):
         count = gcmd.get_int("COUNT", minval=0)
         if not self.loop_begin(count):

--- a/klippy/extras/servo.py
+++ b/klippy/extras/servo.py
@@ -42,7 +42,8 @@ class PrinterServo:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("SET_SERVO", "SERVO", servo_name,
                                    self.cmd_SET_SERVO,
-                                   desc=self.cmd_SET_SERVO_help)
+                                   desc=self.cmd_SET_SERVO_help,
+                                   params=self.cmd_SET_SERVO_params)
     def get_status(self, eventtime):
         return {'value': self.last_value}
     def _set_pwm(self, print_time, value):
@@ -63,6 +64,11 @@ class PrinterServo:
             width = max(self.min_width, min(self.max_width, width))
         return width * self.width_to_value
     cmd_SET_SERVO_help = "Set servo angle"
+    cmd_SET_SERVO_params = {
+        "SERVO": {"type": "string", "required": True},
+        "WIDTH": {"type": "float", "required": False},
+        "ANGLE": {"type": "float", "required": True},
+    }
     def cmd_SET_SERVO(self, gcmd):
         width = gcmd.get_float('WIDTH', None)
         if width is not None:

--- a/klippy/extras/skew_correction.py
+++ b/klippy/extras/skew_correction.py
@@ -35,11 +35,14 @@ class PrinterSkew:
                                desc=self.cmd_GET_CURRENT_SKEW_help)
         gcode.register_command('CALC_MEASURED_SKEW',
                                self.cmd_CALC_MEASURED_SKEW,
-                               desc=self.cmd_CALC_MEASURED_SKEW_help)
+                               desc=self.cmd_CALC_MEASURED_SKEW_help,
+                               params=self.cmd_CALC_MEASURED_SKEW_params)
         gcode.register_command('SET_SKEW', self.cmd_SET_SKEW,
-                               desc=self.cmd_SET_SKEW_help)
+                               desc=self.cmd_SET_SKEW_help,
+                               params=self.cmd_SET_SKEW_params)
         gcode.register_command('SKEW_PROFILE', self.cmd_SKEW_PROFILE,
-                               desc=self.cmd_SKEW_PROFILE_help)
+                               desc=self.cmd_SKEW_PROFILE_help,
+                               params=self.cmd_SKEW_PROFILE_params)
     def _handle_connect(self):
         gcode_move = self.printer.lookup_object('gcode_move')
         self.next_transform = gcode_move.set_move_transform(self, force=True)
@@ -87,6 +90,11 @@ class PrinterSkew:
                 fac, math.degrees(fac))
         gcmd.respond_info(out)
     cmd_CALC_MEASURED_SKEW_help = "Calculate skew from measured print"
+    cmd_CALC_MEASURED_SKEW_params = {
+        "AC": {"type": "float", "required": True},
+        "BD": {"type": "float", "required": True},
+        "AD": {"type": "float", "required": True},
+    }
     def cmd_CALC_MEASURED_SKEW(self, gcmd):
         ac = gcmd.get_float("AC", above=0.)
         bd = gcmd.get_float("BD", above=0.)
@@ -95,6 +103,12 @@ class PrinterSkew:
         gcmd.respond_info("Calculated Skew: %.6f radians, %.2f degrees"
                           % (factor, math.degrees(factor)))
     cmd_SET_SKEW_help = "Set skew based on lengths of measured object"
+    cmd_SET_SKEW_params = {
+        "CLEAR": {"type": "int", "default": 0},
+        "XY": {"type": "string", "required": False},
+        "XZ": {"type": "string", "required": False},
+        "YZ": {"type": "string", "required": False},
+    }
     def cmd_SET_SKEW(self, gcmd):
         if gcmd.get_int("CLEAR", 0):
             self._update_skew(0., 0., 0.)
@@ -115,6 +129,11 @@ class PrinterSkew:
                 factor = plane.lower() + '_factor'
                 setattr(self, factor, calc_skew_factor(*lengths))
     cmd_SKEW_PROFILE_help = "Profile management for skew_correction"
+    cmd_SKEW_PROFILE_params = {
+        "LOAD": {"type": "string", "required": False},
+        "SAVE": {"type": "string", "required": False},
+        "REMOVE": {"type": "string", "required": False},
+    }
     def cmd_SKEW_PROFILE(self, gcmd):
         if gcmd.get('LOAD', None) is not None:
             name = gcmd.get('LOAD')

--- a/klippy/extras/smart_effector.py
+++ b/klippy/extras/smart_effector.py
@@ -71,7 +71,8 @@ class SmartEffectorProbe:
             self.control_pin = None
         self.gcode.register_command("SET_SMART_EFFECTOR",
                                     self.cmd_SET_SMART_EFFECTOR,
-                                    desc=self.cmd_SET_SMART_EFFECTOR_help)
+                                    desc=self.cmd_SET_SMART_EFFECTOR_help,
+                                    params=self.cmd_SET_SMART_EFFECTOR_params)
     def _probe_prepare(self):
         toolhead = self.printer.lookup_object('toolhead')
         if self.probe_accel:
@@ -124,6 +125,11 @@ class SmartEffectorProbe:
         toolhead.dwell(end_time - start_time)
         toolhead.wait_moves()
     cmd_SET_SMART_EFFECTOR_help = 'Set SmartEffector parameters'
+    cmd_SET_SMART_EFFECTOR_params = {
+        "SENSITIVITY": {"type": "int", "required": False},
+        "ACCEL": {"type": "float", "required": False},
+        "RECOVERY_TIME": {"type": "float", "required": False},
+    }
     def cmd_SET_SMART_EFFECTOR(self, gcmd):
         sensitivity = gcmd.get_int('SENSITIVITY', None, minval=0, maxval=255)
         respond_info = []

--- a/klippy/extras/stepper_enable.py
+++ b/klippy/extras/stepper_enable.py
@@ -86,7 +86,8 @@ class PrinterStepperEnable:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command('SET_STEPPER_ENABLE', "STEPPER", name,
                                    self.cmd_SET_STEPPER_ENABLE,
-                                   desc=self.cmd_SET_STEPPER_ENABLE_help)
+                                   desc=self.cmd_SET_STEPPER_ENABLE_help,
+                                   params=self.cmd_SET_STEPPER_ENABLE_params)
         enable = setup_enable_pin(self.printer, config.get('enable_pin', None))
         self.enable_lines[name] = EnableTracking(mcu_stepper, enable)
     def set_motors_enable(self, stepper_names, enable):
@@ -128,6 +129,10 @@ class PrinterStepperEnable:
         # Turn off motors
         self.motor_off()
     cmd_SET_STEPPER_ENABLE_help = "Enable/disable individual stepper by name"
+    cmd_SET_STEPPER_ENABLE_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "ENABLE": {"type": "int", "default": 1},
+    }
     def cmd_SET_STEPPER_ENABLE(self, gcmd):
         stepper_name = gcmd.get('STEPPER')
         stepper_enable = gcmd.get_int('ENABLE', 1)

--- a/klippy/extras/temperature_fan.py
+++ b/klippy/extras/temperature_fan.py
@@ -44,7 +44,8 @@ class TemperatureFan:
         gcode.register_mux_command(
             "SET_TEMPERATURE_FAN_TARGET", "TEMPERATURE_FAN", self.name,
             self.cmd_SET_TEMPERATURE_FAN_TARGET,
-            desc=self.cmd_SET_TEMPERATURE_FAN_TARGET_help)
+            desc=self.cmd_SET_TEMPERATURE_FAN_TARGET_help,
+            params=self.cmd_SET_TEMPERATURE_FAN_TARGET_params)
 
     def set_tf_speed(self, read_time, value):
         if value <= 0.:
@@ -77,6 +78,11 @@ class TemperatureFan:
         return status
     cmd_SET_TEMPERATURE_FAN_TARGET_help = \
         "Sets a temperature fan target and fan speed limits"
+    cmd_SET_TEMPERATURE_FAN_TARGET_params = {
+        "TARGET": {"type": "float", "required": False},
+        "MIN_SPEED": {"type": "float", "required": False},
+        "MAX_SPEED": {"type": "float", "required": False},
+    }
     def cmd_SET_TEMPERATURE_FAN_TARGET(self, gcmd):
         temp = gcmd.get_float('TARGET', self.target_temp_conf)
         self.set_temp(temp)

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -112,13 +112,15 @@ class TemperatureProbe:
         self.gcode.register_mux_command(
             "TEMPERATURE_PROBE_CALIBRATE", "PROBE", pname,
             self.cmd_TEMPERATURE_PROBE_CALIBRATE,
-            desc=self.cmd_TEMPERATURE_PROBE_CALIBRATE_help
+            desc=self.cmd_TEMPERATURE_PROBE_CALIBRATE_help,
+            params=self.cmd_TEMPERATURE_PROBE_CALIBRATE_params
         )
 
         self.gcode.register_mux_command(
             "TEMPERATURE_PROBE_ENABLE", "PROBE", pname,
             self.cmd_TEMPERATURE_PROBE_ENABLE,
-            desc=self.cmd_TEMPERATURE_PROBE_ENABLE_help
+            desc=self.cmd_TEMPERATURE_PROBE_ENABLE_help,
+            params=self.cmd_TEMPERATURE_PROBE_ENABLE_params
         )
 
         # Register Drift Compensation Helper with probe
@@ -324,6 +326,12 @@ class TemperatureProbe:
     cmd_TEMPERATURE_PROBE_CALIBRATE_help = (
         "Calibrate probe temperature drift compensation"
     )
+    cmd_TEMPERATURE_PROBE_CALIBRATE_params = {
+        "PROBE": {"type": "string", "required": True},
+        "METHOD": {"type": "string", "default": "manual"},
+        "TARGET": {"type": "float", "required": True},
+        "STEP": {"type": "float", "default": 2.0},
+    }
     def _auto_probe(self, gcmd):
         fo_params = dict(gcmd.get_command_parameters())
         fo_params['METHOD'] = self._method
@@ -443,6 +451,10 @@ class TemperatureProbe:
     cmd_TEMPERATURE_PROBE_ENABLE_help = (
         "Set adjustment factor applied to drift correction"
     )
+    cmd_TEMPERATURE_PROBE_ENABLE_params = {
+        "PROBE": {"type": "string", "required": True},
+        "ENABLE": {"type": "int", "required": True},
+    }
     def cmd_TEMPERATURE_PROBE_ENABLE(self, gcmd):
         if self.cal_helper is not None:
             self.cal_helper.set_enabled(gcmd)

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -350,24 +350,36 @@ class TMCCommandHelper:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("SET_TMC_FIELD", "STEPPER", self.name,
                                    self.cmd_SET_TMC_FIELD,
-                                   desc=self.cmd_SET_TMC_FIELD_help)
+                                   desc=self.cmd_SET_TMC_FIELD_help,
+                                   params=self.cmd_SET_TMC_FIELD_params)
         gcode.register_mux_command("INIT_TMC", "STEPPER", self.name,
                                    self.cmd_INIT_TMC,
-                                   desc=self.cmd_INIT_TMC_help)
+                                   desc=self.cmd_INIT_TMC_help,
+                                   params=self.cmd_INIT_TMC_params)
         gcode.register_mux_command("SET_TMC_CURRENT", "STEPPER", self.name,
                                    self.cmd_SET_TMC_CURRENT,
-                                   desc=self.cmd_SET_TMC_CURRENT_help)
+                                   desc=self.cmd_SET_TMC_CURRENT_help,
+                                   params=self.cmd_SET_TMC_CURRENT_params)
     def _init_registers(self, print_time=None):
         # Send registers
         for reg_name in list(self.fields.registers.keys()):
             val = self.fields.registers[reg_name] # Val may change during loop
             self.mcu_tmc.set_register(reg_name, val, print_time)
     cmd_INIT_TMC_help = "Initialize TMC stepper driver registers"
+    cmd_INIT_TMC_params = {
+        "STEPPER": {"type": "string", "required": True},
+    }
     def cmd_INIT_TMC(self, gcmd):
         logging.info("INIT_TMC %s", self.name)
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         self._init_registers(print_time)
     cmd_SET_TMC_FIELD_help = "Set a register field of a TMC driver"
+    cmd_SET_TMC_FIELD_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "FIELD": {"type": "string", "required": True},
+        "VALUE": {"type": "int", "required": False},
+        "VELOCITY": {"type": "float", "required": False},
+    }
     def cmd_SET_TMC_FIELD(self, gcmd):
         field_name = gcmd.get('FIELD').lower()
         reg_name = self.fields.lookup_register(field_name, None)
@@ -387,6 +399,11 @@ class TMCCommandHelper:
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         self.mcu_tmc.set_register(reg_name, reg_val, print_time)
     cmd_SET_TMC_CURRENT_help = "Set the current of a TMC driver"
+    cmd_SET_TMC_CURRENT_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "CURRENT": {"type": "float", "required": False},
+        "HOLDCURRENT": {"type": "float", "required": False},
+    }
     def cmd_SET_TMC_CURRENT(self, gcmd):
         ch = self.current_helper
         prev_cur, prev_hold_cur, req_hold_cur, max_cur = ch.get_current()
@@ -522,8 +539,13 @@ class TMCCommandHelper:
         gcode = self.printer.lookup_object("gcode")
         gcode.register_mux_command("DUMP_TMC", "STEPPER", self.name,
                                    self.cmd_DUMP_TMC,
-                                   desc=self.cmd_DUMP_TMC_help)
+                                   desc=self.cmd_DUMP_TMC_help,
+                                   params=self.cmd_DUMP_TMC_params)
     cmd_DUMP_TMC_help = "Read and display TMC stepper driver registers"
+    cmd_DUMP_TMC_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "REGISTER": {"type": "string", "required": False},
+    }
     def cmd_DUMP_TMC(self, gcmd):
         logging.info("DUMP_TMC %s", self.name)
         reg_name = gcmd.get('REGISTER', None)

--- a/klippy/extras/tuning_tower.py
+++ b/klippy/extras/tuning_tower.py
@@ -19,8 +19,19 @@ class TuningTower:
         # Register command
         self.gcode = self.printer.lookup_object("gcode")
         self.gcode.register_command("TUNING_TOWER", self.cmd_TUNING_TOWER,
-                                    desc=self.cmd_TUNING_TOWER_help)
+                                    desc=self.cmd_TUNING_TOWER_help,
+                                    params=self.cmd_TUNING_TOWER_params)
     cmd_TUNING_TOWER_help = "Tool to adjust a parameter at each Z height"
+    cmd_TUNING_TOWER_params = {
+        "COMMAND": {"type": "string", "required": True},
+        "PARAMETER": {"type": "string", "required": True},
+        "START": {"type": "float", "default": 0.0},
+        "FACTOR": {"type": "float", "default": 0.0},
+        "BAND": {"type": "float", "default": 0.0},
+        "STEP_DELTA": {"type": "float", "default": 0.0},
+        "STEP_HEIGHT": {"type": "float", "default": 0.0},
+        "SKIP": {"type": "float", "default": 0.0},
+    }
     def cmd_TUNING_TOWER(self, gcmd):
         if self.normal_transform is not None:
             self.end_test()

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -45,7 +45,8 @@ class VirtualSD:
             desc=self.cmd_SDCARD_RESET_FILE_help)
         self.gcode.register_command(
             "SDCARD_PRINT_FILE", self.cmd_SDCARD_PRINT_FILE,
-            desc=self.cmd_SDCARD_PRINT_FILE_help)
+            desc=self.cmd_SDCARD_PRINT_FILE_help,
+            params=self.cmd_SDCARD_PRINT_FILE_params)
         self.printer.register_event_handler("klippy:analyze_shutdown",
                                             self._handle_analyze_shutdown)
     def _handle_analyze_shutdown(self, msg, details):
@@ -153,6 +154,9 @@ class VirtualSD:
         self._reset_file()
     cmd_SDCARD_PRINT_FILE_help = "Loads a SD file and starts the print.  May "\
         "include files in subdirectories."
+    cmd_SDCARD_PRINT_FILE_params = {
+        "FILENAME": {"type": "string", "required": True},
+    }
     def cmd_SDCARD_PRINT_FILE(self, gcmd):
         if self.work_timer is not None:
             raise gcmd.error("SD busy")

--- a/klippy/extras/z_thermal_adjust.py
+++ b/klippy/extras/z_thermal_adjust.py
@@ -57,7 +57,8 @@ class ZThermalAdjuster:
         # Register gcode commands
         self.gcode.register_command('SET_Z_THERMAL_ADJUST',
                                     self.cmd_SET_Z_THERMAL_ADJUST,
-                                    desc=self.cmd_SET_Z_THERMAL_ADJUST_help)
+                                    desc=self.cmd_SET_Z_THERMAL_ADJUST_help,
+                                    params=self.cmd_SET_Z_THERMAL_ADJUST_params)
 
     def handle_connect(self):
         'Called after all printer objects are instantiated'
@@ -183,6 +184,11 @@ class ZThermalAdjuster:
         gcmd.respond_info(msg)
 
     cmd_SET_Z_THERMAL_ADJUST_help = 'Set/query Z Thermal Adjust parameters.'
+    cmd_SET_Z_THERMAL_ADJUST_params = {
+        "ENABLE": {"type": "int", "required": False},
+        "TEMP_COEFF": {"type": "float", "required": False},
+        "REF_TEMP": {"type": "float", "required": False},
+    }
 
 def load_config(config):
     return ZThermalAdjuster(config)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -82,6 +82,13 @@ class ZAdjustStatus:
     def _motor_off(self):
         self.reset()
 
+# Params read by RetryHelper.start() - merge into a command's own
+# cmd_XXX_params instead of duplicating.
+RETRY_HELPER_PARAMS = {
+    "RETRIES": {"type": "int", "required": False},
+    "RETRY_TOLERANCE": {"type": "float", "required": False},
+}
+
 class RetryHelper:
     def __init__(self, config, error_msg_extra = ""):
         self.gcode = config.get_printer().lookup_object('gcode')
@@ -140,12 +147,8 @@ class ZTilt:
                                desc=self.cmd_Z_TILT_ADJUST_help,
                                params=self.cmd_Z_TILT_ADJUST_params)
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
-    cmd_Z_TILT_ADJUST_params = {
-        "RETRIES": {"type": "int", "required": False},
-        "RETRY_TOLERANCE": {"type": "float", "required": False},
-        "METHOD": {"type": "string", "default": "automatic"},
-        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
-    }
+    cmd_Z_TILT_ADJUST_params = dict(
+        probe.PROBE_POINTS_HELPER_PARAMS, **RETRY_HELPER_PARAMS)
     def cmd_Z_TILT_ADJUST(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)

--- a/klippy/extras/z_tilt.py
+++ b/klippy/extras/z_tilt.py
@@ -137,8 +137,15 @@ class ZTilt:
         # Register Z_TILT_ADJUST command
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('Z_TILT_ADJUST', self.cmd_Z_TILT_ADJUST,
-                               desc=self.cmd_Z_TILT_ADJUST_help)
+                               desc=self.cmd_Z_TILT_ADJUST_help,
+                               params=self.cmd_Z_TILT_ADJUST_params)
     cmd_Z_TILT_ADJUST_help = "Adjust the Z tilt"
+    cmd_Z_TILT_ADJUST_params = {
+        "RETRIES": {"type": "int", "required": False},
+        "RETRY_TOLERANCE": {"type": "float", "required": False},
+        "METHOD": {"type": "string", "default": "automatic"},
+        "HORIZONTAL_MOVE_Z": {"type": "float", "required": False},
+    }
     def cmd_Z_TILT_ADJUST(self, gcmd):
         self.z_status.reset()
         self.retry_helper.start(gcmd)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -176,6 +176,7 @@ class GCodeDispatch:
                 "mux command %s %s %s already registered (%s)" % (
                     cmd, key, value, prev_values))
         prev_values[value] = func
+        self._build_status_commands()
     def get_command_help(self):
         return dict(self.gcode_help)
     def get_status(self, eventtime):
@@ -188,6 +189,18 @@ class GCodeDispatch:
         for cmd in self.gcode_params:
             if cmd in commands:
                 commands[cmd]['params'] = self.gcode_params[cmd]
+        # Surface each mux key's registered values as an enum. Copy-on-write
+        # so this never mutates the (possibly class-shared) static dict.
+        for cmd, (key, values) in self.mux_commands.items():
+            if cmd not in commands:
+                continue
+            params = dict(commands[cmd].get('params', {}))
+            key_param = dict(params.get(key, {}))
+            key_param.setdefault('type', 'string')
+            key_param['required'] = None not in values
+            key_param['enum'] = sorted(v for v in values if v is not None)
+            params[key] = key_param
+            commands[cmd]['params'] = params
         self.status_commands = commands
     def register_output_handler(self, cb):
         self.output_callbacks.append(cb)

--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -114,6 +114,7 @@ class GCodeDispatch:
         self.ready_gcode_handlers = {}
         self.mux_commands = {}
         self.gcode_help = {}
+        self.gcode_params = {}
         self.status_commands = {}
         # Register commands needed before config file is loaded
         handlers = ['M110', 'M112', 'M115',
@@ -130,7 +131,8 @@ class GCodeDispatch:
             return cmd[0].isupper() and cmd[1].isdigit()
         except:
             return False
-    def register_command(self, cmd, func, when_not_ready=False, desc=None):
+    def register_command(self, cmd, func, when_not_ready=False, desc=None,
+                         params=None):
         if func is None:
             old_cmd = self.ready_gcode_handlers.get(cmd)
             if cmd in self.ready_gcode_handlers:
@@ -154,12 +156,15 @@ class GCodeDispatch:
             self.base_gcode_handlers[cmd] = func
         if desc is not None:
             self.gcode_help[cmd] = desc
+        if params is not None:
+            self.gcode_params[cmd] = params
         self._build_status_commands()
-    def register_mux_command(self, cmd, key, value, func, desc=None):
+    def register_mux_command(self, cmd, key, value, func, desc=None,
+                             params=None):
         prev = self.mux_commands.get(cmd)
         if prev is None:
             handler = lambda gcmd: self._cmd_mux(cmd, gcmd)
-            self.register_command(cmd, handler, desc=desc)
+            self.register_command(cmd, handler, desc=desc, params=params)
             self.mux_commands[cmd] = prev = (key, {})
         prev_key, prev_values = prev
         if prev_key != key:
@@ -180,6 +185,9 @@ class GCodeDispatch:
         for cmd in self.gcode_help:
             if cmd in commands:
                 commands[cmd]['help'] = self.gcode_help[cmd]
+        for cmd in self.gcode_params:
+            if cmd in commands:
+                commands[cmd]['params'] = self.gcode_params[cmd]
         self.status_commands = commands
     def register_output_handler(self, cb):
         self.output_callbacks.append(cb)

--- a/klippy/kinematics/extruder.py
+++ b/klippy/kinematics/extruder.py
@@ -26,18 +26,24 @@ class ExtruderStepper:
                                             self._handle_connect)
         gcode = self.printer.lookup_object('gcode')
         if self.name == 'extruder':
-            gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER", None,
-                                       self.cmd_default_SET_PRESSURE_ADVANCE,
-                                       desc=self.cmd_SET_PRESSURE_ADVANCE_help)
+            gcode.register_mux_command(
+                "SET_PRESSURE_ADVANCE", "EXTRUDER", None,
+                self.cmd_default_SET_PRESSURE_ADVANCE,
+                desc=self.cmd_SET_PRESSURE_ADVANCE_help,
+                params=self.cmd_SET_PRESSURE_ADVANCE_params)
         gcode.register_mux_command("SET_PRESSURE_ADVANCE", "EXTRUDER",
                                    self.name, self.cmd_SET_PRESSURE_ADVANCE,
-                                   desc=self.cmd_SET_PRESSURE_ADVANCE_help)
-        gcode.register_mux_command("SET_EXTRUDER_ROTATION_DISTANCE", "EXTRUDER",
-                                   self.name, self.cmd_SET_E_ROTATION_DISTANCE,
-                                   desc=self.cmd_SET_E_ROTATION_DISTANCE_help)
+                                   desc=self.cmd_SET_PRESSURE_ADVANCE_help,
+                                   params=self.cmd_SET_PRESSURE_ADVANCE_params)
+        gcode.register_mux_command(
+            "SET_EXTRUDER_ROTATION_DISTANCE", "EXTRUDER", self.name,
+            self.cmd_SET_E_ROTATION_DISTANCE,
+            desc=self.cmd_SET_E_ROTATION_DISTANCE_help,
+            params=self.cmd_SET_E_ROTATION_DISTANCE_params)
         gcode.register_mux_command("SYNC_EXTRUDER_MOTION", "EXTRUDER",
                                    self.name, self.cmd_SYNC_EXTRUDER_MOTION,
-                                   desc=self.cmd_SYNC_EXTRUDER_MOTION_help)
+                                   desc=self.cmd_SYNC_EXTRUDER_MOTION_help,
+                                   params=self.cmd_SYNC_EXTRUDER_MOTION_params)
     def _handle_connect(self):
         self._set_pressure_advance(self.config_pa, self.config_smooth_time)
     def get_status(self, eventtime):
@@ -87,6 +93,11 @@ class ExtruderStepper:
         self.pressure_advance = pressure_advance
         self.pressure_advance_smooth_time = smooth_time
     cmd_SET_PRESSURE_ADVANCE_help = "Set pressure advance parameters"
+    cmd_SET_PRESSURE_ADVANCE_params = {
+        "EXTRUDER": {"type": "string", "required": False},
+        "ADVANCE": {"type": "float", "required": False},
+        "SMOOTH_TIME": {"type": "float", "required": False},
+    }
     def cmd_default_SET_PRESSURE_ADVANCE(self, gcmd):
         extruder = self.printer.lookup_object('toolhead').get_extruder()
         if extruder.extruder_stepper is None:
@@ -108,6 +119,10 @@ class ExtruderStepper:
         self.printer.set_rollover_info(self.name, "%s: %s" % (self.name, msg))
         gcmd.respond_info(msg, log=False)
     cmd_SET_E_ROTATION_DISTANCE_help = "Set extruder rotation distance"
+    cmd_SET_E_ROTATION_DISTANCE_params = {
+        "EXTRUDER": {"type": "string", "required": True},
+        "DISTANCE": {"type": "float", "required": False},
+    }
     def cmd_SET_E_ROTATION_DISTANCE(self, gcmd):
         rotation_dist = gcmd.get_float('DISTANCE', None)
         if rotation_dist is not None:
@@ -130,6 +145,10 @@ class ExtruderStepper:
         gcmd.respond_info("Extruder '%s' rotation distance set to %0.6f"
                           % (self.name, rotation_dist))
     cmd_SYNC_EXTRUDER_MOTION_help = "Set extruder stepper motion queue"
+    cmd_SYNC_EXTRUDER_MOTION_params = {
+        "EXTRUDER": {"type": "string", "required": True},
+        "MOTION_QUEUE": {"type": "string", "required": True},
+    }
     def cmd_SYNC_EXTRUDER_MOTION(self, gcmd):
         ename = gcmd.get('MOTION_QUEUE')
         self.sync_to_extruder(ename)
@@ -188,7 +207,8 @@ class PrinterExtruder:
             gcode.register_command("M109", self.cmd_M109)
         gcode.register_mux_command("ACTIVATE_EXTRUDER", "EXTRUDER",
                                    self.name, self.cmd_ACTIVATE_EXTRUDER,
-                                   desc=self.cmd_ACTIVATE_EXTRUDER_help)
+                                   desc=self.cmd_ACTIVATE_EXTRUDER_help,
+                                   params=self.cmd_ACTIVATE_EXTRUDER_params)
     def get_status(self, eventtime):
         sts = self.heater.get_status(eventtime)
         sts['can_extrude'] = self.heater.can_extrude
@@ -278,6 +298,9 @@ class PrinterExtruder:
         # Set Extruder Temperature and Wait
         self.cmd_M104(gcmd, wait=True)
     cmd_ACTIVATE_EXTRUDER_help = "Change the active extruder"
+    cmd_ACTIVATE_EXTRUDER_params = {
+        "EXTRUDER": {"type": "string", "required": True},
+    }
     def cmd_ACTIVATE_EXTRUDER(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
         if toolhead.get_extruder() is self:

--- a/klippy/kinematics/generic_cartesian.py
+++ b/klippy/kinematics/generic_cartesian.py
@@ -169,7 +169,8 @@ class GenericCartesianKinematics:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command("SET_STEPPER_CARRIAGES",
                                self.cmd_SET_STEPPER_CARRIAGES,
-                               desc=self.cmd_SET_STEPPER_CARRIAGES_help)
+                               desc=self.cmd_SET_STEPPER_CARRIAGES_help,
+                               params=self.cmd_SET_STEPPER_CARRIAGES_params)
     def _load_kinematics(self, config):
         primary_carriages = []
         for mcconfig in config.get_prefix_sections('carriage '):
@@ -353,6 +354,11 @@ class GenericCartesianKinematics:
             'axis_maximum': axes_max,
         }
     cmd_SET_STEPPER_CARRIAGES_help = "Set stepper carriages"
+    cmd_SET_STEPPER_CARRIAGES_params = {
+        "STEPPER": {"type": "string", "required": True},
+        "CARRIAGES": {"type": "string", "required": True},
+        "DISABLE_CHECKS": {"type": "int", "default": 0},
+    }
     def cmd_SET_STEPPER_CARRIAGES(self, gcmd):
         toolhead = self.printer.lookup_object('toolhead')
         toolhead.flush_step_generation()

--- a/klippy/kinematics/idex_modes.py
+++ b/klippy/kinematics/idex_modes.py
@@ -48,15 +48,18 @@ class DualCarriages:
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command(
                    'SET_DUAL_CARRIAGE', self.cmd_SET_DUAL_CARRIAGE,
-                   desc=self.cmd_SET_DUAL_CARRIAGE_help)
+                   desc=self.cmd_SET_DUAL_CARRIAGE_help,
+                   params=self.cmd_SET_DUAL_CARRIAGE_params)
         gcode.register_command(
                    'SAVE_DUAL_CARRIAGE_STATE',
                    self.cmd_SAVE_DUAL_CARRIAGE_STATE,
-                   desc=self.cmd_SAVE_DUAL_CARRIAGE_STATE_help)
+                   desc=self.cmd_SAVE_DUAL_CARRIAGE_STATE_help,
+                   params=self.cmd_SAVE_DUAL_CARRIAGE_STATE_params)
         gcode.register_command(
                    'RESTORE_DUAL_CARRIAGE_STATE',
                    self.cmd_RESTORE_DUAL_CARRIAGE_STATE,
-                   desc=self.cmd_RESTORE_DUAL_CARRIAGE_STATE_help)
+                   desc=self.cmd_RESTORE_DUAL_CARRIAGE_STATE_help,
+                   params=self.cmd_RESTORE_DUAL_CARRIAGE_STATE_params)
     def _init_steppers(self, rails):
         ffi_main, ffi_lib = chelper.get_ffi()
         self.dc_stepper_kinematics = []
@@ -237,6 +240,10 @@ class DualCarriages:
         for dc_rail in self.dc_rails.values():
             dc_rail.apply_transform()
     cmd_SET_DUAL_CARRIAGE_help = "Configure the dual carriages mode"
+    cmd_SET_DUAL_CARRIAGE_params = {
+        "CARRIAGE": {"type": "string", "required": False},
+        "MODE": {"type": "string", "default": "PRIMARY"},
+    }
     def cmd_SET_DUAL_CARRIAGE(self, gcmd):
         carriage_str = gcmd.get('CARRIAGE', None)
         if carriage_str is None:
@@ -280,6 +287,9 @@ class DualCarriages:
         self.activate_dc_mode(dc_rail, mode)
     cmd_SAVE_DUAL_CARRIAGE_STATE_help = \
             "Save dual carriages modes and positions"
+    cmd_SAVE_DUAL_CARRIAGE_STATE_params = {
+        "NAME": {"type": "string", "default": "default"},
+    }
     def cmd_SAVE_DUAL_CARRIAGE_STATE(self, gcmd):
         state_name = gcmd.get('NAME', 'default')
         self.saved_states[state_name] = self.save_dual_carriage_state()
@@ -292,6 +302,11 @@ class DualCarriages:
                 'toolhead_position': tuple(pos)}
     cmd_RESTORE_DUAL_CARRIAGE_STATE_help = \
             "Restore dual carriages modes and positions"
+    cmd_RESTORE_DUAL_CARRIAGE_STATE_params = {
+        "NAME": {"type": "string", "default": "default"},
+        "MOVE_SPEED": {"type": "float", "default": 0.},
+        "MOVE": {"type": "int", "default": 1},
+    }
     def cmd_RESTORE_DUAL_CARRIAGE_STATE(self, gcmd):
         state_name = gcmd.get('NAME', 'default')
         saved_state = self.saved_states.get(state_name)

--- a/klippy/toolhead.py
+++ b/klippy/toolhead.py
@@ -560,7 +560,8 @@ class ToolHeadCommandHelper:
         gcode.register_command('M400', self.cmd_M400)
         gcode.register_command('SET_VELOCITY_LIMIT',
                                self.cmd_SET_VELOCITY_LIMIT,
-                               desc=self.cmd_SET_VELOCITY_LIMIT_help)
+                               desc=self.cmd_SET_VELOCITY_LIMIT_help,
+                               params=self.cmd_SET_VELOCITY_LIMIT_params)
         gcode.register_command('M204', self.cmd_M204)
     def cmd_G4(self, gcmd):
         # Dwell
@@ -570,6 +571,12 @@ class ToolHeadCommandHelper:
         # Wait for current moves to finish
         self.toolhead.wait_moves()
     cmd_SET_VELOCITY_LIMIT_help = "Set printer velocity limits"
+    cmd_SET_VELOCITY_LIMIT_params = {
+        "VELOCITY": {"type": "float", "required": False},
+        "ACCEL": {"type": "float", "required": False},
+        "SQUARE_CORNER_VELOCITY": {"type": "float", "required": False},
+        "MINIMUM_CRUISE_RATIO": {"type": "float", "required": False},
+    }
     def cmd_SET_VELOCITY_LIMIT(self, gcmd):
         max_velocity = gcmd.get_float('VELOCITY', None, above=0.)
         max_accel = gcmd.get_float('ACCEL', None, above=0.)

--- a/scripts/check_gcode_params.py
+++ b/scripts/check_gcode_params.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Check that declared cmd_XXX_params schemas stay in sync with the
+# gcmd.get()/get_int()/get_float()/get_boolean() calls in the matching
+# cmd_XXX handler.
+#
+# This is a proof-of-concept static check for an opt-in convention: a
+# class may declare "cmd_FOO_params = {...}" next to "def cmd_FOO(self,
+# gcmd)" to describe FOO's parameters (see klippy/gcode.py's
+# register_command()/register_mux_command() "params=" argument, and
+# klippy/extras/heaters.py for example declarations). Modules that don't
+# use the convention are skipped entirely - this only checks commands
+# that have opted in.
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import ast, os, sys
+
+GCMD_GETTERS = ('get', 'get_int', 'get_float', 'get_boolean')
+
+def literal_first_arg(call):
+    if not call.args:
+        return None
+    arg = call.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value
+    return None
+
+def gcmd_param_name(func_node):
+    # By convention handlers are "def cmd_XXX(self, gcmd)" - find the
+    # actual parameter name so calls on unrelated objects that merely
+    # happen to also have a get()/get_int()/etc method (eg, a plain
+    # dict from get_start_args()) aren't mistaken for gcmd calls.
+    args = func_node.args.args
+    if len(args) < 2:
+        return None
+    return args[1].arg
+
+def find_used_params(func_node):
+    used = set()
+    dynamic = False
+    gcmd_name = gcmd_param_name(func_node)
+    if gcmd_name is None:
+        return used, True
+    for node in ast.walk(func_node):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in GCMD_GETTERS
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == gcmd_name):
+            continue
+        name = literal_first_arg(node)
+        if name is None:
+            # Non-literal first argument (eg, a loop over axes) - the
+            # schema can't be verified for this call, so don't report
+            # false positives for it.
+            dynamic = True
+            continue
+        used.add(name)
+    return used, dynamic
+
+def check_class(filename, class_node):
+    errors = []
+    param_specs = {}
+    cmd_methods = {}
+    for node in class_node.body:
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id.startswith('cmd_')
+                and node.targets[0].id.endswith('_params')):
+            cmd_name = node.targets[0].id[len('cmd_'):-len('_params')]
+            try:
+                param_specs[cmd_name] = ast.literal_eval(node.value)
+            except ValueError:
+                errors.append("%s:%d: cmd_%s_params is not a literal dict"
+                              % (filename, node.lineno, cmd_name))
+        elif (isinstance(node, ast.FunctionDef)
+              and node.name.startswith('cmd_')):
+            cmd_methods[node.name[len('cmd_'):]] = node
+    for cmd_name, params in param_specs.items():
+        func_node = cmd_methods.get(cmd_name)
+        if func_node is None:
+            errors.append(
+                "%s: cmd_%s_params declared but no cmd_%s handler found"
+                % (filename, cmd_name, cmd_name))
+            continue
+        declared = set(params)
+        used, dynamic = find_used_params(func_node)
+        undeclared = used - declared
+        if undeclared:
+            errors.append(
+                "%s:%d: cmd_%s reads undeclared param(s): %s"
+                % (filename, func_node.lineno, cmd_name,
+                   ", ".join(sorted(undeclared))))
+        unused = declared - used
+        if unused and not dynamic:
+            # Not an error - params consumed elsewhere (eg, the mux key
+            # of a register_mux_command() is read in gcode.py's
+            # _cmd_mux(), not in the handler body) are expected here.
+            sys.stderr.write(
+                "%s:%d: note: cmd_%s declares param(s) not read in its"
+                " own body (may be a mux key, or read elsewhere): %s\n"
+                % (filename, func_node.lineno, cmd_name,
+                   ", ".join(sorted(unused))))
+    return errors
+
+def check_file(filename):
+    with open(filename, 'r', encoding='utf-8') as f:
+        source = f.read()
+    tree = ast.parse(source, filename=filename)
+    errors = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            errors.extend(check_class(filename, node))
+    return errors
+
+def main():
+    files = sys.argv[1:]
+    if not files:
+        sys.stderr.write("Usage: %s <file.py> [file.py ...]\n" % (sys.argv[0],))
+        sys.exit(-1)
+    all_errors = []
+    for filename in files:
+        if not filename.endswith('.py'):
+            continue
+        all_errors.extend(check_file(filename))
+    if all_errors:
+        sys.stderr.write("\nERROR: cmd_XXX_params check failed:\n")
+        for err in all_errors:
+            sys.stderr.write("%s\n" % (err,))
+        sys.exit(-1)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_gcode_params.py
+++ b/scripts/check_gcode_params.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
 # Check that declared cmd_XXX_params schemas stay in sync with the
 # gcmd.get()/get_int()/get_float()/get_boolean() calls in the matching
-# cmd_XXX handler.
-#
-# This is a proof-of-concept static check for an opt-in convention: a
-# class may declare "cmd_FOO_params = {...}" next to "def cmd_FOO(self,
-# gcmd)" to describe FOO's parameters (see klippy/gcode.py's
-# register_command()/register_mux_command() "params=" argument, and
-# klippy/extras/heaters.py for example declarations). Modules that don't
-# use the convention are skipped entirely - this only checks commands
-# that have opted in.
+# cmd_XXX handler. Only checks classes that opt in by declaring
+# cmd_FOO_params (see gcode.py's register_command() "params=" arg).
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import ast, os, sys
@@ -25,10 +18,9 @@ def literal_first_arg(call):
     return None
 
 def gcmd_param_name(func_node):
-    # By convention handlers are "def cmd_XXX(self, gcmd)" - find the
-    # actual parameter name so calls on unrelated objects that merely
-    # happen to also have a get()/get_int()/etc method (eg, a plain
-    # dict from get_start_args()) aren't mistaken for gcmd calls.
+    # Handlers are "def cmd_XXX(self, gcmd)" - get the actual param name
+    # so unrelated objects with a get()/get_int()/etc method aren't
+    # mistaken for gcmd calls.
     args = func_node.args.args
     if len(args) < 2:
         return None
@@ -49,13 +41,38 @@ def find_used_params(func_node):
             continue
         name = literal_first_arg(node)
         if name is None:
-            # Non-literal first argument (eg, a loop over axes) - the
-            # schema can't be verified for this call, so don't report
-            # false positives for it.
+            # Non-literal arg (eg a loop over axes) - can't verify it
             dynamic = True
             continue
         used.add(name)
     return used, dynamic
+
+def extract_declared_params(value_node):
+    # Only the dict's KEYS need verifying, so a "{**shared, 'OWN': {}}"
+    # merge is fine even though it isn't literal_eval-able. Returns
+    # (declared_keys, unresolved); unresolved means the merged-in part
+    # couldn't be read, so the true declared set may be larger.
+    if isinstance(value_node, ast.Dict):
+        declared = set()
+        unresolved = False
+        for key_node, val_node in zip(value_node.keys, value_node.values):
+            if key_node is None:
+                # "**expr" dict-unpacking entry
+                unresolved = True
+                continue
+            if (isinstance(key_node, ast.Constant)
+                    and isinstance(key_node.value, str)):
+                declared.add(key_node.value)
+            else:
+                unresolved = True
+        return declared, unresolved
+    if isinstance(value_node, ast.Call):
+        # eg "dict(probe.PROBE_POINTS_HELPER_PARAMS, SPEED={...})"
+        return set(), True
+    try:
+        return set(ast.literal_eval(value_node)), False
+    except ValueError:
+        return set(), True
 
 def check_class(filename, class_node):
     errors = []
@@ -67,31 +84,26 @@ def check_class(filename, class_node):
                 and node.targets[0].id.startswith('cmd_')
                 and node.targets[0].id.endswith('_params')):
             cmd_name = node.targets[0].id[len('cmd_'):-len('_params')]
-            try:
-                param_specs[cmd_name] = ast.literal_eval(node.value)
-            except ValueError:
-                errors.append("%s:%d: cmd_%s_params is not a literal dict"
-                              % (filename, node.lineno, cmd_name))
+            param_specs[cmd_name] = extract_declared_params(node.value)
         elif (isinstance(node, ast.FunctionDef)
               and node.name.startswith('cmd_')):
             cmd_methods[node.name[len('cmd_'):]] = node
-    for cmd_name, params in param_specs.items():
+    for cmd_name, (declared, decl_unresolved) in param_specs.items():
         func_node = cmd_methods.get(cmd_name)
         if func_node is None:
             errors.append(
                 "%s: cmd_%s_params declared but no cmd_%s handler found"
                 % (filename, cmd_name, cmd_name))
             continue
-        declared = set(params)
         used, dynamic = find_used_params(func_node)
         undeclared = used - declared
-        if undeclared:
+        if undeclared and not decl_unresolved:
             errors.append(
                 "%s:%d: cmd_%s reads undeclared param(s): %s"
                 % (filename, func_node.lineno, cmd_name,
                    ", ".join(sorted(undeclared))))
         unused = declared - used
-        if unused and not dynamic:
+        if unused and not dynamic and not decl_unresolved:
             # Not an error - params consumed elsewhere (eg, the mux key
             # of a register_mux_command() is read in gcode.py's
             # _cmd_mux(), not in the handler body) are expected here.

--- a/scripts/check_gcode_params.sh
+++ b/scripts/check_gcode_params.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to check that declared cmd_XXX_params schemas stay in sync with
+# their handlers (see scripts/check_gcode_params.py).
+
+# Find SRCDIR from the pathname of this script
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd ${SRCDIR}
+
+find klippy -name '*.py' | xargs ./scripts/check_gcode_params.py

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -41,6 +41,15 @@ finish_test check_whitespace "Check whitespace"
 
 
 ######################################################################
+# Check that declared gcode command params match their handlers
+######################################################################
+
+start_test check_gcode_params "Check gcode command params"
+./scripts/check_gcode_params.sh
+finish_test check_gcode_params "Check gcode command params"
+
+
+######################################################################
 # Run compile tests for several different MCU types
 ######################################################################
 


### PR DESCRIPTION
register_command()/register_mux_command() now accept an optional "params" schema alongside the existing "help" string. It's stored in GCodeDispatch.gcode_params and rides the same status_commands pipe already used for help text, so no new API surface is needed - external tools (eg Mainsail) can read a command's accepted parameters instead of guessing or regex-parsing raw config text client-side.

Converted every built-in cmd_XXX command and register_mux_command() across the tree to declare its params. This is purely additive: no gcmd.get()/get_int()/get_float() call, no default value, and no command behavior changes anywhere in this diff - only new cmd_XXX_params class attributes and a params= kwarg added to existing registration calls.

Added scripts/check_gcode_params.py, an AST-based check that a command's declared params stay in sync with what its handler body actually reads. Wired into scripts/ci-build.sh alongside the existing whitespace check.