### PR TITLE
stm32: fix n32g45x adc clocking and calibration

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -152,7 +152,10 @@ config MACH_N32G45x
 config HAVE_STM32_USBFS
     bool
     default y if MACH_STM32F0x2 || MACH_STM32G0Bx || MACH_STM32L4 || MACH_STM32G4
-    default y if (MACH_STM32F1 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    default y if (MACH_STM32F103 || MACH_STM32F070) && !STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock needs an exact 96Mhz pll output, which only
+    # some reference crystals can produce
+    default y if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_12M || STM32_CLOCK_REF_16M || STM32_CLOCK_REF_24M)
 config HAVE_STM32_USBOTG
     bool
     default y if MACH_STM32F2 || MACH_STM32F4 || MACH_STM32F7 || MACH_STM32H7
@@ -220,7 +223,13 @@ config CLOCK_FREQ
     # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
     # limited number of system clock rates can produce the required 48Mhz
     default 96000000 if MACH_N32G45x && USB
-    default 128000000 if MACH_N32G45x
+    # The n32g45x PLL multiplies the crystal (or its half) by an integer,
+    # so only rates that are an exact multiple of crystal / 2 can be
+    # generated - default to the highest rate each crystal produces exactly
+    default 128000000 if MACH_N32G45x && (STM32_CLOCK_REF_8M || STM32_CLOCK_REF_16M)
+    default 144000000 if MACH_N32G45x && (STM32_CLOCK_REF_12M || STM32_CLOCK_REF_24M)
+    default 140000000 if MACH_N32G45x && STM32_CLOCK_REF_20M
+    default 125000000 if MACH_N32G45x && STM32_CLOCK_REF_25M
 
 config FLASH_SIZE
     hex

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -215,7 +215,11 @@ config CLOCK_FREQ
     default 400000000 if MACH_STM32H743
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
+    # The n32g45x PLL input is HSI/2 (4Mhz) when using the internal oscillator
     default 64000000 if MACH_N32G45x && STM32_CLOCK_REF_INTERNAL
+    # The n32g45x usb clock is PLLCLK divided by 1, 1.5, 2 or 3 - only a
+    # limited number of system clock rates can produce the required 48Mhz
+    default 96000000 if MACH_N32G45x && USB
     default 128000000 if MACH_N32G45x
 
 config FLASH_SIZE

--- a/src/stm32/n32g45x_adc.c
+++ b/src/stm32/n32g45x_adc.c
@@ -131,36 +131,33 @@ gpio_adc_setup(uint32_t pin)
     }
 
     // Determine which ADC block to use
-    ADC_Module *adc;
-    if ((chan >> 5) == 0)
-        adc = NS_ADC1;
-    if ((chan >> 5) == 1)
-        adc = NS_ADC2;
-    if ((chan >> 5) == 2)
-        adc = NS_ADC3;
-    if ((chan >> 5) == 3)
-        adc = NS_ADC4;
+    static ADC_Module * const adc_blocks[] = {
+        NS_ADC1, NS_ADC2, NS_ADC3, NS_ADC4
+    };
+    uint32_t block = chan >> 5;
+    ADC_Module *adc = adc_blocks[block];
+    uint32_t adc_clock_bit = RCC_AHB_PERIPH_ADC1 << block;
     chan &= 0x1F;
 
