### PR TITLE
stm32: read the n32g45x unique id from its documented address

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -215,7 +215,11 @@ config CLOCK_FREQ
     default 400000000 if MACH_STM32H743
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
+    # The n32g45x PLL runs from HSI/2 (4Mhz) and has a max multiplier of 32
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
+    # limited number of system clock rates can produce the required 48Mhz
+    default 96000000 if MACH_N32G45x && USB
     default 128000000 if MACH_N32G45x
 
 config FLASH_SIZE

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -152,7 +152,10 @@ config MACH_N32G45x
 config HAVE_STM32_USBFS
     bool
     default y if MACH_STM32F0x2 || MACH_STM32G0Bx || MACH_STM32L4 || MACH_STM32G4
-    default y if (MACH_STM32F1 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    default y if (MACH_STM32F103 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock needs an exact 96Mhz pll output, which only
+    # some reference crystals can produce
+    default y if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_12M || STM32_CLOCK_REF_16M || STM32_CLOCK_REF_24M)
 config HAVE_STM32_USBOTG
     bool
     default y if MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7 || MACH_STM32H7
@@ -220,7 +223,13 @@ config CLOCK_FREQ
     # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
     # limited number of system clock rates can produce the required 48Mhz
     default 96000000 if MACH_N32G45x && USB
-    default 128000000 if MACH_N32G45x
+    # The n32g45x PLL multiplies the crystal (or its half) by an integer,
+    # so only rates that are an exact multiple of crystal / 2 can be
+    # generated - default to the highest rate each crystal produces exactly
+    default 128000000 if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_16M)
+    default 144000000 if MACH_N32G45x && (STM32_CLOCK_REF_12M || STM32_CLOCK_REF_24M)
+    default 140000000 if MACH_N32G45x && STM32_CLOCK_REF_20M
+    default 125000000 if MACH_N32G45x && STM32_CLOCK_REF_25M
 
 config FLASH_SIZE
     hex

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -215,7 +215,11 @@ config CLOCK_FREQ
     default 400000000 if MACH_STM32H743
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
+    # The n32g45x PLL input is HSI/2 (4Mhz) when using the internal oscillator
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
+    # limited number of system clock rates can produce the required 48Mhz
+    default 96000000 if MACH_N32G45x && USB
     default 128000000 if MACH_N32G45x
 
 config FLASH_SIZE

--- a/src/stm32/internal.h
+++ b/src/stm32/internal.h
@@ -24,6 +24,13 @@
 #include "stm32l4xx.h"
 #endif
 
+#if CONFIG_MACH_N32G45x
+// The n32g45x builds against the stm32f103 headers, but it stores its
+// 96bit unique device id at a different address
+#undef UID_BASE
+#define UID_BASE 0x1FFFF7F0UL
+#endif
+
 // gpio.c
 GPIO_TypeDef *gpio_pin_to_regs(uint32_t pin);
 #define GPIO(PORT, NUM) (((PORT)-'A') * 16 + (NUM))

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -29,11 +29,27 @@
 // The n32g45x PLL multiplier is five bits wide (bit 27 is PLLMUL[4])
 #define PLLMUL_MAX 32
 #define PLLMUL_HIGH_BIT (1 << 27)
+// The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3
+#if CONFIG_CLOCK_FREQ == 72000000
+  #define USBPRE_BITS (0 << 22)
+#elif CONFIG_CLOCK_FREQ == 48000000
+  #define USBPRE_BITS (1 << 22)
+#elif CONFIG_CLOCK_FREQ == 96000000
+  #define USBPRE_BITS (2 << 22)
+#elif CONFIG_CLOCK_FREQ == 144000000
+  #define USBPRE_BITS (3 << 22)
+#else
+  #if CONFIG_USB
+    #error "Unable to generate a 48Mhz usb clock at this system clock rate"
+  #endif
+  #define USBPRE_BITS 0
+#endif
 #else
 #define FREQ_APB2 (CONFIG_CLOCK_FREQ / 2)
 #define FREQ_APB1 (CONFIG_CLOCK_FREQ / 2)
 #define PLLMUL_MAX 16
 #define PLLMUL_HIGH_BIT 0
