### PR TITLE
avr: Add atmega328/P internal temperature sensor support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -3133,9 +3133,9 @@ sensor_type: LM75
 
 ### Builtin micro-controller temperature sensor
 
-The atsam, atsamd, stm32 and rp2040 micro-controllers contain an internal
-temperature sensor. One can use the "temperature_mcu" sensor to
-monitor these temperatures.
+The atsam, atsamd, stm32, rp2040, and atmega328/p
+micro-controllers contain an internal temperature sensor. One can use
+the "temperature_mcu" sensor to monitor these temperatures.
 
 ```
 sensor_type: temperature_mcu

--- a/klippy/extras/temperature_mcu.py
+++ b/klippy/extras/temperature_mcu.py
@@ -82,6 +82,8 @@ class PrinterTemperatureMCU:
             ('stm32l4', self.config_stm32g0),
             ('stm32h723', self.config_stm32h723),
             ('stm32h7', self.config_stm32h7),
+            ('atmega328', self.config_atmega328),
+            ('atmega328P', self.config_atmega328),
             ('', self.config_unknown)]
         for name, func in cfg_funcs:
             if self.mcu_type.startswith(name):
@@ -166,6 +168,9 @@ class PrinterTemperatureMCU:
         cal_adc_110 = self.read16(0x1FF1E840) / 65535.
         self.slope = (110. - 30.) / (cal_adc_110 - cal_adc_30)
         self.base_temperature = self.calc_base(30., cal_adc_30)
+    def config_atmega328(self):
+        self.slope = 1.1 / .00157
+        self.base_temperature = self.calc_base(25., .359 / 1.1)
     def read16(self, addr):
         params = self.debug_read_cmd.send([1, addr])
         return params['val']

--- a/src/avr/adc.c
+++ b/src/avr/adc.c
@@ -12,10 +12,16 @@
 #include "pgm.h" // PROGMEM
 #include "sched.h" // sched_shutdown
 
+#define ADC_TEMPERATURE_PIN 0xfe
+DECL_ENUMERATION("pin", "ADC_TEMPERATURE", ADC_TEMPERATURE_PIN);
+
 static const uint8_t adc_pins[] PROGMEM = {
-#if CONFIG_MACH_atmega168 || CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+#if CONFIG_MACH_atmega168
     GPIO('C', 0), GPIO('C', 1), GPIO('C', 2), GPIO('C', 3),
     GPIO('C', 4), GPIO('C', 5), GPIO('E', 2), GPIO('E', 3),
+#elif CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+    GPIO('C', 0), GPIO('C', 1), GPIO('C', 2), GPIO('C', 3),
+    GPIO('C', 4), GPIO('C', 5), GPIO('E', 2), GPIO('E', 3),ADC_TEMPERATURE_PIN,
 #elif CONFIG_MACH_atmega644p || CONFIG_MACH_atmega1284p
     GPIO('A', 0), GPIO('A', 1), GPIO('A', 2), GPIO('A', 3),
     GPIO('A', 4), GPIO('A', 5), GPIO('A', 6), GPIO('A', 7),
@@ -90,6 +96,8 @@ gpio_adc_setup(uint8_t pin)
         }
     else
 #endif
+    // The internal temperature sensor is not connected to a digital input.
+    if (chan < 8)
         DIDR0 |= 1 << chan;
 
     return (struct gpio_adc){ chan };
@@ -120,6 +128,12 @@ gpio_adc_sample(struct gpio_adc g)
     // The MUX5 bit of ADCSRB selects whether we're reading from
     // channels 0 to 7 (MUX5 low) or 8 to 15 (MUX5 high).
     ADCSRB = ((g.chan >> 3) & 0x01) << MUX5;
+#endif
+#if CONFIG_MACH_atmega328 || CONFIG_MACH_atmega328p
+    // Select the internal temperature sensor with the 1.1V reference.
+    if (g.chan == 8)
+        ADMUX = 0xC0 | g.chan;
+    else
 #endif
     ADMUX = ADMUX_DEFAULT | (g.chan & 0x07);
 


### PR DESCRIPTION
## Summary

Add support for reading the internal temperature sensor on atmega328 and atmega328p devices.

The sensor is read through ADC channel 8 with the internal 1.1V reference. The channel is excluded from the DIDR0 digital input configuration, as it is connected to the internal temperature sensor rather than a digital input.

Add the corresponding slope and base temperature values in `temperature_mcu.py`.

The slope and base temperature values in `temperature_mcu.py` are calculated from the sensor values provided in [PR #4988](https://github.com/Klipper3d/klipper/pull/4988)

## Credits

This work is based on code from
[PR #4988](https://github.com/Klipper3d/klipper/pull/4988) by Hu Guangzheng (`eikeime`).