### PR TITLE
Update docs to clarify M82 does not force absolute extrusion mode

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -11,8 +11,11 @@ Klipper supports the following standard G-Code commands:
 - Move to origin: `G28 [X] [Y] [Z]`
 - Turn off motors: `M18` or `M84`
 - Wait for current moves to finish: `M400`
-- Use absolute/relative distances for extrusion: `M82`, `M83`
 - Use absolute/relative coordinates: `G90`, `G91`
+- Force relative distances for extrusion: `M83`, `M82`
+  - Note: `M83` forces extrusions to use relative coordinates even if
+    `G90` absolute mode is selected. `M82` disables that forced mode
+    (it does not force the extruder to use absolute coordinates).
 - Set position: `G92 [X<pos>] [Y<pos>] [Z<pos>] [E<pos>]`
 - Set speed factor override percentage: `M220 S<percent>`
 - Set extrude factor override percentage: `M221 S<percent>`

--- a/docs/Status_Reference.md
+++ b/docs/Status_Reference.md
@@ -233,8 +233,10 @@ The following information is available in the `gcode_move` object
   override and, for example, 2.0 would double requested extrusions.
 - `absolute_coordinates`: This returns True if in `G90` absolute
   coordinate mode or False if in `G91` relative mode.
-- `absolute_extrude`: This returns True if in `M82` absolute extrude
-  mode or False if in `M83` relative mode.
+- `absolute_extrude`: Returns True if absolute extrusions are
+  permitted. An `M83` force relative extrusion mode command causes
+  this value to return False. An `M82` command returns this value to
+  True.
 - `axis_map`: Provides a mechanism for finding the coordinate
   component for a given G-Code id that is used in `G1` commands. See
   the [Accessing Coordinates](#accessing-coordinates) section for

--- a/klippy/extras/gcode_move.py
+++ b/klippy/extras/gcode_move.py
@@ -26,7 +26,7 @@ class GCodeMove:
                                desc=self.cmd_GET_POSITION_help)
         self.Coord = gcode.Coord
         # G-Code coordinate manipulation
-        self.absolute_coord = self.absolute_extrude = True
+        self.absolute_coord = self.allow_absolute_extrude = True
         self.base_position = [0.0, 0.0, 0.0, 0.0]
         self.last_position = [0.0, 0.0, 0.0, 0.0]
         self.homing_position = [0.0, 0.0, 0.0, 0.0]
@@ -68,7 +68,7 @@ class GCodeMove:
         logging.info("gcode state: absolute_coord=%s absolute_extrude=%s"
                      " base_position=%s last_position=%s homing_position=%s"
                      " speed_factor=%s extrude_factor=%s speed=%s",
-                     self.absolute_coord, self.absolute_extrude,
+                     self.absolute_coord, self.allow_absolute_extrude,
                      self.base_position, self.last_position,
                      self.homing_position, self.speed_factor,
                      self.extrude_factor, self.speed)
@@ -106,7 +106,7 @@ class GCodeMove:
             'speed': self._get_gcode_speed(),
             'extrude_factor': self.extrude_factor,
             'absolute_coordinates': self.absolute_coord,
-            'absolute_extrude': self.absolute_extrude,
+            'absolute_extrude': self.allow_absolute_extrude,
             'homing_origin': self.Coord(self.homing_position),
             'position': self.Coord(self.last_position),
             'gcode_position': self.Coord(move_position),
@@ -141,7 +141,7 @@ class GCodeMove:
                     absolute_coord = self.absolute_coord
                     if axis == 'E':
                         v *= self.extrude_factor
-                        if not self.absolute_extrude:
+                        if not self.allow_absolute_extrude:
                             absolute_coord = False
                     if not absolute_coord:
                         # value relative to position of last move
@@ -167,11 +167,11 @@ class GCodeMove:
         # Set units to millimeters
         pass
     def cmd_M82(self, gcmd):
-        # Use absolute distances for extrusion
-        self.absolute_extrude = True
+        # Don't force relative distances for extrusion
+        self.allow_absolute_extrude = True
     def cmd_M83(self, gcmd):
-        # Use relative distances for extrusion
-        self.absolute_extrude = False
+        # Force relative distances for extrusion
+        self.allow_absolute_extrude = False
     def cmd_G90(self, gcmd):
         # Use absolute coordinates
         self.absolute_coord = True
@@ -229,7 +229,7 @@ class GCodeMove:
         state_name = gcmd.get('NAME', 'default')
         self.saved_states[state_name] = {
             'absolute_coord': self.absolute_coord,
-            'absolute_extrude': self.absolute_extrude,
+            'allow_absolute_extrude': self.allow_absolute_extrude,
             'base_position': list(self.base_position),
             'last_position': list(self.last_position),
             'homing_position': list(self.homing_position),
@@ -244,7 +244,7 @@ class GCodeMove:
             raise gcmd.error("Unknown g-code state: %s" % (state_name,))
         # Restore state
         self.absolute_coord = state['absolute_coord']
-        self.absolute_extrude = state['absolute_extrude']
+        self.allow_absolute_extrude = state['allow_absolute_extrude']
         self.base_position[:4] = state['base_position'][:4]
         self.homing_position = list(state['homing_position'])
         self.speed = state['speed']


### PR DESCRIPTION
The `M83` and `M82` commands have caused some confusion in the past.  Klipper has always treated these commands as a "forced relative extrusion mode" (as Sprinter/Marlin did in the past and as it was believed that common slicers utilized them.)  Update the documentation to make this more clear to (hopefully) avoid future confusion.

This PR is a documentation change and it should not change code behavior.

@pedrolamas fyi.

-Kevin