### PR TITLE
Probe eddy current tap calibration adjustments

### DIFF
--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -414,7 +414,7 @@ class EddyTapCalibration:
             if mc_coeffs is None:
                 raise gcmd.error(
                     "Must complete PROBE_EDDY_CURRENT_CALIBRATE first")
-            self._try_tap(gcmd, mc_coeffs[1][0] * -0.10)
+            self._try_tap(gcmd, mc_coeffs[1][0] * -0.15)
         elif tap_test == 'refine':
             # Attempt tap based on change in slope observed during last tap
             self._refine_tap_threshold = None

--- a/klippy/extras/probe_eddy_current.py
+++ b/klippy/extras/probe_eddy_current.py
@@ -424,6 +424,9 @@ class EddyTapCalibration:
             z_contact, freq_contact, depress_slope, slope, slope2 = coeffs
             contact_slope_delta = depress_slope - slope
             try_tap_threshold = contact_slope_delta * 0.20
+            max_safe_threshold = contact_slope_delta * 0.90
+            gcmd.respond_info("TAP_THRESHOLD tests should remain below %.3f" % (
+                max_safe_threshold))
             self._try_tap(gcmd, try_tap_threshold)
             self._refine_tap_threshold = try_tap_threshold
         elif tap_test == 'verify':


### PR DESCRIPTION
Small tap calibration adjustments.
An optional small bump for the guess value; it seems that often the value is about 60% of refine:
```
# guess vs refine 
16580.839 / 27409.877 = 0.6049 # My carto
3408.364 / 2914.670 = 1.1693 # Eddy
5556.734 / 8928.240 = 0.6223 # Eddy 2
2251.090 / 3347.670 = 0.6724 # Eddy 3
5511.989 / 5232.016 = 1.053 # Eddy 4
```

So, it should be safe to bump it a little to decrease the small percentage where it can be unsuccessful (I guess there were 1 or 2 reports in the past 9 months).
The cons: it basically can hide/forgive too large sensor distance or noise issues, at least during calibration.

With the adjusted constant, it gives a closer-to-refined value for me.
```
$ PROBE_EDDY_CURRENT_TAP_CALIBRATE TAP=guess
// Tap probing with TAP_THRESHOLD=24871.259 SAMPLES=1
$ PROBE_EDDY_CURRENT_TAP_CALIBRATE TAP=refine
// Tap probing with TAP_THRESHOLD=28382.147 SAMPLES=1
24871.259 / 28382.147 = 0.8763
```

The second one outputs the max threshold, so as we generally expect, that tap threshold value can require manual adjustment (up to 40% of contact_slope_delta, if I recall correctly).

I've added a direct output of the value, so one can guess about the ceiling without any explanation.

Regards,
-Timofey

---
_Where refine values can be tricky._
_It seems to be on the low side for BTT Eddy, so one can trigger an error with elevated temperature. Maybe x0.25 is a better default here._
_On Carto probes, it is a bit on the high side, and x0.1 should do. So one will not have issues with temperature. But it can depress ~0.11 mm, which can bend a portal a little._