### PR TITLE
trigger_analog: Fix build error from label followed by declaration

### DIFF
--- a/src/trigger_analog.c
+++ b/src/trigger_analog.c
@@ -88,9 +88,10 @@ static int
 check_trigger(struct trigger_analog *ta, uint32_t time, int32_t value)
 {
     switch (ta->trigger_type) {
-    case TT_ABS_GE:
+    case TT_ABS_GE: {
         uint32_t abs_value = value < 0 ? -value : value;
         return abs_value >= ta->trigger_value;
+    }
     case TT_GT:
         return value > ta->trigger_value;
     case TT_DIFF_PEAK_GT:


### PR DESCRIPTION
Commit cab2f00408daa56d4006e91244a7427b194eea06 introduced a variable declaration directly after a case label in check_trigger(), which some C compilers (gcc 10.2.1-6 in my case) reject with "a label can only be part of a statement and a declaration is not a statement". I scoped the case section using braces, now it builds for me.

