### PR TITLE
Update libusb package for Debian installation script

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -20,7 +20,7 @@ install_packages()
     PKGLIST="${PKGLIST} avrdude gcc-avr binutils-avr avr-libc"
     # ARM chip installation and building
     PKGLIST="${PKGLIST} stm32flash libnewlib-arm-none-eabi"
-    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 pkg-config"
+    PKGLIST="${PKGLIST} gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0-dev pkg-config"
 
     # Update system package info
     report_status "Running apt-get update..."


### PR DESCRIPTION
Updated the libusb-1.0 name since it is not a valid Debian package name — confirmed via apt-cache policy that only libusb-1.0-0, libusb-1.0-0-dev, etc. exist. Given the surrounding context (ARM build tools), libusb-1.0-0-dev is the correct dependency.