### PR TITLE
load_cell_probe: use live/last tare count for safety range

### DIFF
--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -264,7 +264,7 @@ class LoadCellProbeConfigHelper:
     def get_safety_range(self, gcmd=None):
         counts_per_gram = self._load_cell.get_counts_per_gram()
         # calculate the safety band
-        zero = self._load_cell.get_reference_tare_counts()
+        zero = self._load_cell.get_tare_counts()
         safety_counts = int(counts_per_gram * self.get_safety_limit_grams(gcmd))
         safety_min = int(zero - safety_counts)
         safety_max = int(zero + safety_counts)


### PR DESCRIPTION
Upon probing at different temperatures, tare count can drift from the calibrated value.
It seems that for the safety range, we can reuse the last known live value.

So, basically, now, before the probe attempt:
_pause_and_tare() -> self._load_cell.tare(tare_counts) -> self.tare_counts = int(tare_counts)
self._config_helper.get_safety_range(gcmd) -> zero = self._load_cell.get_tare_counts() -> return self.tare_counts

Instead of a fixed reference tare count.

I guess it is disputable, as we had a reference tare count, and probably a live one can be off a bit.
But I guess if we doubt the current tare value, I guess, we should use it.
So, I hope it is a safe change. As long as the current tare value is as safe as the reference one.

I can imagine only one failure condition, where the load cell was preloaded during the live tare. So, basically, if tare happens when the nozzle is already compressed/depressed into the bed, it can be a problem.

Reported by: @vzagranichnyy

Thanks,
-Timofey