+#define USBPRE_BITS 0
 #endif
 
 // Map a peripheral address to its enable bits
@@ -121,6 +137,7 @@ clock_setup(void)
             cfgr |= RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_PPRE1_DIV4;
         else if (CONFIG_CLOCK_FREQ > 36000000)
             cfgr |= RCC_CFGR_PPRE1_DIV2;
+        cfgr |= USBPRE_BITS;
     } else {
         cfgr |= (RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2
                  | RCC_CFGR_ADCPRE_DIV8);

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -17,7 +17,24 @@
  * Clock setup
  ****************************************************************/
 
-#define FREQ_PERIPH (CONFIG_CLOCK_FREQ / 2)
+#if CONFIG_MACH_N32G45x
+// The n32g45x runs the AHB bus at up to 144Mhz, but PCLK2 is limited to
+// 72Mhz and PCLK1 to 36Mhz
+#define FREQ_APB2 (CONFIG_CLOCK_FREQ > 72000000                         \
+                   ? CONFIG_CLOCK_FREQ / 2 : CONFIG_CLOCK_FREQ)
+#define FREQ_APB1 (CONFIG_CLOCK_FREQ > 72000000                         \
+                   ? CONFIG_CLOCK_FREQ / 4                              \
+                   : (CONFIG_CLOCK_FREQ > 36000000                      \
+                      ? CONFIG_CLOCK_FREQ / 2 : CONFIG_CLOCK_FREQ))
+// The n32g45x PLL multiplier is five bits wide (bit 27 is PLLMUL[4])
+#define PLLMUL_MAX 32
+#define PLLMUL_HIGH_BIT (1 << 27)
+#else
+#define FREQ_APB2 (CONFIG_CLOCK_FREQ / 2)
+#define FREQ_APB1 (CONFIG_CLOCK_FREQ / 2)
+#define PLLMUL_MAX 16
+#define PLLMUL_HIGH_BIT 0
+#endif
 
 // Map a peripheral address to its enable bits
 struct cline
@@ -39,7 +56,9 @@ lookup_clock_line(uint32_t periph_base)
 uint32_t
 get_pclock_frequency(uint32_t periph_base)
 {
-    return FREQ_PERIPH;
+    if (periph_base < APB2PERIPH_BASE)
+        return FREQ_APB1;
+    return FREQ_APB2;
 }
 
 // Enable a GPIO peripheral clock
@@ -53,6 +72,26 @@ gpio_clock_enable(GPIO_TypeDef *regs)
 
 // PLL (f103) input: 1 to 25Mhz, output: 16 to 72Mhz
 
+// Return the RCC_CFGR bits that select the given PLL multiplier
+static uint32_t
+pll_multiplier_bits(uint32_t mul)
+{
+    if (PLLMUL_HIGH_BIT && mul > 16)
+        // Multipliers above 16 are encoded with PLLMUL[4] set
+        return ((mul - 17) << RCC_CFGR_PLLMULL_Pos) | PLLMUL_HIGH_BIT;
+    return (mul - 2) << RCC_CFGR_PLLMULL_Pos;
+}
+
+// Return the flash wait states needed at the current system clock rate
+static uint32_t
+flash_latency(void)
+{
+    if (CONFIG_MACH_N32G45x)
+        // 0: <=32Mhz, 1: <=64Mhz, 2: <=96Mhz, 3: <=128Mhz, 4: <=144Mhz
+        return (CONFIG_CLOCK_FREQ - 1) / 32000000;
+    return 2;
+}
+
 // Main clock setup called at chip startup
 static void
 clock_setup(void)
@@ -64,23 +103,33 @@ clock_setup(void)
         RCC->CR |= RCC_CR_HSEON;
         uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
         cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
-        if ((div & 1) && div <= 16)
+        if ((div & 1) && div <= PLLMUL_MAX)
             cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
         else
             div /= 2;
-        cfgr |= (div - 2) << RCC_CFGR_PLLMULL_Pos;
+        cfgr |= pll_multiplier_bits(div);
     } else {
         // Configure 72Mhz PLL from internal 8Mhz oscillator (HSI)
         uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;
-        cfgr = ((0 << RCC_CFGR_PLLSRC_Pos)
-                | ((div2 - 2) << RCC_CFGR_PLLMULL_Pos));
+        cfgr = (0 << RCC_CFGR_PLLSRC_Pos) | pll_multiplier_bits(div2);
     }
