### PR TITLE
RFC: Klippy python 3.14

### DIFF
--- a/klippy/util.py
+++ b/klippy/util.py
@@ -110,6 +110,20 @@ setup_python2_wrappers()
 
 
 ######################################################################
+# Python3 hacks
+######################################################################
+
+def setup_multiprocess_fork_method():
+    if sys.version_info.major < 3:
+        return
+    if sys.version_info.major >= 3 and sys.version_info.minor < 14:
+        return
+    import multiprocessing
+    multiprocessing.set_start_method("fork")
+setup_multiprocess_fork_method()
+
+
+######################################################################
 # General system and software information
 ######################################################################
 

--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -5,10 +5,10 @@
 
 # greenlet is used by the reactor.py code
 greenlet==2.0.2 ; python_version < '3.12'
-greenlet==3.1.1 ; python_version >= '3.12'
+greenlet==3.3.2 ; python_version >= '3.12'
 # cffi is used by "chelper" code and by greenlet
 cffi==1.14.6 ; python_version < '3.12'
-cffi==1.17.1 ; python_version >= '3.12'
+cffi==2.1.1 ; python_version >= '3.12'
 # Jinja2 is used by gcode_macro.py
 Jinja2==2.11.3
 markupsafe==1.1.1       # Needed by Jinja2


### PR DESCRIPTION
Update requirements as expected.

Then there are Python 3.14 shenanigans.
Basically, the type of multiprocess fork has changed by default.
Basically, instead of forking the current process with all memory and threads, a fork master is started at initialization time, which creates a clean Python child every time.

It is possible to use `multiprocessing.set_start_method('fork')` to revert the behaviour.

AFAIU, it is intended to avoid a footgun with broken locks and memory state (as GC.freeze() does to avoid the COW of the whole process memory on fork). More info at (https://github.com/python/cpython/issues/84559)

As a matter of research, I've spent some time around the code to make it behave with `forkserver`.

Basically, with it, it is required to pickle objects.
It is not possible/allowed to reference local functions.
It is not possible/allowed to pickle locks.
Pickling `self.printer` leads to pickling everything, but it fails at queue logging locks.
Pickling of cffi seems to also be not possible.

Pickle adds overhead here, as we didn't get a free memory copy of ADXL data.
It is possible to use shared memory directly, but it would also require a copy of the data to shared memory, I think.
`@staticmethod` is used to avoid reference to `self` and to limit the change scope, as moving the local function out of the object spreads the context over the size of one screen :D.

For Delta Calibrate and `mathutils`, conversion is straightforward.

For ADXL data writing, it is implemented in a way that we don't have to actually call get_samples().
It is useless for data writing.
As `self.samples` is not shared between processes (was never shared #7237), we can simply write data straight away.
<details>
  <summary>Short proof</summary>
  
```
#!/usr/bin/python3
import multiprocessing
multiprocessing.set_start_method('fork')

class State:
    def __init__(self, samples):
        self.samples = samples

    def update_value(self):
        print("update")
        self.samples[1] = 1

samples = [0, 0, 0]
obj = State(samples)
print("Before %s" % (obj.samples))
p = multiprocessing.Process(target=obj.update_value)
p.start()
p.join()
print("After %s" % (obj.samples))
```
  
</details>


For the resonance tester, well, it is possible to get rid of `self.printer` from `aclient` completely, and simply feed it with start/end print times. This will isolate things enough.
But it would require changes across the code... It is also possible to construct/return an "empty" aclient without `self.printer`.

So, instead, I simply clean up the reference, as it is not needed past `finish_measurements()`.
And we cannot call `get_samples()` before that, as the end time is equal to the start time.

So, similar tricks are used in the Resonance computation code, where I temporarily remove the reference.
To avoid heavy refactoring of things.

To sum up:
I think it can be a good thing to directly isolate or pass data between processes, or use shared memory if it is necessary.
We already utilize pipes to implement communication.
Alas, it will lead to the loss of a "free" memory copy, which is unfortunate. So, I'm not sure here.

There is no strong opinion on my side; I can re-enable 'fork' to test it if that is the decision (as was done here: https://github.com/Klipper3d/klipper/pull/7174).

Regards,
-Timofey

---
Well, Python 2.7 seems not to be able to pickle bound methods =\\
So, `@staticmethod` is useless here.