### PR TITLE
stm32: fix n32g45x usb clock and apb/flash timing

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -215,7 +215,11 @@ config CLOCK_FREQ
     default 400000000 if MACH_STM32H743
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
+    # The n32g45x PLL runs from HSI/2 (4Mhz) and has a max multiplier of 32
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
+    # limited number of system clock rates can produce the required 48Mhz
+    default 96000000 if MACH_N32G45x && USB
     default 128000000 if MACH_N32G45x
 
 config FLASH_SIZE

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -152,7 +152,10 @@ config MACH_N32G45x
 config HAVE_STM32_USBFS
     bool
     default y if MACH_STM32F0x2 || MACH_STM32G0Bx || MACH_STM32L4 || MACH_STM32G4
-    default y if (MACH_STM32F1 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    default y if (MACH_STM32F103 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock needs an exact 96Mhz pll output, which only
+    # some reference crystals can produce
+    default y if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_12M || STM32_CLOCK_REF_16M || STM32_CLOCK_REF_24M)
 config HAVE_STM32_USBOTG
     bool
     default y if MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7 || MACH_STM32H7
@@ -220,7 +223,13 @@ config CLOCK_FREQ
     # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
     # limited number of system clock rates can produce the required 48Mhz
     default 96000000 if MACH_N32G45x && USB
-    default 128000000 if MACH_N32G45x
+    # The n32g45x PLL multiplies the crystal (or its half) by an integer,
+    # so only rates that are an exact multiple of crystal / 2 can be
+    # generated - default to the highest rate each crystal produces exactly
+    default 128000000 if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_16M)
+    default 144000000 if MACH_N32G45x && (STM32_CLOCK_REF_12M || STM32_CLOCK_REF_24M)
+    default 140000000 if MACH_N32G45x && STM32_CLOCK_REF_20M
+    default 125000000 if MACH_N32G45x && STM32_CLOCK_REF_25M
 
 config FLASH_SIZE
     hex

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -215,7 +215,11 @@ config CLOCK_FREQ
     default 400000000 if MACH_STM32H743
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
+    # The n32g45x PLL input is HSI/2 (4Mhz) when using the internal oscillator
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
+    # limited number of system clock rates can produce the required 48Mhz
+    default 96000000 if MACH_N32G45x && USB
     default 128000000 if MACH_N32G45x
 
 config FLASH_SIZE

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -29,11 +29,27 @@
 // The n32g45x PLL multiplier is five bits wide (bit 27 is PLLMUL[4])
 #define PLLMUL_MAX 32
 #define PLLMUL_HIGH_BIT (1 << 27)
+// The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3
+#if CONFIG_CLOCK_FREQ == 72000000
+  #define USBPRE_BITS (0 << 22)
+#elif CONFIG_CLOCK_FREQ == 48000000
+  #define USBPRE_BITS (1 << 22)
+#elif CONFIG_CLOCK_FREQ == 96000000
+  #define USBPRE_BITS (2 << 22)
+#elif CONFIG_CLOCK_FREQ == 144000000
+  #define USBPRE_BITS (3 << 22)
+#else
+  #if CONFIG_USB
+    #error "Unable to generate a 48Mhz usb clock at this system clock rate"
+  #endif
+  #define USBPRE_BITS 0
+#endif
 #else
 #define FREQ_APB2 (CONFIG_CLOCK_FREQ / 2)
 #define FREQ_APB1 (CONFIG_CLOCK_FREQ / 2)
 #define PLLMUL_MAX 16
 #define PLLMUL_HIGH_BIT 0
+#define USBPRE_BITS 0
 #endif
 
 // Map a peripheral address to its enable bits
@@ -121,6 +137,7 @@ clock_setup(void)
             cfgr |= RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_PPRE1_DIV4;
         else if (CONFIG_CLOCK_FREQ > 36000000)
             cfgr |= RCC_CFGR_PPRE1_DIV2;
+        cfgr |= USBPRE_BITS;
     } else {
         cfgr |= (RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2
                  | RCC_CFGR_ADCPRE_DIV8);

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -17,7 +17,24 @@
  * Clock setup
  ****************************************************************/
 
-#define FREQ_PERIPH (CONFIG_CLOCK_FREQ / 2)
+#if CONFIG_MACH_N32G45x
+// The n32g45x runs the AHB bus at up to 144Mhz, but PCLK2 is limited to
+// 72Mhz and PCLK1 to 36Mhz
+#define FREQ_APB2 (CONFIG_CLOCK_FREQ > 72000000                         \
+                   ? CONFIG_CLOCK_FREQ / 2 : CONFIG_CLOCK_FREQ)
+#define FREQ_APB1 (CONFIG_CLOCK_FREQ > 72000000                         \
+                   ? CONFIG_CLOCK_FREQ / 4                              \
+                   : (CONFIG_CLOCK_FREQ > 36000000                      \
+                      ? CONFIG_CLOCK_FREQ / 2 : CONFIG_CLOCK_FREQ))
+// The n32g45x PLL multiplier is five bits wide (bit 27 is PLLMUL[4])
+#define PLLMUL_MAX 32
+#define PLLMUL_HIGH_BIT (1 << 27)
+#else
+#define FREQ_APB2 (CONFIG_CLOCK_FREQ / 2)
+#define FREQ_APB1 (CONFIG_CLOCK_FREQ / 2)
+#define PLLMUL_MAX 16
+#define PLLMUL_HIGH_BIT 0
+#endif
 
 // Map a peripheral address to its enable bits
 struct cline
