### PR TITLE
probe_eddy_current: add tap_speed configuration option

### DIFF
--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -998,13 +998,18 @@ class EddyProbeOffsets:
 class EddyParameterHelper:
     def __init__(self, config):
         self._param_helper = probe.ProbeParameterHelper(config)
+        # The "tap" method does not use the section's "speed" option (that
+        # applies to the default descend probing).  Allow the tap probing
+        # speed to be configured; the default preserves previous behavior.
+        self.tap_speed = config.getfloat('tap_speed', 5.0, above=0.)
     def get_probe_params(self, gcmd=None):
         method = None
         if gcmd is not None:
             method = gcmd.get('METHOD', '').lower()
         if method not in ['scan', 'rapid_scan', 'tap']:
             return self._param_helper.get_probe_params(gcmd)
-        probe_speed = gcmd.get_float("PROBE_SPEED", 5.0, above=0.)
+        default_speed = self.tap_speed if method == 'tap' else 5.0
+        probe_speed = gcmd.get_float("PROBE_SPEED", default_speed, above=0.)
         lift_speed = gcmd.get_float("LIFT_SPEED", 5.0, above=0.)
         samples = gcmd.get_int("SAMPLES", 1, minval=1)
         samp_retract_dist = 0.


### PR DESCRIPTION
EddyParameterHelper hardcodes a 5.0mm/s default probing speed for the
scan, rapid_scan and tap methods, so the section speed option only
applies to the default descend probing.  There is no way to configure
the speed of a tap probe other than passing PROBE_SPEED on every
command, which is not possible when tap probing is driven internally
(for example the automatic sampling of TEMPERATURE_PROBE_CALIBRATE).

The tap depress distance grows with probing speed and is rejected above
a fixed 0.250mm limit.  On a machine that measures 0.249mm at 5.0mm/s
taps fail about half the time with no way to tune it; at 1.5mm/s the
same machine measures 0.158mm.

Add a tap_speed option used as the default for the tap method only.  The
5.0 default preserves the current behavior when the option is absent.

Signed-off-by: Rafael Tiengo <ogneit@gmail.com>
