### PR TITLE
configfile: Fix AUTOSAVE parameter loss when masked by main config

### DIFF
--- a/klippy/configfile.py
+++ b/klippy/configfile.py
@@ -291,6 +291,13 @@ class ConfigAutoSave:
             if fileconfig.has_option(section, field):
                 is_dup_field = True
                 lines[lineno] = '#' + lines[lineno]
+                msg = ("SAVE_CONFIG section '%s' option '%s' is"
+                       " overridden by main config" % (section, field))
+                pconfig = self.printer.lookup_object('configfile', None)
+                if pconfig is not None:
+                    pconfig.runtime_warning(msg)
+                else:
+                    logging.warning(msg)
         return "\n".join(lines)
     def load_main_config(self):
         filename = self.printer.get_start_args()['config_file']


### PR DESCRIPTION
### Summary

When loading main configuration in `ConfigAutoSave.load_main_config()`, `autosave_data` was previously stripped of duplicates before initializing `self.fileconfig`. As a result, parameters that were present in the main configuration file (or included files) were removed from `self.fileconfig`. When a subsequent `SAVE_CONFIG` was issued (e.g., after running `Z_OFFSET_APPLY_ENDSTOP` on a delta printer), the reconstructed `*AUTOSAVE*` block was built from `self.fileconfig`, resulting in permanent loss of those parameters (such as delta calibration angles, arm lengths, or updated endstop positions).

This commit preserves the full `autosave_data` when building `self.fileconfig`, while passing `autosave_data_stripped` to `regular_fileconfig` to properly handle duplicate option precedence during runtime lookups.

### Test Plan

1. Perform `DELTA_CALIBRATE` and issue `SAVE_CONFIG` on a delta printer setup.
2. Restart and verify that calibration parameters are written under the `*AUTOSAVE*` section.
3. Perform endstop calibration (`Z_OFFSET_APPLY_ENDSTOP`) and issue `SAVE_CONFIG`.
4. Verify that all delta calibration parameters (`angle`, `arm_length`, `position_endstop`) remain intact under `*AUTOSAVE*` and are not overwritten by initial main config values.