### PR TITLE
display_status: Support M73 remaining time

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -329,7 +329,8 @@ The display_status module is automatically loaded if a
 [display config section](Config_Reference.md#display) is enabled. It
 provides the following standard G-Code commands:
 - Display Message: `M117 <message>`
-- Set build percentage: `M73 P<percent>`
+- Set build percentage and/or remaining print time:
+  `M73 [P<percent>] [R<minutes>]`
 
 Also provided is the following extended G-Code command:
 - `SET_DISPLAY_TEXT MSG=<message>`: Performs the equivalent of M117,

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -87,6 +87,8 @@ The following information is available in the `display_status` object
 [display](Config_Reference.md#display) config section is defined):
 - `progress`: The progress value of the last `M73` G-Code command (or
   `virtual_sdcard.progress` if no recent `M73` received).
+- `remaining_time`: The remaining print time in seconds from the last
+  `M73 R` parameter, or `None` if no remaining time was supplied.
 - `message`: The message contained in the last `M117` G-Code command.
 
 ## endstop_phase

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -11,7 +11,7 @@ class DisplayStatus:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.expire_progress = 0.
-        self.progress = self.message = None
+        self.progress = self.remaining_time = self.message = None
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('M73', self.cmd_M73)
@@ -21,22 +21,29 @@ class DisplayStatus:
             desc=self.cmd_SET_DISPLAY_TEXT_help)
     def get_status(self, eventtime):
         progress = self.progress
-        if progress is not None and eventtime > self.expire_progress:
+        if ((progress is not None or self.remaining_time is not None)
+                and eventtime > self.expire_progress):
             idle_timeout = self.printer.lookup_object('idle_timeout')
             idle_timeout_info = idle_timeout.get_status(eventtime)
             if idle_timeout_info['state'] != "Printing":
                 self.progress = progress = None
+                self.remaining_time = None
         if progress is None:
             progress = 0.
             sdcard = self.printer.lookup_object('virtual_sdcard', None)
             if sdcard is not None:
                 progress = sdcard.get_status(eventtime)['progress']
-        return { 'progress': progress, 'message': self.message }
+        return { 'progress': progress, 'remaining_time': self.remaining_time,
+                 'message': self.message }
     def cmd_M73(self, gcmd):
         progress = gcmd.get_float('P', None)
+        remaining = gcmd.get_float('R', None, minval=0.)
         if progress is not None:
             progress = progress / 100.
             self.progress = min(1., max(0., progress))
+        if remaining is not None:
+            self.remaining_time = remaining * 60.
+        if progress is not None or remaining is not None:
             curtime = self.printer.get_reactor().monotonic()
             self.expire_progress = curtime + M73_TIMEOUT
     def cmd_M117(self, gcmd):

--- a/test/klippy/sdcard_loop.test
+++ b/test/klippy/sdcard_loop.test
@@ -4,6 +4,8 @@ DICTIONARY atmega2560.dict
 CONFIG sdcard_loop.cfg
 
 G28
+M73 P25 R90
+M73 R89
 SDCARD_LOOP_DESIST
 ; Verify long-name functions
 SDCARD_PRINT_FILE FILENAME=big.gcode


### PR DESCRIPTION
## Summary

- accept the standard `R<minutes>` parameter in `M73`
- expose the supplied value as `display_status.remaining_time` in seconds
- allow `P` and `R` to be supplied independently
- clear stale remaining time after printing ends
- document the G-Code and status field

This is a generic core change and is independent of the MakerBot/MightyBoard profile. LCD layout changes are intentionally left for a separate follow-up.

## Testing

- `git diff --check`
- `python3 -m py_compile klippy/extras/display_status.py`
- `./scripts/check_whitespace.sh`
- isolated DisplayStatus checks for P/R conversion, R-only updates, and expiry
- added M73 P/R smoke commands to `test/klippy/sdcard_loop.test`