### PR TITLE
avr: implement bootloader_request() for LUFA/Caterina bootloaders

### DIFF
--- a/src/avr/Kconfig
+++ b/src/avr/Kconfig
@@ -12,6 +12,7 @@ config AVR_SELECT
     select HAVE_GPIO_HARD_PWM
     select HAVE_STRICT_TIMING
     select HAVE_LIMITED_CODE_SIZE if MACH_atmega168 || MACH_atmega328 || MACH_atmega328p || MACH_atmega32u4 || MACH_lgt8f328p
+    select HAVE_BOOTLOADER_REQUEST if USBSERIAL
 
 config BOARD_DIRECTORY
     string

--- a/src/avr/Makefile
+++ b/src/avr/Makefile
@@ -16,7 +16,7 @@ src-$(CONFIG_WANT_SPI) += avr/spi.c
 src-$(CONFIG_WANT_I2C) += avr/i2c.c
 src-$(CONFIG_WANT_HARD_PWM) += avr/hard_pwm.c
 src-$(CONFIG_AVR_WATCHDOG) += avr/watchdog.c
-src-$(CONFIG_USBSERIAL) += avr/usbserial.c generic/usb_cdc.c
+src-$(CONFIG_USBSERIAL) += avr/usbserial.c generic/usb_cdc.c avr/bootloader.c
 src-$(CONFIG_SERIAL) += avr/serial.c generic/serial_irq.c
 
 # Suppress broken "misspelled signal handler" warnings on gcc 4.8.1

--- a/src/avr/bootloader.c
+++ b/src/avr/bootloader.c
@@ -1,0 +1,27 @@
+// AVR support for bootloader entry
+//
+// Copyright (C) 2026  Hans-Albert Maritz <maritz.hans@gmail.com>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h"
+#include <avr/io.h>
+#include <avr/wdt.h>
+#include <stdint.h>
+
+// Caterina and compatible LUFA CDC bootloaders (Arduino Leonardo, Pro Micro,
+// Prusa MMU3, etc.) check for a magic word at RAMEND-1 after a watchdog reset.
+// If present the bootloader holds for ~8s to allow programming; if absent it
+// jumps to the application immediately.  A watchdog reset does not clear SRAM,
+// so the word written here survives to be read by the bootloader.
+#define MAGIC_BOOT_KEY 0x7777u
+
+// Handle reboot requests
+void
+bootloader_request(void)
+{
+    *(volatile uint16_t *)(RAMEND - 1) = MAGIC_BOOT_KEY;
+    wdt_enable(WDTO_15MS);
+    for (;;)
+        ;
+}


### PR DESCRIPTION
## Problem

`usb_cdc.c` already calls `bootloader_request()` when the host opens the serial port at 1200 baud with DTR deasserted (the Arduino/Caterina-style bootloader entry protocol used by `make flash` and tools like `avrdude`). However, the AVR platform had no implementation of this function — the symbol resolved to a weak no-op, so the 1200-baud trigger silently did nothing on all AVR boards.

## Fix

Add `src/avr/bootloader.c` implementing `bootloader_request()` for AVR:

1. Writes the LUFA/Caterina magic word (`0x7777`) to address `RAMEND-1` in a `.noinit` section. The `.noinit` placement is critical: a watchdog reset does **not** zero SRAM, so the value survives to be read by the bootloader. A power-on reset does zero SRAM, which is why the magic word must be written immediately before the reset.

2. Enables the watchdog at 15 ms and spins. The MCU resets, the bootloader reads the magic word, and holds for ~8 seconds to allow `avrdude` to connect.

## Affected boards

Any ATmega32U4 (and potentially other AVR) board with a Caterina-compatible or LUFA CDC bootloader:
- Arduino Leonardo
- Arduino/Sparkfun Pro Micro  
- Prusa MMU3 control board
- Others using the `0x7777` magic word convention

## Testing

Verified on a Prusa MMU3 board (ATmega32U4, LUFA CDC bootloader). Before this fix, `make flash FLASH_DEVICE=...` with the 1200-baud trigger did nothing. After this fix, the board correctly enters the bootloader and `avrdude` flashes successfully.