-    cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_ADCPRE_DIV8;
+    if (CONFIG_MACH_N32G45x) {
+        // Keep PCLK2 <= 72Mhz and PCLK1 <= 36Mhz (RCC_CFGR bits 15:14 are
+        // reserved on the n32g45x - the adc clock is configured separately
+        // in n32g45x_adc.c via RCC_CFG2)
+        if (CONFIG_CLOCK_FREQ > 72000000)
+            cfgr |= RCC_CFGR_PPRE2_DIV2 | RCC_CFGR_PPRE1_DIV4;
+        else if (CONFIG_CLOCK_FREQ > 36000000)
+            cfgr |= RCC_CFGR_PPRE1_DIV2;
+    } else {
+        cfgr |= (RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2
+                 | RCC_CFGR_ADCPRE_DIV8);
+    }
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 
     // Set flash latency
-    FLASH->ACR = (2 << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
+    FLASH->ACR = (flash_latency() << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
 
     // Wait for PLL lock
     while (!(RCC->CR & RCC_CR_PLLRDY))

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -143,6 +143,14 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
+    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
+    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    if (CONFIG_CLOCK_FREQ == 96000000)
+        cfgr |= 2 << 22;
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+    #error "Unable to generate a 48Mhz usb clock at this system clock rate"
+#endif
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -118,6 +118,11 @@ n32g45x_pll_multiplier_bits(uint32_t mul)
 static void
 clock_setup_n32g45x(void)
 {
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL \
+    && (2 * CONFIG_CLOCK_FREQ) % CONFIG_CLOCK_REF_FREQ \
+    && CONFIG_MACH_N32G45x
+    #error "Unable to generate the requested clock rate from this crystal"
+#endif
     // Configure and enable PLL
     uint32_t cfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
@@ -143,12 +148,13 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
-    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
-    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
-    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  The
+    // clock defaults select 96Mhz when usb is enabled, which produces
+    // the 48Mhz the usb peripheral needs through the /2 divisor.
     if (CONFIG_CLOCK_FREQ == 96000000)
         cfgr |= 2 << 22;
-#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000 \
+    && CONFIG_MACH_N32G45x
     #error "Unable to generate a 48Mhz usb clock at this system clock rate"
 #endif
     RCC->CFGR = cfgr;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -39,6 +39,15 @@ lookup_clock_line(uint32_t periph_base)
 uint32_t
 get_pclock_frequency(uint32_t periph_base)
 {
+    if (CONFIG_MACH_N32G45x) {
+        // Both APB busses run at the same rate, using PCLK1's tighter
+        // 36Mhz limit to choose the divisor
+        if (CONFIG_CLOCK_FREQ > 72000000)
+            return CONFIG_CLOCK_FREQ / 4;
+        if (CONFIG_CLOCK_FREQ > 36000000)
+            return CONFIG_CLOCK_FREQ / 2;
+        return CONFIG_CLOCK_FREQ;
+    }
     return FREQ_PERIPH;
 }
 
@@ -81,6 +90,66 @@ clock_setup(void)
 
     // Set flash latency
     FLASH->ACR = (2 << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
+
+    // Wait for PLL lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+
+    // Switch system clock to PLL
+    RCC->CFGR = cfgr | RCC_CFGR_SW_PLL;
+    while ((RCC->CFGR & RCC_CFGR_SWS_Msk) != RCC_CFGR_SWS_PLL)
+        ;
+}
+
+// Return the RCC_CFGR bits that select the given PLL multiplier on the
+// n32g45x, whose PLLMUL field is five bits wide (PLLMUL[4] is bit 27)
+static uint32_t
+n32g45x_pll_multiplier_bits(uint32_t mul)
+{
+    if (mul > 16)
+        // Multipliers above 16 are encoded with PLLMUL[4] (bit 27) set
+        return ((mul - 17) << RCC_CFGR_PLLMULL_Pos) | (1 << 27);
+    return (mul - 2) << RCC_CFGR_PLLMULL_Pos;
+}
+
+// The n32g45x is register compatible with the stm32f103, but has its
+// own clock tree: PCLK2 is limited to 72Mhz and PCLK1 to 36Mhz, and
+// flash wait states scale with HCLK in 32Mhz steps
+static void
+clock_setup_n32g45x(void)
+{
+    // Configure and enable PLL
+    uint32_t cfgr;
+    if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
+        // Configure PLL from external crystal (HSE)
+        RCC->CR |= RCC_CR_HSEON;
+        uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
+        cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
+        if ((div & 1) && div <= 32)
+            cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
+        else
+            div /= 2;
+        cfgr |= n32g45x_pll_multiplier_bits(div);
+    } else {
+        // Configure PLL from internal 8Mhz oscillator (HSI)
+        uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;
+        cfgr = (0 << RCC_CFGR_PLLSRC_Pos) | n32g45x_pll_multiplier_bits(div2);
+    }
+    // Divide both APB busses by the same amount, using PCLK1's tighter
+    // 36Mhz limit to choose the divisor (RCC_CFGR bits 15:14 are
+    // reserved on the n32g45x - the adc clock is configured separately
+    // in n32g45x_adc.c via RCC_CFG2)
+    if (CONFIG_CLOCK_FREQ > 72000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
+    else if (CONFIG_CLOCK_FREQ > 36000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    RCC->CFGR = cfgr;
+    RCC->CR |= RCC_CR_PLLON;
+
+    // Set flash latency (0: <=32Mhz, 1: <=64Mhz, 2: <=96Mhz, 3: <=128Mhz,
+    // 4: <=144Mhz)
+    uint32_t latency = (CONFIG_CLOCK_FREQ - 1) / 32000000;
+    FLASH->ACR = (latency << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
 
     // Wait for PLL lock
     while (!(RCC->CR & RCC_CR_PLLRDY))
@@ -272,7 +341,10 @@ armcm_main(void)
     RCC->APB2ENR = 0;
 
     // Setup clocks
-    clock_setup();
+    if (CONFIG_MACH_N32G45x)
+        clock_setup_n32g45x();
+    else
+        clock_setup();
 
     // Disable JTAG to free PA15, PB3, PB4
     enable_pclock(AFIO_BASE);

--- a/test/configs/n32g45x-canbus.config
+++ b/test/configs/n32g45x-canbus.config
@@ -1,0 +1,4 @@
+# Base config file for Nations N32G45x ARM processor using CAN bus
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G455=y
+CONFIG_STM32_CANBUS_PA11_PA12=y

--- a/test/configs/n32g45x.config
+++ b/test/configs/n32g45x.config
@@ -1,0 +1,3 @@
+# Base config file for Nations N32G45x ARM processor
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G452=y


### PR DESCRIPTION
Depends on #7347 — the diff below includes that PR's commits until it lands;

## What this does

The n32g45x reuses the stm32f103xe headers and therefore inherits `UID_BASE = 0x1FFFF7E8`. Per the N32G45x system-config-block map, that address only covers the last 4 of the 12 bytes `chipid.c` reads as the "unique ID" — the other 8 bytes come from an undocumented region of the system block, not the documented 96-bit UID (which starts at `0x1FFFF7F0`). Override `UID_BASE` for `CONFIG_MACH_N32G45x` so the full 96-bit UID is used.

## Why this is a draft

- **I can't confirm the 8 undocumented bytes are safe to drop.** If they're chip-unique (die coordinates, lot number), the current code is fine as-is and this patch is unnecessary. If they're a fixed constant, CAN UUID uniqueness today rests entirely on the last 4 bytes
- **This is a breaking change for any board already running Klipper on n32g45x.** The CAN UUID and USB serial number both change. `canbus_uuid` in `printer.cfg` will need updating, and any `/dev/serial/by-id/...` udev rule keyed on the old serial breaks too.

## Testing

Compiled a standalone probe with the real build flags: `UID_BASE` resolves to `0x1FFFF7F0` under `MACH_N32G452`, and is unchanged at `0x1FFFF7E8` under `MACH_STM32F103`. No other code references `UID_BASE`, so the diff is confined to this one macro.
