### PR TITLE
temperature_probe: fix METHOD=tap drift calibration

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1585,14 +1585,16 @@ is enabled.
 
 #### TEMPERATURE_PROBE_CALIBRATE
 `TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]
-[METHOD=<method>]`:
+[METHOD=<method>] [SAMPLE_RETRACT_DIST=<value>]`:
 Initiates probe drift calibration for eddy current based probes.  The `TARGET`
 is a target temperature for the last sample.  When the temperature recorded
 during a sample exceeds the `TARGET` calibration will complete.  The `STEP`
 parameter sets temperature delta (in C) between samples. After a sample has
 been taken, this delta is used to schedule a call to `TEMPERATURE_PROBE_NEXT`.
 The default `STEP` is 2. The `METHOD` only supports `tap` as an option,
-if specified, probing will be automated.
+if specified, probing will be automated.  When `METHOD=tap` is used the
+`SAMPLE_RETRACT_DIST` parameter additionally sets the height above the bed
+that each tap is started from.  The default is 4mm.
 
 #### TEMPERATURE_PROBE_NEXT
 `TEMPERATURE_PROBE_NEXT`: After calibration has started this command is run to

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -96,6 +96,7 @@ class TemperatureProbe:
         self.last_measurement = (0., 99999999., 0.,)
         # Calibration State
         self._method = "manual"
+        self.tap_lift_dist = 4.
         self.cal_helper = None
         self.next_auto_temp = 99999999.
         self.target_temp = 0
@@ -361,6 +362,8 @@ class TemperatureProbe:
         cur_temp = self.last_measurement[0]
         target_temp = gcmd.get_float("TARGET", above=cur_temp)
         step = gcmd.get_float("STEP", 2., minval=1.0)
+        self.tap_lift_dist = gcmd.get_float("SAMPLE_RETRACT_DIST", 4.,
+                                            above=0.)
         expected_count = int(
             (target_temp - cur_temp) / step + .5
         )
@@ -422,12 +425,17 @@ class TemperatureProbe:
         curpos[0] = self.start_pos[0]
         curpos[1] = self.start_pos[1]
         toolhead.manual_move(curpos, move_speed)
-        curpos[2] = start_z
-        toolhead.manual_move(curpos, probe_speed)
         self.gcode.register_command("ABORT", None)
         if self._method == "tap":
+            # Do not descend back to the resting height, it is only resting_z
+            # above the bed. Start the tap from the same distance the tap
+            # itself retracts by.
+            curpos[2] = self.last_zero_pos + self.tap_lift_dist
+            toolhead.manual_move(curpos, lift_speed)
             self._auto_probe(gcmd)
             return
+        curpos[2] = start_z
+        toolhead.manual_move(curpos, probe_speed)
         manual_probe.ManualProbeHelper(
             self.printer, gcmd, self._manual_probe_finalize
         )

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -209,9 +209,10 @@ class TemperatureProbe:
                 "Estimated Total Thermal Expansion: %.6f"
                 % (self.total_expansion,)
             )
-        self.last_zero_pos = mpresult.bed_z
-        toolhead = self.printer.lookup_object("toolhead")
-        tool_zero_z = toolhead.get_position()[2]
+        # Use the probe result, not the live toolhead position, as the bed
+        # reference: a "tap" probe retracts once contact is made, so the
+        # toolhead no longer sits at the bed height when this runs.
+        self.last_zero_pos = tool_zero_z = mpresult.bed_z
         try:
             last_temp = self._collect_sample(mpresult, tool_zero_z)
         except Exception:


### PR DESCRIPTION
## Summary

`TEMPERATURE_PROBE_CALIBRATE ... METHOD=tap` does not currently produce a usable thermal drift calibration, for two separate reasons. Two commits; host-side Python plus a G-Codes.md note. No config file changes.

1. The nine drift samples are collected about 4mm above their intended heights, which puts them outside the range covered by a typical `probe_eddy_current` calibration table. Nothing reports an error.
2. Every tap after the first is started from the resting height, a fraction of a millimetre above the bed, which is far too close for contact to be detected reliably.

The two interact, which is why they are submitted together: the second problem is masked by the first. Before fixing (1) the resting height happens to land about 4mm above the bed, which is a workable place to start a tap from, so taps succeed while the samples are wrong. Fixing (1) puts the resting height where it was meant to be and the taps then start failing.

## 1. Bed reference height

`TemperatureProbe._manual_probe_finalize()` takes the bed reference from the live toolhead position:

```python
self.last_zero_pos = mpresult.bed_z
toolhead = self.printer.lookup_object("toolhead")
tool_zero_z = toolhead.get_position()[2]
...
last_temp = self._collect_sample(mpresult, tool_zero_z)
```

`EddyDriftCompensation.collect_sample()` then treats `tool_zero_z` as the bed contact height. It starts the sweep at `tool_zero_z + .05` and steps up in .5mm increments, but logs the heights as `mpresult.bed_z + i * .5 + .05`:

```python
for i in range(DRIFT_SAMPLE_COUNT):
    if i == 0:
        # Move down to first sample location
        cur_pos[2] = tool_zero_z + .05
    ...
    kin_z = i * .5 + .05 + mpresult.bed_z
