### PR TITLE
linux: increase max gpiochip number

### DIFF
--- a/src/linux/gpio.c
+++ b/src/linux/gpio.c
@@ -28,6 +28,13 @@ DECL_ENUMERATION_RANGE("pin", "gpiochip5/gpio0", GPIO(5, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip6/gpio0", GPIO(6, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip7/gpio0", GPIO(7, 0), MAX_GPIO_LINES);
 DECL_ENUMERATION_RANGE("pin", "gpiochip8/gpio0", GPIO(8, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip9/gpio0", GPIO(9, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip10/gpio0", GPIO(10, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip11/gpio0", GPIO(11, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip12/gpio0", GPIO(12, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip13/gpio0", GPIO(13, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip14/gpio0", GPIO(14, 0), MAX_GPIO_LINES);
+DECL_ENUMERATION_RANGE("pin", "gpiochip15/gpio0", GPIO(15, 0), MAX_GPIO_LINES);
 
 struct gpio_line {
     int chipid;
@@ -35,8 +42,10 @@ struct gpio_line {
     int fd;
     int state;
 };
-static struct gpio_line gpio_lines[9 * MAX_GPIO_LINES];
-static int gpio_chip_fd[9] = { -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+static struct gpio_line gpio_lines[16 * MAX_GPIO_LINES];
+static int gpio_chip_fd[16] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
 
 static int
 get_chip_fd(uint8_t chipId)


### PR DESCRIPTION
It seems that for whatever reason, the recent kernel on RPI can use a large number for gpiochip, for example, 13.

So, this is a simple definition to cover additional chip numbers

```
cd ~/klipper
git fetch origin pull/7344/head
git checkout FETCH_HEAD
sudo systemctl restart klipper
```

---
Sometimes I think it can be interesting to generate that data during the build, or generate uncompressed JSON with a gzip header/footer inside the C code...
But it is a little bit complicated.