### PR TITLE
Fix axis twist compensation

### DIFF
--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -57,14 +57,14 @@ class AxisTwistCompensation:
             zo = 0.
             if self.z_compensations:
                 zo += self._get_interpolated_z_compensation(
-                    pos.test_x, self.z_compensations,
+                    pos.bed_x, self.z_compensations,
                     self.compensation_start_x,
                     self.compensation_end_x
                     )
 
             if self.zy_compensations:
                 zo += self._get_interpolated_z_compensation(
-                    pos.test_y, self.zy_compensations,
+                    pos.bed_y, self.zy_compensations,
                     self.compensation_start_y,
                     self.compensation_end_y
                     )

--- a/klippy/extras/axis_twist_compensation.py
+++ b/klippy/extras/axis_twist_compensation.py
@@ -13,6 +13,8 @@ DEFAULT_SPEED = 50.
 DEFAULT_HORIZONTAL_MOVE_Z = 5.
 
 
+# All positions stored as attributes of AxisTwistCompensation are bed
+# coordinates.
 class AxisTwistCompensation:
     def __init__(self, config):
         # get printer
@@ -100,6 +102,9 @@ class AxisTwistCompensation:
         elif axis == 'Y':
             self.zy_compensations = []
 
+
+# All positions stored as attributes of Calibrater are bed
+# coordinates too.
 class Calibrater:
     def __init__(self, compensation, config):
         # setup self attributes
@@ -161,8 +166,8 @@ class Calibrater:
             raise self.gcmd.error(
                 "SAMPLE_COUNT to probe must be at least 2")
 
-        # calculate the points to put the probe at, returned as a list of tuples
-        nozzle_points = []
+        # calculate the points we want to measure, returned as a list of tuples
+        bed_points = []
 
         if axis == 'X':
 
@@ -189,7 +194,7 @@ class Calibrater:
             for i in range(sample_count):
                 x = start_point[0] + i * interval_dist
                 y = start_point[1]
-                nozzle_points.append((x, y))
+                bed_points.append((x, y))
 
         elif axis == 'Y':
 
@@ -216,15 +221,15 @@ class Calibrater:
             for i in range(sample_count):
                 x = start_point[0]
                 y = start_point[1] + i * interval_dist
-                nozzle_points.append((x, y))
+                bed_points.append((x, y))
 
         else:
             raise self.gcmd.error(
                 "AXIS_TWIST_COMPENSATION_CALIBRATE: "
                 "Invalid axis.")
 
-        probe_points = self._calculate_probe_points(
-            nozzle_points, probe_x_offset, probe_y_offset)
+        test_points = self._calculate_test_points(
+            bed_points, probe_x_offset, probe_y_offset)
 
         # verify no other manual probe is in progress
         manual_probe.verify_no_manual_probe(self.printer)
@@ -233,18 +238,18 @@ class Calibrater:
         self.current_point_index = 0
         self.results = []
         self.current_axis = axis
-        self._calibration(probe_points, nozzle_points, interval_dist)
+        self._calibration(test_points, bed_points, interval_dist)
 
-    def _calculate_probe_points(self, nozzle_points,
-                                probe_x_offset, probe_y_offset):
-        # calculate the points to put the nozzle at
-        # returned as a list of tuples
-        probe_points = []
-        for point in nozzle_points:
+    def _calculate_test_points(self, bed_points,
+                               probe_x_offset, probe_y_offset):
+        # calculate the points to move to, so that the probe is aligned with the
+        # bed points, returned as a list of tuples
+        test_points = []
+        for point in bed_points:
             x = point[0] - probe_x_offset
             y = point[1] - probe_y_offset
-            probe_points.append((x, y))
-        return probe_points
+            test_points.append((x, y))
+        return test_points
 
     def _move_helper(self, target_coordinates, override_speed=None):
         # pad target coordinates
@@ -256,19 +261,19 @@ class Calibrater:
         speed = override_speed if override_speed is not None else speed
         toolhead.manual_move(target_coordinates, speed)
 
-    def _calibration(self, probe_points, nozzle_points, interval):
+    def _calibration(self, test_points, bed_points, interval):
         # begin the calibration process
         self.gcmd.respond_info("AXIS_TWIST_COMPENSATION_CALIBRATE: "
                                "Probing point %d of %d" % (
                                    self.current_point_index + 1,
-                                   len(probe_points)))
+                                   len(test_points)))
 
         # horizontal_move_z (to prevent probe trigger or hitting bed)
         self._move_helper((None, None, self.horizontal_move_z))
 
         # move to point to probe
-        self._move_helper((probe_points[self.current_point_index][0],
-                           probe_points[self.current_point_index][1], None))
+        self._move_helper((test_points[self.current_point_index][0],
+                           test_points[self.current_point_index][1], None))
 
         # probe the point
         pos = probe.run_single_probe(self.probe, self.gcmd)
@@ -277,19 +282,19 @@ class Calibrater:
         # horizontal_move_z (to prevent probe trigger or hitting bed)
         self._move_helper((None, None, self.horizontal_move_z))
 
-        # move the nozzle over the probe point
-        self._move_helper((nozzle_points[self.current_point_index]))
+        # move the nozzle over the position that was just probed
+        self._move_helper((bed_points[self.current_point_index]))
 
         # start the manual (nozzle) probe
         manual_probe.ManualProbeHelper(
             self.printer, self.gcmd,
             self._manual_probe_callback_factory(
-                probe_points, nozzle_points, interval))
+                test_points, bed_points, interval))
 
-    def _manual_probe_callback_factory(self, probe_points,
-        nozzle_points, interval):
+    def _manual_probe_callback_factory(self, test_points,
+        bed_points, interval):
         # returns a callback function for the manual probe
-        is_end = self.current_point_index == len(probe_points) - 1
+        is_end = self.current_point_index == len(test_points) - 1
 
         def callback(mpresult):
             if mpresult is None:
@@ -306,7 +311,7 @@ class Calibrater:
             else:
                 # move to next point
                 self.current_point_index += 1
-                self._calibration(probe_points, nozzle_points, interval)
+                self._calibration(test_points, bed_points, interval)
         return callback
 
     def _finalize_calibration(self):


### PR DESCRIPTION
Following discussion on #7246, I applied the fix and tried to clarify the code a bit.

The axis_twist_compensation code works entirely in bed coordinates, but it applied the correction based on the test coordinates instead. This PR correctly applies the correction using the bed coordinate.

I didn't have time to test the change, and I can't even make a real test since I don't have my old printer anymore. It would help me if anyone could test this commit on their printer :pray: 

cc @ramonsaboya @dewi-ny-je