```

With `METHOD=manual` the two agree: the toolhead is left resting at the probed contact point when the manual probe is accepted.

With `METHOD=tap` they no longer do. Tap calibration was added in 4cc47cf5 and was fine at the time; de280e237 then moved the retraction into `EddyTap.run_probe()`, which lifts after contact so that tap analysis can be performed during retraction:

```python
lift_dist = gcmd.get_float('SAMPLE_RETRACT_DIST', 4., above=0.)
...
haltpos = toolhead.get_position()
haltpos[2] += lift_dist
toolhead.manual_move(haltpos, lift_speed)
```

So by the time `_manual_probe_finalize()` runs, `toolhead.get_position()[2]` is the contact point plus the pullback distance. With the 4mm default the sweep runs roughly 4.05mm to 8.05mm above the bed instead of the intended 0.05mm to 4.05mm. Because the logged `kin_z` values are computed from `mpresult.bed_z`, they still report the intended heights, so the mismatch is silent.

Fixed by using the probe result rather than the live toolhead position. For `METHOD=manual` the two values coincide, so this is a no-op there.

## 2. Tap start height

Between samples the toolhead is parked at `tool_zero_z + resting_z`, just above the bed, so the coil soaks up heat. `cmd_TEMPERATURE_PROBE_NEXT()` returns to exactly that height before probing, which suits `METHOD=manual`, where the operator steps down from there.

For `METHOD=tap` it does not. docs/Eddy_Probe.md requires a tap to begin 3-20mm above the bed; from `resting_z` (0.4mm by default) there is almost no travel before contact and the change in slope that identifies the contact point is not resolved. Observed on hardware, taps then abort with

```
Unable to detect tap: invalid depress distance (0.015845 vs 0.030000:0.250000)
```

and because that is raised from the temperature callback that schedules the next sample, rather than from a command, it shuts the printer down mid-calibration.

Fixed by starting the tap `SAMPLE_RETRACT_DIST` above the last probed bed position, the same distance `EddyTap.run_probe()` retracts by. It is read once, when the calibration starts, and documented in G-Codes.md since the parameter now has a meaning for `TEMPERATURE_PROBE_CALIBRATE` itself.

## Testing

Voron 2.4, LDC1612 eddy current probe on mainline `probe_eddy_current`, `descend_z: 2`, `PROBE_EDDY_CURRENT_CALIBRATE` table spanning 0.05mm to 4.14mm, `tap_threshold` calibrated with `PROBE_EDDY_CURRENT_TAP_CALIBRATE`.

With the first fix alone, sample heights were correct but the run aborted at the third sample with the "invalid depress distance" error quoted above. With both fixes a full run completed: `TEMPERATURE_PROBE_CALIBRATE PROBE=carto TARGET=58 STEP=2 METHOD=tap`, bed at 90C, coil from 44.0C to 52.6C, six samples, closed with `TEMPERATURE_PROBE_COMPLETE` once the coil stopped rising. The sweep of the first sample:

```
Probe Values at Temp 44.00C, Z 0.0134mm: Avg Freq = 3186366.882900
Probe Values at Temp 44.00C, Z 0.5134mm: Avg Freq = 3138090.399525
Probe Values at Temp 44.00C, Z 1.0134mm: Avg Freq = 3102422.710475
Probe Values at Temp 44.00C, Z 1.5134mm: Avg Freq = 3075626.338375
Probe Values at Temp 44.00C, Z 2.0134mm: Avg Freq = 3055310.730625
Probe Values at Temp 44.00C, Z 2.5134mm: Avg Freq = 3039682.839750
Probe Values at Temp 44.00C, Z 3.0134mm: Avg Freq = 3027503.905375
Probe Values at Temp 44.00C, Z 3.5134mm: Avg Freq = 3017892.725450
Probe Values at Temp 44.00C, Z 4.0134mm: Avg Freq = 3010214.457575
```

i.e. spanning the calibration table as intended, with monotonically decreasing frequency across it. (The pre-fix behaviour of the first problem was not observed directly on this machine, since the fix was applied before the first run; it follows from the pullback distance.) `temperature_probe carto: generated 9 2D polynomials` was reported, and the resulting table loads and validates on restart:

```
temperature_probe carto: loaded temperature drift calibration. Min Temp: 44.00, Min Freq: 3008512.386450
```

The tap results across that whole 8.5C sweep were -0.036551, -0.035403, -0.037313, -0.034624, -0.040874 and -0.031127, a spread of under 10um, which is consistent with tap being insensitive to coil temperature (on this machine a scanning probe moves about 37um per degree C of coil temperature).

Re-verified on the same machine after applying the review suggestions, from a cold start (coil 31C, bed 27C): three samples collected with no tap failures, i.e. exercising the new start height on samples 2 and 3. Sweep of the third, against a tap contact reported at z=-0.268779:

```
Probe Values at Temp 36.96C, Z -0.2188mm: Avg Freq = 3197554.081500
Probe Values at Temp 36.96C, Z 0.2812mm: Avg Freq = 3146937.308625
...
Probe Values at Temp 36.96C, Z 3.7812mm: Avg Freq = 3012220.732175
```

i.e. 0.05mm to 4.05mm above the contact point, as intended. That run was ended with `TEMPERATURE_PROBE_ABORT` rather than saved.

`python3 -m py_compile klippy/extras/temperature_probe.py` passes.
