### PR TITLE
tmc5262: Add SPI driver bring-up and SpreadCycle support

### DIFF
--- a/docs/Config_Reference.md
+++ b/docs/Config_Reference.md
@@ -4386,6 +4386,206 @@ run_current:
 #   sensorless homing.
 ```
 
+### [tmc5262]
+
+Configure a TMC5262 stepper motor driver via SPI bus. To use this
+feature, define a config section with a "tmc5262" prefix followed by
+the name of the corresponding stepper config section (for example,
+"[tmc5262 stepper_x]").
+
+The TMC5262 is a 65V/4.25A RMS smart stepper driver with integrated
+MOSFETs and Integrated Current Sense (ICS) - no external sense resistor
+is required. It uses a reference resistor (RREF) between the REF pin
+and GND to set the current ranges (typ. 12kΩ ±1%). Communication is
+SPI only - this driver does not support UART.
+
+```
+[tmc5262 stepper_x]
+cs_pin:
+#   The pin corresponding to the TMC5262 chip select line. This pin
+#   will be set to low at the start of SPI messages and raised to high
+#   after the message completes. This parameter must be provided.
+#spi_speed:
+#spi_bus:
+#spi_software_sclk_pin:
+#spi_software_mosi_pin:
+#spi_software_miso_pin:
+#   See the "common SPI settings" section for a description of the
+#   above parameters.
+#chain_position:
+#chain_length:
+#   These parameters configure an SPI daisy chain. The two parameters
+#   define the stepper position in the chain and the total chain length.
+#   Position 1 corresponds to the stepper that connects to the MOSI signal.
+#   The default is to not use an SPI daisy chain.
+#interpolate: True
+#   If true, enable step interpolation (the driver will internally
+#   step at a rate of 256 micro-steps). The default is True.
+run_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   during stepper movement. This parameter must be provided.
+#hold_current:
+#   The amount of current (in amps RMS) to configure the driver to use
+#   when the stepper is not moving. Setting a hold_current is not
+#   recommended (see TMC_Drivers.md for details). The default is to
+#   not reduce the current.
+#rref: 12000
+#   The resistance (in ohms) of the external reference resistor between
+#   the REF pin and GND. The TMC5262 datasheet specifies 12kΩ ±1%.
+#   Valid range is 10000-14000. The default is 12000.
+#current_range:
+#current_range_scale:
+#   These set DRV_CONF.CURRENT_RANGE (0-3) and
+#   DRV_CONF.CURRENT_RANGE_SCALE (0-3). With a 12k RREF, CURRENT_RANGE
+#   selects nominal full-scale ranges of about 1A/2A/3A/4A RMS. By
+#   default Klipper automatically selects both values for run_current.
+#   CURRENT_RANGE_SCALE values below 3 are only valid with CURRENT_RANGE=0.
+#   If SET_TMC_CURRENT will later increase the current, manually select a
+#   range large enough for the maximum intended run current.
+#stealthchop_threshold: 0
+#   The velocity (in mm/s) below which the driver runs in StealthChop+
+#   mode. A non-zero threshold requires driver_COIL_INDUCT to contain
+#   the motor coil inductance in microhenries. The default of 0 disables
+#   StealthChop+.
+#coolstep_threshold:
+#   The velocity (in mm/s) above which CoolStep or CoolStep+ is enabled,
+#   depending on the active chopper mode. If set, sensorless homing speed
+#   must be above this threshold. The default is to not enable CoolStep.
+#high_velocity_threshold:
+#   The velocity (in mm/s) at which the driver internal "high velocity"
+#   threshold (THIGH) is set. Typically used to disable CoolStep or
+#   CoolStep+ at high speeds. The default is unset.
+#driver_MSLUT0: 2863314260
+#driver_MSLUT1: 1251300522
+#driver_MSLUT2: 608774441
+#driver_MSLUT3: 269500962
+#driver_MSLUT4: 4227858431
+#driver_MSLUT5: 3048961917
+#driver_MSLUT6: 1227445590
+#driver_MSLUT7: 4211234
+#driver_W0: 2
+#driver_W1: 1
+#driver_W2: 1
+#driver_W3: 1
+#driver_X1: 128
+#driver_X2: 255
+#driver_X3: 255
+#driver_START_SIN: 0
+#driver_START_SIN90: 247
+#driver_OFFSET_SIN90: 0
+#   These fields control the Microstep Table registers directly. See the
+#   tmc2240 entry above for tuning notes - the wave-table format is the
+#   same on TMC5262.
+#driver_MULTISTEP_FILT: True
+#driver_IHOLDDELAY: 7
+#driver_IRUNDELAY: 4
+#driver_TPOWERDOWN: 10
+#driver_TBL: 2
+#driver_TOFF: 3
+#driver_HEND: 2
+#driver_HSTRT: 5
+#driver_FD3: 0
+#driver_DISFDCC: 0
+#driver_TPFD: 4
+#driver_CHM: 0
+#driver_PWM_FREQ: 0
+#driver_FREEWHEEL: 0
+#driver_SD_ON_MEAS_LO: 14
+#driver_SD_ON_MEAS_HI: 15
+#   These set PWMCONF thresholds that control when the Integrated Current
+#   Sense (ICS) samples each motor coil within the chopper cycle. The
+#   defaults (14/15) come from datasheet Table 8 (p.75) for PWM_FREQ=0
+#   (19.5 kHz). If you change driver_PWM_FREQ, also adjust these per
+#   Table 8 - leaving them at 0 silently disables ICS sampling and breaks
+#   StealthChop+ / StallGuard+ regulation.
+#driver_SLOPE_CONTROL: 3
+#   Controls the slew rate of the gate driver output (DRV_CONF.SLOPE_CONTROL).
+#   0=100V/μs, 1=200V/μs, 2=400V/μs, 3=800V/μs (chip default).
+#   Lower values reduce EMI at the cost of higher driver heat.
+#driver_SGT: 0
+#driver_SEMIN: 0
+#driver_SEUP: 0
+#driver_SEMAX: 0
+#driver_SEDN: 0
+#driver_SEIMIN: 0
+#driver_SFILT: 0
+#driver_CUR_P: 64
+#driver_CUR_I: 10
+#driver_ANGLE_P: 50
+#driver_ANGLE_I: 20
+#driver_CUR_PI_LIMIT: 4095
+#driver_ANGLE_PI_LIMIT: 256
+#driver_ANGLE_LOWER_I_LIMIT: 256
+#   StealthChop+ PI regulator tuning. The TMC5262 replaces TMC2240's
+#   StealthChop2 (with driver_PWM_GRAD / OFS / REG / LIM) by two PI
+#   regulators - one for current amplitude (CUR_P / CUR_I) and one for
+#   electrical angle (ANGLE_P / ANGLE_I), each with a clip limit. The
+#   defaults here match the chip's reset values, which the datasheet
+#   recommends as starting points ("Keep this default value, unless...").
+#   See datasheet pp 33-40 for the tuning guide.
+#   Set the given register during the configuration of the TMC5262
+#   chip. This may be used to set custom motor parameters. The defaults
+#   for each parameter are next to the parameter name in the above list.
+#driver_T_RCOIL_MEAS: 4096
+#driver_COIL_INDUCT: 0
+#driver_RCOIL_MANUAL: False
+#driver_RCOIL_THERMAL_COUPLING:
+#driver_R_COIL_USER_A: 0
+#driver_R_COIL_USER_B: 0
+#   Motor model and coil resistance fields used by StealthChop+,
+#   StallGuard+, and CoolStep+. RCOIL_THERMAL_COUPLING defaults to True
+#   when StealthChop+ is enabled. If RCOIL_MANUAL is True then both
+#   R_COIL_USER_A and R_COIL_USER_B must be non-zero. R_COIL_USER_A/B
+#   are raw 12-bit values whose resistance scaling depends on CURRENT_RANGE;
+#   see the TMC5262 datasheet R_COIL description when using manual values.
+#   These fields do not report or estimate motor coil temperature.
+#driver_TSGP_LOW_VEL_THRS: 4096
+#driver_SGP_THRS: 0
+#driver_SGP_FILT_EN: False
+#driver_SGP_LOW_VEL_FREEZE: False
+#driver_SGP_CLEAR_CUR_PI: True
+#driver_SGP_LOW_VEL_SLOPE: 0
+#driver_SGP_LOW_VEL_CNTS: 0
+#   StallGuard+ configuration fields. The values shown are the TMC5262
+#   reset values.
+#driver_COOL_CUR_DIV: 2
+#driver_LOAD_FILT_EN: True
+#driver_COOLSTEP_P: 128
+#driver_COOLSTEP_I: 16
+#driver_COOL_PI_DOWN_LIMIT: 128
+#driver_COOL_PI_OFF_SPEED: 64
+#driver_COOL_LOW_LOAD_RESERVE: 150
+#driver_COOL_HI_LOAD_RESERVE: 50
+#driver_COOL_LOW_GENERATORIC_RESERVE: 220
+#driver_COOL_HI_GENERATORIC_RESERVE: 100
+#   CoolStep+ configuration fields. The values shown are the TMC5262
+#   reset values. COOL_CUR_DIV accepts 0 through 10; values 11 through
+#   15 are reserved by the chip.
+#driver_DO0_SCOPE_EN: False
+#driver_DO0_SCOPE_SEL: 0
+#driver_DO1_SCOPE_EN: False
+#driver_DO1_SCOPE_SEL: 0
+#   RT-OCSI output routing fields for the DO0 and DO1 pins. Scope select
+#   values 0 through 28 correspond to the signals listed in the TMC5262
+#   RT-OCSI table; values 29 through 31 are reserved.
+#   Do not enable RT-OCSI on the same DO pin configured as diag0_pin or
+#   diag1_pin; each physical DO pin is shared between those functions.
+#diag0_pin:
+#diag1_pin:
+#   The micro-controller pin attached to one of the DO0 / DO1 pins of
+#   the TMC5262. Only a single diag pin should be specified. The pin is
+#   "active low" by default (chip default DO0/DO1 polarity) and is thus
+#   normally prefaced with "^!". Setting this creates a
+#   "tmc5262_stepper_x:virtual_endstop" virtual pin which may be used
+#   as the stepper's endstop_pin to enable sensorless homing. Be sure
+#   to also set driver_SGT to an appropriate sensitivity value. Unlike
+#   TMC2130/5160/2240, the TMC5262 routes the stall signal through
+#   DO_CONF.do0_stall / do1_stall (datasheet pg 140), so the driver
+#   reconfigures DO_CONF at homing start and restores it at homing end.
+#   The default is to not enable sensorless homing.
+```
+
+
 ## Run-time stepper motor current configuration
 
 ### [ad5206]

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -134,7 +134,7 @@ Klipper supports many standard 3d printer features:
   assign a "math formula" to a fan for automatic fan speed updating.
 
 * Support for run-time configuration of TMC2130, TMC2208/TMC2224,
-  TMC2209, TMC2240, TMC2660, and TMC5160 stepper motor drivers. There
+  TMC2209, TMC2240, TMC2660, TMC5160, and TMC5262 stepper motor drivers. There
   is also support for current control of traditional stepper drivers
   via AD5206, DAC084S085, MCP4451, MCP4728, MCP4018, and PWM pins.
 

--- a/docs/TMC_Drivers.md
+++ b/docs/TMC_Drivers.md
@@ -87,6 +87,10 @@ Note that the `stealthchop_threshold` config option does not impact
 sensorless homing as Klipper automatically switches the TMC driver to
 an appropriate mode during sensorless homing operations.
 
+On a TMC5262, enabling StealthChop+ also requires `driver_COIL_INDUCT`
+to be configured with the motor coil inductance. See the TMC5262
+section of the [config reference](Config_Reference.md#tmc5262).
+
 ## TMC interpolate setting introduces small position deviation
 
 The TMC driver `interpolate` setting may reduce the audible noise of
@@ -160,7 +164,7 @@ also find more details on limitations of this setup.
 A few prerequisites are needed to use sensorless homing:
 
 1. A stallGuard capable TMC stepper driver (tmc2130, tmc2209, tmc2660,
-   or tmc5160).
+   tmc5160, or tmc5262).
 2. SPI / UART interface of the TMC driver wired to micro-controller
    (stand-alone mode does not work).
 3. The appropriate "DIAG" or "SG_TST" pin of TMC driver connected to
@@ -242,6 +246,20 @@ homing_retract_dist: 0
 ...
 ```
 
