### PR TITLE
stm32: read the n32g45x unique id from its documented address

### DIFF
--- a/src/stm32/internal.h
+++ b/src/stm32/internal.h
@@ -24,6 +24,13 @@
 #include "stm32l4xx.h"
 #endif
 
+#if CONFIG_MACH_N32G45x
+// The n32g45x builds against the stm32f103 headers, but it stores its
+// 96bit unique device id at a different address
+#undef UID_BASE
+#define UID_BASE 0x1FFFF7F0UL
+#endif
+
 // gpio.c
 GPIO_TypeDef *gpio_pin_to_regs(uint32_t pin);
 #define GPIO(PORT, NUM) (((PORT)-'A') * 16 + (NUM))


### PR DESCRIPTION
The n32g45x builds against the stm32f103xe headers and so inherits UID_BASE = 0x1FFFF7E8. On this chip the 96 bit unique device id is documented to start at 0x1FFFF7F0, so only the first four of the twelve bytes chipid.c reads are actually part of the unique id. The remaining eight bytes come from an undocumented part of the system configuration block and may well be identical on every device.

That matters because those twelve bytes are what the can uuid and the usb serial number are derived from. With eight of them potentially shared between boards, the entropy is far lower than it looks, and two boards can end up harder to tell apart than they should be.

This just overrides UID_BASE for the n32g45x so the full unique id is used.

Note this changes the can uuid and the usb serial number reported by existing n32g45x boards. Katapult needs the matching change, and both have to be flashed together - otherwise the uuid reported by the bootloader no longer matches the one reported by the application. The Katapult side is Arksine/katapult#190.

Tested on a FlashForge AD5M toolhead board (n32g455).

Testing:
```
cd ~/klipper
git fetch origin pull/7363/head
git checkout FETCH_HEAD
make menuconfig
make
```
Then flash the mcu together with the matching Katapult build.
