### PR TITLE
trigger_analog: Fix int32 magnitude check for TT_ABS_GE on AVR

### DIFF
--- a/src/trigger_analog.c
+++ b/src/trigger_analog.c
@@ -89,8 +89,11 @@ static int
 check_trigger(struct trigger_analog *ta, uint32_t time, int32_t value)
 {
     switch (ta->trigger_type) {
-    case TT_ABS_GE:
-        return abs(value) >= ta->trigger_value;
+    case TT_ABS_GE: {
+        // Note: stdlib's abs() is int(16) on AVR; use a 32-bit safe form.
+        int32_t mag = value < 0 ? -value : value;
+        return mag >= ta->trigger_value;
+    }
     case TT_GT:
         return value > ta->trigger_value;
     case TT_DIFF_PEAK_GT:


### PR DESCRIPTION
`check_trigger()` computes the `TT_ABS_GE` magnitude with `abs()`, which
`<stdlib.h>` declares as `int abs(int)`. On AVR `int` is 16-bit, so the `int32_t`
argument is narrowed at the call: the magnitude is taken over the low 16 bits and
sign-extended back to 32 bits before the comparison against `trigger_value`. gcc
emits no warning for this, even under `-Wall`.

The fix computes the magnitude explicitly at `int32_t` width so the comparison
does not depend on the width of the target's `int`. Targets where `int` is 32-bit
— all ARM boards — are unaffected; the narrowing conversion was already a no-op
there.

## Impact

The truncated magnitude is confined to [-32768, 32767]. `load_cell_probe` scales
both sides of the comparison by `FRAC_GRAMS_CONV` (32768), so that ceiling is
just under one gram, while `trigger_value` for the default `trigger_force` of
75.0 g is 2457600. The comparison is never true, and a load cell probe never
triggers on AVR at any realistic trigger force.

Worked examples, where `value` is the filtered reading in 1/32768-gram units:

| force | `value` | low 16 as int16 | 16-bit `abs()` | fires | should fire |
|-------|---------|-----------------|----------------|-------|-------------|
| 1 g   | 32768   | -32768          | -32768         | no    | no          |
| 50 g  | 1638400 | 0               | 0              | no    | no          |
| 75 g  | 2457600 | -32768          | -32768         | no    | **yes**     |
| 100 g | 3276800 | 0               | 0              | no    | **yes**     |
| 150 g | 4915200 | 0               | 0              | no    | **yes**     |

The 1 g row is a further corner: the 16-bit magnitude of -32768 is still -32768,
so `abs()` returns a negative number.

The safety path is unaffected. The raw range check in `trigger_analog_update()`
uses the separate full-width `raw_min`/`raw_max` compares, so an over-force
condition still aborts homing with a `RAW_RANGE` error. The failure mode is
"probe never triggers", not "probe drives into the bed".

## Evidence

Compiling both forms in isolation with `avr-gcc -mmcu=atmega2560 -O2 -Wall`
(`__SIZEOF_INT__` is 2) — `old_form` narrows to the low half and branches on
bit 15, `new_form` branches on bit 31:

```
00000000 <old_form>:            00000044 <new_form>:
   4:  ab 01   movw r20, r22      4c:  97 fd   sbrc r25, 7
   6:  77 fd   sbrc r23, 7
```

The same difference appears in the built `atmega2560` firmware, inside
`trigger_analog_update()` (LTO inlines `check_trigger`):

```
before:  movw r24, r4     ; loads only the low 16 bits (r4:r5)
         sbrc r5, 7       ; branches on bit 15

after:   movw r26, r6     ; also loads the high half (r6:r7)
         movw r24, r4
         sbrc r7, 7       ; branches on bit 31
```

`.text` is 43084 bytes before and after, so the fix is size-neutral on AVR.

## Reach

`TT_ABS_GE` is the only trigger type `load_cell_probe` uses
(`load_cell_probe.py:338`), and it is reachable on AVR: the `atmega2560` and
`atmega644p` dictionaries both contain `config_trigger_analog`, the `abs_ge`
enumeration, and `hx71x_attach_trigger_analog` / `ads1220_attach_trigger_analog`
/ `analog_in_attach_trigger_analog`. The hx71x bit-bang path in particular is a
natural fit for AVR boards.

I don't have a field report for this and can't size the affected user base — it
surfaced while running the AVR regression configs under simavr, not on a printer.
What I can say is that the feature is non-functional rather than degraded on that
MCU family, the root cause is a language-level narrowing rather than a tuning
question, and the fix is three lines with no effect on 32-bit-int targets.

## Testing

I have not run this on a printer and cannot. Verifying it on hardware needs an
8-bit AVR board *and* a load cell ADC wired to it, which is an uncommon pairing —
most load cell installs are on 32-bit boards, where the bug does not exist. My
own printer is an stm32f103xe with a bltouch and no load cell, so it is
unaffected in both respects. My verification is static and simulated only. If a
reviewer considers that insufficient for merge, I understand, and I would rather
say so plainly than imply field testing I did not do.

**Reviewer check, no hardware, about a minute.** `avr-gcc` is already installed
by `scripts/ci-install.sh`:

```c
// repro.c
#include <stdlib.h>
#include <stdint.h>
int32_t trigger_value;
int old_form(int32_t v) { return abs(v) >= trigger_value; }
int new_form(int32_t v) { int32_t mag = v < 0 ? -v : v; return mag >= trigger_value; }
```

```
avr-gcc -mmcu=atmega2560 -O2 -Wall -c repro.c -o repro.o   # no warnings
avr-objdump -d repro.o | grep -E '<(old|new)_form>:|movw|sbrc'
```

This produces the disassembly quoted under Evidence.

**If anyone has the hardware,** `LOAD_CELL_TEST_TAP` is the cheapest check — it
detects a finger tap with no toolhead motion, so there is no bed-contact risk:

1. Configure `[load_cell]` + `[load_cell_probe]` with the default `trigger_force`.
2. Run `LOAD_CELL_TEST_TAP TAPS=3`.
3. Before the fix: no tap is detected and the command fails with
   `Test timeout out`, however hard the cell is pressed.
4. After the fix: each tap reports `Tap Detected!`.

`LOAD_CELL_READ` shows sane force values in both cases — the sensor, filtering,
and reporting path all work. Only the trigger comparison is broken.

**Regression gate**, on a branch rebased onto current master (one commit, one
file):

- All 40 `test/configs/*.config` targets build clean
- `scripts/test_klippy.py -d dict test/klippy/*.test` — all 37 test cases pass,
  against a dictionary set built from this branch
- `klippy.py --import-test` clean
- `scripts/check_whitespace.sh` clean

The klippy regression suite drives MCU dictionaries over a simulated serial link
and never executes AVR code, so it does not exercise this path. The AVR build and
the disassembly are the meaningful checks.