+A TMC5262 uses the same `driver_SGT` sensitivity range, but its
+sensorless stall output is routed through DO0 or DO1:
+```
+[tmc5262 stepper_x]
+diag0_pin: ^!PA1 # Pin connected to TMC5262 DO0 (or use diag1_pin / DO1)
+driver_SGT: -64  # -64 is most sensitive value, 63 is least sensitive
+...
+
+[stepper_x]
+endstop_pin: tmc5262_stepper_x:virtual_endstop
+homing_retract_dist: 0
+...
+```
+
 An example tmc2660 config might look like:
 ```
 [tmc2660 stepper_x]
@@ -266,7 +284,7 @@ command to set the highest sensitivity. For tmc2209:
 ```
 SET_TMC_FIELD STEPPER=stepper_x FIELD=SGTHRS VALUE=255
 ```
-For tmc2130, tmc5160, and tmc2660:
+For tmc2130, tmc5160, tmc5262, and tmc2660:
 ```
 SET_TMC_FIELD STEPPER=stepper_x FIELD=sgt VALUE=-64
 ```

--- a/klippy/extras/angle.py
+++ b/klippy/extras/angle.py
@@ -10,7 +10,7 @@ MIN_MSG_TIME = 0.100
 TCODE_ERROR = 0xff
 
 TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2209", "tmc2240", "tmc2660",
-    "tmc5160"]
+    "tmc5160", "tmc5262"]
 
 CALIBRATION_BITS = 6 # 64 entries
 ANGLE_BITS = 16 # angles range from 0..65535

--- a/klippy/extras/endstop_phase.py
+++ b/klippy/extras/endstop_phase.py
@@ -7,7 +7,7 @@ import math, logging
 import stepper
 
 TRINAMIC_DRIVERS = ["tmc2130", "tmc2208", "tmc2209", "tmc2240", "tmc2660",
-    "tmc5160"]
+    "tmc5160", "tmc5262"]
 
 # Calculate the trigger phase of a stepper motor
 class PhaseCalc:

--- a/klippy/extras/tmc.py
+++ b/klippy/extras/tmc.py
@@ -126,6 +126,7 @@ class TMCErrorCheck:
         # Setup for temperature query
         self.adc_temp = None
         self.adc_temp_reg = self.fields.lookup_register("adc_temp")
+        self.temp_from_adc = getattr(mcu_tmc, "temp_from_adc", None)
         if self.adc_temp_reg is not None:
             pheaters = self.printer.load_object(config, 'heaters')
             pheaters.register_monitor(config)
@@ -213,7 +214,10 @@ class TMCErrorCheck:
             return {'drv_status': None, 'temperature': None}
         temp = None
         if self.adc_temp is not None:
-            temp = round((self.adc_temp - 2038) / 7.7, 2)
+            if self.temp_from_adc is not None:
+                temp = round(self.temp_from_adc(self.adc_temp), 2)
+            else:
+                temp = round((self.adc_temp - 2038) / 7.7, 2)
         last_value, reg_name = self.drv_status_reg_info[:2]
         if last_value != self.last_drv_status:
             self.last_drv_status = last_value
@@ -232,6 +236,8 @@ class TMCStallguardDump:
         self.mcu_tmc = mcu_tmc
         self.mcu = self.mcu_tmc.get_mcu()
         self.fields = self.mcu_tmc.get_fields()
+        self.sg_result_from_drv_status = getattr(
+            mcu_tmc, "sg_result_from_drv_status", None)
         self.sg2_supp = False
         self.sg4_reg_name = None
         # It is possible to support TMC2660, just disable it for now
@@ -284,6 +290,8 @@ class TMCStallguardDump:
                 cs_actual = self.fields.get_field("cs_actual", reg_val)
                 sg_result = self.fields.get_field("sg_result", reg_val)
                 is_stealth = self.fields.get_field("stealth", reg_val)
+                if self.sg_result_from_drv_status is not None:
+                    sg_result = self.sg_result_from_drv_status(reg_val)
                 recv_time = status["#receive_time"]
                 if is_stealth and self.sg4_reg_name == "SG4_RESULT":
                     sg4_ret = self.mcu_tmc.get_register_raw("SG4_RESULT")

--- a/klippy/extras/tmc5262.py
+++ b/klippy/extras/tmc5262.py
@@ -1,0 +1,890 @@
+# TMC5262 configuration
+#
+# Copyright (C) 2026  Kalico Contributors
+# Copyright (C) 2026  Uriah Kessman <fishyfabspnw@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging, math
+from . import tmc, tmc2130
+
+TMC_FREQUENCY = 16000000.
+
+# Preserve silicon defaults when a user overrides one field in an optional
+# TMC5262-specific register.
+OPTIONAL_REGISTER_DEFAULTS = {
+    "DO_SCOPE_CONF": 0x00,
+    "TSGP_LOW_VEL_THRS": 0x1000,
+    "COOLSTEPPLUS_CONF": 0x12,
+    "COOLSTEPPLUS_PI_REG": (16 << 16) | 128,
+    "COOLSTEPPLUS_PI_DOWN": (64 << 16) | 128,
+    "COOLSTEPPLUS_RESERVE_CONF": (100 << 24) | (220 << 16) | (50 << 8) | 150,
+    "SGP_CONF": 1 << 14,
+}
+
+# A complete filtered RCOIL update can take up to 100ms. Allow additional
+# time for queued enable and register writes before a homing move.
+RCOIL_PREFLIGHT_DWELL = .250
+RCOIL_ENABLE_CALLBACK_DWELL = .010
+
+# Keep TMC5262-specific initialization deterministic. In particular, configure
+# the motor model before enabling StealthChop+ and write CHOPCONF.TOFF last.
+TMC5262_REGISTER_INIT_ORDER = (
+    "DRV_CONF", "IHOLD_IRUN", "TPOWERDOWN", "COIL_INDUCT",
+    "R_COIL_USER", "T_RCOIL_MEAS", "CURRENT_PI_REG", "ANGLE_PI_REG",
+    "CUR_ANGLE_LIMIT", "ANGLE_LOWER_LIMIT", "PWMCONF", "TPWMTHRS",
+    "TCOOLTHRS", "THIGH", "TSGP_LOW_VEL_THRS", "DO_CONF",
+    "DO_SCOPE_CONF", "GCONF", "CHOPCONF",
+)
+
+
+OPTIONAL_FIELD_LIMITS = {
+    "do0_scope_sel": 0x1c,
+    "do1_scope_sel": 0x1c,
+    "cool_cur_div": 10,
+}
+
+
+def configure_optional_field(config, fields, field_name):
+    option = "driver_" + field_name.upper()
+    if config.get(option, None) is None:
+        return
+    register = fields.lookup_register(field_name)
+    if (register not in fields.registers
+            and register in OPTIONAL_REGISTER_DEFAULTS):
+        fields.registers[register] = OPTIONAL_REGISTER_DEFAULTS[register]
+    maxval = OPTIONAL_FIELD_LIMITS.get(field_name)
+    if maxval is not None:
+        value = config.getint(option, minval=0, maxval=maxval)
+        fields.set_field(field_name, value)
+    else:
+        fields.set_config_field(config, field_name, 0)
+
+
+def pwm_measurement_defaults(pwm_freq):
+    # TMC5262 datasheet table 8.
+    if not 0 <= pwm_freq <= 8:
+        raise ValueError("driver_PWM_FREQ must be in range 0..8")
+    if pwm_freq <= 2:
+        return 14, 15
+    if pwm_freq <= 5:
+        return 13, 14
+    return 12, 13
+
+
+def _adc_to_celsius(adc_value):
+    return 1.042 * adc_value - 264.6
+
+
+def _adc_to_volts(adc_value):
+    return adc_value * .1409
+
+
+######################################################################
+# Register addresses
+######################################################################
+
+Registers = {
+    "GCONF": 0x00,
+    "GSTAT": 0x01,
+    "DO_CONF": 0x02,
+    "DO_SCOPE_CONF": 0x03,
+    "IOIN": 0x04,
+    "DRV_CONF": 0x0a,
+    "PLL": 0x0b,
+    "IHOLD_IRUN": 0x10,
+    "TPOWERDOWN": 0x11,
+    "TSTEP": 0x12,
+    "TPWMTHRS": 0x13,
+    "TCOOLTHRS": 0x14,
+    "THIGH": 0x15,
+    "TSGP_LOW_VEL_THRS": 0x16,
+    "T_RCOIL_MEAS": 0x17,
+    "STEPS_LOST": 0x1a,
+    "CURRENT_PI_REG": 0x40,
+    "ANGLE_PI_REG": 0x41,
+    "CUR_ANGLE_LIMIT": 0x42,
+    "ANGLE_LOWER_LIMIT": 0x43,
+    "CUR_ANGLE_MEAS": 0x44,
+    "PI_RESULTS": 0x45,
+    "COIL_INDUCT": 0x46,
+    "R_COIL": 0x47,
+    "R_COIL_USER": 0x48,
+    "SGP_CONF": 0x49,
+    "SGP_IND_2_3": 0x4a,
+    "SGP_IND_0_1": 0x4b,
+    "INDUCTANCE_VOLTAGE": 0x4c,
+    "SGP_BEMF": 0x4d,
+    "COOLSTEPPLUS_CONF": 0x4e,
+    "COOLSTEPPLUS_PI_REG": 0x4f,
+    "COOLSTEPPLUS_PI_DOWN": 0x50,
+    "COOLSTEPPLUS_RESERVE_CONF": 0x51,
+    "COOLSTEPPLUS_LOAD_RESERVE": 0x52,
+    "TSTEP_VELOCITY": 0x53,
+    "ADC_VSUPPLY_TEMP": 0x58,
+    "ADC_I": 0x59,
+    "OTW_OV_VTH": 0x5a,
+    "MSLUT0": 0x60,
+    "MSLUT1": 0x61,
+    "MSLUT2": 0x62,
+    "MSLUT3": 0x63,
+    "MSLUT4": 0x64,
+    "MSLUT5": 0x65,
+    "MSLUT6": 0x66,
+    "MSLUT7": 0x67,
+    "MSLUTSEL": 0x68,
+    "MSLUTSTART": 0x69,
+    "MSCNT": 0x6a,
+    "MSCURACT": 0x6b,
+    "CHOPCONF": 0x6c,
+    "COOLCONF": 0x6d,
+    "DRV_STATUS": 0x6f,
+    "PWMCONF": 0x70,
+}
+
+ReadRegisters = [
+    "GCONF", "GSTAT", "DO_CONF", "DO_SCOPE_CONF", "IOIN", "DRV_CONF",
+    "PLL", "IHOLD_IRUN", "TPOWERDOWN", "TSTEP", "TPWMTHRS",
+    "TCOOLTHRS", "THIGH", "TSGP_LOW_VEL_THRS", "T_RCOIL_MEAS",
+    "STEPS_LOST", "CURRENT_PI_REG", "ANGLE_PI_REG", "CUR_ANGLE_LIMIT",
+    "ANGLE_LOWER_LIMIT", "CUR_ANGLE_MEAS", "PI_RESULTS", "COIL_INDUCT",
+    "R_COIL", "R_COIL_USER", "SGP_CONF", "SGP_IND_2_3",
+    "SGP_IND_0_1", "INDUCTANCE_VOLTAGE", "SGP_BEMF",
+    "COOLSTEPPLUS_CONF", "COOLSTEPPLUS_PI_REG", "COOLSTEPPLUS_PI_DOWN",
+    "COOLSTEPPLUS_RESERVE_CONF", "COOLSTEPPLUS_LOAD_RESERVE",
+    "TSTEP_VELOCITY", "ADC_VSUPPLY_TEMP", "ADC_I", "OTW_OV_VTH",
+    "MSCNT", "MSCURACT", "CHOPCONF", "COOLCONF", "DRV_STATUS",
+    "PWMCONF",
+]
+
+
+######################################################################
+# Register field maps
+######################################################################
+
+Fields = {}
+Fields["GCONF"] = {
+    "fast_standstill": 0x01 << 0,
+    "en_pwm_mode": 0x01 << 1,
+    "multistep_filt": 0x01 << 2,
+    "shaft": 0x01 << 3,
+    "small_hysteresis": 0x01 << 4,
+    "stop_enable": 0x01 << 5,
+    "direct_mode": 0x01 << 6,
+    "length_steppulse": 0x0f << 8,
+    "ov_nn": 0x01 << 12,
+    "step_dir": 0x01 << 31,
+}
+Fields["GSTAT"] = {
+    "reset": 0x01 << 0,
+    "drv_err": 0x01 << 1,
+    "uv_cp": 0x01 << 2,
+    "register_reset": 0x01 << 3,
+    "vm_uvlo": 0x01 << 4,
+    "vccio_uv": 0x01 << 5,
+}
+Fields["DO_CONF"] = {
+    "do0_error": 0x01 << 0,
+    "do0_otpw": 0x01 << 1,
+    "diag0_stall": 0x01 << 2,
+    "do0_index": 0x01 << 3,
+    "do0_step": 0x01 << 4,
+    "do0_dir": 0x01 << 5,
+    "do0_xcomp": 0x01 << 6,
+    "do0_ov": 0x01 << 7,
+    "do0_udcstep": 0x01 << 8,
+    "do0_ev_stop_ref": 0x01 << 9,
+    "do0_ev_stop_sg": 0x01 << 10,
+    "do0_ev_pos_reached": 0x01 << 11,
+    "do0_ev_n_deviation": 0x01 << 12,
+    "do1_error": 0x01 << 13,
+    "do1_otpw": 0x01 << 14,
+    "diag1_stall": 0x01 << 15,
+    "do1_index": 0x01 << 16,
+    "do1_step": 0x01 << 17,
+    "do1_dir": 0x01 << 18,
+    "do1_xcomp": 0x01 << 19,
+    "do1_ov": 0x01 << 20,
+    "do1_udcstep": 0x01 << 21,
+    "do1_ev_stop_ref": 0x01 << 22,
+    "do1_ev_stop_sg": 0x01 << 23,
+    "do1_ev_pos_reached": 0x01 << 24,
+    "do1_ev_n_deviation": 0x01 << 25,
+    "do0_npp_pp": 0x01 << 28,
+    "do0_invpp": 0x01 << 29,
+    "do1_npp_pp": 0x01 << 30,
+    "do1_invpp": 0x01 << 31,
+}
+Fields["DO_SCOPE_CONF"] = {
+    "do0_scope_en": 0x01 << 0,
+    "do0_scope_sel": 0x1f << 4,
+    "do1_scope_en": 0x01 << 12,
+    "do1_scope_sel": 0x1f << 16,
+}
+Fields["IOIN"] = {
+    "refl": 0x01 << 0,
+    "refr": 0x01 << 1,
+    "encb": 0x01 << 2,
+    "enca": 0x01 << 3,
+    "drv_enn": 0x01 << 4,
+    "encn": 0x01 << 5,
+    "ext_res_det": 0x01 << 13,
+    "ext_clk": 0x01 << 14,
+    "silicon_rv": 0x07 << 16,
+}
+Fields["DRV_CONF"] = {
+    "current_range": 0x03 << 0,
+    "current_range_scale": 0x03 << 2,
+    "slope_control": 0x03 << 4,
+}
+Fields["PLL"] = {
+    "commit": 0x01 << 0,
+    "ext_not_int": 0x01 << 1,
+    "clk_sys_sel": 0x01 << 2,
+    "clk_fsm_ena": 0x01 << 3,
+    "clock_divider": 0x1f << 5,
+    "clk_1m0_tmo": 0x01 << 12,
+    "clk_loss": 0x01 << 13,
+    "clk_is_stuck": 0x01 << 14,
+}
+Fields["IHOLD_IRUN"] = {
+    "ihold": 0xff << 0,
+    "irun": 0xff << 8,
+    "iholddelay": 0xff << 16,
+    "irundelay": 0x0f << 24,
+}
+Fields["TPOWERDOWN"] = {"tpowerdown": 0xff << 0}
+Fields["TSTEP"] = {"tstep": 0xfffff << 0}
+Fields["TPWMTHRS"] = {"tpwmthrs": 0xfffff << 0}
+Fields["TCOOLTHRS"] = {"tcoolthrs": 0xfffff << 0}
+Fields["THIGH"] = {"thigh": 0xfffff << 0}
+Fields["TSGP_LOW_VEL_THRS"] = {"tsgp_low_vel_thrs": 0xfffff << 0}
+Fields["T_RCOIL_MEAS"] = {"t_rcoil_meas": 0xfffff << 0}
+Fields["STEPS_LOST"] = {"steps_lost": 0xfffff << 0}
+Fields["CURRENT_PI_REG"] = {
+    "cur_p": 0xfff << 0,
+    "cur_i": 0x3ff << 16,
+}
+Fields["ANGLE_PI_REG"] = {
+    "angle_p": 0xfff << 0,
+    "angle_i": 0x3ff << 16,
+}
+Fields["CUR_ANGLE_LIMIT"] = {
+    "angle_pi_limit": 0x3ff << 0,
+    "angle_pi_int_pos_clip": 0x01 << 12,
+    "angle_pi_int_neg_clip": 0x01 << 13,
+    "angle_pi_pos_clip": 0x01 << 14,
+    "angle_pi_neg_clip": 0x01 << 15,
+    "cur_pi_limit": 0xfff << 16,
+    "cur_pi_int_pos_clip": 0x01 << 28,
+    "cur_pi_int_neg_clip": 0x01 << 29,
+    "cur_pi_pos_clip": 0x01 << 30,
+    "cur_pi_neg_clip": 0x01 << 31,
+}
+Fields["ANGLE_LOWER_LIMIT"] = {
+    "angle_lower_i_limit": 0x3ff << 0,
+    "angle_error": 0x3ff << 16,
+}
+Fields["CUR_ANGLE_MEAS"] = {
+    "ampl_meas": 0xfff << 0,
+    "angle_meas": 0x3ff << 16,
+}
+Fields["PI_RESULTS"] = {
+    "pwm_calc": 0x1fff << 0,
+    "angle_corr_calc": 0x3ff << 16,
+}
+Fields["COIL_INDUCT"] = {
+    "coil_induct": 0x7fff << 0,
+    "rcoil_manual": 0x01 << 16,
+    "rcoil_thermal_coupling": 0x01 << 17,
+}
+Fields["R_COIL"] = {
+    "r_coil_auto_b": 0xfff << 0,
+    "r_coil_auto_a": 0xfff << 16,
+}
+Fields["R_COIL_USER"] = {
+    "r_coil_user_b": 0xfff << 0,
+    "r_coil_user_a": 0xfff << 16,
+}
+Fields["SGP_CONF"] = {
+    "sgp_thrs": 0x1ff << 0,
+    "sgp_filt_en": 0x01 << 12,
+    "sgp_low_vel_freeze": 0x01 << 13,
+    "sgp_clear_cur_pi": 0x01 << 14,
+    "sgp_low_vel_slope": 0xff << 16,
+    "sgp_low_vel_cnts": 0x03 << 28,
+}
+Fields["SGP_IND_2_3"] = {
+    "sgp_ind_2": 0x3ff << 0,
+    "sgp_ind_3": 0x3ff << 16,
+}
+Fields["SGP_IND_0_1"] = {
+    "sgp_ind_0": 0x3ff << 0,
+    "sgp_ind_1": 0x3ff << 16,
+}
+Fields["INDUCTANCE_VOLTAGE"] = {
+    "ul_b": 0xfff << 0,
+    "ul_a": 0xfff << 16,
+}
+Fields["SGP_BEMF"] = {
+    "sgp_raw": 0x3ff << 0,
+    "ubemf_abs": 0xfff << 16,
+}
+Fields["COOLSTEPPLUS_CONF"] = {
+    "cool_cur_div": 0x0f << 0,
+    "load_filt_en": 0x01 << 4,
+}
+Fields["COOLSTEPPLUS_PI_REG"] = {
+    "coolstep_p": 0xfff << 0,
+    "coolstep_i": 0x3ff << 16,
+}
+Fields["COOLSTEPPLUS_PI_DOWN"] = {
+    "cool_pi_down_limit": 0xfff << 0,
+    "cool_pi_off_speed": 0xfff << 16,
+}
+Fields["COOLSTEPPLUS_RESERVE_CONF"] = {
+    "cool_low_load_reserve": 0xff << 0,
+    "cool_hi_load_reserve": 0xff << 8,
+    "cool_low_generatoric_reserve": 0xff << 16,
+    "cool_hi_generatoric_reserve": 0xff << 24,
+}
+Fields["COOLSTEPPLUS_LOAD_RESERVE"] = {
+    "sgp_result": 0x3ff << 0,
+    "coolstep_load_reserve": 0x1ff << 16,
+}
+Fields["TSTEP_VELOCITY"] = {"tstep_velocity": 0x7fffff << 0}
+Fields["ADC_VSUPPLY_TEMP"] = {
+    "adc_vsupply": 0x1ff << 0,
+    "adc_temp": 0x1ff << 16,
+}
+Fields["ADC_I"] = {
+    "adc_i_a": 0xfff << 0,
+    "adc_i_b": 0xfff << 16,
+}
+Fields["OTW_OV_VTH"] = {
+    "overvoltage_vth": 0x1ff << 0,
+    "overtempprewarning_vth": 0x1ff << 16,
+}
+Fields["MSLUT0"] = {"mslut0": 0xffffffff}
+Fields["MSLUT1"] = {"mslut1": 0xffffffff}
+Fields["MSLUT2"] = {"mslut2": 0xffffffff}
+Fields["MSLUT3"] = {"mslut3": 0xffffffff}
+Fields["MSLUT4"] = {"mslut4": 0xffffffff}
+Fields["MSLUT5"] = {"mslut5": 0xffffffff}
+Fields["MSLUT6"] = {"mslut6": 0xffffffff}
+Fields["MSLUT7"] = {"mslut7": 0xffffffff}
+Fields["MSLUTSEL"] = {
+    "x3": 0xff << 24,
+    "x2": 0xff << 16,
+    "x1": 0xff << 8,
+    "w3": 0x03 << 6,
+    "w2": 0x03 << 4,
+    "w1": 0x03 << 2,
+    "w0": 0x03 << 0,
+}
+Fields["MSLUTSTART"] = {
+    "start_sin": 0xff << 0,
+    "start_sin90": 0xff << 16,
+    "offset_sin90": 0xff << 24,
+}
+Fields["MSCNT"] = {"mscnt": 0x3ff << 0}
+Fields["MSCURACT"] = {"cur_b": 0x1ff << 0, "cur_a": 0x1ff << 16}
+Fields["CHOPCONF"] = {
+    "toff": 0x0f << 0,
+    "hstrt": 0x07 << 4,
+    "hend": 0x0f << 7,
+    "fd3": 0x01 << 11,
+    "disfdcc": 0x01 << 12,
+    "chm": 0x01 << 14,
+    "tbl": 0x03 << 15,
+    "tpfd": 0x0f << 20,
+    "mres": 0x0f << 24,
+    "intpol": 0x01 << 28,
+    "dedge": 0x01 << 29,
+}
+Fields["COOLCONF"] = {
+    "semin": 0x0f << 0,
+    "seup": 0x03 << 5,
+    "semax": 0x0f << 8,
+    "sedn": 0x07 << 12,
+    "seimin": 0x01 << 15,
+    "sgt": 0x7f << 16,
+    "thigh_sg_off": 0x01 << 23,
+    "sfilt": 0x01 << 24,
+}
+Fields["DRV_STATUS"] = {
+    "sg_result": 0x3ff << 0,
+    "seq_stopped": 0x01 << 10,
+    "ov": 0x01 << 11,
+    "s2vsa": 0x01 << 12,
+    "s2vsb": 0x01 << 13,
+    "stealth": 0x01 << 14,
+    "cs_actual": 0xff << 16,
+    "stallguard": 0x01 << 24,
+    "ot": 0x01 << 25,
+    "otpw": 0x01 << 26,
+    "s2ga": 0x01 << 27,
+    "s2gb": 0x01 << 28,
+    "ola": 0x01 << 29,
+    "olb": 0x01 << 30,
+    "stst": 0x01 << 31,
+}
+Fields["PWMCONF"] = {
+    "pwm_freq": 0x0f << 0,
+    "freewheel": 0x03 << 4,
+    "ol_thrsh": 0x03 << 6,
+    "sd_on_meas_lo": 0x0f << 12,
+    "sd_on_meas_hi": 0x0f << 16,
+}
+
+SignedFields = [
+    "cur_a", "cur_b", "sgt", "offset_sin90", "adc_i_a", "adc_i_b",
+    "angle_error", "angle_meas", "angle_corr_calc", "sgp_thrs",
+    "sgp_ind_0", "sgp_ind_1", "sgp_ind_2", "sgp_ind_3", "ul_a", "ul_b",
+    "sgp_raw", "sgp_result",
+]
+
+FieldFormatters = dict(tmc2130.FieldFormatters)
+FieldFormatters.update({
+    "ov": lambda v: "1(Overvoltage!)" if v else "",
+    "s2vsa": lambda v: "1(ShortToSupply_A!)" if v else "",
+    "s2vsb": lambda v: "1(ShortToSupply_B!)" if v else "",
+    "vm_uvlo": lambda v: "1(VMUndervoltage!)" if v else "",
+    "vccio_uv": lambda v: "1(VCCIOUndervoltage!)" if v else "",
+    "register_reset": lambda v: "1(RegisterReset!)" if v else "",
+    "ext_clk": lambda v: "1(ExternalClock)" if v else "0(Internal16MHz)",
+    "ext_res_det": lambda v: "1" if v else "0(MissingRREF!)",
+    "drv_enn": lambda v: "1(Disabled)" if v else "0(Enabled)",
+    "silicon_rv": lambda v: "%d" % (v,),
+    "clk_loss": lambda v: "1(ClockLoss!)" if v else "",
+    "clk_is_stuck": lambda v: "1(ClockStuck!)" if v else "",
+    "clk_1m0_tmo": lambda v: "1(ClockTimeout!)" if v else "",
+    "adc_temp": lambda v: "0x%03x(%.1fC)" % (v, _adc_to_celsius(v)),
+    "adc_vsupply": lambda v: "0x%03x(%.3fV)" % (v, _adc_to_volts(v)),
+    "angle_meas": lambda v: "%d(%.1fdeg)" % (v, v * 360. / 1024.),
+    "overvoltage_vth": lambda v: "0x%03x(%.3fV)" % (v, _adc_to_volts(v)),
+    "overtempprewarning_vth":
+        lambda v: "0x%03x(%.1fC)" % (v, _adc_to_celsius(v)),
+})
+
+
+######################################################################
+# TMC5262 current helper
+######################################################################
+
+DEFAULT_RREF = 12000.
+KIFS_BASE = 18.
+
+class TMC5262CurrentHelper:
+    def __init__(self, config, mcu_tmc):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.mcu_tmc = mcu_tmc
+        self.fields = mcu_tmc.get_fields()
+        self.rref = config.getfloat("rref", DEFAULT_RREF,
+                                   minval=10000., maxval=14000.)
+        max_current = self._ifs_rms_for(3, 3)
+        run_current = config.getfloat("run_current", above=0.,
+                                      maxval=max_current)
+        hold_current = config.getfloat("hold_current", run_current,
+                                       above=0., maxval=max_current)
+        self.req_hold_current = hold_current
+        cr, crs = self._calc_ranges(run_current)
+        current_range = config.getint("current_range", cr, minval=0, maxval=3)
+        default_scale = crs if current_range == 0 else 3
+        current_range_scale = config.getint(
+            "current_range_scale", default_scale, minval=0, maxval=3)
+        if current_range != 0 and current_range_scale != 3:
+            raise config.error("tmc5262 %s: current_range_scale below 3 is "
+                               "only valid with current_range=0" % (self.name,))
+        self.fields.set_field("current_range", current_range)
+        self.fields.set_field("current_range_scale", current_range_scale)
+        if run_current > self._ifs_rms():
+            raise config.error("tmc5262 %s: run_current %.3f exceeds %.3fA "
+                               "RMS for the selected current range"
+                               % (self.name, run_current, self._ifs_rms()))
+        irun, ihold = self._calc_current(run_current, hold_current)
+        self.fields.set_field("irun", irun)
+        self.fields.set_field("ihold", ihold)
+
+    def _ifs_rms_for(self, cr, crs):
+        i_peak = KIFS_BASE * (cr + 1) * (crs + 1) / (4. * self.rref / 1000.)
+        return i_peak / math.sqrt(2.)
+
+    def _ifs_rms(self):
+        return self._ifs_rms_for(self.fields.get_field("current_range"),
+                                 self.fields.get_field("current_range_scale"))
+
+    def _calc_ranges(self, current):
+        for cr in range(4):
+            if current <= self._ifs_rms_for(cr, 3):
+                if cr == 0:
+                    for crs in range(4):
+                        if current <= self._ifs_rms_for(0, crs):
+                            return 0, crs
+                return cr, 3
+        return 3, 3
+
+    def _calc_current(self, run_current, hold_current):
+        if run_current <= 0.:
+            return 0, 0
+        ifs = self._ifs_rms()
+        irun = max(1, min(250, int(round(run_current / ifs * 250.))))
+        ihold = int(round(min(hold_current, run_current) / run_current * irun))
+        return irun, max(0, min(irun, ihold))
+
+    def _calc_current_from_field(self, field_name):
+        return self._ifs_rms() * self.fields.get_field(field_name) / 250.
+
+    def get_current(self):
+        return (self._calc_current_from_field("irun"),
+                self._calc_current_from_field("ihold"),
+                self.req_hold_current, self._ifs_rms())
+
+    def set_current(self, run_current, hold_current, print_time):
+        self.req_hold_current = hold_current
+        irun, ihold = self._calc_current(run_current, hold_current)
+        self.fields.set_field("ihold", ihold)
+        val = self.fields.set_field("irun", irun)
+        self.mcu_tmc.set_register("IHOLD_IRUN", val, print_time)
+
+
+######################################################################
+# TMC5262 printer object
+######################################################################
+
+class TMC5262CommandHelper(tmc.TMCCommandHelper):
+    def __init__(self, config, mcu_tmc, current_helper, init_callback,
+                 field_validator):
+        self.init_callback = init_callback
+        self.field_validator = field_validator
+        tmc.TMCCommandHelper.__init__(self, config, mcu_tmc, current_helper)
+
+    def _init_registers(self, print_time=None):
+        if self.init_callback():
+            # PLL COMMIT resets the driver control logic, including MSCNT.
+            # Do not retain a phase offset measured before that reset.
+            self.mcu_phase_offset = None
+        tmc.TMCCommandHelper._init_registers(self, print_time)
+
+    def cmd_SET_TMC_FIELD(self, gcmd):
+        field_name = gcmd.get('FIELD').lower()
+        value = gcmd.get_int('VALUE', None)
+        velocity = gcmd.get_float('VELOCITY', None, minval=0.)
+        self.field_validator(gcmd, field_name, value, velocity)
+        tmc.TMCCommandHelper.cmd_SET_TMC_FIELD(self, gcmd)
+
+
+class TMC5262:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.fields = tmc.FieldHelper(Fields, SignedFields, FieldFormatters)
+        self.mcu_tmc = tmc2130.MCU_TMC_SPI(config, Registers, self.fields,
+                                           TMC_FREQUENCY)
+        self.mcu_tmc.temp_from_adc = self._temp_from_adc_register
+        self.mcu_tmc.sg_result_from_drv_status = self._sg_result_from_drv_status
+        # PLL initialization must run before TMCCommandHelper's connect handler.
+        self.printer.register_event_handler("klippy:connect",
+                                            self._handle_pll_init)
+
+        # The TMC5262 routes stall output through DO_CONF instead of GCONF.
+        # The field aliases above let Klipper's common virtual pin helper
+        # handle the hardware DO0/DO1 stall bits as diag0/diag1 signals.
+        self.fields.set_field("do0_invpp", 1)
+        self.fields.set_field("do1_invpp", 1)
+        diag0_pin = config.get("diag0_pin", None)
+        diag1_pin = config.get("diag1_pin", None)
+        if diag0_pin is not None and diag1_pin is not None:
+            raise config.error("tmc5262 %s: specify only one diag pin"
+                               % (self.name,))
+        tmc.TMCVirtualPinHelper(config, self.mcu_tmc)
+
+        current_helper = TMC5262CurrentHelper(config, self.mcu_tmc)
+        self.diag0_pin = diag0_pin
+        self.diag1_pin = diag1_pin
+        cmdhelper = TMC5262CommandHelper(
+            config, self.mcu_tmc, current_helper, self._handle_pll_init,
+            self._validate_runtime_field)
+        cmdhelper.setup_register_dump(ReadRegisters)
+        self.get_phase_offset = cmdhelper.get_phase_offset
+        self.get_status = cmdhelper.get_status
+
+        tmc.TMCWaveTableHelper(config, self.mcu_tmc)
+        self.fields.set_config_field(config, "offset_sin90", 0)
+        self.stealthchop_velocity = config.getfloat(
+            "stealthchop_threshold", None, minval=0.)
+        self.stealthchop_plus_configured = (
+            self.stealthchop_velocity is not None
+            and self.stealthchop_velocity > 0.)
+        tmc.TMCStealthchopHelper(config, self.mcu_tmc)
+        # Reuse Klipper's established CoolStep / StallGuard velocity helpers.
+        tmc.TMCVcoolthrsHelper(config, self.mcu_tmc)
+        tmc.TMCVhighHelper(config, self.mcu_tmc)
+
+        set_config_field = self.fields.set_config_field
+        self.fields.set_field("clock_divider", 15)
+        self.fields.set_field("clk_sys_sel", 1)
+        self.fields.set_field("clk_fsm_ena", 1)
+
+        self.fields.set_field("step_dir", True)
+        set_config_field(config, "multistep_filt", True)
+
+        set_config_field(config, "toff", 3)
+        set_config_field(config, "hstrt", 5)
+        set_config_field(config, "hend", 2)
+        set_config_field(config, "fd3", 0)
+        set_config_field(config, "disfdcc", 0)
+        set_config_field(config, "chm", 0)
+        set_config_field(config, "tbl", 2)
+        set_config_field(config, "tpfd", 4)
+
+        set_config_field(config, "semin", 0)
+        set_config_field(config, "seup", 0)
+        set_config_field(config, "semax", 0)
+        set_config_field(config, "sedn", 0)
+        set_config_field(config, "seimin", 0)
+        set_config_field(config, "sgt", 0)
+        set_config_field(config, "sfilt", 0)
+
+        set_config_field(config, "iholddelay", 7)
+        set_config_field(config, "irundelay", 4)
+
+        set_config_field(config, "pwm_freq", 0)
+        set_config_field(config, "freewheel", 0)
+        try:
+            sd_lo, sd_hi = pwm_measurement_defaults(
+                self.fields.get_field("pwm_freq"))
+        except ValueError as e:
+            raise config.error(str(e))
+        set_config_field(config, "sd_on_meas_lo", sd_lo)
+        set_config_field(config, "sd_on_meas_hi", sd_hi)
+
+        set_config_field(config, "tpowerdown", 10)
+        set_config_field(config, "slope_control", 3)
+
+        # TMC5262 StealthChop+ PI regulators.
+        set_config_field(config, "cur_p", 64)
+        set_config_field(config, "cur_i", 10)
+        set_config_field(config, "angle_p", 50)
+        set_config_field(config, "angle_i", 20)
+        set_config_field(config, "cur_pi_limit", 0xfff)
+        set_config_field(config, "angle_pi_limit", 256)
+        set_config_field(config, "angle_lower_i_limit", 256)
+
+        # TMC5262 motor model used by StealthChop+ and StallGuard+.
+        set_config_field(config, "t_rcoil_meas", 4096)
+        set_config_field(config, "coil_induct", 0)
+        set_config_field(config, "rcoil_manual", False)
+        set_config_field(config, "rcoil_thermal_coupling",
+                         self.stealthchop_plus_configured)
+        set_config_field(config, "r_coil_user_a", 0)
+        set_config_field(config, "r_coil_user_b", 0)
+        if self.stealthchop_plus_configured:
+            if not self.fields.get_field("coil_induct"):
+                raise config.error("tmc5262 %s: StealthChop+ requires "
+                                   "driver_COIL_INDUCT in microhenries"
+                                   % (self.name,))
+            if self.fields.get_field("rcoil_manual"):
+                rcoil_a = self.fields.get_field("r_coil_user_a")
+                rcoil_b = self.fields.get_field("r_coil_user_b")
+                if not rcoil_a or not rcoil_b:
+                    raise config.error("tmc5262 %s: driver_RCOIL_MANUAL "
+                                       "requires nonzero R_COIL_USER_A/B"
+                                       % (self.name,))
+
+        # Always restore TMC5262-only registers to their silicon reset
+        # values before applying optional user overrides. This prevents a
+        # removed option from surviving a host-only FIRMWARE_RESTART.
+        for register, value in OPTIONAL_REGISTER_DEFAULTS.items():
+            self.fields.registers.setdefault(register, value)
+
+        # Optional RT-OCSI, StallGuard+, and CoolStep+ controls. These are
+        # TMC5262-specific extensions to Klipper's common threshold helpers.
+        for field_name in (
+            "do0_scope_en", "do0_scope_sel", "do1_scope_en",
+            "do1_scope_sel", "tsgp_low_vel_thrs", "sgp_thrs",
+            "sgp_filt_en", "sgp_low_vel_freeze", "sgp_clear_cur_pi",
+            "sgp_low_vel_slope", "sgp_low_vel_cnts", "cool_cur_div",
+            "load_filt_en", "coolstep_p", "coolstep_i",
+            "cool_pi_down_limit", "cool_pi_off_speed",
+            "cool_low_load_reserve", "cool_hi_load_reserve",
+            "cool_low_generatoric_reserve", "cool_hi_generatoric_reserve",
+        ):
+            configure_optional_field(config, self.fields, field_name)
+
+        # DO0/DO1 are physically shared between diagnostic output and the
+        # RT-OCSI DAC. Prevent a virtual endstop from being masked by scope
+        # routing on the same pin.
+        if diag0_pin is not None and self.fields.get_field("do0_scope_en"):
+            raise config.error("tmc5262 %s: driver_DO0_SCOPE_EN conflicts "
+                               "with diag0_pin" % (self.name,))
+        if diag1_pin is not None and self.fields.get_field("do1_scope_en"):
+            raise config.error("tmc5262 %s: driver_DO1_SCOPE_EN conflicts "
+                               "with diag1_pin" % (self.name,))
+
+        self._order_register_cache()
+        if self.stealthchop_plus_configured:
+            self.stepper_enable = self.printer.load_object(config,
+                                                           "stepper_enable")
+            self.printer.register_event_handler(
+                "homing:home_rails_begin", self._handle_home_rails_begin)
+
+    def _validate_runtime_field(self, gcmd, field_name, value, velocity):
+        limited_fields = {
+            "do0_scope_en": 1,
+            "do1_scope_en": 1,
+            "do0_scope_sel": 0x1c,
+            "do1_scope_sel": 0x1c,
+            "cool_cur_div": 10,
+        }
+        if field_name not in limited_fields:
+            return
+        if velocity is not None:
+            raise gcmd.error("FIELD=%s requires VALUE" % (field_name,))
+        if value is None or value < 0 or value > limited_fields[field_name]:
+            raise gcmd.error("Invalid value for FIELD=%s" % (field_name,))
+        if (field_name == "do0_scope_en" and value
+                and self.diag0_pin is not None):
+            raise gcmd.error("do0_scope_en conflicts with diag0_pin")
+        if (field_name == "do1_scope_en" and value
+                and self.diag1_pin is not None):
+            raise gcmd.error("do1_scope_en conflicts with diag1_pin")
+
+    def _temp_from_adc_register(self, reg_value):
+        adc_temp = self.fields.get_field(
+            "adc_temp", reg_value, reg_name="ADC_VSUPPLY_TEMP")
+        return _adc_to_celsius(adc_temp)
+
+    def _sg_result_from_drv_status(self, reg_value):
+        result = self.fields.get_field(
+            "sg_result", reg_value, reg_name="DRV_STATUS")
+        if self.fields.get_field(
+                "stealth", reg_value, reg_name="DRV_STATUS"):
+            # In StealthChop+ the same 10-bit DRV_STATUS field mirrors the
+            # signed StallGuard+ result; in SpreadCycle it is unsigned SG2.
+            if result & 0x200:
+                result -= 0x400
+        return result
+
+    def _order_register_cache(self):
+        registers = self.fields.registers
+        for register in TMC5262_REGISTER_INIT_ORDER:
+            if register in registers:
+                value = registers.pop(register)
+                registers[register] = value
+
+    def _home_uses_this_stepper(self, rails):
+        return any(stepper.get_name() == self.name
+                   for rail in rails for stepper in rail.get_steppers())
+
+    def _abort_rcoil_preflight(self, message):
+        try:
+            self.stepper_enable.motor_off()
+        except self.printer.command_error:
+            logging.exception("TMC5262 %s could not disable motors after "
+                              "RCOIL failure", self.name)
+        raise self.printer.command_error(
+            "TMC5262 %s StealthChop+ RCOIL preflight failed: %s. "
+            "No homing move was started." % (self.name, message))
+
+    def _handle_home_rails_begin(self, homing_state, rails):
+        del homing_state
+        if not self._home_uses_this_stepper(rails):
+            return
+        if self.fields.get_field("rcoil_manual"):
+            return
+        try:
+            enable_line = self.stepper_enable.lookup_enable(self.name)
+            did_enable = False
+            if not enable_line.is_motor_enabled():
+                self.stepper_enable.set_motors_enable([self.name], True)
+                did_enable = True
+            toolhead = self.printer.lookup_object("toolhead")
+            if did_enable:
+                reactor = self.printer.get_reactor()
+                eventtime = reactor.monotonic()
+                reactor.pause(eventtime + RCOIL_ENABLE_CALLBACK_DWELL)
+            toolhead.dwell(RCOIL_PREFLIGHT_DWELL)
+            toolhead.wait_moves()
+            drv_status = self.mcu_tmc.get_register("DRV_STATUS")
+            cs_actual = self.fields.get_field("cs_actual", drv_status,
+                                              reg_name="DRV_STATUS")
+            rcoil = self.mcu_tmc.get_register("R_COIL")
+            rcoil_a = self.fields.get_field("r_coil_auto_a", rcoil,
+                                            reg_name="R_COIL")
+            rcoil_b = self.fields.get_field("r_coil_auto_b", rcoil,
+                                            reg_name="R_COIL")
+        except self.printer.command_error as e:
+            self._abort_rcoil_preflight(str(e))
+
+        hard_faults = [
+            field for field in ("s2vsa", "s2vsb", "s2ga", "s2gb", "ot")
+            if self.fields.get_field(field, drv_status,
+                                     reg_name="DRV_STATUS")
+        ]
+        if hard_faults:
+            self._abort_rcoil_preflight(
+                "driver reported %s" % (", ".join(hard_faults),))
+        if cs_actual < 50:
+            self._abort_rcoil_preflight(
+                "CS_ACTUAL=%d is below the required 50" % (cs_actual,))
+        if not rcoil_a or not rcoil_b:
+            self._abort_rcoil_preflight(
+                "R_COIL_AUTO_A/B did not both become nonzero (A=%d, B=%d)"
+                % (rcoil_a, rcoil_b))
+        logging.info("TMC5262 %s StealthChop+ RCOIL ready: A=%d B=%d "
+                     "CS_ACTUAL=%d", self.name, rcoil_a, rcoil_b, cs_actual)
+
+    def _build_pll_value(self, commit, clear_flags=False):
+        val = ((1 if commit else 0) << 0 | (1 << 2) | (1 << 3)
+               | (15 << 5))
+        if clear_flags:
+            val |= (1 << 13) | (1 << 14)
+        return val
+
+    def _pll_is_ready(self, pll):
+        control_mask = ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3)
+                        | (0x1f << 5))
+        fault_mask = (1 << 12) | (1 << 13) | (1 << 14)
+        expected = self._build_pll_value(False)
+        return ((pll & control_mask) == expected and not (pll & fault_mask))
+
+    def _handle_pll_init(self):
+        try:
+            pll = self.mcu_tmc.get_register("PLL")
+            if self._pll_is_ready(pll):
+                return False
+            fault_mask = (1 << 12) | (1 << 13) | (1 << 14)
+            if pll & fault_mask:
+                # Datasheet PLL recovery: disable the FSM before restarting
+                # the normal 0x01ED -> 0x61EC initialization sequence.
+                self.mcu_tmc.set_register(
+                    "PLL", self._build_pll_value(False) & ~(1 << 3))
+            self.mcu_tmc.set_register("PLL", self._build_pll_value(True))
+            reactor = self.printer.get_reactor()
+            deadline = reactor.monotonic() + .020
+            while reactor.monotonic() < deadline:
+                reactor.pause(reactor.monotonic() + .001)
+                pll = self.mcu_tmc.get_register("PLL")
+                if not (pll & 0x01):
+                    break
+            else:
+                raise self.printer.command_error(
+                    "TMC5262 %s PLL commit timed out" % (self.name,))
+            self.mcu_tmc.set_register("PLL",
+                                      self._build_pll_value(False, True))
+            pll = self.mcu_tmc.get_register("PLL")
+            fault_mask = (1 << 12) | (1 << 13) | (1 << 14)
+            if pll & fault_mask:
+                raise self.printer.command_error(
+                    "TMC5262 %s PLL fault after initialization: %s"
+                    % (self.name, self.fields.pretty_format("PLL", pll)))
+            self.mcu_tmc.set_register("GSTAT", 0x3f)
+            return True
+        except self.printer.command_error as e:
+            logging.error("TMC5262 %s PLL init failed: %s", self.name, str(e))
+            raise
+
+
+def load_config_prefix(config):
+    return TMC5262(config)

--- a/scripts/motan/data_logger.py
+++ b/scripts/motan/data_logger.py
@@ -30,6 +30,7 @@ ConfigSubscriptions = [
     ('tmc2260', 'stallguard:{csn}', 'tmc/stallguard_dump', {'name': '{csn}'}),
     ('tmc2240', 'stallguard:{csn}', 'tmc/stallguard_dump', {'name': '{csn}'}),
     ('tmc5160', 'stallguard:{csn}', 'tmc/stallguard_dump', {'name': '{csn}'}),
+    ('tmc5262', 'stallguard:{csn}', 'tmc/stallguard_dump', {'name': '{csn}'}),
 ]
 
 def webhook_socket_create(uds_filename):

--- a/test/klippy/tmc5262.cfg
+++ b/test/klippy/tmc5262.cfg
@@ -1,0 +1,63 @@
+# Test config for TMC5262 driver
+
+[stepper_x]
+step_pin: PC0
+dir_pin: PL0
+enable_pin: !PA7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: tmc5262_stepper_x:virtual_endstop
+position_endstop: 0
+position_max: 250
+
+[tmc5262 stepper_x]
+cs_pin: PG0
+diag0_pin: ^!PB6
+run_current: 1.2
+rref: 12000
+stealthchop_threshold: 0
+coolstep_threshold: 20
+high_velocity_threshold: 200
+driver_COIL_INDUCT: 1500
+driver_SGP_THRS: 5
+driver_SGP_FILT_EN: True
+driver_COOL_CUR_DIV: 2
+driver_LOAD_FILT_EN: True
+driver_COOLSTEP_P: 128
+driver_COOLSTEP_I: 16
+driver_COOL_PI_DOWN_LIMIT: 64
+driver_COOL_PI_OFF_SPEED: 128
+driver_COOL_LOW_LOAD_RESERVE: 150
+driver_COOL_HI_LOAD_RESERVE: 50
+driver_COOL_LOW_GENERATORIC_RESERVE: 220
+driver_COOL_HI_GENERATORIC_RESERVE: 100
+driver_DO1_SCOPE_EN: True
+driver_DO1_SCOPE_SEL: 19
+
+[stepper_y]
+step_pin: PC1
+dir_pin: PL1
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PB4
+position_endstop: 0
+position_max: 200
+
+[stepper_z]
+step_pin: PC2
+dir_pin: PL2
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PB5
+position_endstop: 0.5
+position_max: 200
+
+[mcu]
+serial: /dev/ttyACM0
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100

--- a/test/klippy/tmc5262.test
+++ b/test/klippy/tmc5262.test
@@ -1,0 +1,27 @@
+# Tests for the TMC5262 driver
+CONFIG tmc5262.cfg
+DICTIONARY atmega2560.dict
+
+# Exercise virtual endstop homing
+G28
+
+# Basic register and initialization paths
+DUMP_TMC STEPPER=stepper_x
+DUMP_TMC STEPPER=stepper_x REGISTER=SGP_BEMF
+DUMP_TMC STEPPER=stepper_x REGISTER=COOLSTEPPLUS_CONF
+DUMP_TMC STEPPER=stepper_x REGISTER=DO_SCOPE_CONF
+DUMP_TMC STEPPER=stepper_x REGISTER=TSGP_LOW_VEL_THRS
+DUMP_TMC STEPPER=stepper_x REGISTER=ADC_VSUPPLY_TEMP
+INIT_TMC STEPPER=stepper_x
+
+# Integrated current sense current calculation
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=0
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=1.0
+SET_TMC_CURRENT STEPPER=stepper_x CURRENT=1.5
+
+# Common and TMC5262-specific configuration fields
+SET_TMC_FIELD STEPPER=stepper_x FIELD=sgt VALUE=3
+SET_TMC_FIELD STEPPER=stepper_x FIELD=sgp_thrs VALUE=8
+SET_TMC_FIELD STEPPER=stepper_x FIELD=cool_cur_div VALUE=3
+SET_TMC_FIELD STEPPER=stepper_x FIELD=coolstep_p VALUE=160
+SET_TMC_FIELD STEPPER=stepper_x FIELD=do1_scope_sel VALUE=20

--- a/test/klippy/tmc5262_scope_conflict.test
+++ b/test/klippy/tmc5262_scope_conflict.test
@@ -1,0 +1,6 @@
+# RT-OCSI may not replace a configured TMC5262 virtual endstop output
+CONFIG tmc5262.cfg
+DICTIONARY atmega2560.dict
+SHOULD_FAIL
+
+SET_TMC_FIELD STEPPER=stepper_x FIELD=do0_scope_en VALUE=1


### PR DESCRIPTION
Add basic TMC5262 support: SPI register access, PLL initialization, integrated-current-sense current control, SpreadCycle, driver temperature, and the existing Klipper fault/status helpers.

Reduced in response to Timofey's review. The custom homing preflight and duplicate fault checks are removed. PLL initialization now uses the common connect/enable/INIT_TMC path, named fields, and a 500ms commit timeout. TMC2240 and TMC5262 each supply an explicit temperature conversion.

### Follow-ups

These are separate draft PRs in the fork, not additional upstream submissions. Each is based on the preceding change so it has a small, focused diff:

- [Sensorless homing / DO0 and DO1](https://github.com/Fishyfabspnw/klipper/pull/1)
- [RT-OSCI output configuration](https://github.com/Fishyfabspnw/klipper/pull/2)
- [StealthChop+ configuration](https://github.com/Fishyfabspnw/klipper/pull/3)

This PR requires physical endstops and does not configure StealthChop+, sensorless homing, or RT-OSCI. Both chopper modes remain in the complete series. Optional CoolStep+ configuration is excluded.

### Validation

The revised bring-up commit [6ab2df1d8](https://github.com/Fishyfabspnw/klipper/commit/6ab2df1d82e2c88348c18c925a4394d4aab6d79a) passed [Klipper's full Linux build/test workflow](https://github.com/Fishyfabspnw/klipper/actions/runs/35482416860), including MCU builds and Python 2/3 Klippy tests. Focused local checks also covered delayed PLL commit, power-loss reinitialization, persistent PLL faults, and temperature conversion.

Earlier hardware testing used a NorthPrint3D TMC5262 StepStick on a BTT Octopus Pro V1.1. That testing predates this revision; the revised initialization needs hardware revalidation.

<details>
<summary>Earlier hardware register capture</summary>

![Initialization and driver telemetry](https://github.com/user-attachments/assets/943ec43d-53a6-4da4-b5e4-0e795c6f93e0)

</details>

### Provenance

Derived from the GPLv3 TMC5262 work in KalicoCrew/kalico#892 and adapted to upstream Klipper. Supersedes #7367. Commits include DCO sign-offs.