### PR TITLE
load_cell_probe: Disable debug output

### DIFF
--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -490,11 +490,11 @@ class TappingMove:
                 "each) for piecewise fit" % (below_count, above_count,
                                              FIT_MIN_POINTS))
 
-        gcmd.respond_info("Load cell probe fit: n_below=%d n_above=%d"
-                          " z_contact=%.4f raw=%.4f delta=%.4f"
-                          " depress_slope=%.4f" % (
-                          below_count, above_count, z_contact, raw_z,
-                          raw_z - z_contact, depress_slope))
+        # gcmd.respond_info("Load cell probe fit: n_below=%d n_above=%d"
+        #                   " z_contact=%.4f raw=%.4f delta=%.4f"
+        #                   " depress_slope=%.4f" % (
+        #                   below_count, above_count, z_contact, raw_z,
+        #                   raw_z - z_contact, depress_slope))
 
         if self._load_cell_probing_move._mcu.is_fileoutput():
             # In debugging mode: check fit result


### PR DESCRIPTION
Seems to be an accidental leftover: https://github.com/Klipper3d/klipper/pull/7301/changes#r3730155619
<img width="673" height="1180" alt="image" src="https://github.com/user-attachments/assets/8dc77d1b-1189-4469-94c1-a7aed51dd814" />

jfyi: @mhier 

Thanks,
-Timofey