-    // Enable the ADC
-    uint32_t reg_temp;
-    reg_temp = ADC_RCC_AHBPCLKEN;
-    reg_temp |= (RCC_AHB_PERIPH_ADC1 | RCC_AHB_PERIPH_ADC2 |
-                RCC_AHB_PERIPH_ADC3 | RCC_AHB_PERIPH_ADC4);
-    ADC_RCC_AHBPCLKEN = reg_temp;
+    // Enable and calibrate each adc block only the first time one of its
+    // channels is configured.  Several pins can share a block, and
+    // recalibrating one that is already running leaves it unable to
+    // complete a conversion for any of its other channels.
+    if (!(ADC_RCC_AHBPCLKEN & adc_clock_bit)) {
+        adc_clock_setup();
+        ADC_RCC_AHBPCLKEN |= adc_clock_bit;
 
-    adc_clock_setup();
+        ADC_InitType ADC_InitStructure;
+        ADC_InitStructure.WorkMode       = ADC_WORKMODE_INDEPENDENT;
+        ADC_InitStructure.MultiChEn      = 0;
+        ADC_InitStructure.ContinueConvEn = 0;
+        ADC_InitStructure.ExtTrigSelect  = ADC_EXT_TRIGCONV_NONE;
+        ADC_InitStructure.DatAlign       = ADC_DAT_ALIGN_R;
+        ADC_InitStructure.ChsNumber      = 1;
+        ADC_Init(adc, &ADC_InitStructure);
 
-    ADC_InitType ADC_InitStructure;
-    ADC_InitStructure.WorkMode       = ADC_WORKMODE_INDEPENDENT;
-    ADC_InitStructure.MultiChEn      = 0;
-    ADC_InitStructure.ContinueConvEn = 0;
-    ADC_InitStructure.ExtTrigSelect  = ADC_EXT_TRIGCONV_NONE;
-    ADC_InitStructure.DatAlign       = ADC_DAT_ALIGN_R;
-    ADC_InitStructure.ChsNumber      = 1;
-    ADC_Init(adc, &ADC_InitStructure);
-
-    adc_calibrate(adc);
+        adc_calibrate(adc);
+    }
 
     if (pin == ADC_TEMPERATURE_PIN) {
         NS_ADC1->CTRL2 |= CTRL2_TSVREFE_SET;

--- a/src/stm32/n32g45x_adc.c
+++ b/src/stm32/n32g45x_adc.c
@@ -4,6 +4,7 @@
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
 #include "board/irq.h" // irq_save
 #include "board/misc.h" // timer_from_us
 #include "command.h" // shutdown
@@ -62,16 +63,57 @@ static const uint8_t adc_pins[] = {
 #endif
 };
 
+// The adc needs both a conversion clock (ADCHCLK, derived from HCLK)
+// and a separate 1Mhz reference clock (ADC1M).  Neither has a usable
+// reset default at the clock rates this chip runs at, so configure
+// both before enabling an adc.
+static void
+adc_clock_setup(void)
+{
+    // Pick the smallest divisor that keeps ADCHCLK at or below 9Mhz
+    static const uint8_t adchclk_divs[] = { 1, 2, 4, 6, 8, 10, 12, 16, 32 };
+    uint32_t adchclk_pres = ARRAY_SIZE(adchclk_divs) - 1;
+    uint32_t i;
+    for (i = 0; i < ARRAY_SIZE(adchclk_divs); i++) {
+        if (CONFIG_CLOCK_FREQ / adchclk_divs[i] <= 9000000) {
+            adchclk_pres = i;
+            break;
+        }
+    }
+    // ADC1M is divided down from the same oscillator the pll uses: the
+    // crystal when there is one, otherwise the 8Mhz internal oscillator
+    uint32_t adc1m_src = (CONFIG_STM32_CLOCK_REF_INTERNAL
+                          ? RCC_ADC1MCLK_SRC_HSI : RCC_ADC1MCLK_SRC_HSE);
+    uint32_t adc1m_freq = (CONFIG_STM32_CLOCK_REF_INTERNAL
+                           ? 8000000 : CONFIG_CLOCK_REF_FREQ);
+    uint32_t adc1m_pres = (adc1m_freq / 1000000 - 1) << 11;
+
+    uint32_t reg_temp = ADC_RCC_CFG2;
+    // Run the adc from HCLK, leaving the pll sourced adc clock disabled
+    reg_temp &= CFG2_ADCPLLPRES_RESET_MASK;
+    reg_temp &= RCC_ADCPLLCLK_DISABLE;
+    reg_temp &= CFG2_ADCHPRES_RESET_MASK;
+    reg_temp |= adchclk_pres;
+    reg_temp &= CFG2_ADC1MSEL_RESET_MASK;
+    reg_temp &= CFG2_ADC1MPRES_RESET_MASK;
+    reg_temp |= adc1m_src | adc1m_pres;
+    ADC_RCC_CFG2 = reg_temp;
+}
+
 // Perform calibration
 static void
 adc_calibrate(ADC_Module *adc)
 {
-    adc->CTRL2 = CTRL2_AD_ON_SET;
+    // Match the adc to the HCLK sourced clock selected in adc_clock_setup()
+    adc->CTRL3 &= ~ADC_CTRL3_CKMOD_MSK;
+    // Wake the adc from power down mode and let its input settle
+    adc->CTRL2 |= CTRL2_AD_ON_SET;
+    udelay(10);
     while (!(adc->CTRL3 & ADC_FLAG_RDY))
         ;
     adc->CTRL3 &= (~ADC_CTRL3_BPCAL_MSK);
     udelay(10);
-    adc->CTRL2 = CTRL2_AD_ON_SET | CTRL2_CAL_SET;
+    adc->CTRL2 |= CTRL2_CAL_SET;
     while (adc->CTRL2 & CTRL2_CAL_SET)
         ;
 }
@@ -107,16 +149,7 @@ gpio_adc_setup(uint32_t pin)
                 RCC_AHB_PERIPH_ADC3 | RCC_AHB_PERIPH_ADC4);
     ADC_RCC_AHBPCLKEN = reg_temp;
 
