### PR TITLE
temperature_probe: use the tap contact position as drift reference

### DIFF
--- a/klippy/extras/temperature_probe.py
+++ b/klippy/extras/temperature_probe.py
@@ -211,7 +211,17 @@ class TemperatureProbe:
             )
         self.last_zero_pos = mpresult.bed_z
         toolhead = self.printer.lookup_object("toolhead")
-        tool_zero_z = toolhead.get_position()[2]
+        # A "tap" probe retracts after detecting contact, so the current
+        # toolhead position is not the bed contact position.  Using it as the
+        # drift sample reference shifts every sample up by the retract
+        # distance (~4mm), collecting them in the sensor's far field where
+        # sensitivity is low.  The resulting compensation is ineffective.
+        # Note that collect_sample() already reports the sample heights
+        # relative to mpresult.bed_z, so that is the intended reference.
+        if self._method == "tap":
+            tool_zero_z = mpresult.bed_z
+        else:
+            tool_zero_z = toolhead.get_position()[2]
         try:
             last_temp = self._collect_sample(mpresult, tool_zero_z)
         except Exception:


### PR DESCRIPTION
TEMPERATURE_PROBE_CALIBRATE with METHOD=tap reads the toolhead position
after the tap probe has already retracted, so the drift samples were
referenced ~4mm above the bed contact point.  Every sample was therefore
collected in the eddy sensor far field: on a BTT Eddy the measured
frequency span dropped to 18% of the calibrated range and the resulting
drift compensation corrected essentially nothing (measured: 8um of
correction applied against 73um of real drift over a 13C span).

collect_sample() already logs the sample heights as bed_z relative, which
is the intended reference.  Use it for the tap method; the manual method
is unchanged because there the toolhead is left at the contact position.

After this change the sample frequency span matches the calibration table
to 98% and the compensation applies 85% of the required correction.

Signed-off-by: Rafael Tiengo <ogneit@gmail.com>
