### PR TITLE
display: Add optional 20x4 print time layout

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4557,7 +4557,9 @@ lcd_type:
 #   The name of the display_data group to show on the display. This
 #   controls the content of the screen (see the "display_data" section
 #   for more information). The default is _default_20x4 for hd44780 or
-#   aip31068_spi displays and _default_16x4 for other displays.
+#   aip31068_spi displays and _default_16x4 for other displays. The
+#   optional _print_time_20x4 group displays elapsed and remaining time
+#   on a 20x4 display.
 #menu_timeout:
 #   Timeout for menu. Being inactive this amount of seconds will
 #   trigger menu exit or return to root menu when having autorun

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -329,7 +329,8 @@ The display_status module is automatically loaded if a
 [display config section](Config_Reference.md#display) is enabled. It
 provides the following standard G-Code commands:
 - Display Message: `M117 <message>`
-- Set build percentage: `M73 P<percent>`
+- Set build percentage and/or remaining print time:
+  `M73 [P<percent>] [R<minutes>]`
 
 Also provided is the following extended G-Code command:
 - `SET_DISPLAY_TEXT MSG=<message>`: Performs the equivalent of M117,

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -87,6 +87,8 @@ The following information is available in the `display_status` object
 [display](Config_Reference.md#display) config section is defined):
 - `progress`: The progress value of the last `M73` G-Code command (or
   `virtual_sdcard.progress` if no recent `M73` received).
+- `remaining_time`: The remaining print time in seconds from the last
+  `M73 R` parameter, or `None` if no remaining time was supplied.
 - `message`: The message contained in the last `M117` G-Code command.
 
 ## endstop_phase

--- a/klippy/extras/display/display.cfg
+++ b/klippy/extras/display/display.cfg
@@ -193,6 +193,49 @@ text: { render("_print_status") }
 
 
 ######################################################################
+# Alternative 20x4 layout with elapsed and remaining print time
+######################################################################
+
+[display_data _print_time_20x4 extruder]
+position: 0, 0
+text: { render("_heater_temperature", param_heater_name="extruder") }
+
+[display_data _print_time_20x4 heater_bed]
+position: 0, 10
+text: { render("_heater_temperature", param_heater_name="heater_bed") }
+
+[display_data _print_time_20x4 extruder1]
+position: 1, 0
+text: { render("_heater_temperature", param_heater_name="extruder1") }
+
+[display_data _print_time_20x4 fan]
+position: 1, 10
+text:
+  {% if 'fan' in printer %}
+    { "Fan {:^4.0%}".format(printer.fan.speed) }
+  {% endif %}
+
+[display_data _print_time_20x4 print_time]
+position: 2, 0
+text:
+  {% set elapsed = printer.idle_timeout.printing_time|int %}
+  {% set elapsed_hours = [elapsed // 3600, 99]|min %}
+  {% set remaining = printer.display_status.remaining_time %}
+  {% set progress = printer.display_status.progress * 100 %}
+  {% if remaining is not none %}
+    {% set remaining = remaining|int %}
+    {% set remaining_hours = [remaining // 3600, 99]|min %}
+    { "E:%02d:%02d R:%02d:%02d %3.0f%%" % (elapsed_hours, (elapsed // 60) % 60, remaining_hours, (remaining // 60) % 60, progress) }
+  {% else %}
+    { "E:%02d:%02d R:--:-- %3.0f%%" % (elapsed_hours, (elapsed // 60) % 60, progress) }
+  {% endif %}
+
+[display_data _print_time_20x4 print_status]
+position: 3, 0
+text: { render("_print_status") }
+
+
+######################################################################
 # Default 16x4 glyphs
 ######################################################################
 

--- a/klippy/extras/display_status.py
+++ b/klippy/extras/display_status.py
@@ -11,7 +11,7 @@ class DisplayStatus:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.expire_progress = 0.
-        self.progress = self.message = None
+        self.progress = self.remaining_time = self.message = None
         # Register commands
         gcode = self.printer.lookup_object('gcode')
         gcode.register_command('M73', self.cmd_M73)
@@ -21,22 +21,29 @@ class DisplayStatus:
             desc=self.cmd_SET_DISPLAY_TEXT_help)
     def get_status(self, eventtime):
         progress = self.progress
-        if progress is not None and eventtime > self.expire_progress:
+        if ((progress is not None or self.remaining_time is not None)
+                and eventtime > self.expire_progress):
             idle_timeout = self.printer.lookup_object('idle_timeout')
             idle_timeout_info = idle_timeout.get_status(eventtime)
             if idle_timeout_info['state'] != "Printing":
                 self.progress = progress = None
+                self.remaining_time = None
         if progress is None:
             progress = 0.
             sdcard = self.printer.lookup_object('virtual_sdcard', None)
             if sdcard is not None:
                 progress = sdcard.get_status(eventtime)['progress']
-        return { 'progress': progress, 'message': self.message }
+        return { 'progress': progress, 'remaining_time': self.remaining_time,
+                 'message': self.message }
     def cmd_M73(self, gcmd):
         progress = gcmd.get_float('P', None)
+        remaining = gcmd.get_float('R', None, minval=0.)
         if progress is not None:
             progress = progress / 100.
             self.progress = min(1., max(0., progress))
+        if remaining is not None:
+            self.remaining_time = remaining * 60.
+        if progress is not None or remaining is not None:
             curtime = self.printer.get_reactor().monotonic()
             self.expire_progress = curtime + M73_TIMEOUT
     def cmd_M117(self, gcmd):

--- a/test/klippy/sdcard_loop.test
+++ b/test/klippy/sdcard_loop.test
@@ -4,6 +4,8 @@ DICTIONARY atmega2560.dict
 CONFIG sdcard_loop.cfg
 
 G28
+M73 P25 R90
+M73 R89
 SDCARD_LOOP_DESIST
 ; Verify long-name functions
 SDCARD_PRINT_FILE FILENAME=big.gcode


### PR DESCRIPTION
## Dependency

Stacked on #7340, which adds `display_status.remaining_time`. Until that PR merges, this draft also shows its core commit in the comparison. The LCD change itself is the final commit only.

## Summary

- add an opt-in `_print_time_20x4` display group
- show elapsed time, remaining time, and progress on one 20-character row
- retain the standard heater/fan rows and bottom status row
- keep `_default_20x4` unchanged
- cap displayed hours at 99 so the row remains exactly 20 characters

Example:

```text
E:12:32 R:21:12  34%
```

Enable with:

```ini
[display]
display_group: _print_time_20x4
```

## Testing

- `git diff --check`
- `./scripts/check_whitespace.sh`
- verified 0%, 34%, and 100% renderings are exactly 20 characters