### PR TITLE
tmc: Amend GSTAT drv_err with DRV_STATUS

### DIFF
--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -129,6 +129,20 @@ class TMCErrorCheck:
         if self.adc_temp_reg is not None:
             pheaters = self.printer.load_object(config, 'heaters')
             pheaters.register_monitor(config)
+    def _debug_drv_status(self):
+        # Try to quickly get the DRV_STATUS to describe GSTAT drv_err
+        reg_info = self.drv_status_reg_info
+        last_value, reg_name, mask, err_mask, cs_actual_mask = reg_info
+        try:
+            val = self.mcu_tmc.get_register(reg_name)
+            if val & mask != last_value & mask:
+                fmt = self.fields.pretty_format(reg_name, val)
+                msg = "TMC '%s' reports %s" % (self.stepper_name, fmt)
+                logging.error(msg)
+                return '\n' + msg
+        except:
+            pass
+        return ""
     def _query_register(self, reg_info, try_clear=False):
         last_value, reg_name, mask, err_mask, cs_actual_mask = reg_info
         cleared_flags = 0
@@ -183,7 +197,11 @@ class TMCErrorCheck:
             if self.adc_temp_reg is not None:
                 self._query_temperature()
         except self.printer.command_error as e:
-            self.printer.invoke_shutdown(str(e))
+            error_string = str(e)
+            if "drv_err" in error_string:
+                describe = self._debug_drv_status()
+                error_string += describe
+            self.printer.invoke_shutdown(error_string)
             return self.printer.get_reactor().NEVER
         return eventtime + 1.
     def stop_checks(self):


### PR DESCRIPTION
This is my attempt to work around an issue where GSTAT can return an error after DRV_STATUS has been read.

This is a brute-force method;
Basically, try to read the DRV_STATUS once if GSTAT's drv_err bit is set.

As I don't want to short my driver, it is tested only by directly injecting the error bit into the value.

So, it should output something like that:
```
TMC 'stepper stepper_z' reports error: GSTAT: 00000002 drv_err=1(ErrorShutdown!)
TMC 'stepper stepper_z' reports DRV_STATUS: ffffffff sg_result=1023 s2vsa=1(ShortToSupply_A!) s2vsb=1(ShortToSupply_B!) stealth=1 fsactive=1 cs_actual=31 stallguard=1 ot=1(OvertempError!) otpw=1(OvertempWarning!) s2ga=1(ShortToGND_A!) s2gb=1(ShortToGND_B!) ola=1(OpenLoad_A!) olb=1(OpenLoad_B!) stst=1
Once the underlying issue is corrected, use the
"FIRMWARE_RESTART" command to reset the firmware, reload the
config, and restart the host software.
Printer is shutdown
```

Thanks,
-Timofey