### PR TITLE
command: reject messages that end before their declared arguments

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -55,13 +55,24 @@ f4: *p++ = v & 0x7f;
 
 // Parse an integer that was encoded as a "variable length quantity"
 static uint32_t
-parse_int(uint8_t **pp)
+parse_int(uint8_t **pp, uint8_t *maxend)
 {
-    uint8_t *p = *pp, c = *p++;
+    uint8_t *p = *pp;
+    if (p >= maxend) {
+        // No bytes remain for this argument; signal an incomplete message
+        *pp = maxend + 1;
+        return 0;
+    }
+    uint8_t c = *p++;
     uint32_t v = c & 0x7f;
     if ((c & 0x60) == 0x60)
         v |= -0x20;
     while (c & 0x80) {
+        if (p >= maxend) {
+            // VLQ continues past the end of the message
+            *pp = maxend + 1;
+            return 0;
+        }
         c = *p++;
         v = (v<<7) | (c & 0x7f);
     }
@@ -109,7 +120,7 @@ command_parsef(uint8_t *p, uint8_t *maxend
         case PT_uint16:
         case PT_int16:
         case PT_byte:
-            *args++ = parse_int(&p);
+            *args++ = parse_int(&p, maxend);
             break;
         case PT_buffer: {
             uint_fast8_t len = *p++;
@@ -124,6 +135,8 @@ command_parsef(uint8_t *p, uint8_t *maxend
             goto error;
         }
     }
+    if (p > maxend)
+        goto error;
     return p;
 error:
     shutdown("Command parser error");


### PR DESCRIPTION
### The bug

A message block does not carry an argument count on the wire; `command_parsef()`
takes the count from the command's dictionary entry and then reads that many
arguments from the block. The bounds check runs only *before* each parameter,
and `parse_int()` decodes a variable length quantity with no knowledge of where
the message ends:

```c
/* command_parsef() */
while (num_params--) {
    if (p > maxend)            /* checked only before the parameter */
        goto error;
    ...
    case PT_byte:
        *args++ = parse_int(&p);   /* can advance p well past maxend */

/* parse_int() -- no end pointer */
while (c & 0x80) { c = *p++; v = (v<<7) | (c & 0x7f); }
```

So a block that ends before its declared integer arguments are present is parsed
out of the bytes that follow it in `receive_buf` — the block's own CRC and sync
bytes, and further into the buffer — and the value is passed to the command
handler as an ordinary argument. The block is otherwise completely well formed
(correct length, sequence, CRC and sync), so nothing rejects it.

Because the first byte read past the message is a CRC byte, whether a given
truncated block over-reads by one byte (silently consumed as an argument) or by
several (further into `receive_buf`) is decided by the block's own checksum.

The over-read stays within the 128-byte `receive_buf` on the builds tested, so
it does not fault — it produces a wrong argument value rather than a crash — but
it is reading memory outside the received message and trusting it.

### Reproduce

Send one well-formed block containing a command that declares an integer
parameter, with the parameter omitted (`STM32F407`, USB CDC):

```
07 17 09 60 e9 8e 7e
   07  length
   17  0x10 | sequence
   09  debug_nop
   60  msgid, "ads1220_attach_trigger_analog oid=%c trigger_analog_oid=%c"
       (both declared args absent)
   e9 8e  CRC16-CCITT   (high byte 0xe9 has bit 7 set, so the VLQ read
                          continues past the message)
   7e  sync
```

`parse_int()` begins reading at `maxend` and consumes the CRC bytes as the
`oid` argument.

### The fix

Bound `parse_int()` by the message end, and reject the message if the final
argument runs off the end — mirroring the check the `PT_buffer` case already
performs (`if (p + len > maxend) goto error;`). Valid messages parse
identically; truncated ones now take the existing `Command parser error`
shutdown path instead of reading past the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
