### PR TITLE
Axis twist compensation: allow  to use tap instead of manual probe

### DIFF
--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -1590,7 +1590,7 @@ is enabled.
 
 #### TEMPERATURE_PROBE_CALIBRATE
 `TEMPERATURE_PROBE_CALIBRATE [PROBE=<probe name>] [TARGET=<value>] [STEP=<value>]
-[METHOD=<method>]`:
+[MANUAL_METHOD=<method>]`:
 Initiates probe drift calibration for eddy current based probes.  The `TARGET`
 is a target temperature for the last sample.  When the temperature recorded
 during a sample exceeds the `TARGET` calibration will complete.  The `STEP`

--- a/docs/G-Codes.md
+++ b/docs/G-Codes.md
@@ -157,7 +157,8 @@ The following commands are available when the
 section](Config_Reference.md#axis_twist_compensation) is enabled.
 
 #### AXIS_TWIST_COMPENSATION_CALIBRATE
-`AXIS_TWIST_COMPENSATION_CALIBRATE [AXIS=<X|Y>] [SAMPLE_COUNT=<value>]`
+`AXIS_TWIST_COMPENSATION_CALIBRATE [AXIS=<X|Y>] [SAMPLE_COUNT=<value>]
+[MANUAL_METHOD=manual]`
 
 Calibrates axis twist compensation by specifying the target axis or
 enabling automatic calibration.
@@ -1266,7 +1267,8 @@ applies the change to `tap_z_offset` so that future `tap` probes are
 updated to use the current Z G-Code offset.
 
 #### PROBE_EDDY_CURRENT_CALIBRATE
-`PROBE_EDDY_CURRENT_CALIBRATE CHIP=<config_name>`: This starts a tool
+`PROBE_EDDY_CURRENT_CALIBRATE CHIP=<config_name> [MANUAL_METHOD=manual]`:
+This starts a tool
 that calibrates the sensor resonance frequencies to corresponding Z
 heights. The tool will take a couple of minutes to complete. After
 completion, use the SAVE_CONFIG command to store the results in the

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -40,6 +40,7 @@ class ManualProbe:
         self.gcode_move = self.printer.load_object(config, "gcode_move")
         self.gcode.register_command('MANUAL_PROBE', self.cmd_MANUAL_PROBE,
                                     desc=self.cmd_MANUAL_PROBE_help)
+        self._manual_methods = {}
         # Endstop value for cartesian printers with separate Z axis
         zconfig = lookup_z_endstop_config(config)
         if zconfig is not None:
@@ -78,6 +79,15 @@ class ManualProbe:
                 self.cmd_Z_OFFSET_APPLY_DELTA_ENDSTOPS,
                 desc=self.cmd_Z_OFFSET_APPLY_ENDSTOP_help)
         self.reset_status()
+    def register_manual_method(self, key, callback):
+        if callback:
+            self._manual_methods[key] = callback
+        else:
+            del self._manual_methods[key]
+    def get_manual_method(self, key):
+        if key not in self._manual_methods:
+            raise self.printer.command_error("Not supported manual method")
+        return self._manual_methods[key]
     def manual_probe_finalize(self, mpresult):
         if mpresult is not None:
             self.gcode.respond_info("Z position is %.3f" % (mpresult.bed_z,))
@@ -157,6 +167,24 @@ def verify_no_manual_probe(printer):
             "Already in a manual Z probe. Use ABORT to abort it.")
     gcode.register_command('ACCEPT', None)
 
+# Helper to handle nozzle probe calls
+class AutoProbeHelper:
+    def __init__(self, printer, finalize_callback, pos):
+        self.gcode = printer.lookup_object('gcode')
+        self.command_error = printer.command_error
+        self.pos = pos
+        self.finalize_callback = finalize_callback
+        self.gcode.register_command('ACCEPT', self.cmd_callback)
+    def cmd_callback(self, gcmd):
+        self.gcode.register_command('ACCEPT', None)
+        self.finalize_callback(self.pos)
+    def callback(self, eventtime):
+        try:
+            self.gcode.run_script("ACCEPT")
+        # Necessary error output happened inside run_script
+        except self.command_error:
+            pass
+
 Z_BOB_MINIMUM = 0.500
 BISECT_MAX = 0.200
 
@@ -173,6 +201,14 @@ class ManualProbeHelper:
         self.last_toolhead_pos = self.last_kinematics_pos = None
         # Register commands
         verify_no_manual_probe(printer)
+        method = gcmd.get("MANUAL_METHOD", "manual")
+        if method != "manual":
+            callback = self.manual_probe.get_manual_method(method)
+            pos = callback(gcmd)
+            aph = AutoProbeHelper(printer, finalize_callback, pos)
+            reactor = self.printer.get_reactor()
+            reactor.register_callback(aph.callback)
+            return
         self.gcode.register_command('ACCEPT', self.cmd_ACCEPT,
                                     desc=self.cmd_ACCEPT_help)
         self.gcode.register_command('NEXT', self.cmd_ACCEPT)

--- a/klippy/extras/manual_probe.py
+++ b/klippy/extras/manual_probe.py
@@ -169,19 +169,30 @@ def verify_no_manual_probe(printer):
 
 # Helper to handle nozzle probe calls
 class AutoProbeHelper:
-    def __init__(self, printer, finalize_callback, pos):
+    def __init__(self, printer, probe_callback, gcmd, finalize_callback):
         self.gcode = printer.lookup_object('gcode')
         self.command_error = printer.command_error
-        self.pos = pos
+        self.probe_callback = probe_callback
+        self.gcmd = gcmd
+        self.pos = None
         self.finalize_callback = finalize_callback
-        self.gcode.register_command('ACCEPT', self.cmd_callback)
-    def cmd_callback(self, gcmd):
+        self.gcode.register_command('NEXT', self.cmd_next)
+        self.gcode.register_command('ACCEPT', self.cmd_accept)
+    def cmd_next(self, gcmd):
+        self.gcode.register_command('NEXT', None)
+        pos = self.probe_callback(self.gcmd)
+        self.pos = pos
+    def cmd_accept(self, gcmd):
         self.gcode.register_command('ACCEPT', None)
         self.finalize_callback(self.pos)
     def callback(self, eventtime):
         try:
-            self.gcode.run_script("ACCEPT")
+            self.gcode.run_script("NEXT")
         # Necessary error output happened inside run_script
+        except self.command_error:
+            pass
+        try:
+            self.gcode.run_script("ACCEPT")
         except self.command_error:
             pass
 
@@ -204,8 +215,7 @@ class ManualProbeHelper:
         method = gcmd.get("MANUAL_METHOD", "manual")
         if method != "manual":
             callback = self.manual_probe.get_manual_method(method)
-            pos = callback(gcmd)
-            aph = AutoProbeHelper(printer, finalize_callback, pos)
+            aph = AutoProbeHelper(printer, callback, gcmd, finalize_callback)
             reactor = self.printer.get_reactor()
             reactor.register_callback(aph.callback)
             return

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -1053,6 +1053,19 @@ class PrinterEddyProbe:
         self.cmd_helper = probe.ProbeCommandHelper(config, self,
                                                    can_set_z_offset=False)
         self.printer.add_object('probe', self)
+        # Register tap as a manual probe provider
+        mprobe = self.printer.load_object(config, 'manual_probe')
+        mprobe.register_manual_method("tap", self._handle_manual_probe_via_tap)
+    def _handle_manual_probe_via_tap(self, gcmd):
+        fo_params = dict(gcmd.get_command_parameters())
+        fo_params["METHOD"] = "tap"
+        gcode = self.printer.lookup_object('gcode')
+        fo_gcmd = gcode.create_gcode_command("PROBE", "PROBE", fo_params)
+        probe_session = self.eddy_tap_session.start_probe_session(fo_gcmd)
+        probe_session.run_probe(fo_gcmd)
+        pos = probe_session.pull_probed_results()[0]
+        probe_session.end_probe_session()
+        return pos
     def add_client(self, cb):
         self.sensor_helper.add_client(cb)
     def get_probe_params(self, gcmd=None):

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -387,13 +387,9 @@ class TemperatureProbe:
         # Capture start position and begin initial probe
         toolhead = self.printer.lookup_object("toolhead")
         self.start_pos = toolhead.get_position()[:2]
-        try:
-            manual_probe.ManualProbeHelper(
-                self.printer, gcmd, self._manual_probe_finalize
-            )
-        except self.printer.command_error:
-            self._finalize_drift_cal(False)
-            raise
+        manual_probe.ManualProbeHelper(
+            self.printer, gcmd, self._manual_probe_finalize
+        )
 
     cmd_TEMPERATURE_PROBE_NEXT_help = "Sample next probe drift temperature"
     def cmd_TEMPERATURE_PROBE_NEXT(self, gcmd):
@@ -413,12 +409,9 @@ class TemperatureProbe:
         curpos[2] = start_z
         toolhead.manual_move(curpos, probe_speed)
         self.gcode.register_command("ABORT", None)
-        try:
-            manual_probe.ManualProbeHelper(
-                self.printer, gcmd, self._manual_probe_finalize
-            )
-        except self.printer.command_error as e:
-            self._finalize_drift_cal(False, str(e))
+        manual_probe.ManualProbeHelper(
+            self.printer, gcmd, self._manual_probe_finalize
+        )
 
     cmd_TEMPERATURE_PROBE_COMPLETE_help = "Finish Probe Drift Calibration"
     def cmd_TEMPERATURE_PROBE_COMPLETE(self, gcmd):

--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -156,7 +156,8 @@ class TemperatureProbe:
         smoothed_temp = self.last_measurement[0]
         if self.in_calibration and smoothed_temp >= self.next_auto_temp:
             self.next_auto_temp = 99999999.
-            self.gcode.run_script("TEMPERATURE_PROBE_NEXT")
+            cmd = "TEMPERATURE_PROBE_NEXT MANUAL_METHOD=%s" % (self._method)
+            self.gcode.run_script(cmd)
 
     def get_temp(self, eventtime=None):
         return self.last_measurement[0], self.target_temp
@@ -322,19 +323,8 @@ class TemperatureProbe:
     cmd_TEMPERATURE_PROBE_CALIBRATE_help = (
         "Calibrate probe temperature drift compensation"
     )
-    def _auto_probe(self, gcmd):
-        fo_params = dict(gcmd.get_command_parameters())
-        fo_params['METHOD'] = self._method
-        gcode = self.printer.lookup_object('gcode')
-        fo_gcmd = gcode.create_gcode_command("PROBE", "PROBE", fo_params)
-        pprobe = self.printer.lookup_object("probe")
-        probe_session = pprobe.start_probe_session(fo_gcmd)
-        probe_session.run_probe(fo_gcmd)
-        pos = probe_session.pull_probed_results()[0]
-        probe_session.end_probe_session()
-        self._manual_probe_finalize(pos)
     def cmd_TEMPERATURE_PROBE_CALIBRATE(self, gcmd):
-        self._method = gcmd.get('METHOD', 'manual').lower()
+        self._method = gcmd.get('MANUAL_METHOD', 'manual').lower()
         if self.cal_helper is None:
             raise gcmd.error(
                 "No calibration helper registered for [%s]"
@@ -397,16 +387,13 @@ class TemperatureProbe:
         # Capture start position and begin initial probe
         toolhead = self.printer.lookup_object("toolhead")
         self.start_pos = toolhead.get_position()[:2]
-        if self._method == "tap":
-            try:
-                self._auto_probe(gcmd)
-            except self.printer.command_error:
-                self._finalize_drift_cal(False)
-                raise
-            return
-        manual_probe.ManualProbeHelper(
-            self.printer, gcmd, self._manual_probe_finalize
-        )
+        try:
+            manual_probe.ManualProbeHelper(
+                self.printer, gcmd, self._manual_probe_finalize
+            )
+        except self.printer.command_error:
+            self._finalize_drift_cal(False)
+            raise
 
     cmd_TEMPERATURE_PROBE_NEXT_help = "Sample next probe drift temperature"
     def cmd_TEMPERATURE_PROBE_NEXT(self, gcmd):
@@ -426,15 +413,12 @@ class TemperatureProbe:
         curpos[2] = start_z
         toolhead.manual_move(curpos, probe_speed)
         self.gcode.register_command("ABORT", None)
-        if self._method == "tap":
-            try:
-                self._auto_probe(gcmd)
-            except self.printer.command_error as e:
-                self._finalize_drift_cal(False, str(e))
-            return
-        manual_probe.ManualProbeHelper(
-            self.printer, gcmd, self._manual_probe_finalize
-        )
+        try:
+            manual_probe.ManualProbeHelper(
+                self.printer, gcmd, self._manual_probe_finalize
+            )
+        except self.printer.command_error as e:
+            self._finalize_drift_cal(False, str(e))
 
     cmd_TEMPERATURE_PROBE_COMPLETE_help = "Finish Probe Drift Calibration"
     def cmd_TEMPERATURE_PROBE_COMPLETE(self, gcmd):


### PR DESCRIPTION
This is a simple reimplementation of the feature, which seems to be used among the carto community.

Basically, it allows one to use `METHOD=tap` to get the nozzle reference instead of a manual method.
As the only way to alter tap behavior is to pass gcmd params, normal probe uses "config defaults" in case if tap is specified.

```
$ AXIS_TWIST_COMPENSATION_CALIBRATE METHOD=tap
// AXIS_TWIST_COMPENSATION_CALIBRATE: Probing point 1 of 3
// probe: at 25.000,200.000 bed will contact at z=0.044334
// probe: at 25.000,200.000 bed will contact at z=0.043519
// probe: at 25.000,200.000 bed will contact at z=0.044676
// probe: at 25.000,200.000 bed will contact at z=-0.005754
// AXIS_TWIST_COMPENSATION_CALIBRATE: Probing point 2 of 3
// probe: at 207.500,200.000 bed will contact at z=-0.017603
// probe: at 207.500,200.000 bed will contact at z=-0.017244
// probe: at 207.500,200.000 bed will contact at z=-0.017196
// probe: at 207.500,200.000 bed will contact at z=-0.096507
// AXIS_TWIST_COMPENSATION_CALIBRATE: Probing point 3 of 3
// probe: at 390.000,200.000 bed will contact at z=0.035094
// probe: at 390.000,200.000 bed will contact at z=0.035422
// probe: at 390.000,200.000 bed will contact at z=0.035396
// probe: at 390.000,200.000 bed will contact at z=-0.070225
// AXIS_TWIST_COMPENSATION_CALIBRATE: Calibration complete, offsets: [0.028275985746576277, -0.0009533601955554472, -0.02732262555102083], mean z_offset: 0.078206
```

Regards,
-Timofey

---
~~Depends on context manager: #7338~~