### PR TITLE
temperature_probe: fix command_error handling

### DIFF
--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -400,7 +400,11 @@ class TemperatureProbe:
         toolhead = self.printer.lookup_object("toolhead")
         self.start_pos = toolhead.get_position()[:2]
         if self._method == "tap":
-            self._auto_probe(gcmd)
+            try:
+                self._auto_probe(gcmd)
+            except self.printer.command_error:
+                self._finalize_drift_cal(False)
+                raise
             return
         manual_probe.ManualProbeHelper(
             self.printer, gcmd, self._manual_probe_finalize
@@ -425,7 +429,10 @@ class TemperatureProbe:
         toolhead.manual_move(curpos, probe_speed)
         self.gcode.register_command("ABORT", None)
         if self._method == "tap":
-            self._auto_probe(gcmd)
+            try:
+                self._auto_probe(gcmd)
+            except self.printer.command_error as e:
+                self._finalize_drift_cal(False, str(e))
             return
         manual_probe.ManualProbeHelper(
             self.printer, gcmd, self._manual_probe_finalize


### PR DESCRIPTION
Follow-up for #7327, #7330.
As Tap can produce exceptions since #7249

It can happen that upon an unsuccessful tap ([VoronDiscord](https://discord.com/channels/460117602945990666/1535342461579165777/1535421234337161267)) during temperature calibration, the exception will go to the reactor, and the machine will shut down:
`_check_kick_next() -> self.gcode.run_script("TEMPERATURE_PROBE_NEXT") -> self._auto_probe(gcmd)`

This patch is my attempt to handle them gracefully.
I've reproduced the behaviour by setting tap_threshold low enough to trigger something.

Regards,
-Timofey