### PR TITLE
queuelogger: disable unused LogRecord fields

### DIFF
--- a/klippy/queuelogger.py
+++ b/klippy/queuelogger.py
@@ -59,6 +59,12 @@ MainQueueHandler = None
 
 def setup_bg_logging(filename, debuglevel):
     global MainQueueHandler
+    logging._srcfile = None             # filename, funcName, lineno, module
+    logging.logThreads = False          # thread, threadName
+    logging.logProcesses = False        # process
+    logging.logMultiprocessing = False  # processName
+    if hasattr(logging, "logAsyncioTasks"):
+        logging.logAsyncioTasks = False # taskName, python 3.12+
     ql = QueueListener(filename)
     MainQueueHandler = QueueHandler(ql.bg_queue)
     root = logging.getLogger()


### PR DESCRIPTION
Minor optimizations for logging. 
Klippy logs with the default formatter "%(message)s", but every logging call still collects fields that this formatter never prints:
```
filename, funcName, lineno, module  - stack walk in Logger.findCaller()
thread, threadName                  - get_ident() + current_thread()
process                             - os.getpid(), (the only syscall on the path to the queue)
processName                         - multiprocessing lookup
taskName                            - asyncio.current_task(), python 3.12+
```
Disabling them in `setup_bg_logging()` cuts about 30% off a logging call in main thread:
```
                    python 3.14.6    python 2.7.18
stock               3.24 us/call     13.08 us/call
fields disabled     2.17 us/call     10.93 us/call
                    -33%             -16%
```

Log output is unchanged, none of these fields appear in "%(message)s". `logging.exception()`is unaffected, tracebacks come from `exc_info` rather than from the stack walk. 

Logging flags are process-global, but that shouldn't be a problem.

Python benchmark code:
<details>
<summary>klippy/bench_logging.py</summary>

```python
import gc, logging, os, sys, tempfile
from timeit import default_timer as perf_counter

if sys.version_info[0] == 2:
    import Queue
    sys.modules['queue'] = Queue

import queuelogger

ITERATIONS = 200000
WARMUP = 20000

def disable_fields():
    logging._srcfile = None             # filename, funcName, lineno, module
    logging.logThreads = False          # thread, threadName
    logging.logProcesses = False        # process
    logging.logMultiprocessing = False  # processName
    if hasattr(logging, "logAsyncioTasks"):
        logging.logAsyncioTasks = False # taskName, python 3.12+

def measure():
    log_path = os.path.join(tempfile.mkdtemp(), "bench.log")
    ql = queuelogger.setup_bg_logging(log_path, logging.INFO)
    log = logging.getLogger("bench")
    gc.collect()
    gc.disable()
    try:
        for _ in range(WARMUP):
            log.info("warmup message")
        start = perf_counter()
        for _ in range(ITERATIONS):
            log.info("benchmark message")
        elapsed = perf_counter() - start
    finally:
        gc.enable()
        queuelogger.clear_bg_logging()
        ql.stop()
    os.remove(log_path)
    return elapsed / ITERATIONS * 1e6

print("stock logging    %.2f us/call" % (measure(),))
disable_fields()
print("fields disabled  %.2f us/call" % (measure(),))

```
</details>

As for implementation `logging._srcfile = None`, being a private name, this exact use is anticipated by
the module itself, see `logging/__init__.py`:
```
# _srcfile is only used in conjunction with sys._getframe().
# Setting _srcfile to None will prevent findCaller() from being called. This
# way, you can avoid the overhead of fetching caller information.
```