@@ -39,7 +56,9 @@ lookup_clock_line(uint32_t periph_base)
 uint32_t
 get_pclock_frequency(uint32_t periph_base)
 {
-    return FREQ_PERIPH;
+    if (periph_base < APB2PERIPH_BASE)
+        return FREQ_APB1;
+    return FREQ_APB2;
 }
 
 // Enable a GPIO peripheral clock
@@ -53,6 +72,26 @@ gpio_clock_enable(GPIO_TypeDef *regs)
 
 // PLL (f103) input: 1 to 25Mhz, output: 16 to 72Mhz
 
+// Return the RCC_CFGR bits that select the given PLL multiplier
+static uint32_t
+pll_multiplier_bits(uint32_t mul)
+{
+    if (PLLMUL_HIGH_BIT && mul > 16)
+        // Multipliers above 16 are encoded with PLLMUL[4] set
+        return ((mul - 17) << RCC_CFGR_PLLMULL_Pos) | PLLMUL_HIGH_BIT;
+    return (mul - 2) << RCC_CFGR_PLLMULL_Pos;
+}
+
+// Return the flash wait states needed at the current system clock rate
+static uint32_t
+flash_latency(void)
+{
+    if (CONFIG_MACH_N32G45x)
+        // 0: <=32Mhz, 1: <=64Mhz, 2: <=96Mhz, 3: <=128Mhz, 4: <=144Mhz
+        return (CONFIG_CLOCK_FREQ - 1) / 32000000;
+    return 2;
+}
+
 // Main clock setup called at chip startup
 static void
 clock_setup(void)
@@ -64,23 +103,33 @@ clock_setup(void)
         RCC->CR |= RCC_CR_HSEON;
         uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
         cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
-        if ((div & 1) && div <= 16)
+        if ((div & 1) && div <= PLLMUL_MAX)
             cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
         else
             div /= 2;
-        cfgr |= (div - 2) << RCC_CFGR_PLLMULL_Pos;
+        cfgr |= pll_multiplier_bits(div);
     } else {
         // Configure 72Mhz PLL from internal 8Mhz oscillator (HSI)
         uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;
-        cfgr = ((0 << RCC_CFGR_PLLSRC_Pos)
-                | ((div2 - 2) << RCC_CFGR_PLLMULL_Pos));
+        cfgr = (0 << RCC_CFGR_PLLSRC_Pos) | pll_multiplier_bits(div2);
     }
-    cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_ADCPRE_DIV8;
+    if (CONFIG_MACH_N32G45x) {
+        // Keep PCLK2 <= 72Mhz and PCLK1 <= 36Mhz (RCC_CFGR bits 15:14 are
+        // reserved on the n32g45x - the adc clock is configured separately
+        // in n32g45x_adc.c via RCC_CFG2)
+        if (CONFIG_CLOCK_FREQ > 72000000)
+            cfgr |= RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_PPRE1_DIV4;
+        else if (CONFIG_CLOCK_FREQ > 36000000)
+            cfgr |= RCC_CFGR_PPRE1_DIV2;
+    } else {
+        cfgr |= (RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2
+                 | RCC_CFGR_ADCPRE_DIV8);
+    }
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 
     // Set flash latency