-    reg_temp = ADC_RCC_CFG2;
-    reg_temp &= CFG2_ADCPLLPRES_RESET_MASK;
-    reg_temp |= RCC_ADCPLLCLK_DIV1;
-    reg_temp &= RCC_ADCPLLCLK_DISABLE;
-    ADC_RCC_CFG2 = reg_temp;
-
-    reg_temp = ADC_RCC_CFG2;
-    reg_temp &= CFG2_ADCHPRES_RESET_MASK;
-    reg_temp |= RCC_ADCHCLK_DIV16;
-    ADC_RCC_CFG2 = reg_temp;
+    adc_clock_setup();
 
     ADC_InitType ADC_InitStructure;
     ADC_InitStructure.WorkMode       = ADC_WORKMODE_INDEPENDENT;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -101,6 +101,10 @@ clock_setup(void)
         ;
 }
 
+// The stm32f103 PWR block has just two registers; the n32g45x adds a
+// third one holding the "ex mode" enable bit
+#define N32_PWR_CTRL3 (*(volatile uint32_t *)(PWR_BASE + 0x0c))
+
 // Return the RCC_CFGR bits that select the given PLL multiplier on the
 // n32g45x, whose PLLMUL field is five bits wide (PLLMUL[4] is bit 27)
 static uint32_t
@@ -123,6 +127,14 @@ clock_setup_n32g45x(void)
     && CONFIG_MACH_N32G45x
     #error "Unable to generate the requested clock rate from this crystal"
 #endif
+    // The n32g45x keeps its adc, sdio, qspi, opamp, comp and can2 behind
+    // the "ex mode" bit: while it is clear their RCC enable bits read back
+    // as zero and the peripherals stay unclocked.  The vendor SystemInit()
+    // sets it before configuring any clock, so do the same here.
+    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    N32_PWR_CTRL3 |= 1;
+    RCC->APB1ENR &= ~RCC_APB1ENR_PWREN;
+
     // Configure and enable PLL
     uint32_t cfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -143,6 +143,14 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
