### PR TITLE
config: Add optional MightyBoard laser output

### DIFF
--- a/config/sample-mightyboard-laser.cfg
+++ b/config/sample-mightyboard-laser.cfg
@@ -1,0 +1,36 @@
+# Optional PWM laser configuration for a MightyBoard Rev.E.
+#
+# This reuses PL5 (the optional FET-F output), so remove or comment out the
+# [fan] section using PL5 before including this file. The FET output is not a
+# TTL laser-control signal. Use an electrically appropriate interface and an
+# independent, normally-open hardware interlock that removes laser power.
+# Never rely on software alone for laser safety.
+
+[pwm_tool laser]
+pin: PL5
+hardware_pwm: True
+cycle_time: 0.001
+value: 0
+shutdown_value: 0
+maximum_mcu_duration: 2
+
+[gcode_macro M3]
+description: Set constant laser power (S0-S255)
+gcode:
+    {% set requested = params.S|default(0)|float %}
+    {% set power = 0.0 if requested < 0.0 else 255.0 if requested > 255.0 else requested %}
+    SET_PIN PIN=laser VALUE={power / 255.0}
+
+# Dynamic velocity-compensated power is not implemented. M4 intentionally
+# behaves like M3 so common CAM output remains usable without silent failure.
+[gcode_macro M4]
+description: Set laser power (constant-power compatibility mode)
+gcode:
+    {% set requested = params.S|default(0)|float %}
+    {% set power = 0.0 if requested < 0.0 else 255.0 if requested > 255.0 else requested %}
+    SET_PIN PIN=laser VALUE={power / 255.0}
+
+[gcode_macro M5]
+description: Disable laser output
+gcode:
+    SET_PIN PIN=laser VALUE=0


### PR DESCRIPTION
## Summary

- add an optional PWM laser configuration for MightyBoard Rev.E FET-F / PL5
- provide M3, constant-power M4 compatibility, and M5 macros
- require an electrically appropriate interface and independent normally-open hardware interlock
- document the PL5 conflict with the normal fan output

This is intentionally separate from the MakerBot Replicator printer profile in #7335. Dynamic velocity-compensated M4 power is not implemented.

## Testing

- git diff --check
- reviewed against config/sample-pwm-tool.cfg and docs/Using_PWM_Tools.md