### PR TITLE
load_cell_probe: Workaround move out of range for G28 Z

### DIFF
--- a/klippy/extras/load_cell_probe.py
+++ b/klippy/extras/load_cell_probe.py
@@ -413,6 +413,12 @@ class TappingMove:
         epos, collector = self._load_cell_probing_move.probing_move(gcmd)
         # collect samples from the tap
         toolhead = self._printer.lookup_object('toolhead')
+        # Homing workaround
+        phoming = self._printer.lookup_object('homing')
+        if phoming.check_probe_first_home(gcmd):
+            curpos = toolhead.get_position()
+            curpos[2] -= epos[2]
+            toolhead.set_position(curpos)
 
         # Lift the toolhead while collecting the samples we will use for
         # the fit. The ascent data shall cover both the contact region

--- a/test/klippy/load_cell.cfg
+++ b/test/klippy/load_cell.cfg
@@ -27,8 +27,7 @@ dir_pin: PL1
 enable_pin: !PK0
 microsteps: 16
 rotation_distance: 8
-endstop_pin: PK1
-position_endstop: 0.0
+endstop_pin: probe:z_virtual_endstop
 position_max: 200
 
 [extruder]


### PR DESCRIPTION
It seems that #7301 has introduced some ~~issues with homing_override.~~
I guess, actually just no one used the `endstop_pin: probe:z_virtual_endstop`
So, it was not tested.

This PR is a workaround for what I believe is the reason for `Move out of range`

It can be squashed.
I've received one report that it fixes the issue.
Not sure if it can be implemented better.

So, it seems that upon homing from Z x1.5 of min/max.
It often happens that the toolhead stops inside the > x1.0 range.
So, upon attempting to retract the toolhead, one will get an "Move out of range" error.
As x1.0 + N mm is definitely out of the Z range.

So, it seems that I can utilize the internal G-code parameters to reset the toolhead position before retracting.

Regards,
-Timofey

---

Testing:
```
cd ~/klipper
git fetch origin pull/7355/head
git checkout FETCH_HEAD
sudo systemctl restart klipper
```