+    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
+    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    if (CONFIG_CLOCK_FREQ == 96000000)
+        cfgr |= 2 << 22;
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+    #error "Unable to generate a 48Mhz usb clock at this system clock rate"
+#endif
     RCC->CFGR = cfgr;
     RCC->CR |= RCC_CR_PLLON;
 

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -118,6 +118,11 @@ n32g45x_pll_multiplier_bits(uint32_t mul)
 static void
 clock_setup_n32g45x(void)
 {
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL \
+    && (2 * CONFIG_CLOCK_FREQ) % CONFIG_CLOCK_REF_FREQ \
+    && CONFIG_MACH_N32G45x
+    #error "Unable to generate the requested clock rate from this crystal"
+#endif
     // Configure and enable PLL
     uint32_t cfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
@@ -143,12 +148,13 @@ clock_setup_n32g45x(void)
         cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
     else if (CONFIG_CLOCK_FREQ > 36000000)
         cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
-    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  Of the
-    // three system clock rates this chip's Kconfig offers (64/96/128Mhz),
-    // only 96Mhz (PLLCLK/2) produces the 48Mhz the usb peripheral needs.
+    // The n32g45x usb clock is PLLCLK divided by 1.5, 1, 2 or 3.  The
+    // clock defaults select 96Mhz when usb is enabled, which produces
+    // the 48Mhz the usb peripheral needs through the /2 divisor.
     if (CONFIG_CLOCK_FREQ == 96000000)
         cfgr |= 2 << 22;
-#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000
+#if CONFIG_USB && CONFIG_CLOCK_FREQ != 96000000 \
+    && CONFIG_MACH_N32G45x
     #error "Unable to generate a 48Mhz usb clock at this system clock rate"
 #endif
     RCC->CFGR = cfgr;

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -39,6 +39,15 @@ lookup_clock_line(uint32_t periph_base)
 uint32_t
 get_pclock_frequency(uint32_t periph_base)
 {
+    if (CONFIG_MACH_N32G45x) {
+        // Both APB busses run at the same rate, using PCLK1's tighter
+        // 36Mhz limit to choose the divisor
+        if (CONFIG_CLOCK_FREQ > 72000000)
+            return CONFIG_CLOCK_FREQ / 4;
+        if (CONFIG_CLOCK_FREQ > 36000000)
+            return CONFIG_CLOCK_FREQ / 2;
+        return CONFIG_CLOCK_FREQ;
+    }
     return FREQ_PERIPH;
 }
 
@@ -81,6 +90,66 @@ clock_setup(void)
 
     // Set flash latency
     FLASH->ACR = (2 << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
+
+    // Wait for PLL lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+
+    // Switch system clock to PLL
+    RCC->CFGR = cfgr | RCC_CFGR_SW_PLL;
+    while ((RCC->CFGR & RCC_CFGR_SWS_Msk) != RCC_CFGR_SWS_PLL)
+        ;
+}
+
+// Return the RCC_CFGR bits that select the given PLL multiplier on the
+// n32g45x, whose PLLMUL field is five bits wide (PLLMUL[4] is bit 27)
+static uint32_t
+n32g45x_pll_multiplier_bits(uint32_t mul)
+{
+    if (mul > 16)
+        // Multipliers above 16 are encoded with PLLMUL[4] (bit 27) set
+        return ((mul - 17) << RCC_CFGR_PLLMULL_Pos) | (1 << 27);
+    return (mul - 2) << RCC_CFGR_PLLMULL_Pos;
+}
+
+// The n32g45x is register compatible with the stm32f103, but has its
+// own clock tree: PCLK2 is limited to 72Mhz and PCLK1 to 36Mhz, and
+// flash wait states scale with HCLK in 32Mhz steps
+static void
+clock_setup_n32g45x(void)
+{
+    // Configure and enable PLL
+    uint32_t cfgr;
+    if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
+        // Configure PLL from external crystal (HSE)
+        RCC->CR |= RCC_CR_HSEON;
+        uint32_t div = CONFIG_CLOCK_FREQ / (CONFIG_CLOCK_REF_FREQ / 2);
+        cfgr = 1 << RCC_CFGR_PLLSRC_Pos;
+        if ((div & 1) && div <= 32)
+            cfgr |= RCC_CFGR_PLLXTPRE_HSE_DIV2;
+        else
+            div /= 2;
+        cfgr |= n32g45x_pll_multiplier_bits(div);
+    } else {
+        // Configure PLL from internal 8Mhz oscillator (HSI)
+        uint32_t div2 = (CONFIG_CLOCK_FREQ / 8000000) * 2;
+        cfgr = (0 << RCC_CFGR_PLLSRC_Pos) | n32g45x_pll_multiplier_bits(div2);
+    }
+    // Divide both APB busses by the same amount, using PCLK1's tighter
+    // 36Mhz limit to choose the divisor (RCC_CFGR bits 15:14 are
+    // reserved on the n32g45x - the adc clock is configured separately
+    // in n32g45x_adc.c via RCC_CFG2)
+    if (CONFIG_CLOCK_FREQ > 72000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV4 | RCC_CFGR_PPRE2_DIV4;
+    else if (CONFIG_CLOCK_FREQ > 36000000)
+        cfgr |= RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_PPRE2_DIV2;
+    RCC->CFGR = cfgr;
+    RCC->CR |= RCC_CR_PLLON;
+
+    // Set flash latency (0: <=32Mhz, 1: <=64Mhz, 2: <=96Mhz, 3: <=128Mhz,
+    // 4: <=144Mhz)
+    uint32_t latency = (CONFIG_CLOCK_FREQ - 1) / 32000000;
+    FLASH->ACR = (latency << FLASH_ACR_LATENCY_Pos) | FLASH_ACR_PRFTBE;
 
     // Wait for PLL lock
     while (!(RCC->CR & RCC_CR_PLLRDY))
@@ -272,7 +341,10 @@ armcm_main(void)
     RCC->APB2ENR = 0;
 
     // Setup clocks
-    clock_setup();
+    if (CONFIG_MACH_N32G45x)
+        clock_setup_n32g45x();
+    else
+        clock_setup();
 
     // Disable JTAG to free PA15, PB3, PB4
     enable_pclock(AFIO_BASE);

--- a/test/configs/n32g45x-canbus.config
+++ b/test/configs/n32g45x-canbus.config
@@ -1,0 +1,4 @@
+# Base config file for Nations N32G45x ARM processor using CAN bus
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G455=y
+CONFIG_STM32_CANBUS_PA11_PA12=y

--- a/test/configs/n32g45x.config
+++ b/test/configs/n32g45x.config
@@ -1,0 +1,3 @@
+# Base config file for Nations N32G45x ARM processor
+CONFIG_MACH_STM32=y
+CONFIG_MACH_N32G452=y


### PR DESCRIPTION
The n32g45x adc support has never worked on a board that boots straight into Klipper. There are three separate problems.

The chip keeps its adc behind the "ex mode" bit in PWR_CTRL3, along with sdio, qspi, rng, the crypto engine, opamp, comp and can2. Klipper never sets that bit, so the adc clock enable bits in RCC do not even latch. Writing all ones to RCC_AHBPCLKEN reads back 0x00000057 on my n32g455, without any of the ADC1-4 bits, and the same test on RCC_APB1PCLKEN leaves opamp, comp and can2 clear. gpio_adc_setup() then spins forever waiting for ADC_FLAG_RDY of an adc that has no clock. The mcu goes quiet in the middle of the host's configuration and the host waits for a reply that never arrives, so this looks like dead hardware rather than a missing clock. The vendor SystemInit() in system_n32g45x.c sets the bit before configuring any clock. With it set, the same register reads back 0x0002fa57 and the adc comes up normally.

The adc runs from two clocks: ADCHCLK, divided down from HCLK, and a separate 1MHz reference clock, ADC1M. ADCHCLK was hardcoded to HCLK/16, which its comment shows was picked for a 64MHz HCLK, and ADC1M was left at whatever the reset default happens to be rather than the 1MHz the vendor code selects.

gpio_adc_setup() enabled and calibrated an adc block every time one of its channels was configured. PA0 and PA1 are on the same block, so configuring the second pin recalibrated an adc that was already running, and from then on that block could no longer complete a conversion for the newly added channel. On my board the hotend thermistor stayed at 0C while the mcu busy time reported in the periodic stats more than doubled. stm32/adc.c avoids this with is_enabled_pclock().

Tested on a FlashForge AD5M toolhead board (n32g455, 12MHz crystal, 144MHz, serial). Before, klippy hangs at "Sending MCU 'eboard' printer configuration" and never gets further. After, both thermistor channels report and the printer reaches the ready state:

```
extruder = 23.8 C
heater_bed = 23.3 C
```

This is based on #7347, since it needs clock_setup_n32g45x() from that PR. The first four commits here are that PR and will disappear once it is committed.

Testing:
```
cd ~/klipper
git fetch origin pull/7362/head
git checkout FETCH_HEAD
make menuconfig
make
```
Then flash the mcu and restart klipper.