-    FLASH->ACR = (2 << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
+    FLASH->ACR = (flash_latency() << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
 
     // Wait for PLL lock
     while (!(RCC->CR & RCC_CR_PLLRDY))

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -143,6 +143,14 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
+    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
+    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    if (CONFIG_CLOCK_FREQ == 96000000)
+        cfgr |= 2 << 22;
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+    #error "Unable to generate a 48Mhz usb clock at this system clock rate"
+#endif
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -118,6 +118,11 @@ n32g45x_pll_multiplier_bits(uint32_t mul)
 static void
 clock_setup_n32g45x(void)
 {
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL \
+    && (2 * CONFIG_CLOCK_FREQ) % CONFIG_CLOCK_REF_FREQ \
+    && CONFIG_MACH_N32G45x
+    #error "Unable to generate the requested clock rate from this crystal"
+#endif
     // Configure and enable PLL
     uint32_t cfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
@@ -143,12 +148,13 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
-    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
-    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
-    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  The
+    // clock defaults select 96Mhz when usb is enabled, which produces
+    // the 48Mhz the usb peripheral needs through the /2 divisor.
     if (CONFIG_CLOCK_FREQ == 96000000)
         cfgr |= 2 << 22;
-#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000 \
+    && CONFIG_MACH_N32G45x
     #error "Unable to generate a 48Mhz usb clock at this system clock rate"
 #endif
     RCC->CFGR = cfgr;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -39,6 +39,15 @@ lookup_clock_line(uint32_t periph_base)
 uint32_t
 get_pclock_frequency(uint32_t periph_base)
 {
+    if (CONFIG_MACH_N32G45x) {
+        // Both APB busses run at the same rate, using PCLK1's tighter
+        // 36Mhz limit to choose the divisor
+        if (CONFIG_CLOCK_FREQ > 72000000)
+            return CONFIG_CLOCK_FREQ / 4;
+        if (CONFIG_CLOCK_FREQ > 36000000)
+            return CONFIG_CLOCK_FREQ / 2;
+        return CONFIG_CLOCK_FREQ;
+    }
     return FREQ_PERIPH;
 }
 
@@ -81,6 +90,66 @@ clock_setup(void)
 
     // Set flash latency
     FLASH->ACR = (2 << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
+
+    // Wait for PLL lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+
+    // Switch system clock to PLL
+    RCC->CFGR = cfgr | RCC_CFGR_SW_PLL;
+    while ((RCC->CFGR & RCC_CFGR_SWS_Msk) != RCC_CFGR_SWS_PLL)
+        ;
+}
+
+// Return the RCC_CFGR bits that select the given PLL multiplier on the
+// n32g45x, whose PLLMUL field is five bits wide (PLLMUL[4] is bit 27)
+static uint32_t
+n32g45x_pll_multiplier_bits(uint32_t mul)
+{
+    if (mul > 16)
+        // Multipliers above 16 are encoded with PLLMUL[4] (bit 27) set
+        return ((mul - 17) << RCC_CFGR_PLLMULL_Pos) | (1 << 27);
+    return (mul - 2) << RCC_CFGR_PLLMULL_Pos;
+}
+
+// The n32g45x is register compatible with the stm32f103, but has its
+// own clock tree: PCLK2 is limited to 72Mhz and PCLK1 to 36Mhz, and
+// flash wait states scale with HCLK in 32Mhz steps
+static void
+clock_setup_n32g45x(void)
+{
+    // Configure and enable PLL
+    uint32_t cfgr;
+    if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
+        // Configure PLL from external crystal (HSE)
+        RCC->CR |= RCC_CR_HSEON;
+        uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
+        cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
+        if ((div & 1) && div <= 32)
+            cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
+        else
+            div /= 2;
+        cfgr |= n32g45x_pll_multiplier_bits(div);
+    } else {
+        // Configure PLL from internal 8Mhz oscillator (HSI)
+        uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;
+        cfgr = (0 << RCC_CFGR_PLLSRC_Pos) | n32g45x_pll_multiplier_bits(div2);
+    }
+    // Divide both APB busses by the same amount, using PCLK1's tighter
+    // 36Mhz limit to choose the divisor (RCC_CFGR bits 15:14 are
+    // reserved on the n32g45x - the adc clock is configured separately
+    // in n32g45x_adc.c via RCC_CFG2)
+    if (CONFIG_CLOCK_FREQ > 72000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
+    else if (CONFIG_CLOCK_FREQ > 36000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    RCC->CFGR = cfgr;
+    RCC->CR |= RCC_CR_PLLON;
+
+    // Set flash latency (0: <=32Mhz, 1: <=64Mhz, 2: <=96Mhz, 3: <=128Mhz,
+    // 4: <=144Mhz)
+    uint32_t latency = (CONFIG_CLOCK_FREQ - 1) / 32000000;
+    FLASH->ACR = (latency << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
 
     // Wait for PLL lock
     while (!(RCC->CR & RCC_CR_PLLRDY))
@@ -272,7 +341,10 @@ armcm_main(void)
     RCC->APB2ENR = 0;
 
     // Setup clocks
-    clock_setup();
+    if (CONFIG_MACH_N32G45x)
+        clock_setup_n32g45x();
+    else
+        clock_setup();
 
     // Disable JTAG to free PA15, PB3, PB4
     enable_pclock(AFIO_BASE);

--- a/test/configs/n32g45x-canbus.config
+++ b/test/configs/n32g45x-canbus.config
@@ -1,0 +1,4 @@
+# Base config file for Nations N32G45x ARM processor using CAN bus
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G455=y
+CONFIG_STM32_CANBUS_PA11_PA12=y

--- a/test/configs/n32g45x.config
+++ b/test/configs/n32g45x.config
@@ -1,0 +1,3 @@
+# Base config file for Nations N32G45x ARM processor
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G452=y


### PR DESCRIPTION
## Summary

Fixes USB on the Nations N32G45x, which has not worked since the chip was introduced in #6116 (23e82d37f). `clock_setup()` never programs the USB prescaler bits, so with the default 128MHz system clock the USB clock stays at its reset value of PLLCLK/1.5 = 85.33MHz instead of 48MHz, and the device cannot enumerate. The reference manual requires PLLCLK to be exactly 48/72/96/144MHz for USB_FS_Device to work; from 128MHz none of this chip's divisors (1.5/1/2/3) reach 48MHz.

While tracking this down, two more clock issues turned up. Both are out of spec but apparently within the silicon's margin — the only n32g45x board in the tree, `printer-voxelab-aquila-2021.cfg`, ships at 128MHz and is a serial (non-USB) config, so this path was presumably never exercised at 48MHz either:

- APB1 was left at 64MHz against a 36MHz limit (`PPRE1_DIV2` instead of `DIV4`).
- Flash latency was fixed at 2 wait states, one short of the 3 required above 96MHz.
- `RCC_CFGR` bits 15:14 were written as an ADC prescaler that doesn't exist on this chip (harmless: the ADC clock is set separately via `RCC_CFG2` in `n32g45x_adc.c`).

## What's inside

- Per @KevinOConnor's review, the n32g45x clock setup now lives in its own `clock_setup_n32g45x()`, dispatched from `armcm_main()` alongside the untouched, original `clock_setup()`. `pll_multiplier_bits()`/`flash_latency()` and the `FREQ_APB`/`PLLMUL_MAX`/`USBPRE_BITS` macros are gone; `get_pclock_frequency()` carries a single small `if (CONFIG_MACH_N32G45x)` branch (computed inline, no macro) and everything else is local to `clock_setup_n32g45x()`. The core stm32f103 code path is unchanged.
- Fix the APB1/APB2 dividers and flash latency for 128MHz operation, stop writing the reserved ADC-prescaler bits, and widen the PLL multiplier encoding to 5 bits (`PLLMUL[4]` at bit 27) so multipliers above 16 can be reached. Both APB busses are divided by the same amount (chosen from PCLK1's tighter 36MHz limit), so `get_pclock_frequency()` still returns one value for every peripheral, matching the rest of the stm32 backend and avoiding the assumption `hard_pwm.c` and others make about it being uniform.
- Program the USB prescaler and drop the system clock to 96MHz when USB is selected, since 128MHz has no valid USB divisor. CAN and UART builds stay at 128MHz, so existing boards are unaffected. An unsupported clock combination now fails the build with `#error` instead of shipping a device that can't enumerate.
- Per-crystal clock defaults. The n32g45x PLL can only generate rates that are an exact multiple of crystal/2, and the flat 128MHz default silently produced 126MHz from a 12MHz crystal, 120MHz from 20/24MHz crystals and 125MHz from a 25MHz one — enough to break UART baud rates with no build-time indication. Defaults now pick the highest exact rate per crystal: 128MHz on 8/16MHz (existing boards unchanged), 144MHz on 12/24MHz, 140MHz on 20MHz, 125MHz on 25MHz. The build fails with `#error` if the requested rate isn't exactly reachable, and USB is no longer offered on crystals that cannot produce its 48MHz clock (20/25MHz).
- Add `n32g45x` (USB) and `n32g45x-canbus` test configs — this MCU had no CI coverage before.

## Testing

- Built `n32g45x` (96MHz, USB) and `n32g45x-canbus` (128MHz): `CFGR = 0x00A92D00` / `ACR = 0x12` for the USB build, `CFGR = 0x00392D00` / `ACR = 0x13` for the CAN build (PLL x12/x14, both APB busses at `/4`, USBPRE `/2` on the USB build), matching the expected encoding for these clocks.
- Checked `(2 × CLOCK_FREQ) % CLOCK_REF == 0` and a PLL multiplier within 2..32 for every crystal × default combination (8/12/16/20/24/25MHz and the internal oscillator); each default now lands on an exactly generatable rate.
- Regression-checked by compiled symbol sizes rather than raw bytes: a raw byte diff isn't useful here because the version string is embedded in the compressed `command_identify_data` block, and a one-byte shift there moves everything after it — an untouched `stm32f405` build "differed" by 22KB purely from this. By symbol size, `stm32f103`, `stm32f103-serial` and `stm32f405` builds are unchanged except for `command_identify_data` itself (1-2 bytes, the version string); every other function is byte-identical in size. The `stm32f103` `CFGR` literal is also unchanged (`0x001DE400`).


