### PR TITLE
temperature_probe: restore drift compensation on failed cal

### DIFF
--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -522,6 +522,7 @@ class EddyDriftCompensation:
                 "disabling temperature drift compensation."
                 % (self.name,)
             )
+        self.pre_cal_enabled = self.enabled
 
     def is_enabled(self):
         return self.enabled
@@ -620,6 +621,7 @@ class EddyDriftCompensation:
         return sample_temp
 
     def start_calibration(self):
+        self.pre_cal_enabled = self.enabled
         self.enabled = False
         self.calibration_samples = [[] for _ in range(DRIFT_SAMPLE_COUNT)]
 
@@ -627,6 +629,11 @@ class EddyDriftCompensation:
         cal_samples = self.calibration_samples
         self.calibration_samples = None
         if not success:
+            # Restore the prior enabled state rather than forcing it on:
+            # compensation may have already been disabled (via ENABLE=0,
+            # no drift_calibration configured, or no calibration_temp
+            # set), and an aborted or failed run should not change that.
+            self.enabled = self.pre_cal_enabled
             return
         gcode = self.printer.lookup_object("gcode")
         if len(cal_samples) < 3:


### PR DESCRIPTION
## Summary

Aborting or failing a `TEMPERATURE_PROBE_CALIBRATE` run leaves eddy current thermal drift compensation switched off, with no message, until the printer is restarted. Every eddy scan afterwards - including `BED_MESH_CALIBRATE` - silently loses its temperature correction.

Host-side Python only, one line plus a restore and a comment.

## Cause

`EddyDriftCompensation.start_calibration()` disables compensation for the duration of the run:

```python
def start_calibration(self):
    self.enabled = False
    ...
```

`finish_calibration()` is the only place it could come back, and on an unsuccessful run it returns before touching `self.enabled`:

```python
def finish_calibration(self, success):
    cal_samples = self.calibration_samples
    self.calibration_samples = None
    if not success:
        return
    ...
```

`TemperatureProbe._finalize_drift_cal()` passes `success=False` for `TEMPERATURE_PROBE_ABORT`, for `TEMPERATURE_PROBE_COMPLETE` with fewer than three collected samples, and for any exception raised during the run, such as a failed probe or a failed move. `adjust_freq()` and `unadjust_freq()` both early-return on `not self.enabled`, so from that point on the correction is simply not applied.

Nothing reports this, and the printer carries on as if compensation were active.

## Fix

Save the enabled state in `start_calibration()` and restore it in `finish_calibration()` when the run does not succeed.

Restoring rather than forcing it on: compensation may legitimately have been off before the run started, whether via `TEMPERATURE_PROBE_ENABLE ENABLE=0`, because no `drift_calibration` is configured, or because `calibration_temp` is unset. All three are set up in the constructor, and an aborted run should not change any of them.

The success path is deliberately left alone. A completed calibration only writes the new polynomials to the config file, so compensation stays off until `SAVE_CONFIG` restarts the printer with them loaded. That seems right: the user is explicitly told to run `SAVE_CONFIG`, and re-enabling with the calibration that is about to be replaced would be the wrong behaviour.

Independent of #7327, which touches the same file for an unrelated failure mode. This change does not depend on it.

## Why it matters

On the machine this was found on, the correction is worth about 3um per degree C of probe coil temperature at the 2mm scan height - derived from the fitted polynomials themselves, which are referenced to a tap at each sample and so contain no machine motion - rising to ~6.6um/K at 4mm as sensitivity falls off. The coil swings roughly 20C between a cold printer and a soaked one, so silently losing the correction costs tens of microns across a mesh, with nothing to indicate why. Aborting a calibration part-way through is an easy thing to do - the run can take half an hour or more, since it waits for the coil to heat between samples.

## Testing

Not reproduced on hardware for this submission, and I would rather say so than imply otherwise. The basis is code tracing: `start_calibration()` and `finish_calibration()`, the call sites that reach `_finalize_drift_cal()` with `success=False`, and the `not self.enabled` guards in `adjust_freq()` and `unadjust_freq()`.

What was checked directly: the module compiles, and the diff touches only the failure branch plus the state saved immediately before it, so the success path is byte-for-byte unchanged.

