### PR TITLE
hd44780: Make command delay configurable

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4650,6 +4650,11 @@ d7_pin:
 #   Set the number of characters per line for an hd44780 type lcd.
 #   Possible values are 20 (default) and 16. The number of lines is
 #   fixed to 4.
+#hd44780_delay: 0.000040
+#   The minimum time (in seconds) to wait after sending a command
+#   to the hd44780 chip. This may need to be increased on some
+#   "clone" devices that require more time to process a command.
+#   The default is 0.000040 (40us).
 ...
 ```
 

--- a/klippy/extras/display/hd44780.py
+++ b/klippy/extras/display/hd44780.py
@@ -25,6 +25,8 @@ class HD44780:
                                                        True)
         self.line_length = config.getchoice('line_length', LINE_LENGTH_OPTIONS,
                                             LINE_LENGTH_DEFAULT)
+        self.hd44780_delay = config.getfloat('hd44780_delay', HD44780_DELAY,
+                                             above=0.)
         mcu = None
         for pin_params in pins:
             if mcu is not None and pin_params['chip'] != mcu:
@@ -54,7 +56,7 @@ class HD44780:
             " d4_pin=%s d5_pin=%s d6_pin=%s d7_pin=%s delay_ticks=%d" % (
                 self.oid, self.pins[0], self.pins[1],
                 self.pins[2], self.pins[3], self.pins[4], self.pins[5],
-                self.mcu.seconds_to_clock(HD44780_DELAY)))
+                self.mcu.seconds_to_clock(self.hd44780_delay)))
         cmd_queue = self.mcu.alloc_command_queue()
         self.send_cmds_cmd = self.mcu.lookup_command(
             "hd44780_send_cmds oid=%c cmds=%*s", cq=cmd_queue)


### PR DESCRIPTION
## Summary
Makes the HD44780 LCD display command delay configurable, allowing
users to adjust the timing for displays that require more time to
process commands.

## Key Changes
- Added `hd44780_delay` config option to specify a custom command
  delay (in seconds)
- Default value remains 0.000040 seconds (40 microseconds), so
  existing configs are unaffected
- The configurable delay is used instead of the hardcoded
  `HD44780_DELAY` constant when calculating clock ticks
- Updated Config_Reference.md with the new option

## Real-World Verification
Tested on a multi-printer Klipper setup (4 printers sharing one
klippy checkout). Two printers with genuine-timing HD44780-compatible
displays work fine at the existing 40us default (per the Hitachi
HD44780 datasheet, the minimum enable pulse/cycle timing is ~37us,
so 40us already carries a small margin). A third printer with a
cheaper ACM2004 "clone" display module needed a larger margin and
only displayed reliably once the delay was raised to 50us -
previously only achievable by hand-editing the hardcoded
HD44780_DELAY constant in hd44780.py. With this change, that printer
sets `hd44780_delay: 0.000050` in its own [display] config section,
while the other printers keep the unmodified 40us default - no
shared, repo-wide hack needed for one non-conforming display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
